### PR TITLE
data: import from issue #2252 (recomposed)

### DIFF
--- a/data/people/gretchen-bender.json
+++ b/data/people/gretchen-bender.json
@@ -600,6 +600,18 @@
         }
       ]
     },
+    "griffon-hardy": {
+      "id": "griffon-hardy",
+      "license": "CC0-1.0",
+      "name": "Griffon Hardy",
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0H8FRGNS9",
+          "type": "audiosilo-books-import"
+        }
+      ]
+    },
     "grigoriy-volodin": {
       "id": "grigoriy-volodin",
       "license": "CC0-1.0",

--- a/data/series/bassam-saga.json
+++ b/data/series/bassam-saga.json
@@ -11085,12 +11085,21 @@
           "imported_at": "2026-08-02",
           "ref": "B0H6CC2Y3D",
           "type": "libex-import"
+        },
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0HCDVCX1Z",
+          "type": "audiosilo-books-import"
         }
       ],
       "works": [
         {
           "position": "1",
           "work": "betrayed-by-the-heros-party-i-summoned-their-replacements"
+        },
+        {
+          "position": "2",
+          "work": "betrayed-by-the-heros-party-i-summoned-their-replacements-2"
         }
       ]
     },

--- a/data/series/bk-acx0-382254.json
+++ b/data/series/bk-acx0-382254.json
@@ -6145,6 +6145,28 @@
         }
       ]
     },
+    "blade-academy": {
+      "id": "blade-academy",
+      "license": "CC0-1.0",
+      "name": "Blade Academy",
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0H8FRGNS9",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "works": [
+        {
+          "position": "1",
+          "work": "blade-angels"
+        },
+        {
+          "position": "2",
+          "work": "blade-angels-2"
+        }
+      ]
+    },
     "blade-and-bone": {
       "id": "blade-and-bone",
       "license": "CC0-1.0",

--- a/data/series/how-to-catch-a-bogle.json
+++ b/data/series/how-to-catch-a-bogle.json
@@ -5615,24 +5615,6 @@
         }
       ]
     },
-    "i-summoned-their-replacements": {
-      "id": "i-summoned-their-replacements",
-      "license": "CC0-1.0",
-      "name": "I Summoned Their Replacements",
-      "sources": [
-        {
-          "imported_at": "2026-08-20",
-          "ref": "B0HCDVCX1Z",
-          "type": "audiosilo-books-import"
-        }
-      ],
-      "works": [
-        {
-          "position": "2",
-          "work": "betrayed-by-the-heros-party-i-summoned-their-replacements-2"
-        }
-      ]
-    },
     "i-survived": {
       "id": "i-survived",
       "license": "CC0-1.0",

--- a/data/series/how-to-catch-a-bogle.json
+++ b/data/series/how-to-catch-a-bogle.json
@@ -5615,6 +5615,24 @@
         }
       ]
     },
+    "i-summoned-their-replacements": {
+      "id": "i-summoned-their-replacements",
+      "license": "CC0-1.0",
+      "name": "I Summoned Their Replacements",
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0HCDVCX1Z",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "works": [
+        {
+          "position": "2",
+          "work": "betrayed-by-the-heros-party-i-summoned-their-replacements-2"
+        }
+      ]
+    },
     "i-survived": {
       "id": "i-survived",
       "license": "CC0-1.0",

--- a/data/series/luxes-lullaby-trilogy.json
+++ b/data/series/luxes-lullaby-trilogy.json
@@ -7014,6 +7014,24 @@
         }
       ]
     },
+    "magic-girls-of-multiverse-inn": {
+      "id": "magic-girls-of-multiverse-inn",
+      "license": "CC0-1.0",
+      "name": "Magic Girls of Multiverse Inn",
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0CSG2VZPW",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "works": [
+        {
+          "position": "1",
+          "work": "magic-girls-of-multiverse-inn"
+        }
+      ]
+    },
     "magic-guardian-academy": {
       "id": "magic-guardian-academy",
       "license": "CC0-1.0",

--- a/data/series/ring-of-fire.json
+++ b/data/series/ring-of-fire.json
@@ -751,6 +751,11 @@
           "imported_at": "2026-08-02",
           "ref": "B0G362VXWP",
           "type": "libex-import"
+        },
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0HCX3DKT5",
+          "type": "audiosilo-books-import"
         }
       ],
       "works": [
@@ -769,6 +774,10 @@
         {
           "position": "4",
           "work": "born-to-rule-rise-of-a-second-son-4"
+        },
+        {
+          "position": "5",
+          "work": "born-to-rule-rise-of-a-second-son-5"
         }
       ]
     },

--- a/data/series/shadow.json
+++ b/data/series/shadow.json
@@ -14356,6 +14356,14 @@
         {
           "position": "1",
           "work": "side-by-side-a-cozy-slice-of-life-mens-romance"
+        },
+        {
+          "position": "3",
+          "work": "side-by-side-3"
+        },
+        {
+          "position": "2",
+          "work": "side-by-side-book-2"
         }
       ]
     },

--- a/data/series/soulguard.json
+++ b/data/series/soulguard.json
@@ -6565,6 +6565,10 @@
         {
           "position": "19",
           "work": "theurge"
+        },
+        {
+          "position": "4.2",
+          "work": "a-checkered-past"
         }
       ]
     },

--- a/data/series/the-reluctant-valkyrie.json
+++ b/data/series/the-reluctant-valkyrie.json
@@ -12059,24 +12059,6 @@
         }
       ]
     },
-    "the-second-son-saga": {
-      "id": "the-second-son-saga",
-      "license": "CC0-1.0",
-      "name": "The Second Son Saga",
-      "sources": [
-        {
-          "imported_at": "2026-08-20",
-          "ref": "B0HCX3DKT5",
-          "type": "audiosilo-books-import"
-        }
-      ],
-      "works": [
-        {
-          "position": "5",
-          "work": "born-to-rule-rise-of-a-second-son-5"
-        }
-      ]
-    },
     "the-second-star-trilogy-1": {
       "id": "the-second-star-trilogy-1",
       "license": "CC0-1.0",

--- a/data/series/the-reluctant-valkyrie.json
+++ b/data/series/the-reluctant-valkyrie.json
@@ -12059,6 +12059,24 @@
         }
       ]
     },
