### PR TITLE
ci: fix ai-verify claude install + fail loudly on skip

### DIFF
--- a/.github/scripts/ai-verify.sh
+++ b/.github/scripts/ai-verify.sh
@@ -14,8 +14,8 @@
 #      setup-token`) drives the Claude Code CLI in headless mode. This token
 #      only authenticates through the CLI, never the raw Messages API.
 #   2. ANTHROPIC_API_KEY drives a direct Messages API request via curl.
-# If neither is set (the normal case on fork pull requests), the script writes a
-# neutral skip.
+# If neither is set, the script writes a skip - which is a FAILURE, not a
+# neutral outcome; see EXIT STATUS below.
 #
 # SECURITY: the context file is UNTRUSTED DATA (a contributor's diff). On the
 # curl path it is embedded into the request as a JSON string via `jq --arg`
@@ -28,11 +28,16 @@
 # and the CLI runs with NO tools (`--allowedTools ""`) so it cannot touch the
 # workspace. Nothing from the diff is ever executed here.
 #
-# This script NEVER exits non-zero for an operational reason (missing
-# credential, missing CLI, transport error, unparseable model output): it writes
-# a neutral "skip" verdict so a data pull request is never blocked by the
-# verifier's own plumbing. Only a genuine {verdict:"flag"} signals a concern, and
-# even that is advisory - a human still reviews.
+# EXIT STATUS answers "did a verdict happen", not "is the data good". A pass and
+# a flag both exit 0 - a flag is advisory, a human still reviews - while every
+# operational skip (missing credential, missing CLI, transport error,
+# unparseable model output) writes its skip verdict and comment and then exits
+# NON-ZERO. A skip is a verification that did not happen, and reporting it as a
+# green check made this workflow vacuous: the CLI's npm install silently stopped
+# landing a runnable binary, every run posted "AI verification skipped", and
+# every one of them still reported PASS (diagnosed on PR #2251, 2026-08-20). The
+# check is advisory BY CONVENTION - it is not branch-protected - so a red skip
+# blocks no merge; it just stops the tick from lying.
 set -uo pipefail
 
 CONTEXT_FILE="${1:?context file required}"
@@ -52,11 +57,11 @@ skip() {
     echo "$reason"
   } > "$COMMENT_OUT"
   echo "ai-verify: skipped - $reason" >&2
-  exit 0
+  exit 1
 }
 
 if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-  skip "No \`CLAUDE_CODE_OAUTH_TOKEN\` or \`ANTHROPIC_API_KEY\` secret is configured (this is expected on fork pull requests, which run with a read-only token and no secrets). A maintainer can re-run verification after pushing the branch to the repository."
+  skip "No \`CLAUDE_CODE_OAUTH_TOKEN\` or \`ANTHROPIC_API_KEY\` secret is configured for this repository. The workflow runs only on same-repo branches, so a missing secret here is a repository configuration problem rather than anything about this pull request."
 fi
 
 if [ ! -s "$CONTEXT_FILE" ]; then

--- a/.github/workflows/ai-verify.yml
+++ b/.github/workflows/ai-verify.yml
@@ -2,20 +2,24 @@ name: ai-verify
 
 # Advisory AI review of a data pull request's diff. This is a judgement layer on
 # top of the mechanical `check` workflow (schema/integrity/formatting), never a
-# replacement for it: it posts a PASS/FLAG comment and label, and never blocks a
-# merge.
+# replacement for it: it posts a PASS/FLAG comment and label. Neither verdict
+# blocks a merge - this check is not branch protected. The job's COLOUR is a
+# separate signal: red means no verdict was reached (see the script's EXIT
+# STATUS block).
 #
 # SECURITY: this uses the plain `pull_request` trigger, NOT
 # `pull_request_target`, which is FORBIDDEN in this repo (the "pwn request"
 # supply-chain pattern). Consequences, accepted deliberately:
 #   - Fork pull requests run with a read-only token and NO secrets, so neither
-#     CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is present there. The script
-#     then writes a neutral "skip" notice rather than failing. A fork PR is
-#     therefore AI-verified only after a
+#     CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is present there. The job
+#     therefore does not run on a fork PR at all (see the `if:` below): a fork
+#     run could only ever reach the script's skip, which is now a RED check (see
+#     the script's EXIT STATUS note), and a permanently-red check nobody can fix
+#     teaches people to ignore the colour. A fork PR is AI-verified after a
 #     maintainer pushes its branch to this repository (a same-repo branch gets