+    "the-second-son-saga": {
+      "id": "the-second-son-saga",
+      "license": "CC0-1.0",
+      "name": "The Second Son Saga",
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0HCX3DKT5",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "works": [
+        {
+          "position": "5",
+          "work": "born-to-rule-rise-of-a-second-son-5"
+        }
+      ]
+    },
     "the-second-star-trilogy-1": {
       "id": "the-second-star-trilogy-1",
       "license": "CC0-1.0",

--- a/data/works/0/a-charming-magic.json
+++ b/data/works/0/a-charming-magic.json
@@ -2082,6 +2082,52 @@
       ],
       "title": "A Check for a Billion"
     },
+    "a-checkered-past": {
+      "added_at": "2026-08-20",
+      "authors": [
+        "terry-mancour"
+      ],
+      "id": "a-checkered-past",
+      "language": "en",
+      "license": "CC0-1.0",
+      "recordings": {
+        "john-lee-2020": {
+          "abridged": false,
+          "added_at": "2026-08-20",
+          "asin": [
+            {
+              "asin": "B0C2N6HR96",
+              "region": "us"
+            }
+          ],
+          "id": "john-lee-2020",
+          "language": "en",
+          "license": "CC0-1.0",
+          "narrators": [
+            "john-lee"
+          ],
+          "publisher": "Podium Audio",
+          "release_date": "2020-09-14",
+          "runtime_min": 52,
+          "sources": [
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0C2N6HR96",
+              "type": "audiosilo-books-import"
+            }
+          ],
+          "work": "a-checkered-past"
+        }
+      },
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0C2N6HR96",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "title": "A Checkered Past"
+    },
     "a-checklist-for-murder": {
       "added_at": "2026-07-29",
       "authors": [

--- a/data/works/0/abyss.json
+++ b/data/works/0/abyss.json
@@ -12136,6 +12136,51 @@
       ],
       "title": "Academy of Legends"
     },
+    "academy-of-legends-1": {
+      "added_at": "2026-08-20",
+      "authors": [
+        "vic-void"
+      ],
+      "id": "academy-of-legends-1",
+      "language": "en",
+      "license": "CC0-1.0",
+      "recordings": {
+        "sloane-mitchell-2025": {
+          "abridged": false,
+          "added_at": "2026-08-20",
+          "asin": [
+            {
+              "asin": "B0F7792RHD",
+              "region": "us"
+            }
+          ],
+          "id": "sloane-mitchell-2025",
+          "language": "en",
+          "license": "CC0-1.0",
+          "narrators": [
+            "sloane-mitchell"
+          ],
+          "release_date": "2025",
+          "runtime_min": 392,
+          "sources": [
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0F7792RHD",
+              "type": "audiosilo-books-import"
+            }
+          ],
+          "work": "academy-of-legends-1"
+        }
+      },
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0F7792RHD",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "title": "Academy of Legends 1"
+    },
     "academy-of-legends-2": {
       "added_at": "2026-08-02",
       "authors": [
@@ -12160,6 +12205,10 @@
             {
               "asin": "B0GQ6S6Y4Y",
               "region": "de"
+            },
+            {
+              "asin": "B0GQ6DZ7BM",
+              "region": "us"
             }
           ],
           "chapters": [
@@ -12274,6 +12323,11 @@
               "imported_at": "2026-08-02",
               "ref": "B0GQ6S6Y4Y",
               "type": "libex-import"
+            },
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0GQ6DZ7BM",
+              "type": "audiosilo-books-import"
             }
           ],
           "work": "academy-of-legends-2"

--- a/data/works/0/all-the-skills-4-a-deck-building-litrpg.json
+++ b/data/works/0/all-the-skills-4-a-deck-building-litrpg.json
@@ -30,6 +30,10 @@
             {
               "asin": "B0CXF768N8",
               "region": "ca"
+            },
+            {
+              "asin": "B0CXF9VWN1",
+              "region": "us"
             }
           ],
           "chapters": [
@@ -324,6 +328,11 @@
               "imported_at": "2026-07-30",
               "ref": "B0CXF768N8",
               "type": "libex-import"
+            },
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0CXF9VWN1",
+              "type": "audiosilo-books-import"
             }
           ],
           "work": "all-the-skills-4-a-deck-building-litrpg"

--- a/data/works/0/american-kings.json
+++ b/data/works/0/american-kings.json
@@ -15352,6 +15352,288 @@
               "region": "us"
             }
           ],
+          "chapters": [
+            {
+              "length_ms": 3545872,
+              "start_ms": 0,
+              "title": "Chapter 1"
+            },
+            {
+              "length_ms": 1021352,
+              "start_ms": 3545872,
+              "title": "Chapter 2"
+            },
+            {
+              "length_ms": 1280301,
+              "start_ms": 4567224,
+              "title": "Chapter 3"
+            },
+            {
+              "length_ms": 1972860,
+              "start_ms": 5847525,
+              "title": "Chapter 4"
+            },
+            {
+              "length_ms": 1759143,
+              "start_ms": 7820385,
+              "title": "Chapter 5"
+            },
+            {
+              "length_ms": 604322,
+              "start_ms": 9579528,
+              "title": "Chapter 6"
+            },
+            {
+              "length_ms": 416055,
+              "start_ms": 10183850,
+              "title": "Chapter 7"
+            },
+            {
+              "length_ms": 1790862,
+              "start_ms": 10599905,
+              "title": "Chapter 8"
+            },
+            {
+              "length_ms": 802946,
+              "start_ms": 12390767,
+              "title": "Chapter 9"
+            },
+            {
+              "length_ms": 928891,
+              "start_ms": 13193713,
+              "title": "Chapter 10"
+            },
+            {
+              "length_ms": 1965058,
+              "start_ms": 14122604,
+              "title": "Chapter 11"
+            },
+            {
+              "length_ms": 1346060,
+              "start_ms": 16087662,
+              "title": "Chapter 12"
+            },
+            {
+              "length_ms": 466442,
+              "start_ms": 17433722,
+              "title": "Chapter 13"
+            },
+            {
+              "length_ms": 1352887,
+              "start_ms": 17900164,
+              "title": "Chapter 14"
+            },
+            {
+              "length_ms": 1129093,
+              "start_ms": 19253051,
+              "title": "Chapter 15"
+            },
+            {
+              "length_ms": 675468,
+              "start_ms": 20382144,
+              "title": "Chapter 16"
+            },
+            {
+              "length_ms": 774849,
+              "start_ms": 21057612,
+              "title": "Chapter 17"
+            },
+            {
+              "length_ms": 1006259,
+              "start_ms": 21832461,
+              "title": "Chapter 18"
+            },
+            {
+              "length_ms": 673378,
+              "start_ms": 22838720,
+              "title": "Chapter 19"
+            },
+            {
+              "length_ms": 1212871,
+              "start_ms": 23512098,
+              "title": "Chapter 20"
+            },
+            {
+              "length_ms": 901584,
+              "start_ms": 24724969,
+              "title": "Chapter 21"
+            },
+            {
+              "length_ms": 1609467,
+              "start_ms": 25626553,
+              "title": "Chapter 22"
+            },
+            {
+              "length_ms": 543439,
+              "start_ms": 27236020,
+              "title": "Chapter 23"
+            },
+            {
+              "length_ms": 2799862,
+              "start_ms": 27779459,
+              "title": "Chapter 24"
+            },
+            {
+              "length_ms": 2254704,
+              "start_ms": 30579321,
+              "title": "Chapter 25"
+            },
+            {
+              "length_ms": 1059433,
+              "start_ms": 32834025,
+              "title": "Chapter 26"
+            },
+            {
+              "length_ms": 425250,
+              "start_ms": 33893458,
+              "title": "Chapter 27"
+            },
+            {
+              "length_ms": 911522,
+              "start_ms": 34318708,
+              "title": "Chapter 28"
+            },
+            {
+              "length_ms": 2522058,
+              "start_ms": 35230230,
+              "title": "Chapter 29"
+            },
+            {
+              "length_ms": 855701,
+              "start_ms": 37752288,
+              "title": "Chapter 30"
+            },
+            {
+              "length_ms": 568192,
+              "start_ms": 38607989,
+              "title": "Chapter 31"
+            },
+            {
+              "length_ms": 1628647,
+              "start_ms": 39176181,
+              "title": "Chapter 32"
+            },
+            {
+              "length_ms": 1113257,
+              "start_ms": 40804828,
+              "title": "Chapter 33"
+            },
+            {
+              "length_ms": 680298,
+              "start_ms": 41918085,
+              "title": "Chapter 34"
+            },
+            {
+              "length_ms": 726831,
+              "start_ms": 42598383,
+              "title": "Chapter 35"
+            },
+            {
+              "length_ms": 1348940,
+              "start_ms": 43325214,
+              "title": "Chapter 36"
+            },
+            {
+              "length_ms": 825794,
+              "start_ms": 44674154,
+              "title": "Chapter 37"
+            },
+            {
+              "length_ms": 665251,
+              "start_ms": 45499948,
+              "title": "Chapter 38"
+            },
+            {
+              "length_ms": 957916,
+              "start_ms": 46165199,
+              "title": "Chapter 39"
+            },
+            {
+              "length_ms": 546458,
+              "start_ms": 47123115,
+              "title": "Chapter 40"
+            },
+            {
+              "length_ms": 2121560,
+              "start_ms": 47669573,
+              "title": "Chapter 41"
+            },
+            {
+              "length_ms": 674864,
+              "start_ms": 49791133,
+              "title": "Chapter 42"
+            },
+            {
+              "length_ms": 2176545,
+              "start_ms": 50465997,
+              "title": "Chapter 43"
+            },
+            {
+              "length_ms": 532526,
+              "start_ms": 52642542,
+              "title": "Chapter 44"
+            },
+            {
+              "length_ms": 2117427,
+              "start_ms": 53175068,
+              "title": "Chapter 45"
+            },
+            {
+              "length_ms": 486597,
+              "start_ms": 55292495,
+              "title": "Chapter 46"
+            },
+            {
+              "length_ms": 222772,
+              "start_ms": 55779092,
+              "title": "Chapter 47"
+            },
+            {
+              "length_ms": 232245,
+              "start_ms": 56001864,
+              "title": "Chapter 48"
+            },
+            {
+              "length_ms": 655452,
+              "start_ms": 56234109,
+              "title": "Chapter 49"
+            },
+            {
+              "length_ms": 51455,
+              "start_ms": 56889561,
+              "title": "Chapter 50"
+            },
+            {
+              "length_ms": 1725196,
+              "start_ms": 56941016,
+              "title": "Chapter 51"
+            },
+            {
+              "length_ms": 228948,
+              "start_ms": 58666212,
+              "title": "Chapter 52"
+            },
+            {
+              "length_ms": 440761,
+              "start_ms": 58895160,
+              "title": "Chapter 53"
+            },
+            {
+              "length_ms": 215016,
+              "start_ms": 59335921,
+              "title": "Chapter 54"
+            },
+            {
+              "length_ms": 1217468,
+              "start_ms": 59550937,
+              "title": "Chapter 55"
+            },
+            {
+              "length_ms": 759849,
+              "start_ms": 60768405,
+              "title": "Chapter 56"
+            }
+          ],
           "cover_url": "https://m.media-amazon.com/images/I/417Ux4ZA5ML._SL500_.jpg",
           "id": "nick-landrum-2011",
           "language": "en",