-#     the secret and a write token), or a maintainer re-runs via workflow_dispatch
-#     / applies the `ai-verify` label. We do NOT weaken this to reach fork
-#     secrets.
+#     the secret and a write token) or re-runs it via workflow_dispatch, which
+#     runs from the default branch WITH the secret. We do NOT weaken this to
+#     reach fork secrets.
 #   - The diff is passed to the model as untrusted DATA and never executed (see
 #     .github/scripts/ai-verify.sh).
 on:
@@ -41,8 +45,17 @@ permissions:
 # (observed on 26 of 30 open intake PRs, three runs created in the same
 # second). No-op runs therefore get their own `-noop` group; only real runs
 # supersede each other.
+#
+# A FORK pull request is the SECOND class of no-op run, and it exists because
+# the job-level `if` below stopped admitting forks at all. Its `opened` and
+# `synchronize` events are not `labeled`, so the original selector called them
+# real and put them in the `-run` group - where a push to the fork PR would
+# cancel the workflow_dispatch a maintainer had started for it, which is now the
+# only route by which a fork PR gets verified. That is the same defect the
+# paragraph above describes, reached from the other side, so the fork case joins
+# the same `-noop` group rather than getting a mechanism of its own.
 concurrency:
-  group: ai-verify-${{ github.event.pull_request.number || github.event.inputs.pr }}-${{ (github.event.action == 'labeled' && github.event.label.name != 'ai-verify') && 'noop' || 'run' }}
+  group: ai-verify-${{ github.event.pull_request.number || github.event.inputs.pr }}-${{ ((github.event.action == 'labeled' && github.event.label.name != 'ai-verify') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)) && 'noop' || 'run' }}
   cancel-in-progress: true
 
 jobs:
@@ -54,9 +67,14 @@ jobs:
     # `env` may reference `secrets`). Empty on fork PRs (no secrets).
     env:
       HAS_OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
-    # Same-repo branches (secrets + write token available), a maintainer-applied
-    # `ai-verify` label, or a manual dispatch. Fork PRs without the label are
-    # skipped - they cannot reach the secret anyway.
+    # Same-repo branches (secrets + write token available) or a manual dispatch.
+    # A fork PR is not run at all: it cannot reach the secret, so the ONLY thing
+    # it could produce is the script's skip, and a skip is now a red check. The
+    # `ai-verify` label used to opt a fork PR in here; it bought a run that could
+    # not verify anything, which under the new exit rule is a red check no
+    # contributor can clear. Dropping that arm is what makes "red means no
+    # verdict" exception-free. The label still re-triggers a SAME-REPO PR through
+    # the `labeled` narrowing below.
     #
     # A `labeled` event is narrowed to the opt-in `ai-verify` label and EXCLUDES
     # the two outcome labels this workflow applies at the end (ai-verified /
@@ -72,10 +90,8 @@ jobs:
         (
           github.event.action != 'labeled' ||
           github.event.label.name == 'ai-verify'
-        ) && (
-          github.event.pull_request.head.repo.full_name == github.repository ||
-          contains(github.event.pull_request.labels.*.name, 'ai-verify')
-        )
+        ) &&
+        github.event.pull_request.head.repo.full_name == github.repository
       )
     steps:
       - name: Checkout
@@ -124,9 +140,20 @@ jobs:
       # subscription token authenticates through the CLI, not the raw API). When
       # only ANTHROPIC_API_KEY is set the script uses curl and this is skipped.
       # ubuntu-latest ships Node 20+, so npm is available.
+      #
+      # `claude --version` is a LIVENESS PROBE, not a formality. For a window
+      # around 2026-08-20 this install stopped landing the platform-native
+      # binary: npm reported success, `claude` was on PATH, and every invocation
+      # exited 1 with "claude native binary not installed" (diagnosed on PR
+      # #2251; it resolved itself upstream, so the install line is unchanged).
+      # An install whose failure only shows up three steps later, as a "skipped"
+      # comment, is what let that outage run silently. The probe moves the next
+      # one to the step that causes it.
       - name: Install Claude Code CLI
         if: steps.gather.outputs.has_changes == 'true' && env.HAS_OAUTH == 'true'
-        run: npm install -g @anthropic-ai/claude-code
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
 
       - name: Run AI verification
         if: steps.gather.outputs.has_changes == 'true'
@@ -135,16 +162,31 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: bash .github/scripts/ai-verify.sh context.txt verdict.json comment.md
 
+      # Runs even when the verification step FAILED (a skip), so the skip keeps
+      # its human-readable trace on the pull request while the job stays red.
+      # The comment file is absent only when a step before the script failed, in
+      # which case the job log is the whole trace.
       - name: Post the verdict and label the PR
-        if: steps.gather.outputs.has_changes == 'true'
+        if: ${{ !cancelled() && steps.gather.outputs.has_changes == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ steps.gather.outputs.pr }}
         run: |
-          gh pr comment "$PR" --body-file comment.md || echo "could not comment (read-only token on a fork PR?)"
+          if [ ! -s comment.md ]; then
+            echo "::warning::ai-verify produced no comment - verification did not reach a verdict; see the log above"
+            exit 0
+          fi
+          gh pr comment "$PR" --body-file comment.md || echo "::warning::could not post the ai-verify comment on PR $PR"
           verdict="$(jq -r '.verdict // "skip"' verdict.json 2>/dev/null || echo skip)"
+          # A skip CLEARS both outcome labels rather than leaving the previous
+          # push's. The label is the same claim as the tick: a PR that passed
+          # yesterday and cannot be verified today must not keep a green
+          # `ai-verified` badge asserting a verdict this run did not reach.
+          # Removing a label fires `unlabeled`, which is not in this workflow's
+          # trigger `types`, so this cannot re-fire the job.
           case "$verdict" in
             pass) gh pr edit "$PR" --remove-label ai-flagged --add-label ai-verified || true ;;
             flag) gh pr edit "$PR" --remove-label ai-verified --add-label ai-flagged || true ;;
-            *)    echo "verdict=$verdict; no label applied" ;;
+            *)    gh pr edit "$PR" --remove-label ai-verified --remove-label ai-flagged || true
+                  echo "verdict=$verdict; outcome labels cleared" ;;
           esac

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -119,11 +119,16 @@ Two automations sit in front of the human review step. Neither bypasses it.
   make (factual consistency, plausible provenance, the correct license layer,
   no copied publisher prose, sane sidecar spoiler positions and length). It
   posts a PASS/FLAG comment and applies an `ai-verified` or `ai-flagged` label.
-  This is **advisory only**: it never blocks a merge, and a `flag` is a prompt
-  for a maintainer to look closer, not a veto. It runs on same-repo branches;
-  fork pull requests are verified only after a maintainer pushes the branch to
-  the repository (fork runs have no secret and a read-only token by design - the
-  repo never adopts `pull_request_target`).
+  The VERDICT is **advisory only**: a `flag` is a prompt for a maintainer to
+  look closer, not a veto, and the check is not branch protected, so neither
+  verdict blocks a merge. The job's COLOUR answers a different question -
+  whether a verdict happened at all - and a verification that could not run
+  leaves it red rather than green; the rule and the reason live on
+  `.github/scripts/ai-verify.sh` (the `EXIT STATUS` block). It runs on same-repo
+  branches only; fork pull requests are verified after a maintainer pushes the
+  branch to the repository or re-runs the workflow by hand (fork runs have no
+  secret and a read-only token by design - the repo never adopts
+  `pull_request_target`).
 
 **Merge policy is unchanged by these automations.** A `bot-intake` pull request
 is treated exactly like one "opened by anyone else": it must pass CI, and it


### PR DESCRIPTION
## ⚠️ Maintainer review required

This touches `.github/**` and `GOVERNANCE.md`, which per GOVERNANCE.md and CODEOWNERS **always need maintainer review**. Requesting @KodeStar. **Not merging, and auto-merge is not enabled.**

---

## Background: the outage self-resolved, the silence did not

Diagnosed on PR #2251 (batch 27) on 2026-08-20: `npm install -g @anthropic-ai/claude-code` had stopped landing the platform-native binary on `ubuntu-latest`. The package installed clean, `claude` was on `PATH`, and every invocation exited 1 with `claude native binary not installed`. The script wrote its "AI verification skipped" comment — **and the job still reported PASS**.