@@ -15372,6 +15654,10 @@
               "imported_at": "2026-07-17",
               "ref": "B004SC4CKK",
               "type": "audible-lookup"
+            },
+            {
+              "ref": "B004SC4CKK",
+              "type": "libex-import"
             }
           ],
           "work": "american-psycho"

--- a/data/works/ascendant-king/betrayal-of-the-court.json
+++ b/data/works/ascendant-king/betrayal-of-the-court.json
@@ -5611,6 +5611,53 @@
       ],
       "title": "Betrayed by the Hero's Party, I Summoned Their Replacements"
     },
+    "betrayed-by-the-heros-party-i-summoned-their-replacements-2": {
+      "added_at": "2026-08-20",
+      "authors": [
+        "ethan-gale"
+      ],
+      "id": "betrayed-by-the-heros-party-i-summoned-their-replacements-2",
+      "language": "en",
+      "license": "CC0-1.0",
+      "recordings": {
+        "dorian-james-2026": {
+          "abridged": false,
+          "added_at": "2026-08-20",
+          "asin": [
+            {
+              "asin": "B0HCDVCX1Z",
+              "region": "us"
+            }
+          ],
+          "id": "dorian-james-2026",
+          "language": "en",
+          "license": "CC0-1.0",
+          "narrators": [
+            "dorian-james",
+            "nikki-lyons"
+          ],
+          "publisher": "Royal Guard Publishing LLC",
+          "release_date": "2026",
+          "runtime_min": 555,
+          "sources": [
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0HCDVCX1Z",
+              "type": "audiosilo-books-import"
+            }
+          ],
+          "work": "betrayed-by-the-heros-party-i-summoned-their-replacements-2"
+        }
+      },
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0HCDVCX1Z",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "title": "Betrayed by the Hero's Party, I Summoned Their Replacements 2"
+    },
     "betrayed-dr-rebecca-sharp": {
       "added_at": "2026-07-29",
       "authors": [

--- a/data/works/ascendant-king/blackout-nation-episode-2-darkness-descends.json
+++ b/data/works/ascendant-king/blackout-nation-episode-2-darkness-descends.json
@@ -14880,6 +14880,10 @@
             {
               "asin": "B0DK81D9LM",
               "region": "de"
+            },
+            {
+              "asin": "B0DK7XHLJT",
+              "region": "us"
             }
           ],
           "chapters": [
@@ -15048,7 +15052,7 @@
           ],
           "publisher": "Eden Redd",
           "release_date": "2024-10-18",
-          "runtime_min": 512,
+          "runtime_min": 513,
           "sources": [
             {
               "imported_at": "2026-08-02",
@@ -15059,6 +15063,11 @@
               "imported_at": "2026-08-02",
               "ref": "B0DK81D9LM",
               "type": "libex-import"
+            },
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0DK7XHLJT",
+              "type": "audiosilo-books-import"
             }
           ],
           "work": "blackwood-milk-farm-book-6"

--- a/data/works/ascendant-king/blackwood-milk-farm-collection.json
+++ b/data/works/ascendant-king/blackwood-milk-farm-collection.json
@@ -1997,6 +1997,100 @@
       ],
       "title": "Blade and Bone [Dramatized Adaptation]"
     },
+    "blade-angels": {
+      "added_at": "2026-08-20",
+      "authors": [
+        "griffon-hardy"
+      ],
+      "id": "blade-angels",
+      "language": "en",
+      "license": "CC0-1.0",
+      "recordings": {
+        "stone-smith-2026": {
+          "abridged": false,
+          "added_at": "2026-08-20",
+          "asin": [
+            {
+              "asin": "B0H8FRGNS9",
+              "region": "us"
+            }
+          ],
+          "id": "stone-smith-2026",
+          "language": "en",
+          "license": "CC0-1.0",
+          "narrators": [
+            "stone-smith",
+            "melanie-hastings"
+          ],
+          "publisher": "Royal Guard Publishing LLC",
+          "release_date": "2026",
+          "runtime_min": 746,
+          "sources": [
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0H8FRGNS9",
+              "type": "audiosilo-books-import"
+            }
+          ],
+          "work": "blade-angels"
+        }
+      },
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0H8FRGNS9",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "title": "Blade Angels"
+    },
+    "blade-angels-2": {
+      "added_at": "2026-08-20",
+      "authors": [
+        "griffon-hardy"
+      ],
+      "id": "blade-angels-2",
+      "language": "en",
+      "license": "CC0-1.0",
+      "recordings": {
+        "stone-smith-2026": {
+          "abridged": false,
+          "added_at": "2026-08-20",
+          "asin": [
+            {
+              "asin": "B0HCX74WZS",
+              "region": "us"
+            }
+          ],
+          "id": "stone-smith-2026",
+          "language": "en",
+          "license": "CC0-1.0",
+          "narrators": [
+            "stone-smith",
+            "melanie-hastings"
+          ],
+          "publisher": "Royal Guard Publishing LLC",
+          "release_date": "2026",
+          "runtime_min": 804,
+          "sources": [
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0HCX74WZS",
+              "type": "audiosilo-books-import"
+            }
+          ],
+          "work": "blade-angels-2"
+        }
+      },
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0HCX74WZS",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "title": "Blade Angels 2"
+    },
     "blade-bastard-vol-1": {
       "added_at": "2026-08-02",
       "authors": [

--- a/data/works/ascendant-king/born-of-water-elemental-magic-epic-fantasy-adventure.json
+++ b/data/works/ascendant-king/born-of-water-elemental-magic-epic-fantasy-adventure.json
@@ -10544,6 +10544,53 @@
       ],
       "title": "Born to Rule: Rise of a Second Son 4"
     },
+    "born-to-rule-rise-of-a-second-son-5": {
+      "added_at": "2026-08-20",
+      "authors": [
+        "shane-hammond"
+      ],
+      "id": "born-to-rule-rise-of-a-second-son-5",
+      "language": "en",
+      "license": "CC0-1.0",
+      "recordings": {
+        "raya-kane-2026": {
+          "abridged": false,
+          "added_at": "2026-08-20",
+          "asin": [
+            {
+              "asin": "B0HCX3DKT5",
+              "region": "us"
+            }
+          ],
+          "id": "raya-kane-2026",
+          "language": "en",
+          "license": "CC0-1.0",
+          "narrators": [
+            "raya-kane",
+            "richard-brock"
+          ],
+          "publisher": "Royal Guard Publishing LLC",
+          "release_date": "2026",
+          "runtime_min": 525,
+          "sources": [
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0HCX3DKT5",
+              "type": "audiosilo-books-import"
+            }
+          ],
+          "work": "born-to-rule-rise-of-a-second-son-5"
+        }
+      },
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0HCX3DKT5",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "title": "Born to Rule: Rise of a Second Son 5"
+    },
     "born-to-run": {
       "added_at": "2026-08-02",
       "authors": [

--- a/data/works/deep-fried-death/dragon-dream-g-a-aiken.json
+++ b/data/works/deep-fried-death/dragon-dream-g-a-aiken.json
@@ -3159,6 +3159,53 @@
       ],
       "title": "Dragon Emperor 6"
     },
+    "dragon-emperor-7": {
+      "added_at": "2026-08-20",
+      "authors": [
+        "eric-vall"
+      ],
+      "id": "dragon-emperor-7",
+      "language": "en",
+      "license": "CC0-1.0",
+      "recordings": {
+        "alex-perone-2020": {
+          "abridged": false,
+          "added_at": "2026-08-20",
+          "asin": [
+            {
+              "asin": "B0876FJ1F1",
+              "region": "us"
+            }
+          ],
+          "id": "alex-perone-2020",
+          "language": "en",
+          "license": "CC0-1.0",
+          "narrators": [
+            "alex-perone",
+            "marissa-parness"
+          ],
+          "publisher": "Eric Vall",
+          "release_date": "2020",
+          "runtime_min": 465,
+          "sources": [
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0876FJ1F1",
+              "type": "audiosilo-books-import"
+            }
+          ],
+          "work": "dragon-emperor-7"
+        }
+      },
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0876FJ1F1",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "title": "Dragon Emperor 7"
+    },
     "dragon-emperor-7-human-to-dragon-to-god": {
       "added_at": "2026-08-01",
       "authors": [
@@ -3323,6 +3370,10 @@
             {
               "asin": "B087KSMCCB",
               "region": "us"
+            },
+            {
+              "asin": "B087KPFG51",
+              "region": "us"
             }
           ],
           "chapters": [
@@ -3433,6 +3484,11 @@
               "imported_at": "2026-08-01",
               "ref": "B087KSMCCB",
               "type": "libex-import"
+            },
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B087KPFG51",
+              "type": "audiosilo-books-import"
             }
           ],
           "work": "dragon-emperor-8"

--- a/data/works/deep-fried-death/dragon-dream-g-a-aiken.json
+++ b/data/works/deep-fried-death/dragon-dream-g-a-aiken.json
@@ -3159,53 +3159,6 @@
       ],
       "title": "Dragon Emperor 6"
     },
-    "dragon-emperor-7": {
-      "added_at": "2026-08-20",
-      "authors": [
-        "eric-vall"
-      ],
-      "id": "dragon-emperor-7",
-      "language": "en",
-      "license": "CC0-1.0",
-      "recordings": {
-        "alex-perone-2020": {
-          "abridged": false,
-          "added_at": "2026-08-20",
-          "asin": [
-            {
-              "asin": "B0876FJ1F1",
-              "region": "us"
-            }
-          ],
-          "id": "alex-perone-2020",
-          "language": "en",
-          "license": "CC0-1.0",
-          "narrators": [
-            "alex-perone",
-            "marissa-parness"
-          ],
-          "publisher": "Eric Vall",
-          "release_date": "2020",
-          "runtime_min": 465,
-          "sources": [
-            {
-              "imported_at": "2026-08-20",
-              "ref": "B0876FJ1F1",
-              "type": "audiosilo-books-import"
-            }
-          ],
-          "work": "dragon-emperor-7"
-        }
-      },
-      "sources": [
-        {
-          "imported_at": "2026-08-20",
-          "ref": "B0876FJ1F1",
-          "type": "audiosilo-books-import"
-        }
-      ],
-      "title": "Dragon Emperor 7"
-    },
     "dragon-emperor-7-human-to-dragon-to-god": {
       "added_at": "2026-08-01",
       "authors": [
@@ -3225,6 +3178,10 @@
           "asin": [
             {
               "asin": "B0876FMKZN",
+              "region": "us"
+            },
+            {
+              "asin": "B0876FJ1F1",
               "region": "us"
             }
           ],
@@ -3330,12 +3287,17 @@
           ],
           "publisher": "Eric Vall",
           "release_date": "2020-04-23",
-          "runtime_min": 464,
+          "runtime_min": 465,
           "sources": [
             {
               "imported_at": "2026-08-01",
               "ref": "B0876FMKZN",
               "type": "libex-import"
+            },
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0876FJ1F1",
+              "type": "audiosilo-books-import"
             }
           ],
           "work": "dragon-emperor-7-human-to-dragon-to-god"

--- a/data/works/eagle-strike/fowl-play.json
+++ b/data/works/eagle-strike/fowl-play.json
@@ -1586,6 +1586,133 @@
               "region": "us"
             }
           ],