**The install has since recovered upstream on its own.** Batch 28's ai-verify ran a real review this morning (`verdict=pass`), and an intake run reached `verdict=flag`. So this PR **does not change the install method** — the reuse review flagged replacing it with `curl … | bash` as introducing the repo's only unpinned network install, for a breakage that had already healed.

What this PR fixes is the reason the outage ran silently for an unknown number of data PRs. This is **hardening: making the next one loud instead of silent.**

## Defect 1 — a skipped verification reported success

`.github/scripts/ai-verify.sh` documented, deliberately, that it *never* exits non-zero for an operational reason, so a data PR could not be blocked by the verifier's own plumbing. That trade was wrong in one direction: the check is **not branch protected**, so a red skip blocks nothing, while a green skip is a tick that lies. This repo's discipline reads the comment — but the tick should not need a human to know it is meaningless.

**Fix.** Exit status now answers *"did a verdict happen"*, not *"is the data good"*:

| outcome | exit | check |
|---|---|---|
| `pass` | 0 | green |
| `flag` | 0 | green (advisory — a human still reviews) |
| any skip (no credential, missing/broken CLI, transport error, unparseable output) | **1** | **red** |

The skip comment still posts — the posting step moved to `if: ${{ !cancelled() && … }}` — so the human-readable trace survives while the job stays red.

**A skip now also clears the `ai-verified` / `ai-flagged` labels.** Found in review: a PR that passed on an earlier push and then hits a transport error kept its green `ai-verified` badge while the check went red. The label is the same claim as the tick. (`unlabeled` is not in the trigger `types`, so this cannot re-fire the job.)

## Defect 2 — a broken install surfaced three steps later

The install step gained a **`claude --version` liveness probe**. The install line itself is untouched; the probe means the next regression of this class fails at the step that causes it, with the real error, instead of appearing three steps later as a "skipped" comment.

## Consequence — the job no longer runs on fork PRs

`contains(github.event.pull_request.labels.*.name, 'ai-verify')` was the **only** arm admitting fork PRs (a same-repo PR already satisfies the `head.repo.full_name == github.repository` arm). A fork `pull_request` run never receives secrets, so under the new rule it could only ever produce the script's skip — **a permanently red check no contributor can clear**, which teaches people to ignore the colour. Dropping that arm is what makes "red means no verdict" exception-free.

Fork PRs are verified exactly as GOVERNANCE.md already described: a maintainer pushes the branch to this repository, or re-runs via `workflow_dispatch` (which runs from the default branch **with** the secret). The `ai-verify` label still re-triggers a **same-repo** PR through the `labeled` narrowing. We do not weaken the no-`pull_request_target` posture to reach fork secrets.

**Concurrency follow-on (found in review).** A fork PR's `opened`/`synchronize` events are not `labeled`, so the original selector called them real runs and filed them in the `-run` group — where a push to the fork PR would `cancel-in-progress` the very `workflow_dispatch` a maintainer had started for it. That is the same defect the existing `-noop` comment describes, reached from the other side, so the fork case now joins the same `-noop` group.

## Local validation

The workflow itself **cannot be run locally** — it needs the runner, the secrets and a real PR event. Done here:

- `bash -n .github/scripts/ai-verify.sh` — clean.
- `actionlint` (v1.7.12) over all workflows — clean.
- Both `run:` blocks extracted and `bash -n`'d — clean.
- **Exercised the reachable skip paths for real**: no-credentials (`exit=1`), missing CLI with a token set (`exit=1`), and a mocked `curl` failure on the API path (`exit=1`) — each writing both `verdict.json` and `comment.md` before exiting.
- Verified all 12 `skip()` call sites are in the main shell (none inside `$( )` or a pipeline, where `exit` would only leave a subshell) and that the `pass`/`flag` path still reaches `exit 0` under `set -uo pipefail` with mocked responses on both transports.
- Traced the step `if:` semantics: a failed Install skips "Run AI verification" (implicit `success()`), and the Post step still runs (its `if:` contains a status function, so `success()` is not implied), warns, and exits 0 with the job red from Install.

**The proof will be the first data PR after merge** — it should either post a real PASS/FLAG comment with a green check, or go red with a skip comment naming the reason.

## Not in this PR

Filed separately as 2257 — real but independent gather-step defects, including one where a large data PR's diff fills the 200KB cap so the full-text section never reaches the model at all.