+          "chapters": [
+            {
+              "length_ms": 20177,
+              "start_ms": 0,
+              "title": "Opening Credits"
+            },
+            {
+              "length_ms": 18575,
+              "start_ms": 20177,
+              "title": "Disclaimer"
+            },
+            {
+              "length_ms": 68220,
+              "start_ms": 38752,
+              "title": "Preface"
+            },
+            {
+              "length_ms": 2869266,
+              "start_ms": 106972,
+              "title": "Saint-Ex’s Boa"
+            },
+            {
+              "length_ms": 924130,
+              "start_ms": 2976238,
+              "title": "Little Brown Bats"
+            },
+            {
+              "length_ms": 2650511,
+              "start_ms": 3900368,
+              "title": "Vole Forest"
+            },
+            {
+              "length_ms": 2376400,
+              "start_ms": 6550879,
+              "title": "Two Black Dogs"
+            },
+            {
+              "length_ms": 622503,
+              "start_ms": 8927279,
+              "title": "Rain Fox"
+            },
+            {
+              "length_ms": 2422189,
+              "start_ms": 9549782,
+              "title": "Dancing Fly"
+            },
+            {
+              "length_ms": 1901458,
+              "start_ms": 11971971,
+              "title": "Dancing Fox"
+            },
+            {
+              "length_ms": 1395867,
+              "start_ms": 13873429,
+              "title": "Panther Creek Fawn"
+            },
+            {
+              "length_ms": 3040954,
+              "start_ms": 15269296,
+              "title": "Last Day at River Cabins"
+            },
+            {
+              "length_ms": 1132484,
+              "start_ms": 18310250,
+              "title": "A Reptile Dysfunction"
+            },
+            {
+              "length_ms": 1814940,
+              "start_ms": 19442734,
+              "title": "Dr. and Mr. Frankenstein"
+            },
+            {
+              "length_ms": 2538080,
+              "start_ms": 21257674,
+              "title": "Endless Possibilities for Mischief"
+            },
+            {
+              "length_ms": 1739546,
+              "start_ms": 23795754,
+              "title": "Meadowlark"
+            },
+            {
+              "length_ms": 1980616,
+              "start_ms": 25535300,
+              "title": "Spotted Foxes"
+            },
+            {
+              "length_ms": 1126538,
+              "start_ms": 27515916,
+              "title": "Elk and Badgers"
+            },
+            {
+              "length_ms": 701335,
+              "start_ms": 28642454,
+              "title": "Elephants"
+            },
+            {
+              "length_ms": 1566674,
+              "start_ms": 29343789,
+              "title": "Whales and Polar Bears"
+            },
+            {
+              "length_ms": 1309233,
+              "start_ms": 30910463,
+              "title": "Magpies"
+            },
+            {
+              "length_ms": 1730025,
+              "start_ms": 32219696,
+              "title": "Spotted Owls"
+            },
+            {
+              "length_ms": 2254610,
+              "start_ms": 33949721,
+              "title": "Sand Dollars"
+            },
+            {
+              "length_ms": 1117134,
+              "start_ms": 36204331,
+              "title": "Fields of Dun and Gunny"
+            },
+            {
+              "length_ms": 37824,
+              "start_ms": 37321465,
+              "title": "End Credits"
+            }
+          ],
           "cover_url": "https://m.media-amazon.com/images/I/91fJ4rjGnTS.jpg",
           "id": "stacey-glemboski-2021",
           "language": "en",

--- a/data/works/galactic-marine/here-with-me.json
+++ b/data/works/galactic-marine/here-with-me.json
@@ -9664,6 +9664,10 @@
             {
               "asin": "B0CZPKBY63",
               "region": "us"
+            },
+            {
+              "asin": "B0CZPJXK83",
+              "region": "us"
             }
           ],
           "chapters": [
@@ -10157,12 +10161,17 @@
           ],
           "publisher": "Podium Audio",
           "release_date": "2024-07-09",
-          "runtime_min": 1416,
+          "runtime_min": 1417,
           "sources": [
             {
               "imported_at": "2026-08-02",
               "ref": "B0CZPKBY63",
               "type": "libex-import"
+            },
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0CZPJXK83",
+              "type": "audiosilo-books-import"
             }
           ],
           "work": "heretical-fishing-2-a-cozy-guide-to-annoying-the-cults-outsmarting-the-fish-and-alienating-oneself"

--- a/data/works/limitless-lands/magic-for-nothing.json
+++ b/data/works/limitless-lands/magic-for-nothing.json
@@ -1728,6 +1728,53 @@
         }
       ],
       "title": "Magic Gifts (Dramatized Adaptation)"
+    },
+    "magic-girls-of-multiverse-inn": {
+      "added_at": "2026-08-20",
+      "authors": [
+        "eric-vall"
+      ],
+      "id": "magic-girls-of-multiverse-inn",
+      "language": "en",
+      "license": "CC0-1.0",
+      "recordings": {
+        "c-c-thompson-2024": {
+          "abridged": false,
+          "added_at": "2026-08-20",
+          "asin": [
+            {
+              "asin": "B0CSG2VZPW",
+              "region": "us"
+            }
+          ],
+          "id": "c-c-thompson-2024",
+          "language": "en",
+          "license": "CC0-1.0",
+          "narrators": [
+            "c-c-thompson",
+            "jd-tanner"
+          ],
+          "publisher": "Eric Vall",
+          "release_date": "2024",
+          "runtime_min": 612,
+          "sources": [
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0CSG2VZPW",
+              "type": "audiosilo-books-import"
+            }
+          ],
+          "work": "magic-girls-of-multiverse-inn"
+        }
+      },
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0CSG2VZPW",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "title": "Magic Girls of Multiverse Inn"
     }
   }
 }

--- a/data/works/queens-knight/shadow-wizard.json
+++ b/data/works/queens-knight/shadow-wizard.json
@@ -2674,6 +2674,10 @@
             {
               "asin": "B074HMP13B",
               "region": "uk"
+            },
+            {
+              "asin": "B07G9JK4H8",
+              "region": "us"
             }
           ],
           "chapters": [
@@ -2957,7 +2961,7 @@
           ],
           "publisher": "Bolinda Publishing Pty Ltd",
           "release_date": "2017-10-05",
-          "runtime_min": 575,
+          "runtime_min": 576,
           "sources": [
             {
               "imported_at": "2026-08-02",
@@ -2973,6 +2977,11 @@
               "imported_at": "2026-08-02",
               "ref": "B074HMP13B",
               "type": "libex-import"
+            },
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B07G9JK4H8",
+              "type": "audiosilo-books-import"
             }
           ],
           "work": "shadowblack"

--- a/data/works/sharpes-sword/sicario.json
+++ b/data/works/sharpes-sword/sicario.json
@@ -8892,6 +8892,100 @@
       ],
       "title": "Siddhartha's Brain"
     },
+    "side-by-side-3": {
+      "added_at": "2026-08-20",
+      "authors": [
+        "j-t-knight"
+      ],
+      "id": "side-by-side-3",
+      "language": "en",
+      "license": "CC0-1.0",
+      "recordings": {
+        "jim-swanson-2026": {
+          "abridged": false,
+          "added_at": "2026-08-20",
+          "asin": [
+            {
+              "asin": "B0GWS6BY73",
+              "region": "us"
+            }
+          ],
+          "id": "jim-swanson-2026",
+          "language": "en",
+          "license": "CC0-1.0",
+          "narrators": [
+            "jim-swanson",
+            "raya-kane"
+          ],
+          "publisher": "Royal Guard Publishing LLC",
+          "release_date": "2026",
+          "runtime_min": 725,
+          "sources": [
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0GWS6BY73",
+              "type": "audiosilo-books-import"
+            }
+          ],
+          "work": "side-by-side-3"
+        }
+      },
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0GWS6BY73",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "title": "Side by Side 3"
+    },
+    "side-by-side-4": {
+      "added_at": "2026-08-20",
+      "authors": [
+        "j-t-knight"
+      ],
+      "id": "side-by-side-4",
+      "language": "en",
+      "license": "CC0-1.0",
+      "recordings": {
+        "jim-swanson-2026": {
+          "abridged": false,
+          "added_at": "2026-08-20",
+          "asin": [
+            {
+              "asin": "B0HC7W9R2Y",
+              "region": "us"
+            }
+          ],
+          "id": "jim-swanson-2026",
+          "language": "en",
+          "license": "CC0-1.0",
+          "narrators": [
+            "jim-swanson",
+            "raya-kane"
+          ],
+          "publisher": "Royal Guard Publishing LLC",
+          "release_date": "2026",
+          "runtime_min": 607,
+          "sources": [
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0HC7W9R2Y",
+              "type": "audiosilo-books-import"
+            }
+          ],
+          "work": "side-by-side-4"
+        }
+      },
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0HC7W9R2Y",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "title": "Side by Side 4"
+    },
     "side-by-side-a-cozy-slice-of-life-mens-romance": {
       "added_at": "2026-07-29",
       "authors": [
@@ -9129,6 +9223,53 @@
         }
       ],
       "title": "Side by Side: A Cozy Slice of Life Men's Romance"
+    },
+    "side-by-side-book-2": {
+      "added_at": "2026-08-20",
+      "authors": [
+        "j-t-knight"
+      ],
+      "id": "side-by-side-book-2",
+      "language": "en",
+      "license": "CC0-1.0",
+      "recordings": {
+        "jim-swanson-2025": {
+          "abridged": false,
+          "added_at": "2026-08-20",
+          "asin": [
+            {
+              "asin": "B0G452JWZP",
+              "region": "us"
+            }
+          ],
+          "id": "jim-swanson-2025",
+          "language": "en",
+          "license": "CC0-1.0",
+          "narrators": [
+            "jim-swanson",
+            "raya-kane"
+          ],
+          "publisher": "Royal Guard Publishing LLC",
+          "release_date": "2025",
+          "runtime_min": 538,
+          "sources": [
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B0G452JWZP",
+              "type": "audiosilo-books-import"
+            }
+          ],
+          "work": "side-by-side-book-2"
+        }
+      },
+      "sources": [
+        {
+          "imported_at": "2026-08-20",
+          "ref": "B0G452JWZP",
+          "type": "audiosilo-books-import"
+        }
+      ],
+      "title": "Side by Side, Book 2"
     },
     "side-character": {
       "added_at": "2026-07-29",

--- a/data/works/sharpes-sword/succubus-lord.json
+++ b/data/works/sharpes-sword/succubus-lord.json
@@ -1259,6 +1259,10 @@
             {
               "asin": "B08JQPHD1K",
               "region": "de"
+            },
+            {
+              "asin": "B08JQP67CF",
+              "region": "us"
             }
           ],
           "chapters": [
@@ -1389,6 +1393,11 @@
               "imported_at": "2026-08-02",
               "ref": "B08JQPHD1K",
               "type": "libex-import"
+            },
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B08JQP67CF",
+              "type": "audiosilo-books-import"
             }
           ],
           "work": "succubus-lord-16"

--- a/data/works/sharpes-sword/summoned-to-thirteenth-grave.json
+++ b/data/works/sharpes-sword/summoned-to-thirteenth-grave.json
@@ -1320,6 +1320,10 @@
             {
               "asin": "B08J592WJT",
               "region": "us"
+            },
+            {
+              "asin": "B08J4GT6XN",
+              "region": "us"
             }
           ],
           "chapters": [
@@ -1439,6 +1443,11 @@
               "imported_at": "2026-08-01",
               "ref": "B08J592WJT",
               "type": "libex-import"
+            },
+            {
+              "imported_at": "2026-08-20",
+              "ref": "B08J4GT6XN",
+              "type": "audiosilo-books-import"
             }
           ],
           "work": "summoner-16"

--- a/data/works/terrible-revenge/the-4-h-harvest.json
+++ b/data/works/terrible-revenge/the-4-h-harvest.json
@@ -3517,6 +3517,10 @@
       "authors": [
         "robert-greene"
       ],
+      "genres": [
+        "philosophy",
+        "politics"
+      ],
       "id": "the-48-laws-of-power",
       "language": "en",
       "license": "CC0-1.0",
@@ -3777,6 +3781,7 @@
               "title": "Law 48"
             }
           ],
+          "cover_url": "https://m.media-amazon.com/images/I/41PfHefFq1L.jpg",
           "id": "don-leslie-2007",
           "language": "en",
           "license": "CC0-1.0",
@@ -3806,6 +3811,10 @@
           "imported_at": "2026-08-02",
           "ref": "B002VA8IXS",
           "type": "audiosilo-books-import"
+        },
+        {
+          "ref": "B002VA8IXS",
+          "type": "libex-import"
         }
       ],
       "title": "The 48 Laws of Power"

--- a/data/works/the-erstwhile/the-hobbit.json
+++ b/data/works/the-erstwhile/the-hobbit.json
@@ -375,6 +375,7 @@
               "title": "Part Five"
             }
           ],
+          "cover_url": "https://m.media-amazon.com/images/I/81wq-zTbNNL.jpg",
           "id": "nicol-williamson-2007",
           "language": "en",
           "license": "CC0-1.0",

--- a/data/works/the-erstwhile/the-little-school-bus-that-talked.json
+++ b/data/works/the-erstwhile/the-little-school-bus-that-talked.json
@@ -11846,6 +11846,88 @@
               "region": "us"
             }
           ],
+          "chapters": [
+            {
+              "length_ms": 35159,
+              "start_ms": 0,
+              "title": "Opening Credits"
+            },
+            {
+              "length_ms": 355515,
+              "start_ms": 35159,
+              "title": "Author’s Foreword"
+            },
+            {
+              "length_ms": 941361,
+              "start_ms": 390674,
+              "title": "Chapter One: The Plateau"
+            },
+            {
+              "length_ms": 841792,
+              "start_ms": 1332035,
+              "title": "Chapter Two: The Recesses"
+            },
+            {
+              "length_ms": 728503,
+              "start_ms": 2173827,
+              "title": "Chapter Three: The Group"
+            },
+            {
+              "length_ms": 829416,
+              "start_ms": 2902330,
+              "title": "Chapter Four: Water"
+            },
+            {
+              "length_ms": 1445325,
+              "start_ms": 3731746,
+              "title": "Chapter Five: Frost and Snow"
+            },
+            {
+              "length_ms": 742737,
+              "start_ms": 5177071,
+              "title": "Chapter Six: Air and Light"
+            },
+            {
+              "length_ms": 1522508,
+              "start_ms": 5919808,
+              "title": "Chapter Seven: Life: The Plants"
+            },
+            {
+              "length_ms": 1981661,
+              "start_ms": 7442316,
+              "title": "Chapter Eight: Life: Birds, Animals, Insects"
+            },
+            {
+              "length_ms": 1632710,
+              "start_ms": 9423977,
+              "title": "Chapter Nine: Life: Man"
+            },
+            {
+              "length_ms": 744037,
+              "start_ms": 11056687,
+              "title": "Chapter Ten: Sleep"
+            },
+            {
+              "length_ms": 1194434,
+              "start_ms": 11800724,
+              "title": "Chapter Eleven: The Senses"
+            },
+            {
+              "length_ms": 498742,
+              "start_ms": 12995158,
+              "title": "Chapter Twelve: Being"
+            },
+            {
+              "length_ms": 4102464,
+              "start_ms": 13493900,
+              "title": "Afterword by Jeanette Winterson"
+            },
+            {
+              "length_ms": 51050,
+              "start_ms": 17596364,
+              "title": "End Credits"
+            }
+          ],
           "cover_url": "https://m.media-amazon.com/images/I/91VtXu5+YeL.jpg",
           "id": "tilda-swinton-2019",
           "language": "en",

--- a/data/works/the-twelve-tasks/the-warriors-shade.json
+++ b/data/works/the-twelve-tasks/the-warriors-shade.json
@@ -3396,6 +3396,7 @@
               "title": "Chapter 186"
             }
           ],
+          "cover_url": "https://m.media-amazon.com/images/I/81jPLJGiW2L.jpg",
           "id": "scott-brick-2020",
           "language": "en",
           "license": "CC0-1.0",


### PR DESCRIPTION
Recomposition of the intake bot's PR #2253 (issue #2252, submitted by @shurialvaro), which could not be rebased mechanically: the chapter-batch waves merged since it was cut (batches 28/29) split several packs it touches, and the pack merge driver refuses the shape. The import's changes are member-disjoint from the batches, so this re-applies the same entries onto current main in one commit.

Content (identical to #2253 except where adjudicated below):
- 11 works, 11 recordings, 1 person, 4 series imported
- 8 re-release ASINs merged into existing recordings
- 7 recordings attested from the bulk mirror per the trust-tier rule

ai-verify findings on #2253, adjudicated:
- **Kept the recorded `release_date` 2024-10-18** on `blackwood-milk-farm-book-6`/`sierra-kline-2024`: the export's bare `2000` is implausible for a 2024 self-published title (Audiobookshelf default-date garbage). The ASIN merge itself (B0DK7XHLJT) is kept.
- **Kept the recorded `release_date` 2017-10-05 and publisher of record (Bolinda)** on `shadowblack`/`joe-jameson-2017`: the export's `2020`/`Orbit` describe the merged US re-release, whose region rides on the added ASIN (B07G9JK4H8) per the one-recording-per-production model.
- **Spellmonger position 4.2 (`a-checkered-past`) verified real**: a John Lee / Podium Spellmonger short story; the fractional position is the submitter's own metadata. Kept.
- The sparse new series and the unlinked `side-by-side-4` are correct: the export states no series for that row (omit-never-guess), and a personal library legitimately holds only the volumes it holds.

Supersedes #2253.
Closes #2252.
