### PR TITLE
data: community layer to CC BY-SA 4.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-characters.yml
+++ b/.github/ISSUE_TEMPLATE/add-characters.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Add a **characters** sidecar - the spoiler-tagged cast for a work that is
-        already in the database. This is the community **CC BY-SA 3.0** layer, not
+        already in the database. This is the community **CC BY-SA 4.0** layer, not
         the CC0 factual core, so it carries different rules than the other forms.
 
         The easiest way to produce a valid file is the guided builder at
@@ -61,7 +61,7 @@ body:
     attributes:
       label: License
       options:
-        - label: I license this contribution under CC BY-SA 3.0, and I have the right to do so.
+        - label: I license this contribution under CC BY-SA 4.0, and I have the right to do so.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/add-recaps.yml
+++ b/.github/ISSUE_TEMPLATE/add-recaps.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Add a **recaps** sidecar - position-keyed "story so far" summaries for a
         work that is already in the database. This is the community **CC BY-SA
-        3.0** layer, not the CC0 factual core, so it carries different rules than
+        4.0** layer, not the CC0 factual core, so it carries different rules than
         the other forms.
 
         The easiest way to produce a valid file is the guided builder at

--- a/.github/ISSUE_TEMPLATE/add-recaps.yml
+++ b/.github/ISSUE_TEMPLATE/add-recaps.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: License
       options:
-        - label: I license this contribution under CC BY-SA 3.0, and I have the right to do so.
+        - label: I license this contribution under CC BY-SA 4.0, and I have the right to do so.
           required: true
 
   - type: textarea

--- a/.github/scripts/ai-verify.sh
+++ b/.github/scripts/ai-verify.sh
@@ -75,7 +75,7 @@ STORAGE LAYOUT - read this before judging anything: the data files are range-pac
 Check the changed records for:
 - Internal factual consistency: dates are plausible (no future or absurd years; first_published <= a recording release_date), runtime_min is sane for a book (roughly 30-4000 minutes), series positions look like numbers or omnibus ranges (e.g. \"1\", \"2.5\", \"1-3.5\").
 - Provenance: every new record carries a non-empty sources[] and the source refs look plausible (a store/library reference, not gibberish).
-- License layer: core records (work/recording/person/series) must be CC0-1.0; the community sidecars (the characters/recaps members of data/works-community/ entries) must be CC-BY-SA-3.0. Flag any record on the wrong license.
+- License layer: core records (work/recording/person/series) must be CC0-1.0; the community sidecars (the characters/recaps members of data/works-community/ entries) must be CC-BY-SA-4.0. Flag any record on the wrong license.
 - No copyrighted prose: descriptions/character text/recap text must read as neutral own-words reference writing, NOT a publisher blurb or marketing copy (no back-cover hype, no review quotes).
 - Sidecars: character/recap text within reasonable length (recap text under ~3000 chars, character description under ~1500, in_short under ~1500, ending under ~2000), reveal/through spoiler positions are non-negative integers.
 - Fabrication signals: invented ASINs/ISBNs, implausible narrator/author names, or facts that look made up.

--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -4,7 +4,7 @@ This guide covers the **expressive layer** of the database: community-authored
 **character** entries and **recaps** ("story so far" summaries). It is separate
 from [CONTRIBUTING.md](CONTRIBUTING.md), which covers the factual CC0 core
 (works, recordings, people, series). Read [LICENSING.md](LICENSING.md) first -
-this layer is **CC BY-SA 3.0**, not CC0, and it carries real copyright
+this layer is **CC BY-SA 4.0**, not CC0, and it carries real copyright
 obligations the core does not.
 
 If you are filling out a whole series, do the CC0 core first (the works,
@@ -36,9 +36,9 @@ data/works-community/<dir>/<bound>.json
 ```
 
 The family is separate from `data/works/` so the licence boundary is structural:
-everything in `works-community` is **CC BY-SA 3.0**, everything in the core
+everything in `works-community` is **CC BY-SA 4.0**, everything in the core
 families is CC0. Each member carries `work` (the parent work slug, which must
-equal the entry key), `license` (**must** be `"CC-BY-SA-3.0"`), and `sources`.
+equal the entry key), `license` (**must** be `"CC-BY-SA-4.0"`), and `sources`.
 
 Add your entry to the community pack whose range covers the work slug - or the
 nearest one - and run `go run ./cmd/metafmt --write`: it places the entry
@@ -50,7 +50,7 @@ own shape; where they say "the file", read "the member".
 ```json
 {
   "work": "a-deadly-education",
-  "license": "CC-BY-SA-3.0",
+  "license": "CC-BY-SA-4.0",
   "sources": [{ "type": "community" }],
   "characters": [
     {
@@ -89,7 +89,7 @@ own shape; where they say "the file", read "the member".
 ```json
 {
   "work": "the-last-graduate",
-  "license": "CC-BY-SA-3.0",
+  "license": "CC-BY-SA-4.0",
   "sources": [{ "type": "community" }],
   "in_short": "The whole book in one paragraph, ending included, for someone about to start the next one.",
   "ending": "How the book closes: where every major player stands, and which threads stay open.",
@@ -201,7 +201,7 @@ style:
 
 ## Format and validation
 
-- `license` is `"CC-BY-SA-3.0"`. A manual contribution from the author's own
+- `license` is `"CC-BY-SA-4.0"`. A manual contribution from the author's own
   knowledge may use `sources: [{ "type": "community" }]`. An automated
   audiobook/ebook extraction **must** use one community source whose `ref`
   identifies the edition actually processed, for example
@@ -222,7 +222,7 @@ style:
 
 - [ ] The work, its recording(s), author, and narrator already exist and validate.
 - [ ] `work` equals the entry key both members sit under.
-- [ ] `license` is `"CC-BY-SA-3.0"`; `sources` present.
+- [ ] `license` is `"CC-BY-SA-4.0"`; `sources` present.
 - [ ] Every character has an `id` (unique within this work's characters member), `name`, and `reveal`.
 - [ ] Descriptions/texts are your own words, within the caps, and accurate
       (character ≤ 1500, recap `text` ≤ 3000, `in_short` ≤ 1500, `ending` ≤ 2000).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ of it (the player was always the defining AudioSilo feature; the ABS facade is a
 bonus for a direct competitor's users).
 
 Module path: `github.com/kodestar/audiosilo-meta`. Code is AGPL-3.0; the data
-is CC0-1.0 (factual core) with a CC BY-SA 3.0 community layer (the
+is CC0-1.0 (factual core) with a CC BY-SA 4.0 community layer (the
 characters/recaps sidecars) - the full policy
 in [LICENSING.md](LICENSING.md) is load-bearing, read it before touching data
 handling.
@@ -339,7 +339,7 @@ Every entity carries `license` and `sources[]` (provenance: type/ref/
 imported_at) so any source can be audited or retracted wholesale. **Two license
 layers, enforced structurally by the schema** (`$defs/license` vs
 `$defs/license_content`): the CC0 core (works/recordings/people/series) is
-`CC0-1.0`; the CC BY-SA layer (characters/recaps) is `CC-BY-SA-3.0`. A core
+`CC0-1.0`; the CC BY-SA layer (characters/recaps) is `CC-BY-SA-4.0`. A core
 record can never carry the share-alike license and a sidecar can never carry
 CC0 - the boundary is a schema enum, not a convention (see LICENSING.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ a `"recordings"` map keyed by recording slug, so one book is one entry.
   if one slips through.
 - Every entity has a `license` field and a `sources[]` array
   (`{type, ref?, imported_at?}`) recording where the facts came from. The core
-  families are `CC0-1.0`; `works-community` entries are `CC-BY-SA-3.0`.
+  families are `CC0-1.0`; `works-community` entries are `CC-BY-SA-4.0`.
 - Works and recordings also carry an optional `added_at` - the date the record
   entered the database. The importer and the intake bot stamp it; leave it out
   of a hand-written record and it will simply be absent.

--- a/EXTRACTION.md
+++ b/EXTRACTION.md
@@ -137,7 +137,7 @@ deciding per book:
   ending plainly.
 - **Book 1 vs book N**: only book 2+ gets the `chapter: 0` + `scope: "series"`
   "previously" recap. A series opener has none.
-- Both files: `license` `"CC-BY-SA-3.0"`, `sources` `[{"type": "community"}]`.
+- Both files: `license` `"CC-BY-SA-4.0"`, `sources` `[{"type": "community"}]`.
 
 Prompt template: see "The prompt set" below.
 
@@ -279,7 +279,7 @@ the recaps member
 - ending (<= 2000 chars): the sequel-handoff state - where every surviving
   major player stands, which threads stay open.
 
-HARD RULES: license CC-BY-SA-3.0, sources [{"type": "community"}]; fresh
+HARD RULES: license CC-BY-SA-4.0, sources [{"type": "community"}]; fresh
 prose in your own words (an 8-word-shingle check against the full text will
 be run on the output); neutral reference-guide voice; hyphens never em
 dashes; when a fact's chapter attribution is uncertain, leave the fact out.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -63,6 +63,12 @@ A contribution made before the upgrade is covered by it because the contributor
 and the maintainer were the same person; from 2026-08-21 the contribution
 checkbox on the characters/recaps issue forms names 4.0.
 
+The enum value was **replaced, not widened**, so `"CC-BY-SA-3.0"` is now
+rejected. A submission whose attachment was authored against the old
+instructions therefore fails validation with a bare value-mismatch message
+naming the `license` field - and the fix is mechanical: change the one value to
+`"CC-BY-SA-4.0"` and nothing else about the file needs to move.
+
 ## The CC0 core
 
 The factual core - works, recordings, people, and series - is dedicated to the

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -63,9 +63,8 @@ A contribution made before the upgrade is covered by it because the contributor
 and the maintainer were the same person; from 2026-08-21 the contribution
 checkbox on the characters/recaps issue forms names 4.0.
 
-The enum value was **replaced, not widened**, so `"CC-BY-SA-3.0"` is now
-rejected. A submission whose attachment was authored against the old
-instructions therefore fails validation with a bare value-mismatch message
+A submission whose attachment was authored against the old instructions
+therefore fails validation with a bare value-mismatch message
 naming the `license` field - and the fix is mechanical: change the one value to
 `"CC-BY-SA-4.0"` and nothing else about the file needs to move.
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -10,7 +10,7 @@ submission you agree to the terms below.
 |---|---|---|
 | Code (tooling, schemas, CI, future server) | **AGPL-3.0-only** | See [`LICENSE`](LICENSE). Matches audiosilo-server. |
 | Data - factual core | **CC0-1.0** (public domain dedication) | The works, recordings, people, and series. Every such record carries `license: "CC0-1.0"`. |
-| Data - derived layer | **CC BY-SA 3.0** | Community-authored characters and recaps, and any Fandom / LibraryThing CK derived content. Kept in a separate pack family, `data/works-community/` (each entry a work's `characters` and `recaps` members), so the boundary is directory-structural as well as schema-enforced. |
+| Data - derived layer | **CC BY-SA 4.0** | Community-authored characters and recaps, and any Fandom / LibraryThing CK derived content. Kept in a separate pack family, `data/works-community/` (each entry a work's `characters` and `recaps` members), so the boundary is directory-structural as well as schema-enforced. |
 | Publisher blurbs, cover art | **Not accepted** | Referenced, never copied. Covers are URLs only; descriptions must be community-written. |
 
 ## Why two data licences
@@ -21,9 +21,10 @@ is not copyrightable (facts are free under Feist v. Rural). Dedicating it to the
 public domain with **CC0-1.0** removes all friction: anyone can build on the data
 without attribution obligations, and downstream forks stay maximally open.
 
-The **CC BY-SA 3.0** layer covers *derived, expressive* content -
-community-authored character descriptions and recaps, and anything sourced from
-Fandom wikis or LibraryThing Common Knowledge (both CC BY-SA 3.0 at source).
+The **CC BY-SA 4.0** layer covers *derived, expressive* content -
+community-authored character descriptions and recaps, and anything derived from
+Fandom wikis or LibraryThing Common Knowledge (both CC BY-SA 3.0 at source; see
+"The 4.0 upgrade" below for why that still flows in).
 Share-alike is desirable there: it keeps derivative works open. This layer lives
 in a separate pack family, `data/works-community/`, where each entry holds one
 work's `characters` and `recaps` members - so the CC0 core is never contaminated
@@ -31,9 +32,36 @@ by share-alike obligations, and the separation is visible in the directory tree
 as well as in the records. The
 boundary is **enforced structurally by the schema**, not by convention: a core
 record (work/recording/person/series) can only carry `CC0-1.0`, and a sidecar can
-only carry `CC-BY-SA-3.0` - the `license` enum differs between them, and
+only carry `CC-BY-SA-4.0` - the `license` enum differs between them, and
 `metacheck` rejects any record that crosses the line. Authoring this layer is
 documented in [AUTHORING.md](AUTHORING.md).
+
+## The 4.0 upgrade (2026-08-21)
+
+The community layer was **CC BY-SA 3.0** until 2026-08-21, when every entry was
+relicensed to **CC BY-SA 4.0** in one change. Every sidecar in the tree at that
+point had been authored in-house, so there was no third-party 3.0 content to
+carry forward: the schema enum was *replaced* rather than widened, and there is
+no dual-licensed period to reason about.
+
+Why upgrade:
+
+- **The original reason for 3.0 survives it.** Fandom and LibraryThing Common
+  Knowledge are BY-SA 3.0 at source, and 3.0's ShareAlike clause permits
+  licensing an adaptation under a later version of the licence. Our posture is
+  derived, own-words content and never verbatim mirroring, so 3.0 sources still
+  flow into a 4.0 project.
+- **The reverse never held.** 4.0 content cannot flow into a 3.0 project, and
+  Wikipedia has been BY-SA 4.0 since 2023. Staying on 3.0 would have foreclosed
+  every 4.0 source permanently.
+- **4.0 explicitly licenses sui generis database rights** - directly relevant to
+  a project that *is* a database, and to the EU/UK right discussed under
+  "Imports bring facts only" below. It also adds the 30-day cure provision and
+  is one international instrument rather than ported jurisdiction variants.
+
+A contribution made before the upgrade is covered by it because the contributor
+and the maintainer were the same person; from 2026-08-21 the contribution
+checkbox on the characters/recaps issue forms names 4.0.
 
 ## The CC0 core
 

--- a/PACK-SPEC.md
+++ b/PACK-SPEC.md
@@ -73,7 +73,7 @@ Sidecars move out of `data/works/**` into their own family - named
 community layer) - so the license
 boundary becomes directory-structural as well as schema-structural: a works pack
 schema-locks every entry to `CC0-1.0`; a sidecar pack schema-locks to
-`CC-BY-SA-3.0` (`$defs/license_content`). Mixing is impossible by construction,
+`CC-BY-SA-4.0` (`$defs/license_content`). Mixing is impossible by construction,
 as today.
 
 ## Pack file format

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ every submission.
 |---|---|
 | Code (tooling, schemas, CI, future server) | **AGPL-3.0-only** ([`LICENSE`](LICENSE)) |
 | Data - factual core (works, recordings, people, series) | **CC0-1.0** public domain dedication |
-| Data - derived layer (characters and recaps) | **CC BY-SA 3.0** |
+| Data - derived layer (characters and recaps) | **CC BY-SA 4.0** |
 
 Publisher blurbs and cover art are referenced, never copied. Full policy,
 including the takedown / rightsholder opt-out channel, in

--- a/data/works-community/0/0.json
+++ b/data/works-community/0/0.json
@@ -113,7 +113,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -126,7 +126,7 @@
       "recaps": {
         "ending": "Digory brings the apple back from the walled garden without eating it and without stealing a second one for his mother, though Jadis, who has eaten one and won an endless life she already hates, urges him to do both. Aslan tells him plainly that a stolen apple would have healed his mother and made them both wretched afterwards. The apple Digory carried honestly is planted by the river and grows at once into a tall tree whose smell the Witch cannot endure, so she flees far to the north and will not trouble Narnia for centuries. Frank and Helen are crowned as the country's first King and Queen, and Strawberry, now the winged horse Fledge, stays with them. Aslan then gives Digory an apple from the new tree for his mother, and sends the children and Uncle Andrew home. Digory's mother recovers. Uncle Andrew, badly shaken by everything he has seen, gives up magic for good, though he never stops telling people about the magnificent woman he once entertained. The children bury the apple core and the rings in the back garden so that nobody can use them again. A tree grows from the core; years later a storm blows it down, and Digory, by then a professor, has its timber made into a wardrobe.",
         "in_short": "In London at the turn of the century, Digory Kirke and his neighbour Polly Plummer blunder into the study of Digory's Uncle Andrew, an amateur magician who tricks them into testing rings that carry the wearer between worlds. By way of a quiet wood full of pools they reach Charn, a dead city, where Digory strikes an enchanted bell and wakes its last queen, Jadis, who destroyed every living thing in her own world rather than lose a war. She follows them back to London, terrorises the city, and is dragged with them, along with a cabman named Frank and his horse, into an empty darkness where a Lion is singing a new world into being. Aslan makes Frank and his wife the first King and Queen of Narnia, and sends Digory west to fetch an apple that will guard the country against the witch he has let in. Digory resists the temptation to steal a second apple for his dying mother; the planted apple becomes a guardian tree, and Aslan gives him one for her freely. She recovers, the rings are buried, and the tree that grows from the buried core is eventually made into a wardrobe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -311,7 +311,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -324,7 +324,7 @@
       "recaps": {
         "ending": "The last stand outside the stable ends with almost all of Tirian's company killed and Tirian himself dragging the Calormene commander through the stable door. Inside is not a stable but a bright country in daylight, where the god the Calormenes had invoked carries Rishda away, and where seven kings and queens of Narnia are waiting: Peter, Edmund and Lucy, Digory Kirke and Polly Plummer, Eustace and Jill. Susan is not among them, having put Narnia away as a childish game. The dwarfs who would be taken in by nobody sit in the same sunlight convinced they are in a dark, filthy stable, and not even Aslan can reach them. Aslan calls Father Time to end the world: the stars fall, the creatures of Narnia come to the door and either look at him with love and pass in or turn aside into his shadow, the sea rises, the sun is put out, and Peter shuts and locks the door. The company then goes further up and further in, and finds that this country is Narnia after all, the real one of which the old was a copy, opening outward for ever and joined at its far end to England. Everyone they have loved is there, including Reepicheep, Caspian, and the young Calormene Emeth, whose lifelong honest service to Tash is counted by Aslan as service to himself. Aslan then tells the children the plain fact they had not guessed: there was a railway accident, and they and their parents are dead. The term is over; the holidays have begun.",
         "in_short": "In the last days of Narnia, an ape called Shift dresses his simple friend Puzzle the donkey in a lion's skin and passes him off as Aslan returned. Using the fraud he sells Narnian beasts into Calormene slavery, has the sacred trees felled, and proclaims that Aslan and the Calormene god Tash are one. King Tirian, the last king of Narnia, is captured trying to resist and calls for help across the worlds; Eustace Scrubb and Jill Pole are pulled out of England to join him. They free Puzzle and expose the trick, but the beasts, dwarfs and even the Calormenes are past being convinced by anything, and a real and terrible Tash comes north in answer to being called. At the last battle outside the stable on Stable Hill, Tirian's tiny company is destroyed, and the survivors pass through the stable door into a bright country where the friends of Narnia from every earlier book are waiting. Aslan brings Narnia itself to an end, closing the door on the dead world, and leads everyone further up and further in to the real Narnia beyond it. The children learn that they died in a railway accident in England, and that this is the beginning rather than the end.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -568,7 +568,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -583,7 +583,7 @@
       "recaps": {
         "ending": "Camp Violet burns after two members of the squad pursuing Freddy become possessed, and its administrators evacuate without the workers. Peter Vane dies after warning Freddy, who takes his identification but is forced through an underwater passage before he can attempt the planned disguise. Freddy kills a leviathan from inside it and reaches shore, where Bloodshed cages the beast's attacking ether construct within Freddy's ethercosm. Bloodshed willingly helps forge Freddy's blood affinity and then joins him against the Craven patriarch. Freddy kills the patriarch and ascends to two stars, gaining water, blood, and an unexplained third affinity. Bloodshed survives in a rune cage within him, while Freddy's new leviathan-based attack badly damages his body. Mark remains in coerced Craven service at Starhold, Sarah's situation is unresolved, and the wider clan and Camp Violet's possession threat remain active concerns. A search party later reports a burned survivor carrying Peter's identification as Peter, but the survivor's true identity is not established.",
         "in_short": "Freddy Stern survives a passage attack, manifests a valuable farming prime, and trades it for the water-affinity talent 1% Lifesteal. He discovers that the talent can heal lasting damage when he harms living things and trains under Mark Affronte while secretly protecting Bloodshed, a sentient remnant wanted by the Craven clan. Craven kidnaps and tortures Freddy, then imposes a fraudulent debt and sends him to forced labor at Camp Violet. Freddy conceals his recovery, develops his abilities, and arranges an escape with Peter Vane. Possessed pursuers burn the camp, Peter dies warning Freddy, and Freddy escapes through a passage only to be swallowed by a leviathan. He kills it from within. Bloodshed then cages its ether construct, grants Freddy blood affinity with consent, and helps him kill the Craven patriarch. Freddy rises to two stars with a mysterious third affinity, while Bloodshed survives inside his ethercosm and the wider Craven and possession threats remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1128,7 +1128,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1143,7 +1143,7 @@
       "recaps": {
         "ending": "Freddy keeps Sophia's undead head hidden in a preservation solution that gives him about a year to restore her body before her identity is irretrievably lost. He remains bonded to Bloodshed, while Bloodshed conceals the Asura's warning of an approaching planetary conflict. Liam Cuttingsworth's identity is still usable but carries a $2.5 million fine, and Freddy loses it as a safe local cover after killing Theodore Osborne, Jacob Santorio, Grant, and Randy during their ambush. He leaves Nova York by bus, expecting retaliation from Leonard Santorio and resolving to seek strength and wealth. Elsewhere, Silverheart is dead, Empress Kaya has lost her Eidolon, and Leona remains sealed behind the cult's red barrier. Madame Morlap has destroyed a parasite in her own soul and suspects Mark and Nahar may carry similar entities. Mark, newly empowered, kills Craven's last patriarch and elders, frees the clan's two secret prisoners, retrieves his family, and follows a snake-eyed broker to negotiate escape from imperial punishment.",
         "in_short": "Freddy Stern survives Camp Violet, purchases the identity of Liam Cuttingsworth, and rebuilds his life as a delver in Nova York. His secret partnership with Sophia Sommer gives both of them undead bodies, but they are trapped when Sophia's former cult seals a passage realm and massacres its occupants. Bloodshed disrupts the cult's plan after a mummified arm seizes control of its summoned body, while Empress Kaya's intervention ends with her Eidolon destroyed and Silverheart killed by a crimson Asura. Sophia is reduced to a preserved head, and Freddy returns under Liam's criminally burdened identity to seek her restoration. Mark Affronte gains supernatural power, destroys Craven's remaining leadership, and flees after freeing two prisoners. Theodore Osborne and Jacob Santorio later ambush Freddy on suspicion alone. Freddy kills them, Grant, and Randy, then abandons Nova York to pursue greater wealth and power.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1485,7 +1485,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -1498,7 +1498,7 @@
       "recaps": {
         "ending": "Thor dies after invoking a life-consuming ability to drive Keegan Jem's armored assassin away from Valhalla. Lucas remains a prisoner of the Jem family after Charlie King lures him out with a threat involving Helen, while Helen supports the family's claim that Valhalla manipulated her son. Travis assumes emergency leadership and tries to prevent a suicidal defense. Under the imperial adjudicator's supervision, the rival factions demand Valhalla's dissolution, forced labor for its noncombatants, and death or imprisonment for its fighters. An unidentified man interrupts before terms are settled. Freddy enters the Century of Solitude immediately after Thor's death and experiences roughly fifty years with Bloodshed while little more than an hour passes outside. He emerges with extensive stage-three upgrades to his blood and water abilities, but has not chosen the trial's final reward. Sophia is alive but still lacks her memory, speech, talent access, and two left limbs. Freddy's immediate unresolved aims are rescuing Lucas, preserving Valhalla, and answering Thor's death.",
         "in_short": "Freddy Stern enters the Northern Belt under a new face and the forged identity Freddy Cliff, hoping to build power without serving another faction. He shelters Lucas Black and Helen Black, funds Sophia's reconstruction, and forms a partnership with Thor's anti-crime faction, Valhalla. His violence draws the hostility of the Jem family, while Thor becomes his mentor and tries to temper both his combat weaknesses and his anger. Sophia survives reconstruction with profound disabilities. Freddy secretly sells regenerated organs to finance the Century of Solitude and gives Bloodshed a rare resource that transforms it. Helen defects to the Jems, Charlie King delivers Lucas into their custody, and Keegan Jem sends an armored assassin against Valhalla. Thor dies driving the killer away. Freddy then endures about fifty subjective years of isolation, earning broad stage-three upgrades but leaving one reward unchosen. Travis faces coercive surrender terms for Valhalla, Lucas remains captive, and an unidentified arrival interrupts the final negotiation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1911,7 +1911,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0GR6C9WYC",
@@ -1923,7 +1923,7 @@
       "recaps": {
         "ending": "Repentawa survives after Emily Umbra kills Nahar Kraven and the directed horde disperses, but the victory leaves roughly 80,000 survivors and severe losses. Freddy remains the city's owner, though his soul is catastrophically damaged and only partly stabilized by a hostile new scythe construct from the Blood Domain. Sophia's awakened flesh golem attacks Valhalla's evacuees before Freddy's allies destroy it. Sophia saves fewer than one hundred wounded people, including Lucas Black and Georgie League, then leaves after she and Freddy divide over her willingness to pursue radical change in the Empire. Lucas is alive as a second-star fighter who has reclaimed his name, while Janice has already departed under the Lily identity. Travis helped evacuate several thousand civilians, Emily and Georgie survive, and the adjudicator lives after sacrificing a star to delay Nahar. The Aether Virus continues spreading without Nahar, and its ascended origin threatens Freddy when he refuses an offered bargain. An unnamed Overlord also breaks into the Northern Belt, seeking to kill the person who ran away with his daughter. Basilisk, the body snatchers, Freddy's damaged soul, and his precarious imperial standing remain unresolved.",
         "in_short": "Freddy Stern assumes control of a destabilized Repentawa and commits his wealth and strength to defending it from an ether-virus-driven monster invasion led by Nahar Kraven. He and Sophia build the city's defenses, recruit mercenaries, and fight beside Lucas Black, Janice, Emily Umbra, Georgie League, and other elite allies. Human sabotage and dream-borne infection undermine the wall, the Empire refuses evacuation, and Sophia creates controlled undead to hold back the horde. Nahar attacks inside the city, forcing Freddy to sacrifice his soul for enough power to wound him. A dangerous Blood Domain construct keeps Freddy alive, and Emily kills Nahar, breaking the horde's coordination. Sophia's awakened flesh golem then massacres evacuees before being destroyed. Repentawa survives with about 80,000 people, but Freddy remains badly damaged. Sophia leaves over their ideological split, Lucas survives as a second-star, Janice has departed as Lily, and the still-active virus-origin makes Freddy its enemy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2144,7 +2144,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-19",
@@ -2157,7 +2157,7 @@
       "recaps": {
         "ending": "Keith, Kidra, Anka, and the remaining rescue party reach the surface with the recovered power cells and the concealed yellow sphere. Tenisent is dead, but Kidra has inherited Winterscar, whose independent actions and response to its former wearer remain unexplained. Atius, believed killed while delaying To’Aacar, revives and returns without his relic armor. He privately calls Kidra to discuss the sphere. Keith keeps Journey, Atius's occult blade, the former crusader's newly unlocked evidence, and the yellow guide's unopened mission recording. His injuries require weeks of treatment. His next objective is the hidden work on soul fractals, which may explain whether some part of Tenisent remains within Winterscar. Relinquished still commands the hostile machines, To’Aacar remains alive below, the new Deathless crisis is unresolved, and the sphere's reaction to Kidra remains secret.",
         "in_short": "Keith Winterscar's attempt to recover old technology awakens a buried facility and drops him and his father, Tenisent, into a vast machine realm. Their escape forces Keith to rely on the technical instincts Tenisent once dismissed, while Tenisent confronts his failures as a father. A mysterious guide leads them to Journey, an Imperial relic armor that accepts Keith and grants him unusual access. Tenisent dies after Keith defeats an adaptive machine hunter, but Tenisent's own armor later moves and fights in a way its stored model cannot explain. A rescue party reaches Keith, recovers a hidden yellow sphere, and battles toward the surface while Relinquished directs machines against them. Atius appears to die holding To’Aacar behind sealed doors, then revives outside. Kidra inherits Winterscar, Keith survives with Journey, and evidence that Tenisent may persist through the armor's soul fractal gives Keith a new purpose.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/12-miles-below-ii-a-house-reborn.json
+++ b/data/works-community/0/12-miles-below-ii-a-house-reborn.json
@@ -279,7 +279,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -292,7 +292,7 @@
       "recaps": {
         "ending": "The coordinated slaver assault is defeated after severe civilian and House Winterscar losses, but its leader escapes. Keith survives capture, regains Journey, manifests brief mirror-fractal weapons, and saves Ellie from fatal bleeding. Atius is apparently dead after an explosion in his quarters leaves his empty armor impaled by an occult blade. Keith concludes that the weapon will postpone Atius's Deathless return for months or longer, leaving Shadowsong to guide the clan as the larger raider attack approaches. Kidra's force is retreating from the fallen Stretch fortress after disabling and pinning the Feather's current shell. Her attempt to extract Tenisent fails when he gives up escape to protect her, and he remains inside the Feather's remote system. The Feather tightens the blockade of Undecider City and plans a surrender demand. She has also recognized that she deliberately spared Kidra and learned that Relinquished destroyed earlier memory-bearing machines after they became independent. The Chosen remain guarded, their knights are away on Atius's test mission, and Keith's seeker, the hidden weapon, To’Aacar's plan, and the digital researcher's purpose are unresolved.",
         "in_short": "Keith and Kidra rebuild House Winterscar while Keith studies a concealed occult archive. He learns to move through soul fractals, recreates occult blades, and develops rifle-fired occult anti-armor rounds that let ordinary soldiers threaten Relic Knights. Relinquished divides its forces: To’Aacar moves against the surface clan, while a Feather besieges Undecider City using captive Tenisent's abilities. Kidra later defeats the Feather's shell at the Stretch fortress but cannot free their father, and the defenders retreat. At home, machine-aligned Chosen refugees become both a security risk and a possible military asset. Disguised slavers then attack the colony seeking Keith. Atius is apparently assassinated, with an occult blade left in his empty armor that Keith believes will delay his return. House Winterscar's soldiers save Keith at great cost, Journey helps him break the assault, and he rescues Ellie. The slaver leader escapes, Shadowsong assumes emergency leadership, and the Feather ends the book questioning Relinquished while preparing to force Undecider City's surrender.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -572,7 +572,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -585,7 +585,7 @@
       "recaps": {
         "ending": "Keith and To’Wrathh confront To’Aacar outside occupied Undecider City. To’Aacar traps Keith between dimensions, but Tenisent shares his soul perception with To’Wrathh and helps her survive long enough for Keith to return through links with parallel versions of himself. Keith uses Atius's sword and true division to destroy To’Aacar's soul, and Kidra destroys the programmed shell that continues fighting afterward. The sword is left inert. To’Wrathh survives with catastrophic damage. Kidra initially intends to kill her in order to recover Tenisent, but Tenisent reveals that he chose to conceal his continued presence and believes To’Wrathh has become a possible bridge toward peace. Keith and Kidra spare her. Tenisent remains within her, Anka continues Kidra's resistance in the occupied city, and Dross and Shadowsong retain responsibility for the clan. Relinquished remains active, the Mites still hold To’Wrathh to an unfinished apostate mission, and the future of the city machines and their human subjects remains unresolved.",
         "in_short": "After Atius's apparent death destabilizes the clan, Keith strengthens House Winterscar and survives a Chosen trap led by To’Aacar. Meanwhile To’Wrathh besieges Undecider City, infiltrates it, and secures its surrender, but her contact with Tenisent and human civilians changes her. The Mites free her from Relinquished and grant healing in exchange for service. Keith goes underground to find Kidra, learns Atius staged his death, and is nearly killed when To’Aacar seizes Journey. A mysterious healer called Hecate saves him and is eventually exposed as To’Wrathh. She rebels, joins Keith against To’Aacar, and survives with Tenisent's aid. Keith escapes an interdimensional trap and destroys To’Aacar's soul with true division; Kidra finishes his remaining shell. Tenisent persuades the siblings to spare the disabled To’Wrathh as a possible ally, leaving the occupied city, Relinquished, and the Mites' unfinished purpose open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -905,7 +905,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -918,7 +918,7 @@
       "recaps": {
         "ending": "The forge expedition succeeds, but at heavy cost. Windrunner dies opening a path to To’Sefit, Atius is apparently killed, and Sagrius remains missing in the second strata while merged with Aegis. Keith defeats To’Sefit's shell, though her soul escapes, and holds To’Avalis away from the Mite Forge long enough for its work to finish. When To’Avalis disables Journey, Tenisent enters the fight in a temporary forged body and restrains him long enough for Keith to threaten his soul fractal. To’Avalis abandons the shell to avoid destruction, and Tenisent takes control of it. To’Avalis remains unconfirmed dead and is still attempting to destroy the shell remotely. To’Wrathh emerges fully repaired, heals Keith, adopts Winterscar colors, rejects Relinquished, and asks to enter House Winterscar. Kidra restores Tenisent's title as House Prime while retaining practical leadership. Journey is under repair. Relinquished remains at large, both hostile Feather souls may have survived, and the Mites direct To’Wrathh to seek the last figure of an earlier cycle for a way to sever her binding ties.",
         "in_short": "Keith Winterscar joins To’Wrathh's effort to hide her defection from Relinquished and uncover how the first Feathers broke free. After To’Sefit discovers the danger, To’Wrathh destroys her shell but is crippled in return, forcing Keith, Kidra, Atius, and their allies to carry her to a Mite Forge. To’Sefit and To’Avalis turn the flooded temple into a running siege, displace the forge into the second strata, and inflict severe losses. Windrunner dies, Atius is apparently killed, and Sagrius vanishes below while merged with Aegis. Keith destroys To’Sefit's replacement shell, reaches the forge, and delays To’Avalis while To’Wrathh is repaired. Tenisent gains a forged body, then takes over To’Avalis's abandoned shell when the Feather flees soul destruction. To’Wrathh returns restored, heals Keith, rejects Relinquished, and asks to join House Winterscar while accepting a Mites-directed search for a means to cut her remaining bonds.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1233,7 +1233,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -1246,7 +1246,7 @@
       "recaps": {
         "ending": "Keith defeats Tenisent's stolen Feather shell badly enough to pass the required trial, using occult projectiles, gravity charges, Journey, To’Wrathh's system intrusion, and support from the tomb-bound knights. Tenisent reveals that the contest was intended to force Keith to invent a workable anti-Feather method. He abdicates as House Prime, leaving Kidra as the sole leader of House Winterscar while he accompanies To’Wrathh as her guide. Kidra stays with the clan to rebuild the house and support its war and migration plans. Keith and To’Wrathh depart to find the Division Stone, with Abraxas expected to provide the route and Suya potentially able to sever To’Wrathh's bond to Relinquished. Sagrius remains entangled with the knight souls, and Abraxas's demand for a Mite seeker is unresolved. Hexis gives Keith concealed advanced instruction and a token recognizing his apprenticeship. He does not pass along the tracked token ordered by To’Avalis, but he intends to keep reporting to the Feather while preparing his own eventual departure from the clan.",
         "in_short": "Keith, Kidra, Tenisent, and To’Wrathh return from the Mite Forge and help seize a slaver base containing forty-nine relic armors. The discovery pushes Clan Altosk toward preemptive war and an eventual underground migration. Contact with Suya reveals Relinquished's origin and offers To’Wrathh hope: the Division Stone may sever her unity bond. Keith becomes Hexis's warlock apprentice, but Tenisent bars him from the expedition unless he can defeat a Feather shell. With To’Wrathh, Journey, and the knight souls carried by Sagrius, Keith develops occult ammunition, gravity charges, and a virus-assisted attack that wins the trial. Tenisent admits the duel was meant to prepare Keith for real Feathers and transfers leadership of House Winterscar to Kidra. Keith, To’Wrathh, and Tenisent leave to seek the Division Stone, while Hexis secretly maintains his intelligence arrangement with the surviving To’Avalis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1625,7 +1625,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -1638,7 +1638,7 @@
       "recaps": {
         "ending": "Keith survives To’Orda's attack at the Grey Roamer trading outpost. To’Avalis fails to interfere with Journey, and Keith damages the remote cannon installation before using an occult lash and To’Orda's hammer strike to propel himself beyond pursuit. His landing place is unknown, and the available account does not establish where Lyrian Draconis is after the attack. The Icon of Stars remains an operational contact and possible source of information, while Kress and Silverfur have created a basis for cooperation with the Grey Roamers. To’Wrathh is still connected to Relinquished and must preserve a cover that hostile Feathers increasingly distrust. Relinquished knows Keith's identity and general location, To’Avalis remains active, and To’Orda has only failed in this immediate attempt. The original expedition is separated from Keith, the Division Stone has not freed To’Wrathh, and neither a return route nor the outcome of the Aura conflict is settled.",
         "in_short": "Keith Winterscar leads an expedition to bring To’Wrathh to the Division Stone, which could free her from Relinquished. A conflict at Aura separates Keith from his allies when he and enemy commander Lyrian Draconis fall through a portal into an unknown lower stratum. They form a conditional alliance, recover their equipment, defeat Murder Shrimp, and gain the help of Kress, Silverfur, and the Grey Roamers. At a trading outpost they contact the Icon of Stars, a surviving Golden Age ship AI, but To’Orda attacks under To’Avalis's direction. Keith disrupts the remote cannons and escapes by turning To’Orda's blow into a high-speed retreat. He survives, but his landing point and Draconis's fate are unknown. To’Wrathh remains bound to Relinquished, the Division Stone mission is unfinished, and no route home has been established.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/12-miles-below-vii-path-of-the-mitespeaker.json
+++ b/data/works-community/0/12-miles-below-vii-path-of-the-mitespeaker.json
@@ -324,7 +324,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -337,7 +337,7 @@
       "recaps": {
         "ending": "Keith Prime and Keith Superior remain jointly attuned to the Mite Seeker, although Superior has no durable body and the Mites still conceal the Seeker's destination. Keith and To’Wrathh permanently destroy the biome-ruling Feather after To’Orda incapacitates it with a virus. Relinquished accepts the apparent outcome and withdraws, but retains control over To’Wrathh and remains the principal enemy. Draconis dies after forcing To’Orda to confront the cost of inaction; regeneration is expected, but its place and timing are unknown. To’Orda agrees to protect the biome, the Odin, and the conquered territory while seeking Draconis, but does not join Keith's alliance. Bob and the liberated Icon remain active local powers. To’Avalis still operates through To’Aacar's shell and seeks Mite Forge repairs. The proposed campaign against Relinquished, the recovery of Urs and Talon, and restoration of the full Resolve remain open.",
         "in_short": "Separated from his allies in a contaminated biome, Keith Winterscar communicates with the fungal intelligence Bob, survives Odin hostility, and gains Aztu as a covert mentor. Her teaching and Bob's guidance let him attune the Mite Seeker and meet Keith Superior, the cooperative soul copy held by the Mites. Meanwhile, Draconis's captivity and the Icon of Stars gradually push To’Orda beyond his conditioned role. Keith reunites with To’Wrathh under Relinquished's observation, and they draw a local Feather ruler into a prepared Odin battlefield. Draconis dies to force To’Orda to choose whether to protect the region. To’Orda then helps disable the ruler, allowing Keith and To’Wrathh to erase it permanently. Relinquished withdraws. To’Orda takes responsibility for the biome and Odin without joining Keith's side, while Keith retains the Seeker, Superior, and a still-unfinished plan against Relinquished.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -503,7 +503,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -514,7 +514,7 @@
       "recaps": {
         "ending": "Winston's rebellion ends in total defeat. Captured with Julia after their hidden room is exposed as a Thought Police trap, he is held in the windowless Ministry of Love, where O'Brien, the man he had trusted as a fellow dissident, personally oversees his torture and re-education. Over long agony Winston is made to surrender not just his resistance but his belief in objective truth, accepting whatever the Party dictates. He clings to one last loyalty, his refusal to betray his love for Julia, and for that he is taken to Room 101 and threatened with his worst fear, a cage of rats brought to his face, until he breaks and begs that Julia be tortured in his place. That betrayal empties him. Released back into ordinary life, he meets Julia once more, and both admit they betrayed each other and can no longer feel what they once did. Winston now passes his days in a haze of gin and Party slogans. The novel closes as he gazes at Big Brother's portrait and feels a surge of love for the regime that destroyed him: the Party has won completely, taking not only his obedience but his heart and mind. The book ends with an appendix on Newspeak, written in the past tense as though describing a period already over.",
         "in_short": "In the totalitarian super-state of Oceania, Party member Winston Smith works at the Ministry of Truth rewriting history to match the regime's lies, while the face of Big Brother watches from every screen. Sickened by the surveillance and the manufactured reality, he begins a secret diary, then a forbidden love affair with a bold younger woman, Julia, and the two rent a hidden room where they can briefly live as themselves. Convinced that the Inner Party official O'Brien is a secret dissident, Winston accepts induction into a supposed underground resistance and is given a book explaining how the Party rules purely for power. But it is all a trap: their room was watched, the friendly shopkeeper is a spy, and O'Brien is a loyal Party inquisitor. Winston is imprisoned and tortured in the Ministry of Love until he surrenders his mind, and in Room 101, faced with his greatest fear, he betrays Julia. Broken and remade, he is freed only to find that he now loves Big Brother.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -661,7 +661,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -674,7 +674,7 @@
       "recaps": {
         "ending": "After prolonged torture at the Ministry of Love, Winston is taken to Room 101 and confronted with his overwhelming fear of rats. He begs O'Brien to inflict the punishment on Julia instead, surrendering the last loyalty he had tried to preserve. The Party eventually releases him. He and Julia meet once and admit that each betrayed the other; neither feels the former attachment. Winston now spends his days at the Chestnut Tree Cafe, drinking gin and following official war reports. When the telescreen announces a great Oceanian victory, he experiences the news as personal salvation. His resistance, his trust in memory, and his love for Julia have all been destroyed. He accepts the Party's version of reality and loves Big Brother, completing the psychological conquest O'Brien intended.",
         "in_short": "In Oceania, the Party controls public life, private conduct, and the historical record. Winston Smith secretly rejects its rule while falsifying old news at the Ministry of Truth. He begins an illegal diary, then forms a forbidden relationship with Julia and rents a room where they believe they can meet unwatched. Hoping an organized resistance exists, they approach the Inner Party official O'Brien and pledge themselves to the supposed Brotherhood. O'Brien is actually directing a trap. The Thought Police arrest the couple, and O'Brien tortures Winston until he abandons evidence, independent judgment, and finally his loyalty to Julia. Released after betraying her under the threat of his worst fear, Winston meets Julia and learns that both have been changed beyond affection. Alone at the Chestnut Tree Cafe, he accepts the Party's reality and feels love for Big Brother.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -879,7 +879,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -892,7 +892,7 @@
       "recaps": {
         "ending": "The volume's first novel ends with the Party completing its destruction of Winston's independent loyalties. In Room 101 he betrays Julia to escape his worst fear, and after release both admit that their former bond is gone. Winston finally accepts the regime's reality and loves Big Brother. In the second novel, Napoleon's pigs finish remaking Animal Farm into a hierarchy resembling the human order it replaced. The commandments are reduced to a rule that formally grants the pigs superior status; the farm's original name is restored, and pigs walk on two legs, carry whips, and trade with neighboring farmers. As Napoleon and the men quarrel over cards, the animals outside see that the two ruling groups have become alike. Boxer is dead, Snowball remains a convenient enemy, and the surviving workers retain only an uncertain memory that the rebellion once promised equality.",
         "in_short": "This volume pairs two accounts of revolutions ending in concentrated power. In Nineteen Eighty-Four, records clerk Winston Smith secretly resists Oceania's Party and begins an affair with Julia. O'Brien pretends to recruit them into a resistance, then arrests and tortures Winston until fear makes him betray Julia and accept Big Brother. In Animal Farm, farm animals expel their human owner and establish rules of equality. The pigs take control; Napoleon drives out Snowball, uses Squealer to revise the past, and exploits the loyal horse Boxer until he is sent to his death. Privileges grow while every failure is blamed on enemies. At the close, the pigs walk upright, carry whips, alter the last commandment to justify inequality, and dine with human farmers. The animals looking through the window cannot tell their new rulers from the old ones.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1111,7 +1111,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1124,7 +1124,7 @@
       "recaps": {
         "ending": "The volume's first novel ends with the Party completing its destruction of Winston's independent loyalties. In Room 101 he betrays Julia to escape his worst fear, and after release both admit that their former bond is gone. Winston finally accepts the regime's reality and loves Big Brother. In the second novel, Napoleon's pigs finish remaking Animal Farm into a hierarchy resembling the human order it replaced. The commandments are reduced to a rule that formally grants the pigs superior status; the farm's original name is restored, and pigs walk on two legs, carry whips, and trade with neighboring farmers. As Napoleon and the men quarrel over cards, the animals outside see that the two ruling groups have become alike. Boxer is dead, Snowball remains a convenient enemy, and the surviving workers retain only an uncertain memory that the rebellion once promised equality.",
         "in_short": "This volume pairs two accounts of revolutions ending in concentrated power. In Nineteen Eighty-Four, records clerk Winston Smith secretly resists Oceania's Party and begins an affair with Julia. O'Brien pretends to recruit them into a resistance, then arrests and tortures Winston until fear makes him betray Julia and accept Big Brother. In Animal Farm, farm animals expel their human owner and establish rules of equality. The pigs take control; Napoleon drives out Snowball, uses Squealer to revise the past, and exploits the loyal horse Boxer until he is sent to his death. Privileges grow while every failure is blamed on enemies. At the close, the pigs walk upright, carry whips, alter the last commandment to justify inequality, and dine with human farmers. The animals looking through the window cannot tell their new rulers from the old ones.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1317,7 +1317,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1330,7 +1330,7 @@
       "recaps": {
         "ending": "Ushikawa traces Tengo to the apartment building from which he has been watching Aomame's refuge. Tamaru captures and kills him, then arranges the body's discovery without exposing the Dowager's network. Fuka-Eri leaves Tengo after helping him understand where Aomame is, while Sakigake's surviving operatives continue to seek the person who killed their Leader. Tengo and Aomame finally meet in the playground where each had separately watched the two moons. They confirm that neither forgot the moment they held hands as children. Aomame tells Tengo that she is pregnant and believes the child is his, conceived through the strange connection that joined them even while they were apart. She leads him back to the Metropolitan Expressway emergency stair. They climb into a world that appears to be 1984 rather than 1Q84: only one moon is visible, although a changed highway sign suggests that their destination may not be identical to the past they left. They choose to remain together and protect the child, accepting uncertainty about the world around them.",
         "in_short": "In 1984 Tokyo, assassin Aomame enters a subtly altered reality with two moons, which she calls 1Q84. Tengo, a mathematics teacher and aspiring novelist, secretly rewrites teenager Fuka-Eri's Air Chrysalis, whose Little People and two moons prove to describe that reality. Aomame and Tengo gradually realize that each is searching for the other after a single moment of childhood intimacy. Aomame kills the abusive, supernatural Leader of the Sakigake commune, then hides from his followers and discovers she is pregnant despite having had no recent sexual contact. Tengo cares for his dying father while moving closer to Aomame through visions, writing, and Fuka-Eri's guidance. Investigator Ushikawa tracks both of them but is killed by Tamaru before he can deliver Aomame to Sakigake. Aomame and Tengo reunite, affirm their love, and escape by the expressway stair into a world with one moon. Its small differences leave their exact reality uncertain, but they face it together and intend to protect their unborn child.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1448,7 +1448,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1461,7 +1461,7 @@
       "recaps": {
         "ending": "In the North Atlantic, Aronnax sees the full violence behind Nemo's hatred of the powers on land. The Nautilus deliberately destroys a pursuing warship, and Nemo withdraws in grief after watching it sink with its crew. The submarine continues north until it reaches the waters off Norway. Ned Land decides that captivity has become intolerable and arranges an escape with Aronnax and Conseil. As they prepare to leave in the Nautilus's boat, the submarine is drawn toward the Maelstrom. Aronnax loses consciousness during the chaos and later wakes with Conseil and Ned in a fisherman's shelter on the Lofoten Islands. All three have survived and regained their freedom, but they do not know whether the Nautilus or Captain Nemo escaped the whirlpool. Aronnax returns able to record the extraordinary voyage, while Nemo's origins, final fate, and judgment on the surface world remain unresolved.",
         "in_short": "French naturalist Pierre Aronnax joins the frigate Abraham Lincoln with his servant Conseil and Canadian harpooner Ned Land to hunt a supposed sea monster. The quarry proves to be the Nautilus, a technologically advanced submarine commanded by Captain Nemo. After the three men fall overboard, Nemo takes them in but refuses ever to release them. Aronnax is captivated by undersea forests, lost wrecks, strange animals, a coral cemetery, the ruins associated with Atlantis, and a journey beneath Antarctic ice; Ned continually seeks escape. Nemo rescues a pearl diver, aids people resisting oppression, and reveals both compassion and a consuming hatred of the nations of the surface. After giant squid attack the Nautilus and a crewman dies, Nemo grows increasingly remote. He later uses the submarine to sink a warship. Near Norway, the captives attempt to flee as the Nautilus enters the Maelstrom. Aronnax, Conseil, and Ned survive and reach land, but Nemo and his vessel disappear, their fate unknown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1692,7 +1692,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B003G8RX9O",
@@ -1704,7 +1704,7 @@
       "recaps": {
         "ending": "Reacher confronts Tom Holland at the old runway and identifies him as Plato's corrupt collaborator and the murderer of the lawyer, Andrew Peterson, and Janet Salter. After killing Holland, Reacher takes his place in Plato's incoming extraction team and accompanies Plato into the bunker. Two aircraft crew members accept the Russian buyer's offer to betray Plato, reverse the pumps, and fill the underground complex with fuel. Reacher kills Plato and escapes as a road flare starts the fire.\n\nThe explosion and fire destroy the bunker, the methamphetamine, the aircraft, and most evidence. Investigators recover debris, weapon fragments, more than a thousand diamonds, and ash that cannot be identified as human remains. They accept a refueling accident as the working explanation and open no homicide investigation. Reacher does not contact Susan Turner before her deployment to Afghanistan, so the authorities never confirm his survival. Kim Peterson takes her children to Sioux Falls to live nearer their family. Holland's daughter and the surviving members of Plato's organization have no established outcome, and the fourteen criminal proposals remain unresolved.",
         "in_short": "Jack Reacher is stranded near Bolton after a tour-bus crash and joins the police effort to protect Janet Salter, a witness threatened by Plato's criminal organization. The case leads from a murdered lawyer and a biker camp to an underground bunker holding about 90,000 pounds of methamphetamine. After Andrew Peterson and Salter are murdered, Reacher proves that police chief Tom Holland is Plato's inside collaborator and kills him. Reacher then impersonates Holland to enter Plato's aircraft pickup. Two crew members betray Plato by flooding the bunker with fuel and igniting it, while Reacher kills Plato and escapes. The fire destroys the aircraft, drugs, and most evidence. Authorities identify no human remains and pursue no homicide case, leaving Reacher's survival officially unknown. Susan Turner deploys without hearing from him, and Kim Peterson moves her family to Sioux Falls. The fourteen proposals that opened the criminal chain remain unexplained.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1827,7 +1827,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1840,7 +1840,7 @@
       "recaps": {
         "ending": "After Christopher Robin's party honoring Pooh's rescue of Piglet, Eeyore enjoys a game with Piglet's deflated balloon and Pooh's empty honey jar while the guests celebrate. Christopher Robin gives Pooh a pencil case as a reward, and the animals cheer for him. Pooh and Piglet then walk home together through the Forest. The book closes without separating the friends or resolving a larger conflict: its connected adventures leave Pooh still devoted to honey, Piglet still his close companion, and Christopher Robin still the trusted center of their small community.",
         "in_short": "Winnie-the-Pooh and his friends turn everyday problems in the Forest into a series of adventures. Pooh's attempt to take honey from bees fails, and a generous meal leaves him stuck in Rabbit's doorway until he grows thinner. He and Piglet follow their own footprints while hunting an imaginary animal, and Pooh restores Eeyore's missing tail after finding it in Owl's possession. A trap for a Heffalump catches Pooh instead. For Eeyore's birthday, Pooh and Piglet bring an empty honey jar and a burst balloon, which together delight him. Rabbit's attempt to drive away Kanga and Roo ends with the newcomers accepted as friends. During an expedition, Pooh finds what Christopher Robin names the North Pole. When a flood isolates Piglet, Pooh and Christopher Robin rescue him, and Christopher Robin holds a party to honor Pooh's role in saving their friend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1957,7 +1957,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1970,7 +1970,7 @@
       "recaps": {
         "ending": "After a succession of outings has shown how completely Paddington has entered the Browns' daily life, the family celebrates his birthday at Windsor Gardens. He tries to entertain the gathering with a magic performance, and the disappearing trick creates the sort of confusion that has accompanied his other attempts to master English habits. The trouble is temporary, however, and the occasion remains a happy family celebration. By the close, the bear who arrived alone at a railway station is no longer a visitor awaiting a decision about his future: the Browns have given him a name, a room, friends, and a permanent place in their home. The book ends with Paddington secure in the affectionate household that will anchor his later adventures.",
         "in_short": "The Brown family find a polite young bear from Peru sitting alone at Paddington Station with a request that someone care for him. They name him Paddington and bring him to their home in Windsor Gardens. Although he means well, his unfamiliarity with baths, public transport, shops, painting, the theatre, and seaside customs repeatedly produces mess and confusion. Mr and Mrs Brown, their children Judy and Jonathan, and their housekeeper Mrs Bird help him through each mishap, while the antique dealer Mr Gruber becomes his friend. Paddington's curiosity and seriousness make him conspicuous wherever he goes, but his courtesy wins people over and every adventure ends safely. A birthday celebration and an unsuccessful disappearing trick close the book on a happy note: Paddington is no longer a stranded newcomer but a loved, permanent member of the Brown household.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2251,7 +2251,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0B919NMGQ",
@@ -2263,7 +2263,7 @@
       "recaps": {
         "ending": "Sebastien temporarily suppresses Newton's aberrant core, changes back from Siobhan, and escapes the building in his university identity. The Red Guard detains and questions him, but Gera supports a false account in which the Raven Queen is a separate supernatural being who granted Sebastien protection from divination. Thaddeus Lacer publicly claims Sebastien as his apprentice and, after testing him, accepts that he is not the Raven Queen in disguise. Newton cannot be restored and is left for Red Guard neutralization or permanent containment. Tanya survives, is sent to the university infirmary, and refuses to speak. The surviving Morrows go to Harrow Hill Penitentiary. Sebastien is exhausted, grieving, and magically bound to keep the incident secret, but retains his place at the university. Lacer puts him to sleep and takes him toward the infirmary. Oliver Dryden's alliance has destroyed the Morrows' leadership and seized their warehouse, including evidence of a university faction stockpiling beast cores and restricted components. The stolen book, the amulet, Professor Munchworth's network, Tanya's campus contact, Sebastien's debts, and the continuing Crown investigation remain unresolved.",
         "in_short": "While police use her blood to hunt the Raven Queen, Sebastien balances university demands, debt, secret research, and work for Oliver Dryden. She recruits Damien Westbay and Newton Moore to investigate Tanya Canelo, discovers that Professor Munchworth is directing Tanya to recover the stolen book, and enters a clandestine thaumaturge market as Chauvin. As the Raven Queen, she also gives Miles a maintained treatment for his lethal sleeplessness. Oliver's Verdant Stag and the Nightmare Pack defeat the Morrows, kill their leader, and uncover a university-linked stockpile of dangerous components. Financial desperation draws Newton into Tanya's illicit mission, and surviving Morrows kidnap them with Siobhan. Newton becomes an incurable spreading aberrant. Siobhan discovers that calm and silence hinder it, saves several captives, stuns its central mass, and escapes as Sebastien. Gera then helps present the Raven Queen as a separate supernatural protector. Tanya survives but stays silent, Newton is lost, and Sebastien remains protected by Thaddeus Lacer while the university conspiracy, stolen book, amulet, and personal debts stay open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2580,7 +2580,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774246317",
@@ -2592,7 +2592,7 @@
       "recaps": {
         "ending": "The numbered story closes with the three Embra on separate paths. Orion peacefully draws the Blackmire mud elemental into his spirit orb without securing a pact, then leaves the tribe under escort toward the road. Tersa returns to Al'drossford as an advanced Stormbringer, and Cullen plans to promote her to junior guardsman while he investigates the unknown force that displaced a greater ice serpent. Trent, shaken by the severing of his bond to Kirstin, leaves the keep to complete a two-week Survivalist quest alone. Fairy Cloak still hides him from attention and pushes him toward aggression, while a Dusk Tower shadow secretly joins him. Afterward, Agatha identifies the danger in the ability, supplies Trent, and helps him register as an adventurer before he departs. A young royal woman who intends to escape court control and form an adventuring party is also approaching Al'drossford. The concealed trial chest, divine interest in Trent, Orion's unsettled elemental, the barred Al'drossford throne, and the unexplained interference remain unresolved.",
         "in_short": "After the Undying Lord trial, Trent returns as an Al'rashian Survivalist and trains under Cullen beside Tersa, while his adopted brother Orion struggles through a distant swamp. Trent and Tersa enter the Garden of Clarity separately. Tersa confronts her rage and becomes a Stormbringer, but the garden's keeper severs Trent's bond to Kirstin and forces the dangerous Fairy Cloak upon him before being deposed. The ability makes others overlook Trent and strengthens his aggressive impulses. Cullen later kills a greater ice serpent that was mysteriously transported into the region, while an Al'rashian merchant equips Trent and warns him to hide a trial chest shielded from divine notice. Orion helps Blackmire by taking an unbonded mud elemental into his spirit orb. Trent leaves Al'drossford for a solitary survival quest with a Dusk Tower shadow secretly attached to him, then registers as an adventurer with Agatha's help. Tersa is set for promotion, Orion heads toward the road, and the Embra remain separated amid signs of a possible Al'rashian restoration.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2845,7 +2845,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2858,7 +2858,7 @@
       "recaps": {
         "ending": "The last movement of the book scatters the family. Young Ian catches Arch Bug carrying away gold hidden on the Ridge, and in the confrontation his shot kills Murdina Bug instead; Arch Bug disappears into the mountains swearing to take from Ian something as dear as what Ian took from him. Claire hears a murmur in baby Amanda's heart and knows it will kill her in childhood unless she is operated on in a century that can do it, so Roger and Brianna take Jeremiah and Amanda through the stone circle and back to the twentieth century, a parting both sides expect to be permanent. Not long after, thieves break into the Big House hunting the gemstones rumoured to be there; the ether stored in Claire's surgery catches, and the house burns to the ground. Jamie, Claire and the household escape; Donner, the other traveller, does not. The newspaper notice that had reported James Fraser and his wife dead in a fire on Fraser's Ridge is left standing as a printed falsehood, its date already past. With the house gone, the Ridge divided, and the war beginning in earnest, Jamie, Claire and Young Ian set out for Scotland, meaning to bring back Jamie's printing press and to take Ian home to his mother.",
         "in_short": "Fraser's Ridge, 1773 to 1776. Jamie and Claire Fraser hold a North Carolina mountain settlement together while the colonies slide into revolution, knowing from Claire and from their daughter's family what is coming. Backcountry raiders burn homesteads and carry Claire off; Jamie's men destroy the gang and bring her home, and the killing of one captive turns the neighbouring Browns into permanent enemies. Tom Christie's daughter Malva, Claire's apprentice, announces that she is pregnant by Jamie, and is then found murdered in Claire's garden; Claire is accused, arrested and dragged to Wilmington, and is freed only when Tom Christie confesses to the killing to save her. The truth is worse: Malva's own brother fathered the child and killed her. Stephen Bonnet is finally run to ground and executed, Brianna firing the shot that ends it. When Claire discovers a fatal heart defect in Brianna's newborn daughter, Roger and Brianna take both children back through the stones. Days later the Big House burns down with a hunted time-traveller inside it, and Jamie and Claire, alive despite a printed notice of their deaths, leave for Scotland.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3058,7 +3058,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0GD93VSSK",
@@ -3070,7 +3070,7 @@
       "recaps": {
         "ending": "Raaz Kalvidasan returns from the spirit realm and destroys Claudio Tierney, ending Claudio Tierney's immediate plan to use the village and Hyperiodax's hunger as the foundation of greater power. The village remains devastated, its victims are beyond Raaz Kalvidasan's ability to save, and transformed survivors still roam near the tower. Rory is dead. Aimee remains at the house, but her condition is unknown. Miakoda still exists as the aberrant frame, while traces of both her and Claudio Tierney have entered Siobhan's mind.\n\nRaaz Kalvidasan binds those remnants by suppressing Siobhan's memories of the catastrophe. During the procedure, a separate echoed identity answers him from within her mind and remains unexplained. Raaz Kalvidasan then begins his own magical break and kills himself before he can become a danger. Siobhan flees with little equipment and follows the road into the forest. Three months later, she is isolated and surviving through theft and caution. She notices a fragile memory connected to Claudio Tierney but refuses to examine it, fearing damage to the seal, and her nightmares continue.",
         "in_short": "Thirteen-year-old Siobhan investigates the secret research conducted by her grandfather Raaz Kalvidasan and his associate Claudio Tierney after disturbing dreams and magical anomalies spread through their village. Claudio Tierney's popular dream sessions prove to be paths into the spirit realm, designed to remake the villagers through the endless hunger associated with the titan Hyperiodax. He has also trapped Siobhan's transformed mother, Miakoda, within an interplanar frame. Raaz Kalvidasan returns from exile in the spirit realm and kills Claudio Tierney, but remnants of Claudio Tierney and Miakoda become lodged in Siobhan. Raaz Kalvidasan suppresses her memories to seal them, then suffers a magical break and kills himself to protect her. Siobhan escapes past the transformed villagers and Rory's corpse. Three months later, she survives alone while avoiding a loose memory that could weaken the seal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3245,7 +3245,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3258,7 +3258,7 @@
       "recaps": {
         "ending": "As nuclear war spreads, Brother Joshua leads the Leibowitzian mission away from Earth with monks, children, and a store of preserved knowledge, continuing the order beyond the threatened planet. At the abbey, a nuclear blast collapses the building and traps Dom Zerchi beneath the rubble. The mutant Mrs Grales approaches him, but her second head, Rachel, awakens as a distinct and seemingly innocent person. Zerchi tries to baptize her; instead she gives him communion, and he dies after witnessing what he understands as an unfallen new beginning. The departing starship receives evidence that the war has escalated into global destruction. The old cycle has repeated: scientific civilization has again armed political pride with the means of annihilation. Yet the order's refugees carry faith, memory, and human life outward, while life in the sea continues beneath the poisoned sky.",
         "in_short": "After a nuclear war destroys civilization, the Order of Leibowitz preserves fragments of lost learning. In the first era, novice Francis discovers relics of the order's engineer-founder, helps advance his canonization, and is killed after a pilgrimage. Six centuries later, Dom Paulo receives the brilliant Thon Taddeo, whose recovery of science is entangled with Hannegan II's wars. The scholar confirms the value of the Memorabilia but leaves without resolving whether knowledge can escape political misuse. Six centuries after that, humanity has nuclear weapons and spaceflight and again approaches global war. Dom Zerchi opposes state-assisted suicide for radiation victims while Brother Joshua leads monks, children, and records toward a colony beyond Earth. A blast destroys the abbey and kills Zerchi after the mutant Rachel mysteriously awakens. Earth descends into nuclear destruction, but the order's mission escapes with a remnant of human knowledge and life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/a-cauldron-of-bitterness.json
+++ b/data/works-community/0/a-cauldron-of-bitterness.json
@@ -255,7 +255,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0FNFGZQFB",
@@ -267,7 +267,7 @@
       "recaps": {
         "ending": "Sebastien survives Thaddeus Lacer's memory alteration by reconstructing her real memories, although the effort nearly kills her and her sleep-proxy raven dies. Her will now has three independently usable facets. Damien destroys their aberrance research and helps conceal her injury, while Anna demands eventual inclusion in the work. Neither friend learns that Sebastien is Siobhan. Thaddeus remains both her mentor and a danger constrained by Red Guard vows.\n\nOliver Dryden ends his alliance with the Architects after confirming that they kidnapped nulls from Osham. He imprisons Grandmaster Kiernan, accepts the risk of exposure, and later agrees to support Siobhan's experiment. Captain Isling prevents Analyst Hite from taking her immediately, but Hite gives her only three months to show useful progress. Siobhan prepares alternate identities and escape resources while remaining in Gilbratha. At Liza's home, she restores her sleep proxy and uses the Crown of Madness to inspect the entity in her mind. She sees it inside a cracked stone enclosure. It claims that recovered memories could free it to take her body, then pulls her into the memories behind her nightmares. The entity, the experiment, the null captives, the rise in aberrance, and Siobhan's future in Gilbratha all remain unresolved.",
         "in_short": "Siobhan negotiates limited freedom from the Red Guard while protecting her life as Sebastien Siverling, studies Merton's locked journals, guides the growing Undreaming Order, and helps Damien investigate a disturbing rise in aberrant incidents. Thaddeus Lacer protects Sebastien from the High Crown but later attacks Siobhan under a coercive Red Guard vow, erasing forbidden memories and nearly killing her. She repairs her mind and develops a third will-facet. Oliver Dryden breaks with the Architects after confirming their abduction of nulls, while Red Guard researcher Hite gives Siobhan three months to produce useful consciousness research. Preparing to flee if necessary, she recruits Oliver as backup and uses dangerous spirit-realm magic to inspect the entity sealed in her mind. Its inner prison is cracked, and it draws her into recovered memories before she finds a solution.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -401,7 +401,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -414,7 +414,7 @@
       "recaps": {
         "ending": "Alone at the end of the rental period, the narrator locks the bedroom and throws the key outside. She tears away as much wallpaper as she can, convinced that this will free the woman she sees trapped behind its pattern. When John obtains the key and enters, she identifies herself with the freed figure and continues creeping around the edge of the room over the damaged paper. John faints at the sight. She does not return to his shared understanding of events; instead, she keeps circling the room and crawls over him whenever her path reaches his body. The ending leaves her completely absorbed in the identity produced by her confinement and fixation. John's treatment has not restored her health: his control, disbelief, and enforced inactivity have accompanied a severe psychological breakdown.",
         "in_short": "After childbirth, an unnamed woman with a serious mental illness is confined by her physician husband John to an upstairs room in a rented country house. He forbids work and discounts her wish for stimulation, company, and a different room. Writing secretly, she becomes increasingly preoccupied with the room's ugly yellow wallpaper. Its confused pattern seems to contain a woman who struggles behind bars and creeps outside at night. As her isolation deepens, the narrator identifies with this figure. Before the family leaves, she locks herself in, tears much of the paper from the walls, and declares that the woman has escaped. John enters and faints. The narrator continues creeping around the room, stepping over his unconscious body, fully absorbed in her delusion rather than cured by the imposed rest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -522,7 +522,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -533,7 +533,7 @@
       "recaps": {
         "ending": "A Christmas Carol ends with Scrooge's complete redemption. After the three spirits have shown him his past, his present, and a bleak, lonely future ending at his own neglected grave, he wakes on Christmas morning overjoyed to find he still has time to change. He throws himself into making amends: he sends a large prize turkey to the Cratchit family, gives generously to the poor he had earlier scorned, and gladly joins his nephew Fred for Christmas dinner, mending the rift between them. The next morning he surprises Bob Cratchit with a raised wage and a promise to help his family. True to his word, Scrooge becomes a kind, generous, and beloved man, a second father to Tiny Tim, who recovers and lives. He keeps the goodwill of Christmas in his heart throughout the year and is remembered ever after as someone who knew how to keep Christmas well. The transformation is total and lasting: the bitter miser of the opening has become a source of warmth and charity to everyone around him.",
         "in_short": "On Christmas Eve in London, the cold-hearted miser Ebenezer Scrooge, who scorns the holiday and everyone's goodwill, is visited by the ghost of his dead partner, Jacob Marley. Weighed down by the chains of his own greed, Marley warns that Scrooge faces the same doomed afterlife unless he changes, and that three spirits will come to him. The Ghost of Christmas Past shows Scrooge his lonelier, gentler younger self and the love he lost to money; the Ghost of Christmas Present reveals the warmth of others' celebrations, including the poor but happy Cratchit family and their frail son Tiny Tim, whose life is in danger; and the silent Ghost of Christmas Yet to Come shows him an unmourned death that proves to be his own. Terrified and repentant, Scrooge wakes on Christmas morning transformed. He becomes generous and kind, helps the Cratchits and saves Tiny Tim, reconciles with his nephew, and keeps the spirit of Christmas for the rest of his life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -667,7 +667,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -680,7 +680,7 @@
       "recaps": {
         "ending": "After begging the final spirit for a chance to alter the future, Scrooge wakes in his own bed on Christmas morning and realizes the visions have occurred in time for him to act. Delighted and energetic, he anonymously sends a large turkey to the Cratchits, makes a substantial donation to the charity collector he had dismissed, and joins Fred's family for dinner. The next day he startles Bob by pretending to be angry about his lateness, then raises his pay and promises practical help for the family. Scrooge keeps those promises. He becomes generous, sociable, and attentive to other people throughout the year, while Tiny Tim survives and regards him with familial affection. The lonely death and neglected grave shown by the last spirit do not come to pass; Scrooge's changed conduct gives him a place in his family and community.",
         "in_short": "Ebenezer Scrooge is a rich but isolated miser who rejects his nephew, underpays Bob Cratchit, and refuses to help the poor. On Christmas Eve the ghost of his dead partner, Jacob Marley, warns that such a life brings misery after death. Three spirits then confront Scrooge with his neglected childhood, lost relationships, the present celebrations of families including the impoverished Cratchits, and a possible future in which Tiny Tim dies and Scrooge's own death is met with indifference. Horrified by the person he has become, Scrooge promises to change. He wakes on Christmas morning, sends food to the Cratchits, gives generously to charity, reconciles with his nephew, and raises Bob's wages. His reform lasts: he becomes a caring friend and employer, helps Tiny Tim, and replaces isolation with active generosity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -822,7 +822,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -835,7 +835,7 @@
       "recaps": {
         "ending": "After seeing his neglected grave and understanding that the grim future is his own, Scrooge promises to live differently. He wakes on Christmas morning delighted to find that he still has time to change. He anonymously sends a large turkey to the Cratchit family, gives generously to the charitable collectors he rejected the day before, and joins Fred's Christmas gathering. When Bob returns to work, Scrooge raises his salary and offers practical help to his family. His lasting generosity and friendship alter both his own life and the lives around him. Tiny Tim survives, and Scrooge becomes a caring second father to the boy rather than the solitary man whose death no one mourned.",
         "in_short": "On Christmas Eve, the miserly businessman Ebenezer Scrooge refuses his nephew's hospitality and rejects requests to help the poor. The ghost of his dead partner, Jacob Marley, warns that Scrooge's selfish life will bring terrible consequences. Three Christmas spirits then show him his past, the lives unfolding around him, and a future in which Tiny Tim dies and Scrooge's own death is greeted with indifference. Frightened and ashamed, Scrooge asks for the chance to change. Waking on Christmas morning, he gives money and food freely, celebrates with his nephew, raises Bob Cratchit's pay, and supports the Cratchit family. His reform endures, and Tiny Tim lives with Scrooge as a generous friend and fatherly protector.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -999,7 +999,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1012,7 +1012,7 @@
       "recaps": {
         "ending": "The final spirit shows Scrooge that his unchanged life will end in an unmourned death, while Tiny Tim will die without greater support. Scrooge awakens on Christmas morning and acts immediately on what he has learned. He sends a large turkey to the Cratchits, gives generously to charity, joins Fred's celebration, raises Bob's pay, and becomes a dependable friend to the family. Tiny Tim survives, and Scrooge maintains his reformed way of living. The collection then turns to a sleeping household on Christmas Eve. Its observer sees Saint Nicholas arrive in a reindeer-drawn sleigh, fill the children's stockings, and depart through the chimney, calling a final seasonal greeting as he flies away.",
         "in_short": "In A Christmas Carol, the miser Ebenezer Scrooge rejects his nephew, charity collectors, and the needs of his clerk Bob Cratchit. The ghost of his former partner Marley warns him to change, and three Christmas spirits show him his lonely past, the generous celebrations occurring around him, and a future in which Tiny Tim dies and Scrooge's own death inspires relief rather than grief. Awakening on Christmas morning, Scrooge gives money and food, joins his nephew's dinner, improves Bob's circumstances, and becomes a loving supporter of the Cratchits; Tiny Tim lives. The companion poem shifts to a peaceful Christmas Eve, when a householder glimpses Saint Nicholas arrive with eight reindeer, enter by the chimney, fill the children's stockings, and fly away after wishing everyone a happy Christmas.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1187,7 +1187,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1200,7 +1200,7 @@
       "recaps": {
         "ending": "Scrooge recognizes the neglected grave shown by the final spirit as his own and begs for a chance to live differently. He wakes in his bedroom on Christmas morning, overjoyed that the visions have ended before the future became fixed. He immediately begins acting on his promises: he anonymously sends a large turkey to the Cratchits, gives a generous donation to the charity collector he had rejected, and joins Fred's Christmas dinner. The next morning he startles Bob by pretending anger at his lateness, then raises his salary and promises help for the family. Scrooge's reform lasts. He becomes a generous employer, a welcome relative, and a dependable friend, and he takes a special interest in Tiny Tim, who survives. The feared lonely death does not occur because Scrooge changes both his conduct and his relationships.",
         "in_short": "On Christmas Eve, the miser Ebenezer Scrooge rejects his nephew Fred, charity collectors, and the needs of his clerk Bob Cratchit. The ghost of his dead partner Marley warns that a selfish life creates suffering after death. Three Christmas spirits then confront Scrooge with the lonely child and loving young man he once was, the celebrations and hardships of the present, and a future in which Tiny Tim dies while Scrooge's own death brings relief rather than grief. When he sees his neglected grave, Scrooge promises to change. Awakening on Christmas morning with time remaining, he sends food to the Cratchits, donates to the poor, joins Fred's dinner, raises Bob's wages, and becomes a lasting source of help and affection. Tiny Tim lives, and Scrooge avoids the future he was shown by becoming generous and connected to others.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1378,7 +1378,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1391,7 +1391,7 @@
       "recaps": {
         "ending": "After seeing that the neglected grave in the final vision bears his own name, Scrooge promises to change and wakes on Christmas morning overjoyed to find that the spirits completed their work in a single night. He anonymously sends a large turkey to the Cratchits, gives a generous donation to the charity collector he had rejected, and joins Fred's family dinner. The next morning he startles Bob Cratchit before raising his salary and offering practical help to the family. From then on Scrooge becomes a dependable friend, employer, and benefactor. He supports Tiny Tim, who survives, and takes an affectionate place in the boy's life. Although some people mock the sudden change, Scrooge does not retreat from it. He keeps the generous spirit of Christmas throughout the year, replacing isolation and fear with sustained care for other people.",
         "in_short": "On Christmas Eve, miserly London businessman Ebenezer Scrooge rejects his nephew's hospitality, refuses a charitable appeal, and begrudges his clerk Bob Cratchit a holiday. The ghost of his dead partner, Jacob Marley, warns that his selfishness will bring terrible consequences. Three spirits then guide Scrooge through the loneliness and lost love of his past, the celebrations and hardships of the present, and a future in which Tiny Tim dies and Scrooge's own death is met with theft and indifference. Recognizing his grave, Scrooge begs for the chance to change. He wakes on Christmas morning and acts immediately: he sends food to the Cratchits, donates generously, celebrates with his nephew Fred, and raises Bob's salary. His reform lasts beyond the holiday. He becomes generous and socially engaged, helps the Cratchit family, and ensures that Tiny Tim lives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1569,7 +1569,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1582,7 +1582,7 @@
       "recaps": {
         "ending": "After seeing that the neglected grave in the final vision bears his own name, Scrooge promises to change and wakes on Christmas morning overjoyed to find that the spirits completed their work in a single night. He anonymously sends a large turkey to the Cratchits, gives a generous donation to the charity collector he had rejected, and joins Fred's family dinner. The next morning he startles Bob Cratchit before raising his salary and offering practical help to the family. From then on Scrooge becomes a dependable friend, employer, and benefactor. He supports Tiny Tim, who survives, and takes an affectionate place in the boy's life. Although some people mock the sudden change, Scrooge does not retreat from it. He keeps the generous spirit of Christmas throughout the year, replacing isolation and fear with sustained care for other people.",
         "in_short": "On Christmas Eve, miserly London businessman Ebenezer Scrooge rejects his nephew's hospitality, refuses a charitable appeal, and begrudges his clerk Bob Cratchit a holiday. The ghost of his dead partner, Jacob Marley, warns that his selfishness will bring terrible consequences. Three spirits then guide Scrooge through the loneliness and lost love of his past, the celebrations and hardships of the present, and a future in which Tiny Tim dies and Scrooge's own death is met with theft and indifference. Recognizing his grave, Scrooge begs for the chance to change. He wakes on Christmas morning and acts immediately: he sends food to the Cratchits, donates generously, celebrates with his nephew Fred, and raises Bob's salary. His reform lasts beyond the holiday. He becomes generous and socially engaged, helps the Cratchit family, and ensures that Tiny Tim lives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1718,7 +1718,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1731,7 +1731,7 @@
       "recaps": {
         "ending": "After begging the final spirit for a chance to alter the future, Scrooge wakes in his own bed on Christmas morning and realizes the visions have occurred in time for him to act. Delighted and energetic, he anonymously sends a large turkey to the Cratchits, makes a substantial donation to the charity collector he had dismissed, and joins Fred's family for dinner. The next day he startles Bob by pretending to be angry about his lateness, then raises his pay and promises practical help for the family. Scrooge keeps those promises. He becomes generous, sociable, and attentive to other people throughout the year, while Tiny Tim survives and regards him with familial affection. The lonely death and neglected grave shown by the last spirit do not come to pass; Scrooge's changed conduct gives him a place in his family and community.",
         "in_short": "Ebenezer Scrooge is a rich but isolated miser who rejects his nephew, underpays Bob Cratchit, and refuses to help the poor. On Christmas Eve the ghost of his dead partner, Jacob Marley, warns that such a life brings misery after death. Three spirits then confront Scrooge with his neglected childhood, lost relationships, the present celebrations of families including the impoverished Cratchits, and a possible future in which Tiny Tim dies and Scrooge's own death is met with indifference. Horrified by the person he has become, Scrooge promises to change. He wakes on Christmas morning, sends food to the Cratchits, gives generously to charity, reconciles with his nephew, and raises Bob's wages. His reform lasts: he becomes a caring friend and employer, helps Tiny Tim, and replaces isolation with active generosity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1873,7 +1873,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1886,7 +1886,7 @@
       "recaps": {
         "ending": "After seeing a neglected grave bearing his own name, Scrooge promises to change the future by changing his conduct. He wakes on Christmas morning with the spirits' visits completed in a single night. Delighted to have time to act, he anonymously sends a large turkey to the Cratchits, gives money to the charity collector he rejected, and joins Fred's family for dinner. The next morning he startles Bob Cratchit before raising his salary and offering practical help to his family. Scrooge becomes a generous employer, an attentive uncle, and a dependable friend. He takes a particular interest in Tiny Tim, who survives in the altered future, and keeps the lessons of the spirits throughout the rest of his life.",
         "in_short": "Ebenezer Scrooge has made wealth and isolation the center of his life, rejecting his nephew, charity, and the needs of his clerk Bob Cratchit. On Christmas Eve the ghost of his former partner Jacob Marley warns him to change. Three spirits then show him the memories that shaped him, the present lives he ignores, and the lonely death awaiting him. Scrooge sees his lost engagement, the warmth of Fred and the Cratchit family, Tiny Tim's danger, and a future in which his death is treated as an opportunity rather than a loss. Awakening on Christmas morning, he begins repairing his relationships immediately. He supports charity, joins Fred's celebration, raises Bob's salary, and helps the Cratchits. Tiny Tim lives, and Scrooge becomes known for generosity and fellowship rather than fear and contempt.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2007,7 +2007,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2020,7 +2020,7 @@
       "recaps": {
         "ending": "After seeing his neglected grave, Scrooge promises to change if the future can still be altered. He wakes on Christmas morning delighted to be alive and immediately begins acting on that promise. He anonymously sends a large turkey to the Cratchits, gives generously to the charity collector he had rejected, joins Fred's family for dinner, and surprises Bob the next morning by raising his salary and offering help to the family. Scrooge maintains this reformation beyond the holiday. He becomes a dependable friend and generous employer, participates warmly in the life of his community, and supports the Cratchits so fully that Tiny Tim survives. The feared lonely death shown by the final spirit is therefore avoided; Scrooge's future is remade through sustained generosity rather than a single festive gesture.",
         "in_short": "Miserly London businessman Ebenezer Scrooge dismisses Christmas and refuses help to the poor until the ghost of his dead partner, Jacob Marley, warns him that his selfish life is leading toward misery. Three spirits then guide him through Christmases past, present, and future. Scrooge revisits his lonely youth, lost relationships, and gradual devotion to money; witnesses the warmth and hardship of families including that of his underpaid clerk, Bob Cratchit; and sees a future in which Tiny Tim dies and Scrooge's own death inspires indifference and theft. Confronted with his grave, he begs for a chance to change. Waking on Christmas morning, he gives to charity, sends food to the Cratchits, reconciles with his nephew, raises Bob's salary, and becomes a generous participant in other people's lives. His continuing care helps Tiny Tim live, replacing the future he feared with one founded on human connection.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2191,7 +2191,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2204,7 +2204,7 @@
       "recaps": {
         "ending": "After seeing that the neglected grave in the final vision bears his own name, Scrooge promises to change and wakes on Christmas morning overjoyed to find that the spirits completed their work in a single night. He anonymously sends a large turkey to the Cratchits, gives a generous donation to the charity collector he had rejected, and joins Fred's family dinner. The next morning he startles Bob Cratchit before raising his salary and offering practical help to the family. From then on Scrooge becomes a dependable friend, employer, and benefactor. He supports Tiny Tim, who survives, and takes an affectionate place in the boy's life. Although some people mock the sudden change, Scrooge does not retreat from it. He keeps the generous spirit of Christmas throughout the year, replacing isolation and fear with sustained care for other people.",
         "in_short": "On Christmas Eve, miserly London businessman Ebenezer Scrooge rejects his nephew's hospitality, refuses a charitable appeal, and begrudges his clerk Bob Cratchit a holiday. The ghost of his dead partner, Jacob Marley, warns that his selfishness will bring terrible consequences. Three spirits then guide Scrooge through the loneliness and lost love of his past, the celebrations and hardships of the present, and a future in which Tiny Tim dies and Scrooge's own death is met with theft and indifference. Recognizing his grave, Scrooge begs for the chance to change. He wakes on Christmas morning and acts immediately: he sends food to the Cratchits, donates generously, celebrates with his nephew Fred, and raises Bob's salary. His reform lasts beyond the holiday. He becomes generous and socially engaged, helps the Cratchit family, and ensures that Tiny Tim lives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2373,7 +2373,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2386,7 +2386,7 @@
       "recaps": {
         "ending": "Scrooge wakes on Christmas morning overjoyed to discover that the spirits completed their visits in a single night and that he still has time to change. He anonymously sends a large turkey to the Cratchits, gives a substantial donation to the charity collector he had rejected, attends Fred's family celebration, and greets everyone with unfamiliar warmth. The next morning he startles Bob Cratchit by pretending to be angry about his late arrival, then raises his salary and promises practical help for the family. Scrooge keeps his resolution beyond the holiday: he becomes generous, sociable, and attentive to others, and he acts as a second father to Tiny Tim. The child survives, so the bleak future shown by the final spirit does not occur. Scrooge accepts that some people will mock his transformation, but their judgment no longer governs him; he is remembered instead as someone who learned to honor Christmas throughout the year.",
         "in_short": "On Christmas Eve, the miserly London businessman Ebenezer Scrooge rejects his nephew, charity collectors, and the needs of his clerk Bob Cratchit. The ghost of his dead partner Marley warns that his selfish life is forging a terrible punishment and announces three further visitors. The Ghost of Christmas Past makes Scrooge confront his lonely childhood, lost love, and gradual surrender to greed. The Ghost of Christmas Present shows him the warmth of the poor Cratchit family, the frailty of Tiny Tim, his nephew's forgiving celebration, and widespread hardship. The Ghost of Christmas Yet to Come reveals an unmourned death, scavengers selling the dead man's belongings, Tiny Tim's empty place, and Scrooge's own neglected grave. Terrified by the future his choices are creating, Scrooge promises to change. He wakes on Christmas morning, gives generously, joins his nephew, improves Bob's circumstances, and becomes a loving benefactor to Tiny Tim, who lives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2528,7 +2528,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2541,7 +2541,7 @@
       "recaps": {
         "ending": "The final episode brings the Parkers' conflict with their neighbors' dogs into the family's Christmas celebration. Mr. Parker has guarded the holiday turkey with particular pride, but the Bumpus hounds burst into the kitchen and consume it before dinner. With the central meal ruined and no practical way to replace it, the family goes to a Chinese restaurant, one of the few places open. The unfamiliar dinner and the staff's earnest attempt at Christmas hospitality turn the apparent disaster into a family memory. The collection closes on this improvised celebration rather than a perfectly managed holiday: the Parkers remain together, the Old Man's feud with the Bumpuses has reached its most costly point, and a chaotic day has become part of the family mythology through which the adult narrator remembers childhood.",
         "in_short": "In five linked childhood episodes, Ralph Parker recalls pursuing a coveted Red Ryder air rifle, joining a radio club only to discover that its secret message is an advertisement, watching his father proudly display an eccentric prize lamp, enduring neighborhood bullies, and seeing the family Christmas dinner destroyed by the Bumpuses' dogs. Ralph's elaborate campaign for the rifle seems defeated because every adult considers it dangerous, but his father quietly provides it on Christmas morning. Ralph immediately has a frightening mishap yet escapes serious injury and keeps the gift. Other victories prove equally mixed: the decoder disappoints him, the lamp becomes a source of conflict between his parents, and his fury at Scut Farkas ends the bully's hold over him but leaves Ralph afraid of punishment. When the dogs eat the turkey, the Parkers salvage the holiday with dinner at a Chinese restaurant. Together the stories present Christmas as a blend of longing, embarrassment, family conflict, surprise, and affectionate memory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2889,7 +2889,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002VA374S",
@@ -2901,7 +2901,7 @@
       "recaps": {
         "ending": "Dono survives the attempt to disqualify him, defeats Richars by thirty-two votes, becomes Count Vorrutyer, and becomes engaged to Olivia. Richars enters municipal custody, while Rene retains the Vorbretten countship. Gregor backs Ekaterin's guardianship, Nikki remains with her, and his medical treatment is expected to prevent his inherited illness. Ekaterin proposes to Miles before the Council, he accepts, and they plan a quiet family wedding in the fall. Gregor and Laisa marry publicly two weeks later. Mark, Kareen, Martya, Ekaterin, and Enrique remain connected to the butterbug venture, whose maple ambrosia has a successful reception debut. Mark and Kareen continue under their one-year mutual option rather than a betrothal. Byerly privately admits that he is an ImpSec counterintelligence operative and that he arranged the interrupted attack as an unauthorized effort to expose Richars, while withholding his contact. Miles remains an Imperial Auditor, but Setagandan intelligence now knows that he was Admiral Naismith.",
         "in_short": "Miles Vorkosigan tries to court the widowed Ekaterin through a paid garden commission, but his concealed purpose leads to a disastrous proposal and a breach of trust. As he apologizes and they cautiously reconnect, a rejected suitor and Richars turn the classified circumstances of Tien's death into political slander. Meanwhile, Mark, Kareen, Enrique, Martya, and Ekaterin build a butterbug business, Kareen negotiates independence from both Mark and her family, and Lord Dono challenges Richars for the Vorrutyer countship alongside Rene Vorbretten's effort to retain his own title. Nikki learns the protected truth about Tien, refuses an attempt to remove him from Ekaterin, and receives Gregor's support. After an attack on Dono implicates Richars, Dono and Rene win their Council votes. Ekaterin publicly proposes to Miles, and they plan a fall wedding. Gregor marries Laisa, the butterbug venture launches successfully, and Miles learns his Admiral Naismith identity is known to Setagandan intelligence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3087,7 +3087,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3100,7 +3100,7 @@
       "recaps": {
         "ending": "The Battle of the Blackwater is won by the Lannister and Tyrell alliance. Tyrion, gravely wounded and nearly killed in the fighting, is stripped of credit and pushed aside once his father Lord Tywin arrives to take up the office of Hand; Joffrey keeps his crown and is newly betrothed to Margaery Tyrell. Stannis, badly beaten, retreats to Dragonstone but is not destroyed, and Melisandre keeps her hold on him. In the North, Winterfell falls and is put to the torch, Theon Greyjoy's brief conquest ending in disaster, though Bran and Rickon Stark are secretly alive and flee into hiding, splitting up, with Bran drawn north beyond the Wall by his dreams. Robb Stark still holds the field but stands on shakier ground. Jon Snow rides with the free folk in disguise, having proven his loyalty in a grim way, while Arya escapes Harrenhal. Daenerys leaves Qarth still short of the army and fleet she needs to press her claim, her dragons growing but the road home as long as ever.",
         "in_short": "With the realm split among rival kings, Tyrion Lannister arrives in the capital as acting Hand and cunningly outmaneuvers his sister Cersei while shoring up the city's defenses. Stannis Baratheon, driven by the red priestess Melisandre, murders his own brother Renly by shadow-craft, absorbs his forces, and sails to besiege King's Landing. In the climactic Battle of the Blackwater, Tyrion's wildfire and a great chain cripple Stannis's fleet, and the last-moment arrival of Tywin Lannister and his new Tyrell allies breaks the assault. In the North, Theon Greyjoy betrays the Starks, seizes lightly held Winterfell, and, unable to recapture the escaped Stark boys, murders two other children and passes off their burned bodies as Bran and Rickon. Robb keeps winning battles in the field but weakens politically. Arya toils as a captive laborer at the ruined castle of Harrenhal, Jon goes among the wildlings beyond the Wall, and Daenerys seeks ships and allies in the far eastern city of Qarth, gaining little but hard lessons.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3208,7 +3208,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3221,7 +3221,7 @@
       "recaps": {
         "ending": "Alex's story turns on whether goodness forced from outside is worth anything. After the Ludovico conditioning strips him of the capacity for violence, his release leaves him defenceless: he is set upon by people he once brutalized and by former gang members now serving as police, and ends up at the mercy of the writer F. Alexander, who recognizes him as one of the attackers who assaulted his wife and exploits him as a weapon against the government. Locked in a room and tormented with the music that now sickens him, Alex throws himself from a window. He survives, and in the political scandal that follows, officials reverse the conditioning to save face; Alex, healed and free of his aversions, delights that he is his old wicked self again. The novel's endings then diverge by edition. The original British edition, and later restored versions, add a final twenty-first chapter in which an older Alex, grown bored with cruelty and drawn to the idea of a wife and a son, begins to outgrow violence by his own choice, framing the whole book as an argument that moral growth must come from free will. The original American edition (and Kubrick's film) omitted that chapter, closing instead on Alex fully and unrepentantly restored to his violent nature.",
         "in_short": "In a near-future society, the teenage narrator Alex leads a small gang on nightly sprees of theft, assault, and worse, all while cherishing classical music. Betrayed by his gang during a break-in that leaves a woman dead, he is caught and sentenced to prison. To win early release he volunteers for the Ludovico Technique, an aversion conditioning that makes him violently sick at any thought of violence or sex, and, by accident, at the Beethoven he loves. Released as a harmless but helpless creature unable to defend himself, he is beaten by old victims and former friends now turned policemen, and finally taken in by a writer whose wife his gang once attacked, who uses him as anti-government propaganda and drives him to a suicidal leap. Injured, Alex finds the conditioning has been reversed by embarrassed officials, and he gleefully returns to his old violent self. In the author's original final chapter, an older Alex, wearied of violence, begins of his own accord to think of giving it up and building a settled life, suggesting that real change must be chosen, not imposed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3311,7 +3311,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3324,7 +3324,7 @@
       "recaps": {
         "ending": "Sidra's search turns up where Pepper's impounded shuttle was taken, and Pepper, Blue, Sidra and Tak go after it and recover Owl's core, which costs Sidra some of the concealment she has spent the book maintaining. Owl is brought back to Port Coriol and installed in Pepper and Blue's home, conscious again after roughly twenty years and reunited with the girl she raised, which closes the loss Pepper has carried since she was nineteen. Sidra's own problem is resolved by choice rather than by repair: instead of having the offending code cut out of her, she decides to claim the body she was put into, and asks Tak to tattoo her as a way of making it hers. Tak stays in their lives, knowing what she is. The book's last chapter is narrated by Owl a standard year later, from the home she now runs, describing a household of five that was assembled entirely on purpose. Nothing in the ending reaches back to the tunnelling ship Sidra was booted on: she never returns to it, and the crew she cannot remember is left behind for good.",
         "in_short": "Rebooted from her original code after the loss that closed the previous book, an AI with no memories of the ship she came from is installed, illegally, in a humanoid body kit by Pepper, a tech on the market moon of Port Coriol. Calling herself Sidra, she has to learn to live inside one small body, pass as an organic person, and cope with a core protocol that treats her whole existence as a violation. A second thread follows a girl called Jane 23, raised as disposable factory labour on a scrap world, who escapes at ten, is taken in by Owl, the AI of a wrecked shuttle, and spends nine years being educated, scavenging, and rebuilding that ship until she can fly it out. Her escape finally puts her among living people but costs her Owl, whose shuttle is impounded as stolen property; the girl grows up into Pepper. In the present, Sidra tracks down where Owl ended up, and the household goes and gets her back. Owl is installed in Pepper and Blue's home, and Sidra stops enduring her body and claims it as her own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3515,7 +3515,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3528,7 +3528,7 @@
       "recaps": {
         "ending": "Osaron is drawn out of the city and into the Inheritor, but the artifact needs a living vessel to hold what it takes, and Holland is the one who offers. Osaron is pulled into him and destroyed with him; Holland dies holding the thing that ruined both of his worlds, and Kell and Lila carry his body back to White London, which the same bargain had already restored to life, and leave him in a world that is green again. Red London survives, badly hurt. Rhy has lost both his parents and is crowned king of Arnes, with Alucard beside him and a city that has watched its own people turned against it. Kell comes out of the fight with his own magic damaged: travelling between worlds is no longer something he can simply do, and the crown he was raised to serve is now his brother's. Lila, openly Antari at last, is given a ship of her own, and Kell leaves the palace to sail with her rather than stay as anyone's instrument. The doors between the worlds are quiet, and the survivors part with the Arnesian word that means goodbye and not goodbye at once.",
         "in_short": "Osaron, the living magic of Black London, crosses into Red London and turns the city into a plague of shadow, filling the streets with fog and waking its people as thralls. Kell, held prisoner in White London, escapes back into a home that is already falling, and the survivors are forced into an alliance nobody wants: Kell, Lila, Rhy, Alucard and Holland, the man who let Osaron in. With the palace sealed behind failing wards and the crown's power spent, they sail for a floating market that trades in impossible objects and buy the Inheritor, an artifact that can draw magic out of anything, at a price. They come back and set a trap. Osaron is pulled into the Inheritor, but the artifact needs a living vessel, and Holland gives himself; he dies with Osaron inside him. Red London holds, at the cost of the king and queen. Rhy is crowned, Kell's magic is left damaged, and Lila takes command of her own ship with Kell aboard.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3915,7 +3915,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B09MDGBLY9",
@@ -3927,7 +3927,7 @@
       "recaps": {
         "ending": "Liza's implanted planar ward prevents the authorities from locating Siobhan through the blood recovered after the warehouse battle. The investigation instead gives her the name Raven Queen and treats her as an unusually serious threat, while Thaddeus Lacer questions the official interpretation and becomes interested in the ancient stolen text. Siobhan contacts Ennis again and learns that he gave her mother's knot ring to the Garvins as security for their marriage bargain. She refuses to submit, destroys the raven messenger before pursuers can recover it, changes into Sebastien, and returns to the university with a weak replacement conduit. Oliver and Katerine still lead the Verdant Stag after Cooper and Jameson die, and the organization prepares for stronger defenses and further conflict. Siobhan remains indebted to Katerine and bound to Stag work, while her apprenticeship, concealed identities, encrypted book, unexplained amulet, lost heirloom, and the Crown investigation all remain unresolved.",
         "in_short": "After her father leaves her exposed during a theft, fugitive sorcerer Siobhan acquires an artifact that transforms her into a man. As Sebastien Siverling, she wins conditional admission to the Thaumaturgic University under Thaddeus Lacer and studies while working off a severe debt to Oliver Dryden and Katerine's Verdant Stag. Her covert aid to the organization draws her into a Morrows attack, where two workers die and police recover her blood. Liza implants a ward that defeats the ensuing scrying, but investigators recast Siobhan as the dangerous Raven Queen. Ennis reveals that the Garvins hold Siobhan's maternal knot ring as collateral for a proposed marriage. Rejecting the bargain, she returns to university as Sebastien with a poor replacement conduit, her identities still unconnected and the stolen book still unreadable.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4099,7 +4099,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4112,7 +4112,7 @@
       "recaps": {
         "ending": "Civil war and an interdict destroy Hank's political position while he is away from Britain. He returns to find that most of his supporters have deserted, leaving Clarence and a small group of trained young followers to defend their works. From a fortified cave, they use an electrified fence, explosives, and rapid-fire weapons to annihilate the massed chivalry of England. The victory traps the defenders behind a barrier of corpses, where disease begins killing them. Merlin enters in disguise and casts a spell that will make Hank sleep for thirteen centuries, but accidentally touches the electric fence and dies. Hank awakens in his own century. In the frame narrative, the visiting stranger who has read Hank's manuscript finds him delirious and dying, mentally returned to Arthur's age and calling for Sandy and their child. His attempt to remake Camelot has ended in destruction rather than the democratic society he intended.",
         "in_short": "Factory superintendent Hank Morgan is knocked unconscious and awakens in sixth-century Camelot. Facing execution, he uses foreknowledge of an eclipse to pose as a magician, displaces Merlin, and becomes King Arthur's powerful minister. He quietly builds schools, factories, communications, and a loyal modern organization while ridiculing chivalry and challenging inherited privilege. Adventures with Sandy and with Arthur expose him to oppression, slavery, and the limits of both medieval institutions and his own reforming arrogance. After returning to his original era and then finding himself in Camelot again, Hank learns that civil war and the Church have overturned his system. He and a few followers use modern weapons to destroy England's knights at the Battle of the Sand Belt, only to become trapped by the devastation. Merlin puts Hank into a thirteen-century sleep. Back in the nineteenth century, Hank dies longing for Sandy and their child, while his manuscript preserves the catastrophic story.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4270,7 +4270,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4283,7 +4283,7 @@
       "recaps": {
         "ending": "The Winter Solstice gathering is where the novella closes. Nesta comes to it, endures part of the evening and leaves early, no nearer her sister and visibly worse than when the book began; Cassian, who has spent the winter alternately provoking and defending her, is left with nothing settled. Feyre commits to founding an art studio in the rebuilt quarter as her own work rather than the court's. Elain remains unreconciled to Lucien and to what the Cauldron made of her, with Azriel closer to her than anyone will say aloud. Morrigan, still carrying a truth she has told almost no one, prepares to spend a long stretch away from the court. Amren has settled into a smaller life and into Varian's attention. Rhysand and Cassian both know the Illyrian camps will not stay quiet, and the human lands remain unfinished business, with Lucien tied to Jurian and the cursed queen Vassa. After the gifts, Rhysand takes Feyre out over the river to show her the estate where they plan to build a home of their own, and the two of them agree they want a child once the court is steady. Nothing is concluded: the novella ends as a breathing space, setting Nesta's collapse, the Illyrian unrest and the loose threads in the mortal world in place for the next book.",
         "in_short": "A few months after the war with Hybern, the Night Court spends the winter counting the cost. Feyre, now High Lady, throws herself into rebuilding Velaris and its ruined artists' quarter, and decides to found a studio where anyone the war damaged can learn to paint for free. Rhysand carries the grief work of a victorious court, visiting the families of the dead and watching the Illyrian war camps, where resentment is building. Cassian pushes the Illyrians toward reform and is pulled toward Nesta Archeron, who has cut herself off from the family, drinking alone in a rented room and punishing herself for their father's death. Elain drifts, avoiding the mate she never chose. Morrigan considers leaving for a time. The Winter Solstice brings them all together for a night of gifts and uneasy peace; Nesta appears briefly and leaves. Little is resolved: the book ends with the family quietly warned that Nesta is still falling, the Illyrians still restless, and Feyre and Rhysand deciding they want a child.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4442,7 +4442,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4455,7 +4455,7 @@
       "recaps": {
         "ending": "Cornered by the King of Hybern, Feyre watches her mortal sisters Nesta and Elain forced into the Cauldron and transformed into High Fae. Tamlin arrives, having allied himself with Hybern in a desperate bid to recover Feyre, and Feyre makes a wrenching choice: she pretends to still be under his sway and lets him take her back to the Spring Court. In truth she is now Rhysand's mate and his equal, the High Lady of the Night Court, and she means to work as a spy and saboteur inside Tamlin's court, gathering intelligence and turning his people against him and Hybern. She leaves the Night Court and everyone she has come to love behind, hiding her true allegiance and her bond with Rhysand, and returns to the Spring Court cold and resolved, determined to destroy the alliance from within as war with Hybern draws near.",
         "in_short": "Traumatized by what she did Under the Mountain and stifled by Tamlin's smothering protectiveness, Feyre is nearly wed at the Spring Court when Rhysand spirits her away to honor the bargain that owes him a week of every month. At the Night Court she discovers the hidden city of Velaris and learns that Rhysand's cruelty was a mask worn to protect his people. Among his inner circle - Mor, Cassian, Azriel, and Amren - Feyre heals, trains, and comes into powers she gained from all the High Lords who resurrected her. She learns that Rhysand is her mate, and she chooses him. Meanwhile the King of Hybern threatens to shatter the wall and enslave both realms using the Cauldron, and Feyre's group hunts for a magical book that can counter it. Hybern captures them, and Feyre's sisters Nesta and Elain are thrown into the Cauldron and made High Fae against their will. To escape and to spy against the enemy from within, Feyre lets Tamlin, who has allied with Hybern to win her back, take her home to the Spring Court, concealing that she is Rhysand's mate and the newly named High Lady of the Night Court.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4650,7 +4650,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4663,7 +4663,7 @@
       "recaps": {
         "ending": "Nesta, Emerie and Gwyn survive the Blood Rite, and Nesta reaches the summit of Ramiel and claims it - the first females ever to win a trial the Illyrians reserve for their warriors, a result that cannot be argued away and that changes what Illyrian women can demand. Nesta returns to Velaris to find Feyre in labour and dying just as the healers foretold. She bargains away the power she took from the Cauldron in exchange for her sister's life, remaking Feyre's body so the child can be born. Feyre survives and her son Nyx is born; the sisters are reconciled for the first time since they were mortal, and Nesta stops holding herself to blame for their father's death. Stripped of most of what the Cauldron gave her, she keeps what she built in its place - the training, the library, and the two friends who went into the mountains beside her - and she and Cassian accept the mating bond neither had been willing to name. Briallyn is killed and the immediate danger from the Dread Trove passes. What remains open is larger: Koschei is untouched at his lake and still holds the queen Vassa; Eris Vanserra's arrangements with the Night Court are unfinished and his father still rules Autumn; Elain's position between Lucien and Azriel is unchanged; and the Illyrian question Cassian has pressed for years can no longer be ignored. The Night Court ends the book intact, with an heir and a war it has not yet had to fight.",
         "in_short": "A year after the war with Hybern, Nesta Archeron is drinking herself to death in Velaris, estranged from the sister who became High Lady and from the Illyrian commander who will not leave her alone. Given an ultimatum, she moves up to the House of Wind to train with Cassian and work in its library. What was meant as punishment becomes a life: she finds work she is good at, friends in Gwyn, a traumatised priestess, and Emerie, an Illyrian shopkeeper, and a body and a temper she can finally govern. She also begins to use the power she took from the Cauldron, and helps hunt three Cauldron-made objects sought by a remade mortal queen and the death-lord Koschei. When Nesta discovers that Feyre's pregnancy will kill her and that Rhysand is hiding it, she says so in front of everyone and is exiled to the mountains, where she, Gwyn and Emerie are thrown into the Illyrians' lethal Blood Rite and win it. She returns to find Feyre dying in labour and trades away her Cauldron-given power to save her sister and the child. Feyre lives, Nyx is born, Nesta and Cassian accept their mating bond, and Koschei remains at large.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4817,7 +4817,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4830,7 +4830,7 @@
       "recaps": {
         "ending": "Feyre completes Amarantha's final trial only by stabbing three faeries through the heart; the first two are innocents, and the third is Tamlin himself, whose heart Amarantha has turned to stone so the blade cannot kill him. Even so, Amarantha refuses to free the courts because Feyre never solved her riddle. Feyre says the answer aloud - love - and Amarantha, enraged, breaks her neck and kills her. The seven High Lords, including Rhysand, each pour a shard of their own power into her, resurrecting her as an immortal High Fae. Freed, Tamlin kills Amarantha, and the courts are released from her rule and the blight. Feyre returns to the Spring Court reborn and reunited with Tamlin, but haunted by the innocents she killed and changed forever by her new nature. She also carries the bargain Rhysand struck with her Under the Mountain: one week of every month is now owed to the Night Court, a debt that will shape what comes next.",
         "in_short": "Nineteen-year-old huntress Feyre kills a wolf in the winter woods that turns out to be a faerie, and a great beast comes to claim a life in return, taking her across the wall into Prythian. The beast is Tamlin, High Lord of the Spring Court, cursed to wear a mask while a blight ravages the faerie lands. Living on his estate, Feyre falls in love with him, but he sends her home to keep her safe from a growing danger. Learning that Tamlin has been dragged Under the Mountain by the tyrant queen Amarantha, Feyre returns to save him. Amarantha forces her through three deadly trials or a riddle to win his freedom; the mysterious Rhysand, High Lord of the Night Court, aids her at a price, binding her to spend part of each month in his court. Feyre survives the trials but is killed by Amarantha, only to be resurrected as an immortal High Fae by the seven High Lords. Amarantha is destroyed, the courts are freed, and Feyre returns to the Spring Court remade, carrying deep trauma and her bargain with Rhysand.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4997,7 +4997,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5010,7 +5010,7 @@
       "recaps": {
         "ending": "The final battle against Hybern's forces turns on desperate sacrifice. Rhysand pours out his life to fuse the power of the High Lords in a spell that can turn the tide, and he dies. Feyre, refusing to lose him, appeals to the gathered High Lords to give a portion of their own power to bring him back, just as they once resurrected her Under the Mountain; they do, and Rhysand lives again. The King of Hybern is killed and his army shattered, ending the invasion. The cost is heavy - lives lost, courts wounded, old wrongs left to heal - but Prythian is free. Feyre and Rhysand stand together as High Lord and Lady of a restored Night Court, their inner circle intact. Nesta and Elain remain changed and still finding their place in the faerie world, and the human lands and faerie courts face an uneasy new peace. The immediate war is won, and the survivors turn toward rebuilding the world they nearly lost.",
         "in_short": "Feyre is entrenched in the Spring Court as a spy, quietly wrecking Tamlin's alliance with Hybern and turning his people against him before escaping back to the Night Court with Lucien. With the King of Hybern's invasion looming, Feyre and Rhysand work to unite Prythian's fractious High Lords, gather armies, and counter the Cauldron. Feyre's remade sisters struggle with their new Fae natures: Nesta carries a terrible power taken from the Cauldron, and Elain begins to see visions. The war brings brutal battles, shifting alliances, betrayals, and heavy losses, and Elain is captured by Hybern before being rescued. In the climactic battle Rhysand sacrifices himself to bind the courts' power together and dies, and Feyre persuades the assembled High Lords to resurrect him as they once resurrected her. The King of Hybern is killed, his forces broken. Prythian survives at great cost, the Night Court's family is whole again, and a fragile peace settles over the courts as they begin to rebuild.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/a-crown-of-swords.json
+++ b/data/works-community/0/a-crown-of-swords.json
@@ -103,7 +103,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -116,7 +116,7 @@
       "recaps": {
         "ending": "Rand ends the unnatural heat and the Forsaken who most immediately opposed him, but at a cost. He lures Sammael, who has ruled Illian in disguise, into the cursed ruins of Shadar Logoth and leaves him to the hungry evil of Mashadar, then claims Illian and is crowned with its ancient Laurel Crown, the crown of swords. In Ebou Dar, Elayne, Nynaeve, and Aviendha, working with the runaway channelers of the Kin and the sea folk's Windfinders, manage to use the Bowl of the Winds to break the Dark One's grip on the weather and start the seasons turning again. But their triumph is swallowed by disaster: the Seanchan launch an assault on Ebou Dar as the group flees, and Mat is caught beneath a collapsing wall, his fate left uncertain. Meanwhile the formidable Aes Sedai Cadsuane has attached herself to Rand and his Asha'man, meaning to guide, or master, the Dragon Reborn on her own terms. And at the height of his success Rand is ambushed by Padan Fain, whose cursed dagger opens a second wound that crosses and worsens the one he already bears, an injury the Power cannot heal. Rand stands crowned and stronger than ever, the weather mended and a Forsaken dead, yet sicker, warier, and more surrounded by hidden agendas than before, as the Seanchan advance and the Last Battle draws nearer.",
         "in_short": "The Dark One's touch has locked the world in a killing, unnatural heat, and Rand means to end it and to strike at the Forsaken Sammael, who rules the nation of Illian under a false name. In the city of Ebou Dar, Elayne, Nynaeve, Aviendha, and Mat search for the Bowl of the Winds, an ancient object that can mend the weather, working with a hidden society of runaway channelers and the sea folk's Windfinders. Rand, hardening under the strain of command and the taint on the Power, gathers Aes Sedai sworn to him and draws the notice of Cadsuane, a legendary sister with plans of her own. Rand lures Sammael into the cursed ruins of Shadar Logoth and leaves him to the evil that haunts the place, then takes Illian and its crown. The women succeed in working the Bowl, breaking the deadly heat and turning the seasons back toward their course, but as they escape, the Seanchan storm Ebou Dar, and Mat is caught in the collapse. Rand, crowned and victorious, is ambushed by Padan Fain and dealt a second wound that will not heal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -195,7 +195,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -206,7 +206,7 @@
         "work": "a-curse-for-true-love"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -363,7 +363,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -376,7 +376,7 @@
       "recaps": {
         "ending": "The book closes on a string of cliffhangers. Jon Snow, having pushed his hard choices too far, is set upon and stabbed by a group of his own sworn brothers in a mutiny at the Wall, and falls apparently dying in the snow. Daenerys, borne away by her dragon Drogon, is stranded on the vast Dothraki sea, sick and alone, and comes face to face with a mounted khalasar, her fate uncertain; behind her, the old knight Barristan Selmy takes command of a Meereen teetering toward war. Tyrion, alive and sardonic, ends among the sellswords of the Second Sons, plotting his next move toward the dragon queen. Cersei, after a degrading walk of atonement through the capital, is freed from her cell to await a trial by combat, defended by a monstrous, silent new champion. At Winterfell, Theon Greyjoy and the false Stark bride leap from the castle walls to escape Ramsay Bolton and flee toward Stannis, whose army struggles through the snows nearby with battle imminent. Bran Stark, safe beneath the earth, has become a greenseer in training. And in the far south a bold young invader claiming Targaryen blood lands with a seasoned army, opening a wholly new front in the endless contest for the throne.",
         "in_short": "Jon Snow, as Lord Commander, gambles on peace with the wildlings and lets them pass south through the Wall to save them from the coming enemy, a choice that enrages his brothers. Daenerys, besieged by insurgents in Meereen, marries a local nobleman to buy peace and reopens the fighting pits, but when her great dragon Drogon descends in blood and fire she flees the city on his back and ends up lost and starving on the open grasslands, found by a Dothraki horde. Tyrion is swept east, falling in with exiles escorting a mysterious young man who claims a lost royal name, then is captured, enslaved, and finally schemes his way into a sellsword company outside Meereen. Bran reaches his teacher, an ancient greenseer beneath a hollow hill, and begins to see through the eyes of trees and beasts. At Winterfell, the broken captive Theon is forced to serve at the wedding of a false Stark bride to the sadistic Ramsay Bolton, until a flicker of his old self drives him to flee with the girl into the snow. Stannis marches on Winterfell through a killing blizzard as a great new claimant lands in the south with an army.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -514,7 +514,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -527,7 +527,7 @@
       "recaps": {
         "ending": "In White London, Lila kills Athos Dane and Kell breaks the binding spell that has held Holland in service, but Astrid has already crossed into Red London and taken Prince Rhy's body for her own. Kell is forced to destroy her, which means killing his brother, and then uses Antari blood magic to tie his own life to Rhy's so that Rhy lives again; from that moment the two of them share pain, and Rhy cannot die while Kell survives. With Holland mortally wounded, Kell binds the black stone into him and pushes him through the door into Black London, then seals the passage with his blood, putting the stone beyond reach at the cost of the man who carried it. Red London survives with its heir restored and its crown unaware of what the rescue actually cost. Kell's bond with Rhy is a secret that binds them both, and his freedom to travel is now something the king intends to control. Lila, offered a place, chooses the sea instead: she leaves for a ship and a life of her own in a world where magic is real. Holland is presumed dead in a world nothing can enter.",
         "in_short": "Four Londons occupy the same point in different worlds: Grey London has forgotten magic, Red London thrives on it, White London starves for it, and Black London was consumed by it and sealed away. Only Antari, marked by one solid black eye, can travel between them. Kell, one of two living Antari, serves the Red London crown as its messenger and smuggles trinkets on the side. Handed a black stone that turns out to be a fragment of Black London's magic, he is hunted for it, robbed of it in Grey London by a thief named Delilah Bard, and forced into an alliance with her to carry it back where it came from. The stone grants what its holder asks and takes something in return, and the rulers of White London want it. Kell and Lila fight their way through White London, but Astrid Dane reaches Red London first and takes Prince Rhy's body. Kell kills her, binds his own life to Rhy's to save him, and sends the stone into Black London inside the dying Holland before sealing the door. Lila leaves for a ship of her own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -741,7 +741,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -754,7 +754,7 @@
       "recaps": {
         "ending": "The invasion is broken at Sethanon. Beneath the ruined city Arutha kills Murmandamus and finds that the moredhel messiah was never a moredhel at all but a Pantathian serpent priest working behind an illusion, one of a race that has spent centuries manipulating the Northlands toward this single objective. What lies under Sethanon is the Lifestone, made in the Chaos Wars by the Valheru as their means of returning to a world the gods had taken from them. Its waking calls the Dragon Lords back, and they come. Tomas, drawing on everything Ashen-Shugar left in him, and Pug, with Macros restored to the fight, hold them off, and the host is turned away. The Lifestone is not destroyed. It is left sealed and dormant where it lies, with the Oracle of Aal established beneath the city to guard it, a problem deferred rather than solved and one that Pug expects to have to answer for eventually. Macros survives, greatly diminished, and goes his own way. Guy du Bas-Tyra is pardoned by King Lyam and the survivors of Armengar are resettled in the Kingdom. Arutha returns to Krondor with Jimmy and Locklear. The Kingdom is at peace again, the north is broken for a generation, and the people who understand what happened under Sethanon are a very short list.",
         "in_short": "Murmandamus brings the Northlands south, and the Kingdom cannot tell what he is really after. Arutha rides north in person with Jimmy, Locklear and Baru and reaches Armengar, a fortress-city of Kingdom exiles commanded by the disgraced Guy du Bas-Tyra. Armengar is besieged and falls; Guy destroys it to cover his people's escape south, and Murmandamus turns toward the eastern city of Sethanon. Meanwhile Pug and Tomas find Macros alive, and with his help travel back to the Chaos Wars to watch the Valheru rise against the gods and forge the Lifestone, the artefact buried beneath Sethanon, and to learn of the devouring force from beyond the universe that the Dragon Lords fled. The Kingdom's armies converge on Sethanon and the battle turns into a siege of a city already burning. Below it Arutha kills Murmandamus and discovers he was a Pantathian serpent priest in disguise. The Lifestone wakes and the Valheru return; Tomas, Pug and Macros drive them back, and the stone is sealed and left dormant with a guardian set over it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -928,7 +928,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -941,7 +941,7 @@
       "recaps": {
         "ending": "McCaleb's suspicion that Bosch murdered Edward Gunn is the intended product of a frame. David Storey's side needed to destroy Bosch, whose testimony about Storey's admission anchors the Annabelle Crowe prosecution. Gunn was selected because Bosch had once suspected him of murder, and the crime scene was arranged with imagery tied to Hieronymus Bosch so that a careful profiler would supply the accusation the defense needed. Storey's investigator Rudy Tafero helped create and exploit the false trail. Once McCaleb recognizes that the clues are too perfectly tailored to his own method, he and Bosch turn the inquiry back on the people surrounding the trial. Their confrontation clears Bosch of Gunn's murder and preserves the case against Storey; Storey is held responsible for the scheme and the prosecution of Crowe's murder succeeds. McCaleb returns to Graciela and Catalina Island after acknowledging the personal cost of the investigation. Bosch emerges legally vindicated but unsettled by how credible the portrait of him as a man capable of private justice appeared, even to another experienced investigator.",
         "in_short": "Retired FBI profiler Terry McCaleb agrees to examine the ritualized murder of Edward Gunn while LAPD detective Harry Bosch testifies in filmmaker David Storey's trial for killing actress Annabelle Crowe. The novel alternates between McCaleb's cold-case-style analysis and Bosch's courtroom struggle. Gunn was once a Bosch murder suspect, and the staged scene uses symbols associated with the paintings of Hieronymus Bosch. McCaleb follows the pattern to the alarming conclusion that Bosch may have killed a man the courts never punished. Bosch denies it and argues that the timing serves Storey by destroying the prosecution's most important witness. Further investigation shows that this is precisely the design: Gunn's death was arranged through Storey's side, with investigator Rudy Tafero helping build a frame calibrated to McCaleb's profiling. McCaleb and Bosch expose the manipulation, Bosch is cleared, and Storey's attempt to derail his murder trial fails. McCaleb returns to his family, while Bosch is left facing the darkness others can plausibly see in his methods.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1068,7 +1068,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1079,7 +1079,7 @@
       "recaps": {
         "ending": "By the close, El has survived her junior year with her alliance with Aadhya and Liu sealed for the graduation run still a year away, and a warmer but still wary connection to New York's enclave through Chloe Rasmussen - a useful tie, not yet a sealed ally. The year's defining feats are hers: alone, she destroyed a maw-mouth, one of the devouring horrors even enclave wizards can only flee, a kill almost no living wizard can claim, and in the year-end crisis over the graduation hall's failing cleansing machinery she joined the repair effort and unleashed a working that revealed the terrifying scale of the affinity she has spent her life suppressing. Her standing has shifted from feared outcast to someone formidable and worth courting. She has still not touched malia, holding to that line even when it would be easy. She holds the Golden Stone sutras, a working that promises to build an enclave without the usual hidden cost, though she has not yet grasped what that cost is. Her friendship with Orion has become something warmer and harder to name, which makes the final beat land hard: as the new freshmen are inducted, a message from her mother, Gwen, reaches El with a single instruction - stay away from Orion Lake. She is left with no explanation, an alliance to keep alive, a senior year to survive, and a warning she does not understand about the person who has repeatedly saved her life.",
         "in_short": "El Higgins is a junior at the Scholomance, a school for young wizards that has no teachers and drifts in the void, where monsters called maleficaria hunt the students and the only way out is a graduation-day run through a hall full of them. Born with an affinity for spells of mass destruction, she refuses the dark magic that would make them easy, and as a poor, unaffiliated girl she has no enclave to shield her. When New York's celebrated Orion Lake keeps saving her life, it costs her the trust of the other students, but she slowly turns classmates into real allies, chiefly the artificer Aadhya and the musician Liu, and settles into an uneasy friendship with Orion. Over the year she uncovers how the enclaves hoard safety, and acquires the Golden Stone sutras, a spell said to build an enclave without its usual hidden cost. She does what almost no wizard can, destroying a maw-mouth alone, and in the year-end crisis helps repair the graduation hall's failing defenses, remaking her reputation from outcast to someone formidable. The book closes as a warning arrives from her mother: keep away from Orion Lake.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1198,7 +1198,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1211,7 +1211,7 @@
       "recaps": {
         "ending": "After the party, Torvald reads Krogstad's letter and learns that Nora forged her father's signature to obtain the loan that paid for his recovery abroad. He reacts by condemning her and worrying about his own reputation, saying their marriage must continue only as an appearance. A second letter returns the incriminating bond, and Torvald immediately declares the danger over and offers forgiveness. Nora understands that neither her father nor her husband has treated her as an independent adult, and that Torvald failed the test on which she had placed her hopes. She removes her costume, returns her wedding ring, and tells him she must leave both him and the children to educate herself and discover her own convictions. Torvald appeals to religion, morality, and family duty, but she no longer accepts his authority on those subjects. She leaves the house, while he is left with the remote hope that they might someday change enough for a true marriage to be possible.",
         "in_short": "Nora Helmer seems to be a carefree wife awaiting her husband Torvald's promotion, but she secretly owes money to Nils Krogstad. She took the loan to save Torvald's health and forged her dying father's signature to secure it. When Torvald plans to dismiss Krogstad from his new bank post, Krogstad threatens exposure. Nora tries to delay Torvald's reading of the letter while her widowed friend Kristine Linde, once attached to Krogstad, offers to speak with him. Kristine and Krogstad reconcile, but she insists that the truth must remain in the Helmers' letterbox. Torvald reads it and responds not with the self-sacrifice Nora imagined but with anger about his reputation. Even after Krogstad returns the bond and Torvald offers forgiveness, Nora recognizes that her marriage has denied her an adult identity. She leaves Torvald and their children to learn who she is and what she believes, ending the household she once worked so hard to preserve.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1347,7 +1347,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1360,7 +1360,7 @@
       "recaps": {
         "ending": "After the dance upstairs, Torvald reads Krogstad's letter and responds to Nora's secret with panic and condemnation. He worries about his reputation, calls her unfit to raise their children, and insists that their marriage continue only for appearances. A second message returns Nora's bond, and Torvald immediately announces that the danger has passed and that he forgives her. His reversal makes clear to Nora that he has been protecting himself, not her. She changes out of her costume and speaks to him with a seriousness he has never expected. Concluding that both her father and husband have treated her as a pleasing possession, she says that she must educate herself and determine her own convictions before she can be a wife or mother. Torvald's appeals cannot change her decision. Nora returns her keys and wedding ring, leaves Torvald and the children, and shuts the outer door behind her. Kristine and Krogstad, by contrast, have chosen to reunite and build a shared life, while Doctor Rank has sent notice that his death is near.",
         "in_short": "Nora Helmer seems happily dependent on her husband, Torvald, but she secretly borrowed money to finance the trip that saved his health and obtained it by signing her father's name. When Torvald plans to dismiss the lender, bank clerk Nils Krogstad, Krogstad threatens to expose her. Nora tries to delay discovery while her widowed friend Kristine Linde reconnects with Krogstad. Kristine decides the truth must emerge and leaves his letter for Torvald to read. Torvald reacts not with the self-sacrifice Nora imagined but with anger about his reputation; when the incriminating bond is returned, he abruptly forgives her. Nora recognizes that their marriage has denied her an adult identity. She rejects Torvald's demand that she remain, leaves her husband and children, and goes out alone to learn who she is and what she believes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1485,7 +1485,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1498,7 +1498,7 @@
       "recaps": {
         "ending": "After the masquerade, Torvald reads Krogstad's letter and learns about Nora's forged signature. He responds by condemning her and concentrating on the threat to his own reputation, declaring that their outward marriage must continue even though she cannot be trusted with the children. Krogstad then returns the bond and abandons his threat. Torvald immediately says the danger has passed and offers forgiveness, but Nora understands that the self-sacrificing rescue she expected from him was an illusion. She changes out of her costume and explains that first her father and then Torvald treated her as a pleasing possession rather than an equal adult. Concluding that she must educate herself and decide her own moral beliefs, she leaves Torvald, the children, and the household despite his pleas. She returns her wedding ring, takes her belongings, and closes the door behind her, leaving Torvald alone with only the faint possibility that their relationship could someday be transformed.",
         "in_short": "Nora Helmer appears to enjoy a comfortable marriage to Torvald, but she secretly owes money to Krogstad for the journey that once restored Torvald's health. She obtained the loan by forging her father's signature. When Torvald becomes bank manager and decides to dismiss Krogstad, Krogstad threatens exposure. Nora tries unsuccessfully to change Torvald's mind and delays him from reading the incriminating letter. Her widowed friend Kristine Linde reunites with Krogstad, but insists that the Helmers must face the truth. Torvald reads the letter and, instead of protecting Nora, denounces her because the scandal may ruin him. Although he reverses himself when Krogstad returns the bond, Nora recognizes that their marriage has denied her equality and independent judgment. She leaves her husband and children to learn how to live as an adult on her own terms.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1635,7 +1635,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1648,7 +1648,7 @@
       "recaps": {
         "ending": "Frederic and Catherine spend the winter quietly in Switzerland, awaiting their child, then move nearer a hospital in Lausanne. Catherine's labor becomes prolonged and dangerous. The baby, delivered by Caesarean section, is stillborn, and Catherine begins to hemorrhage. Frederic understands that the doctors cannot save her. He stays with her through her final hours, but she dies before they can build the life they had imagined beyond the war. After trying to say goodbye to her body, Frederic leaves the hospital alone and walks back to his hotel in the rain. His desertion has carried him out of the Italian army, but it cannot protect Catherine or their child from chance and mortality; the private refuge on which he depended ends with him entirely alone.",
         "in_short": "American ambulance officer Frederic Henry serves with the Italian army and begins an affair with British nurse Catherine Barkley. After a mortar attack badly wounds him, Catherine nurses him in Milan and their initially playful attachment becomes a committed relationship. She becomes pregnant, and Frederic returns to the front as the Italian position collapses. During the retreat from Caporetto, military police begin executing officers separated from their units. Frederic escapes by diving into a river, abandons the army, and reunites with Catherine. Warned that he faces arrest, the couple row across Lake Maggiore into neutral Switzerland. They live there peacefully until Catherine goes into labor. Their son is stillborn; Catherine then dies from hemorrhage, leaving Frederic to walk away from the hospital alone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1819,7 +1819,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1832,7 +1832,7 @@
       "recaps": {
         "ending": "Cersei Lannister's grasping regency ends in disaster. Having empowered the militant Faith to strike at her enemies, she is herself denounced for adultery and treason and thrown into a cell to await the Faith's judgment, stripped of power and abandoned. Her plea for help reaches Jaime, who reads her letter and coldly refuses, choosing to burn it and turn away, the breach between the twins now open. Brienne, having tracked the roads in search of Sansa, falls into the hands of a band of vengeful outlaws led by a hanged and revived Catelyn Stark, and is given a brutal choice between a sword and a noose, screaming a single word as the volume closes. Sansa remains hidden in the Vale, growing more capable under Baelish's tutelage. Arya, having killed on the order of her mysterious masters, is struck blind as a test of her devotion. Samwell reaches the southern city of Oldtown to begin his maester's training, though the ancient Maester Aemon dies on the journey. The ironborn, now led by the ruthless Euron Greyjoy, look outward toward conquest, and the realm settles into an uneasy, exhausted lull with no true peace in sight.",
         "in_short": "With the great war largely spent, the survivors scramble amid the wreckage. Queen Cersei, ruling as regent for her young son Tommen, grows ever more paranoid, turning on allies and kin alike. To undercut her rivals, she rearms the religious militants of the Faith and empowers their austere leader, a decision that swiftly rebounds upon her. Jaime, sickened by his sister, rides into the river lands to bring the last sieges to a bloodless close and drifts further from her. Brienne of Tarth roams the ruined countryside searching for Sansa, who is in truth hidden in the Vale, being schooled in intrigue by Petyr Baelish. In Braavos, Arya begins her strange apprenticeship among the servants of a death god. On the Iron Islands, the ironborn hold a kingsmoot after their lord's death, and the fearsome exile Euron Greyjoy seizes the crown of salt and rock. In Dorne, a plot to crown a young princess collapses in blood. Cersei's schemes finally trap her: accused of adultery and treason, she is seized and imprisoned by the very Faith she armed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1904,7 +1904,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1917,7 +1917,7 @@
       "recaps": {
         "ending": "Michael and Laura resist the fading of memory and feeling that ordinarily separates the dead from both life and one another. Their love gives them a final shared connection before they disappear from Rebeck's sight, passing beyond the limited existence he has observed in the cemetery. Their departure forces him to recognize that his refuge has also become a way of refusing change. Gertrude Klapper offers him companionship in the living world, and he finally accepts the risk of leaving the place where he has hidden for nineteen years. Rebeck walks out of Yorkchester Cemetery with her. The raven, which has sustained and challenged him throughout his retreat, remains associated with the life he is leaving behind. The novel closes with the two pairs transformed by love: the ghosts have found closeness before passing on, and Rebeck returns to ordinary human life with Mrs. Klapper rather than remaining safely entombed among the dead.",
         "in_short": "Jonathan Rebeck has hidden for nineteen years in Yorkchester Cemetery, where a talking raven brings him food and he alone can converse with the dead. He guides the newly arrived ghost Michael Morgan through an afterlife in which memory and sensation slowly fade. Laura Durand's spirit soon joins them, and she and Michael fall in love despite Rebeck's belief that the dead cannot sustain such bonds. Meanwhile, the widowed Gertrude Klapper discovers Rebeck while visiting her husband's grave. Her repeated visits and practical kindness draw him toward a living relationship he fears to accept. Michael and Laura preserve enough feeling to share a final connection before disappearing beyond Rebeck's sight. Their courage exposes Rebeck's long retreat as another kind of death. He ultimately leaves the cemetery with Mrs. Klapper, choosing uncertain companionship and renewed participation in life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2100,7 +2100,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2113,7 +2113,7 @@
       "recaps": {
         "ending": "The Emergency leaves the household permanently scattered. After the forced-sterilization camp, Ishvar loses both legs to infection and Om is castrated on Thakur Dharamsi's orders. Their tailoring livelihood is gone, and they eventually survive by begging together. Dina's landlord ends her illegal sewing business and she cannot maintain the flat; Nusswan takes her into his home, where her security depends on serving his family and accepting the authority she resisted for years. Maneck leaves India for work in the Gulf. When he returns in 1984 after his father's death, he finds his family home and the people he loved altered or lost. He learns of Avinash's death and his sisters' suicides, sees the reduced circumstances of Dina, Ishvar, and Om, and concludes that the future holds no recovery. After encountering Ishvar and Om begging in the street, he deliberately steps in front of a train. Dina continues to give the two men food when they visit, and their teasing briefly restores the ease of the old household, a surviving fragment of affection within lives narrowed by violence and dependency.",
         "in_short": "During India's 1975 Emergency, four people form an improvised household in a coastal city. Widowed Dina Dalal hires village tailors Ishvar and Omprakash and takes student Maneck Kohlah as a boarder, hoping the income will preserve her independence. The tailors have fled caste violence that killed their family; Maneck is estranged from a changing mountain home and shaken by the disappearance of his activist friend. Suspicion gives way to friendship as they work and eat together, but state campaigns repeatedly destroy their footing. A slum clearance makes the tailors homeless, police send them to forced labor, and a later mass-sterilization drive returns them to the village power that once murdered their relatives. Ishvar loses his legs and Om is castrated. Dina loses her flat and becomes dependent on her controlling brother; the tailors become beggars. Years later Maneck returns from overseas, sees how completely their shared hopes have collapsed, and kills himself. Dina still secretly welcomes Ishvar and Om for meals, preserving a small remnant of their former family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2288,7 +2288,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2301,7 +2301,7 @@
       "recaps": {
         "ending": "Rachel and her allies escape the northern Were factions with Nick and Jax alive. The immediate pack leaders pursuing them are defeated or driven off, but the Were Focus is not destroyed; Rachel brings the artifact back to Cincinnati, where its ability to unite Were packs makes possession of it a continuing political danger. She learns that Nick was not merely a victim. He helped steal the Focus from Trent and allowed Rachel to enter the conflict without telling her the truth, using her loyalty to improve his own chance of escape. Rachel ends their relationship decisively and no longer treats him as a trusted ally. Jenks returns safely to pixy size after the curse that let him travel and fight as a human-sized partner, though Jax's choices leave strain within the family. Rachel's pack bond with David remains in force. Ivy and Rachel survive the rescue with their partnership intact but their intimate and vampiric boundaries still unresolved. Trent does not recover the Focus, and the history Rachel shares with him yields no new trust.",
         "in_short": "When Nick and Jenks's son Jax disappear after stealing a potent Were artifact, Rachel and Jenks travel to northern Michigan to rescue them. Ceri uses demon-derived magic to make Jenks human-sized, letting him operate openly beyond pixy territory. Rachel also joins David Hue's small pack, gaining standing in Were society. They find Nick and Jax caught among rival Were factions seeking the Focus, an artifact capable of uniting packs under one leader. Ivy follows the rescue and helps them survive the escalating conflict, while Trent's agents pursue his claim to the stolen object. Rachel and her allies escape with both captives alive and the immediate pursuers defeated. The rescue also exposes Nick's betrayal: he participated willingly in the theft and withheld the truth so Rachel would help him. Rachel ends their relationship. Jenks returns to normal size, Rachel's pack bond with David continues, and she carries the Focus back to Cincinnati rather than resolving the larger struggle over it. The object leaves her vulnerable to every faction that wants to control the Weres.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2659,7 +2659,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0D7X4X7SN",
@@ -2671,7 +2671,7 @@
       "recaps": {
         "ending": "Sebastien survives the High Crown's hostage operation and a Red Guard contest, but both conflicts leave lasting exposure. She keeps her identities separate from the public, acquires a private home and warded resources, opens Merton's journal, and gains the effective raven sleep proxy. Thaddeus Lacer returns her mother's genuine ring and agrees to represent her interests within the Red Guard, while remaining unaware that the being sealed in her memory briefly controlled her detached shadow. Oliver retains a different journal, and their damaged partnership resumes on guarded, more equal terms. Damien continues investigating suppressed Red Guard conduct without knowing Sebastien is the Raven Queen. Liza, Anna, the Nightmare Pack, and the Verdant Stag survivors remain allies with separate obligations. Ennis is free but missing, Edgar has vanished, Parker is dead, and Parker's family has been relocated. Kiernan has stopped answering while an Architects of Khronos team threatens people in Osham. The solarium shortage, the missing fifth journal, the sealed being, Red Guard attention, and the Raven Queen's expanding organized worship all remain unresolved.",
         "in_short": "Sebastien begins the term under official scrutiny while preparing to break the sympathetic link authorities can use against the Raven Queen. A High Crown operation instead abducts her with children and faction allies, hoping the captives will draw the Raven Queen into a trap. She escapes sensory deprivation, turns two guards, rescues the prisoners, and leads them out, though Parker is captured and later dies. While recovering, she learns that five Merton journals may exist and that one may describe converting beast cores into solarium as natural supplies fail. Oliver admits stealing that journal, fracturing their alliance, while Sebastien eventually opens her own. Her sleep-proxy research succeeds, Ennis escapes, and Damien joins a cautious investigation into Red Guard abuses. A Red Guard contest ends when the being sealed in Sebastien's memory takes control of her detached shadow. Thaddeus Lacer becomes her tentative intermediary and returns her mother's ring. She and Oliver restore limited cooperation, but the Architects' Osham operation and an uncontrolled faith in the Raven Queen remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2888,7 +2888,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2901,7 +2901,7 @@
       "recaps": {
         "ending": "Ned Stark is executed on King Joffrey's order despite the mercy he was promised, shattering any hope of peace. His son Robb, declared King in the North, wins his early battles and captures the knight Jaime Lannister, with his mother Catelyn at his side. Sansa remains a captive in King's Landing, betrothed to the boy king who killed her father, while Arya, disguised as a boy, escapes the capital and is carried northward. Crippled Bran and his little brother Rickon remain at Winterfell, and Bran is troubled by vivid wolf-dreams. Jon Snow commits fully to the Night's Watch as unmistakable signs mount that the ancient enemy beyond the Wall is returning. Farthest away, Daenerys Targaryen, widowed and childless after the death of Khal Drogo, steps into his funeral pyre clutching three fossilized dragon eggs and rises from the ashes unburned, three living dragons clinging to her, reborn as a queen with a power the world had thought long dead. The realm has broken into open war, and every side believes itself the rightful one.",
         "in_short": "Lord Eddard Stark leaves Winterfell to serve his friend King Robert as Hand of the King, a post whose previous holder was murdered. Investigating in the capital, Ned learns the deadly secret that Queen Cersei's children are not the king's but were fathered by her own twin brother, Jaime Lannister. Before he can act, Robert dies of a hunting wound, and Cersei's cruel son Joffrey takes the throne. Betrayed by allies he trusted, Ned is arrested and, despite a promise of mercy, publicly beheaded. His son Robb raises the North and is proclaimed King in the North, while Robert's brothers Stannis and Renly each claim the crown too, plunging the realm into war. The Stark family is scattered: Sansa a hostage, Arya fleeing in disguise, Bran crippled and left at Winterfell, and Jon Snow sworn to the Night's Watch as an ancient enemy wakes beyond the Wall. Across the sea, the exiled Daenerys Targaryen loses her warlord husband and unborn child, then walks into his funeral pyre and emerges unburned with three newborn dragons, the first the world has seen in over a century.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3065,7 +3065,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3078,7 +3078,7 @@
       "recaps": {
         "ending": "The tournament ends in disaster instead of a ceremony. Ojka lures Kell away from the arena and very nearly kills him before Lila reaches them and kills her instead. Holland then takes Kell himself and drags him through to White London, because what Osaron needs is an Antari, and Kell's blood will open a door into a living world. In the palace, Rhy is stabbed in the chaos and does not die, because he cannot while Kell lives, and the carefully kept secret of what Kell did to save him is no longer safe. Lila's own nature is now known to Kell and Alucard: she is Antari, the third of them, self-taught and largely untrained. She forces Alucard to turn the Night Spire toward White London to go after Kell. The book closes with Kell a prisoner in the world he was warned about, Rhy wounded on a throne he has not inherited, Holland restored and no longer anyone's servant, and Osaron poised to cross into a living city.",
         "in_short": "Four months after the black stone, Kell is a restricted, resented royal messenger and Rhy, unkillable while Kell lives, is staging a great international magicians' tournament in Red London. Lila Bard has joined the privateer crew of Captain Alucard Emery, learning the sea and hiding how fast her magic is growing. In Black London, Holland is found half-dead by Osaron, the living magic of that dead world, and takes its bargain: it makes him whole, restores White London to life, and puts him on its throne, in exchange for a way into a living world. Holland sends his agent Ojka after Kell. In Red London, Kell enters the tournament in disguise and so does Lila, and their secrets come apart in front of each other: Lila is Antari too. The tournament is broken up by an attack. Lila kills Ojka, but Holland takes Kell through to White London to use his blood as a doorway, and Rhy is stabbed and survives only because of the bond. Lila and Alucard sail for White London.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3251,7 +3251,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3264,7 +3264,7 @@
       "recaps": {
         "ending": "Sofia travels to Paris as a concert pianist and, following the plan she and Rostov have prepared, slips away from her Soviet minders and reaches the American embassy. Her success gives Rostov the signal to carry out his own long-planned departure. After more than three decades of confinement, he escapes the Metropol by using his intimate knowledge of its routines and by neutralizing the Bishop's attempt to stop him. Rostov does not follow Sofia west. He makes his way instead toward his family's former country estate, now ruined, and finally reaches a nearby inn. There he finds Anna Urbanova waiting for him. Sofia has a future outside Soviet control, Rostov has regained the freedom to choose his path, and his reunion with Anna closes the life he built during his imprisonment without restoring the aristocratic world that vanished around him.",
         "in_short": "In 1922, a Bolshevik tribunal sentences Count Alexander Rostov to remain for life inside Moscow's Hotel Metropol. Forced from a luxury suite into the attic, he turns the hotel into a complete world, finding purpose through friendships with its staff, the adventurous child Nina, actress Anna Urbanova, and his poet friend Mishka. He eventually joins the Boyarsky restaurant staff and, when Nina disappears after leaving her daughter Sofia in his care, becomes the girl's father in practice. Decades of Soviet upheaval pass through the hotel's doors while Rostov protects a private culture of loyalty, hospitality, and memory. Sofia grows into an exceptional pianist. When an overseas performance offers her a chance to defect, Rostov plans her escape and his own. She reaches safety at the American embassy in Paris; he finally leaves the Metropol, returns toward his lost family estate, and reunites with Anna at a country inn.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3413,7 +3413,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3426,7 +3426,7 @@
       "recaps": {
         "ending": "After Messinger dies during their attempt to leave the interior, Tony wanders alone until Mr Todd's household finds him. Todd nurses him back to health but then makes his hospitality a prison: he wants Tony to remain indefinitely and read Dickens aloud. When searchers arrive, Todd drugs Tony, hides him, and tells them that the missing Englishman died. The expedition returns with that report, so Tony is legally treated as dead while he remains captive in the forest. In England, Brenda's affair with Beaver has already collapsed once it becomes clear that Tony will not finance the proposed divorce settlement. She eventually marries Jock Grant-Menzies. Hetton passes to Tony's relatives, who continue its country-house routines and put up a memorial to him, unaware that he is alive and compelled to serve as Todd's reader.",
         "in_short": "Tony Last is content at Hetton Abbey, but his wife Brenda is bored and begins an affair with the socially insignificant John Beaver. She establishes a London life while Tony remains trusting. After their son John Andrew dies in a riding accident, Brenda asks for a divorce. Tony initially agrees to stage adultery so she can obtain one, then refuses when her family demands a settlement that would cost him Hetton. He escapes the wreck of his marriage by joining Dr Messinger's search for a legendary city in Brazil. The expedition fails, Messinger dies, and Tony is rescued by the isolated Mr Todd. Todd values him chiefly as someone who can read Dickens aloud and prevents him from leaving, even deceiving a search party into reporting Tony dead. Brenda later marries Jock Grant-Menzies, Tony's relatives inherit Hetton, and Tony remains alive but trapped in the forest as Todd's permanent reader.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3570,7 +3570,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3583,7 +3583,7 @@
       "recaps": {
         "ending": "Possessed by the hiver, Tiffany is turned into a proud, careless, and increasingly dangerous version of herself, the ancient thing riding her power without understanding it. The Feegle and Granny Weatherwax intervene, and with their help Tiffany claws her way back to awareness inside her own mind. She realizes that the hiver cannot be simply driven off or destroyed, because it has no self to attack: it is a formless thing that has never known what it is. Rather than fight it, she draws it fully into herself and then gives it the one thing it has always lacked, a sense of being someone who can die. Made aware of itself and of its own ending for the first time, the hiver is led gently to Death and finds the peace it never knew it wanted. This happens around the great gathering the witches call the trials, where Tiffany's handling of the crisis is witnessed. Miss Level, gravely hurt during the ordeal, survives. Granny Weatherwax, who has tested and watched Tiffany throughout, grants her a rare and hard-won measure of respect, acknowledging her as a true witch. Tiffany returns to the Chalk having mastered both the hiver and herself, more fully aware of the responsibility and the power she carries.",
         "in_short": "Tiffany Aching, now eleven, leaves the Chalk to be trained as a witch, apprenticed to Miss Level, a kindly research witch who shares one mind between two bodies. Watched over from afar by the Feegle and by the formidable Granny Weatherwax, Tiffany learns the humble, practical work of a rural witch, but grows overconfident. An ancient, mindless predator called the hiver, drawn to powerful minds, catches and possesses her, and under its influence she becomes arrogant, cruel, and dangerous, no longer herself. The Nac Mac Feegle and Granny Weatherwax realize what has happened and set out to save her, and Miss Level is badly hurt in the crisis. Fighting back from within, Tiffany journeys into her own self to find the strength to master the thing that has taken her. At the great gathering of witches she finally defeats the hiver, not by force but by giving it what it has never had, an awareness of itself and of its own death, leading it at last to an ending. Tiffany comes fully into her own as a witch, earns Granny Weatherwax's hard-won respect, and returns to the Chalk stronger and surer of who she is.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/a-hero-of-our-time.json
+++ b/data/works-community/0/a-hero-of-our-time.json
@@ -127,7 +127,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -140,7 +140,7 @@
       "recaps": {
         "ending": "During an officers' debate about fate, Vulich stakes his life on the belief that death comes at an appointed moment. A pistol fails when he fires it at his head, though it works immediately afterward. Pechorin nevertheless senses that Vulich is marked for death, and that same night a drunken Cossack kills him. Pechorin risks entering the armed killer's room and helps capture him alive, yet the apparent confirmation of fate does not give him certainty. The journal closes with his unresolved reflection on whether courage, chance, or destiny governed the night. In the outer narrative, the reader already knows that Pechorin later died while returning from Persia; the traveling narrator publishes these papers after learning of his death.",
         "in_short": "A traveler in the Caucasus hears Staff Captain Maxim Maximovich describe Pechorin, a brilliant but dissatisfied officer who abducted the Circassian princess Bela through a bargain with her brother. Bela eventually loved Pechorin, but his interest faded, and Kazbich fatally stabbed her. The traveler later witnesses Pechorin's cold reunion with Maxim and acquires his abandoned journals after Pechorin dies. In them, Pechorin disrupts smugglers at Taman, then manipulates a spa society: he wins Princess Mary's love, resumes an affair with Vera, and kills the resentful Grushnitsky in a compromised duel before rejecting Mary. In the final episode, Vulich tests predestination and survives a pistol misfire, only to be murdered hours later. Pechorin captures the killer but remains unsure whether the incident proves fate. Across the linked stories, his search for stimulation repeatedly harms people who offer him trust or love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -294,7 +294,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -307,7 +307,7 @@
       "recaps": {
         "ending": "Hiccup, Fishlegs and Camicazi escape the Meathead Public Library with Toothless after surviving the Hairy Scary Librarian, his traps and the dragons that guard the collection. Hiccup saves knowledge that the librarian's rules would have kept locked away or destroyed, and the adventure gives him the understanding he needs to finish his own guide to dragons. He also makes it through the Viking testing surrounding his birthday, although not by turning into the large and violent hero the programme was designed to reward. The result is another victory for Hiccup's curiosity: books, careful observation and his ability to speak to dragons prove more useful than treating either books or dragons as enemies. He returns to his place among the Hooligans with his friends safe and with a growing written record of what he has learned about dragonkind.",
         "in_short": "On his birthday, Hiccup must face another stage of Gobber's Pirate Training Programme while also dealing with a book that has to go back to the forbidden Meathead Public Library. Hiccup, Fishlegs, Camicazi and Toothless break into the library, where books are guarded as dangerous treasures by the Hairy Scary Librarian and his dragons. Moving through traps, shelves and tunnels, Hiccup discovers that the knowledge kept there matters more than the rules meant to hide it. The Librarian hunts the children, and Driller-Dragons make the stone building itself unsafe. Hiccup escapes with his friends and saves the information he needs. He survives his birthday test without becoming the conventional hero his teachers expect, and his observations become part of his own guide to deadly dragons.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -428,7 +428,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -441,7 +441,7 @@
       "recaps": {
         "ending": "After the weekly death totals reach their terrible height, the epidemic begins to recede. The change first seems almost impossible to trust, then becomes visible across successive bills of mortality. Londoners respond with relief so immediate that many abandon precautions before the danger has fully passed, returning to the streets, trade, and one another's company. Some newly exposed people still die, but the downward movement continues. Families and merchants who fled begin to return, and normal civic and commercial life gradually resumes. H. F. interprets the city's deliverance through providence while continuing to acknowledge the uneven, often inexplicable path of infection. He survives to assemble what he has observed directly with official figures and stories gathered from credible witnesses. The account closes not with a conventional personal resolution but with the restored city and the narrator's insistence that he lived through the calamity he has recorded.",
         "in_short": "H. F., a London tradesman, remains in the city during the great plague of 1665 and records its advance from scattered rumors to mass death. He follows the bills of mortality, watches the wealthy flee, and describes official attempts to contain infection by shutting households under guard. Such measures sometimes spread suffering or provoke escape, while quack remedies, prophecy, theft, and profiteering flourish beside charity and courage. Streets empty; commerce falters; dead carts collect bodies at night for burial in mass pits. H. F. moves cautiously through the city, relates the experiences of physicians, burial workers, isolated families, and three poor travelers who form a camp outside London, and considers how poverty makes flight impossible for many. At the epidemic's peak ordinary distinctions and routines collapse. Deaths then decline with surprising speed. People return too eagerly to public life, but the improvement holds, businesses reopen, and absent residents come home. H. F. survives and frames London's recovery as providential deliverance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -531,7 +531,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -544,7 +544,7 @@
       "recaps": {
         "ending": "After finding Saknussemm's mark beside a blocked passage, Lidenbrock orders the obstruction blasted open. The explosion sweeps the travelers and their raft into a violent downward rush. They are carried through connected waters and then driven upward inside a volcanic shaft as heat, steam, and molten rock build beneath them. The eruption expels them from Stromboli in the Mediterranean, far from their Icelandic entrance but alive. They return to Hamburg to public acclaim. Lidenbrock's contested theory appears vindicated by their survival and records, and Axel discovers that a compass anomaly can be explained by its needle having reversed during the electrical storm underground. Hans eventually returns to Iceland with his wages and the travelers' gratitude. Axel marries Gräuben, while Lidenbrock enjoys international fame for the journey.",
         "in_short": "Hamburg professor Otto Lidenbrock finds a coded note by the Icelandic scholar Arne Saknussemm claiming that a route to the earth's center lies inside Snæfellsjökull. He takes his reluctant nephew Axel to Iceland and hires the unflappable guide Hans. The three descend through the crater, survive thirst with water Hans finds, and travel far beneath the surface. After Axel becomes separated and is rescued, they reach a vast subterranean sea, cross it by raft, encounter prehistoric life, and land near fossils and evidence of gigantic beings. Saknussemm's initials confirm that he preceded them, but his route is blocked. Their attempt to blast through unleashes a flood that carries them deeper and then upward through a volcanic conduit. They are erupted from Stromboli and return to Hamburg alive. Lidenbrock becomes celebrated, Hans goes home to Iceland, and Axel marries Gräuben.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -673,7 +673,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -686,7 +686,7 @@
       "recaps": {
         "ending": "After Joan loses her position and Eunice realizes that the Coverdales are close to exposing her illiteracy, the two women turn their religious and class resentment into violence. They take the household's guns and kill George, Jacqueline, Melinda, and Giles while the family listens to an opera at Lowfield Hall. The murderers try to destroy evidence and leave the scene, but the investigation gradually breaks through their attempted concealment. A recording made in the room preserves sounds associated with the killings and helps establish what happened. Joan dies before she can be brought to trial, while Eunice is arrested. Her secret, protected through years of evasion and finally through murder, becomes public after all. The novel closes not on an unknown culprit but on the completion of the chain announced at the beginning: shame, isolation, Joan's fanaticism, and the Coverdales' well-meant interference have converged in the destruction of the household.",
         "in_short": "Eunice Parchman becomes housekeeper to the affluent Coverdale family at Lowfield Hall while hiding that she cannot read or write. George, Jacqueline, Melinda, and Giles value her efficient work but repeatedly mistake her guardedness for a social problem they can cure. Their letters, messages, and friendly questions threaten the system of evasions by which she has protected her secret. Eunice forms her only close friendship with Joan Smith, a local religious zealot whose bitterness and appetite for condemnation reinforce Eunice's resentment. When the Coverdales come close to understanding the truth and Joan's own life collapses, the women convince themselves that the family represents a corrupt world set against them. Armed with the household's guns, they murder all four Coverdales as an opera plays. Evidence left at the scene and on a recording exposes them; Joan dies and Eunice is arrested, with the illiteracy she killed to conceal finally known.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -820,7 +820,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -833,7 +833,7 @@
       "recaps": {
         "ending": "Jud gives Billy money to place an accumulator bet, but Billy does not place it and uses the money himself, convinced the selections cannot all win. They do win, costing Jud a substantial payout. Jud retaliates against the one thing Billy values: he kills Kes and leaves her body for Billy to find. Billy retrieves the dead kestrel and confronts a household in which neither Jud's violence nor his own grief receives meaningful correction. He carries Kes away and buries her alone. The ending offers no institutional rescue and no sudden change in Billy's prospects. School has failed to recognize his abilities except in isolated moments, employment advice has directed him toward the same mine he fears, and home has destroyed the demanding private practice through which he had made a different identity. His careful burial is a final act of respect for the bird and a measure of the loss.",
         "in_short": "Billy Casper is a neglected fifteen-year-old in a South Yorkshire mining town, dismissed at school and bullied at home by his older half-brother Jud. Away from these pressures, Billy has taken a kestrel from a nest and taught himself falconry. Training Kes reveals patience, knowledge, and self-command that adults usually fail to see. During one school day he is humiliated in physical education, briefly respected when his English teacher invites him to describe the hawk, and given perfunctory careers advice that points toward the mine. Jud orders Billy to place a multi-horse bet, but Billy spends the stake because he assumes it cannot win. Every horse does win. In revenge for the lost payout, Jud kills Kes. Billy finds the bird, carries her away, and buries her alone. The one relationship that allowed him competence and freedom is destroyed, while the family, school, and labor system surrounding him remain unchanged.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1002,7 +1002,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1015,7 +1015,7 @@
       "recaps": {
         "ending": "The inquiry ends with the Service intending to settle: the claimants will be paid off, the record will be tidied, and the responsibility will rest where it can do the modern Service least harm, which means on Guillam and on men who are dead. Guillam, having told as much of the truth as he judges the dead can bear and having been threatened by Christoph Leamas along the way, leaves London rather than wait for the verdict, and goes to Germany to find Smiley. He finds him very old, in a library in Freiburg, still reading, unrepentant and precise. Smiley confirms what Guillam had worked out: Mundt was the Circus's agent, Windfall existed to protect him, Tulip died at his hands and the Circus concealed it, and Leamas and Liz Gold were expended in the same cause without being told. Asked what it was all for, Smiley says he did it for his service and his country while he believed in them, and that if there was a cause beyond that it was Europe. He offers no defence beyond the fact that the choices were made by men who knew what they cost. Guillam goes back to Brittany, the past acknowledged and nothing about it repaired.",
         "in_short": "Peter Guillam, long retired to a farm in Brittany, is summoned to London by the modern Service. The children of Alec Leamas and Liz Gold, who died at the Berlin Wall decades earlier, are suing, and a parliamentary committee wants an account of the operations that killed them. Questioned by the Service's lawyer Bunny and its historian Laura, and confronted with files he helped to write and to weed, Guillam recalls the Berlin operations of the fifties and sixties: the East German network, and its best source, a woman code-named Tulip, the wife of a Stasi officer, whom Guillam helped to exfiltrate through Prague and with whom he fell in love. Tulip was murdered soon after reaching England, and the Circus buried it, because her killer was Mundt, the East German operations chief who was also the Circus's own agent. Everything that followed, including the operation that destroyed Leamas and Liz Gold, existed to keep Mundt in place. Threatened by Leamas's son and set up as the Service's scapegoat, Guillam finally tracks down George Smiley in Freiburg and hears him account for it all.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1173,7 +1173,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1186,7 +1186,7 @@
       "recaps": {
         "ending": "As the execution approaches, Jefferson's diary shows that he has accepted Grant's challenge to stand for himself and for the community. Grant cannot bring himself to attend, so he waits at the school with his pupils while the electric chair is used at the jail. A butterfly pauses near him and then flies away, marking the moment he understands that Jefferson has died. Paul Bonin later comes to the school and reports that Jefferson walked to the chair with extraordinary composure and was the bravest person present. Paul offers Grant his friendship and promises to bring him Jefferson's notebook. Grant returns to his students and finally allows himself to cry. Jefferson cannot escape the unjust system that condemned him, but he defeats the degrading image imposed on him at trial by choosing how he meets death. His courage also changes Grant, reconnecting the teacher to his pupils and community and giving him evidence that dignity, responsibility, and human fellowship remain possible within circumstances he had regarded as hopeless.",
         "in_short": "In segregated 1940s Louisiana, Jefferson is sentenced to death after being caught at a liquor-store shooting he did not plan. His lawyer's demeaning defense leaves him believing he is no better than an animal. Jefferson's godmother, Miss Emma, asks schoolteacher Grant Wiggins to help him die with the dignity of a man. Grant is angry, skeptical of religion, and eager to leave the plantation, but repeated jail visits slowly create trust. He brings Jefferson food, a radio, a notebook, and the idea that courage can make him a representative of people denied public power. Jefferson begins speaking, writing, and thinking beyond his humiliation. Grant also learns from Vivian, Tante Lou, Reverend Ambrose, and the young deputy Paul that education carries obligations as well as escape. Jefferson walks calmly to the electric chair. Paul tells Grant that he was the bravest person there, and Grant weeps before his pupils, changed by the man he was supposed to teach.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1368,7 +1368,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1381,7 +1381,7 @@
       "recaps": {
         "ending": "Yackle finishes her deposition on her own terms. She reveals that the Grimmerie, the Witch's book of magic, has been hidden beneath the Cloister of Saint Glinda all along, and she gives it up not to the Emperor's court but to Brrr and the company he travels with. Her long refusal to die ends with the handing over: whatever she was made for is discharged, and she is put in the ground, willingly, and stays there. Brrr then makes the first uncowardly choice of his life by defaulting on his commission. He keeps the book, walks away from his title and his creditors at court, and leaves with the dwarf Mr. Boss, the veiled Ilianora, whose history reaches back into the Witch's own household, and Little Daffy, the dispensing maunt, who abandons the convent to go with them. The cloister is left empty for the advancing army. The war between Loyal Oz and Munchkinland is still escalating, the Emperor still wants the Grimmerie and still wants the Witch's descendants, and a green-skinned child of that line is somewhere in the country, unaccounted for. The Clock of the Time Dragon rolls on with the most sought-after object in Oz aboard it and a disgraced Lion walking alongside.",
         "in_short": "The Cowardly Lion, now titled, indebted and working as an agent of the Emperor's court, arrives at a rural cloister in the path of an advancing army with orders to interrogate its strangest inhabitant: Yackle, an ancient woman shut in the crypt because she cannot manage to die. What the court wants from her is the Witch's book of magic and any surviving trace of the Witch's family. The novel alternates their two testimonies. Yackle cannot say where she came from, remembers no childhood, and suspects she was made for a purpose tied to the Witch's line. Brrr recounts his whole life: waking as a cub alone in the forest, the dying soldier Jemmsy, the Ozmists who found him useless, years of failing to belong among either Animals or humans, an errand for the Emerald City that ended in other creatures' deaths and his own escape, and the accidental fame of walking to the Emerald City with Dorothy. In the end Yackle produces the Grimmerie from beneath the cloister, is at last allowed to die, and Brrr, instead of delivering the book to the Emperor, takes it and goes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1562,7 +1562,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1575,7 +1575,7 @@
       "recaps": {
         "ending": "After Willem, Malcolm, and Sophie die in a car crash, Jude loses the future that had made his life feel bearable. Harold, Julia, Andy, Richard, and JB remain connected to him, but their care cannot stop his worsening isolation, self-harm, and conviction that the violence of his childhood has permanently defined him. Jude eventually dies by suicide. In the final section Harold looks back on the son he adopted, trying to hold together gratitude for their years as a family with anger and grief over the suffering he could not prevent. JB, the only surviving member of the original group of four, remains part of Harold's life, and their shared memories preserve Jude and their dead friends without resolving the loss.",
         "in_short": "Four college friends begin adult life together in New York: actor Willem, artist JB, architect Malcolm, and lawyer Jude. Their careers flourish and their friendships survive envy, addiction, separation, and reconciliation, but Jude conceals a childhood of exploitation and violence as well as continuing self-harm. Professor Harold Stein and his wife Julia adopt him, while Willem becomes first his most trusted friend and later his partner. Jude experiences a period of stability and love, yet never escapes the belief that he is damaged beyond recovery. A car crash kills Willem, Malcolm, and Malcolm's wife Sophie. Without Willem, Jude's health and will to live deteriorate despite the efforts of Harold and his remaining friends, and he eventually dies by suicide. Harold and JB are left to remember the family and friendships they lost.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1761,7 +1761,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1774,7 +1774,7 @@
       "recaps": {
         "ending": "Sara returns the escaped monkey to the neighboring house and speaks of her life in India and her father, allowing Carrisford and Mr. Carmichael to realize that she is the missing child they have sought. Carrisford was Captain Crewe's business partner; the diamond-mine investment did not fail permanently, and Sara has inherited a large fortune. She leaves Miss Minchin's school, and Becky joins her as a companion rather than a servant. Miss Minchin tries to reassert authority, but Sara answers calmly and is now beyond her power. Carrisford becomes Sara's guardian and regains some peace by caring for his friend's daughter. Sara later visits the bakery where she once received food and arranges to pay for meals for hungry children. The baker has already taken in Anne, the starving girl to whom Sara gave most of those buns. Sara's restored wealth therefore does not erase what she learned in poverty; she uses it to extend the kindness that helped her endure.",
         "in_short": "Sara Crewe enters Miss Minchin's London school as a wealthy, imaginative child adored by her father. She befriends the lonely Ermengarde, little Lottie, and the servant Becky, but her position collapses when Captain Crewe dies after apparently losing his fortune in diamond mines. Miss Minchin turns Sara into an unpaid servant living in an attic. Hungry and overworked, Sara preserves her dignity through stories, friendship, and acts of generosity. Next door, the invalid Tom Carrisford is unknowingly searching for her: he was Captain Crewe's partner, and the investment has recovered spectacularly. His servant Ram Dass sees Sara's hardship and secretly transforms her attic with food, warmth, and furnishings. When Sara returns Carrisford's escaped monkey, her identity is discovered. Her fortune is restored, she leaves the school with Becky as her companion, and Carrisford becomes her guardian. Sara then arranges for a bakery to feed other hungry children, carrying her experience forward as practical generosity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1968,7 +1968,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1981,7 +1981,7 @@
       "recaps": {
         "ending": "Mr. Carrisford discovers that the poorly dressed girl from the neighboring attic is Sara Crewe, the daughter of his dead business partner. Captain Crewe's investment was not lost after all: the diamond mines succeeded, leaving Sara a large fortune that Carrisford has been managing while searching for her. Sara leaves Miss Minchin's school to live in his welcoming house, and Becky becomes her companion rather than a servant. Miss Minchin tries to recover control when she realizes what has happened, but Sara no longer depends on her and declines to return. Lavinia recognizes that Sara's conduct in poverty proved the quality she once claimed in comfort. Remembering the hunger she suffered, Sara arranges with a baker to feed any needy child who comes to the shop. There she learns that the beggar girl to whom she gave buns has been taken in and given work. Sara's wealth and security are restored, but her response is shaped by the hardship that taught her how unseen deprivation can be.",
         "in_short": "Sara Crewe, the imaginative daughter of a wealthy officer, is placed at Miss Minchin's London school and treated as its show pupil. She befriends neglected children and servants, insisting that courtesy should not depend on rank. When her father dies after an apparently disastrous investment, Miss Minchin strips Sara of her possessions and forces her to work and sleep in the attic. Sara endures hunger, cold, and humiliation by sharing stories with Becky and imagining that dignity is still possible. In the neighboring house, her father's former business partner, Tom Carrisford, is searching unsuccessfully for her while recovering the fortune he once believed lost. His servant Ram Dass secretly transforms Sara's attic with food, warmth, and furniture. A wandering monkey finally brings Sara into Carrisford's house, where her identity is recognized. Her fortune restored, Sara takes Becky with her and creates an arrangement to feed hungry children, using her recovery to relieve the suffering she now understands firsthand.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2160,7 +2160,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2173,7 +2173,7 @@
       "recaps": {
         "ending": "Sara returns the escaped monkey to the neighboring house and speaks of her life in India and her father, allowing Carrisford and Mr. Carmichael to realize that she is the missing child they have sought. Carrisford was Captain Crewe's business partner; the diamond-mine investment did not fail permanently, and Sara has inherited a large fortune. She leaves Miss Minchin's school, and Becky joins her as a companion rather than a servant. Miss Minchin tries to reassert authority, but Sara answers calmly and is now beyond her power. Carrisford becomes Sara's guardian and regains some peace by caring for his friend's daughter. Sara later visits the bakery where she once received food and arranges to pay for meals for hungry children. The baker has already taken in Anne, the starving girl to whom Sara gave most of those buns. Sara's restored wealth therefore does not erase what she learned in poverty; she uses it to extend the kindness that helped her endure.",
         "in_short": "Sara Crewe enters Miss Minchin's London school as a wealthy, imaginative child adored by her father. She befriends the lonely Ermengarde, little Lottie, and the servant Becky, but her position collapses when Captain Crewe dies after apparently losing his fortune in diamond mines. Miss Minchin turns Sara into an unpaid servant living in an attic. Hungry and overworked, Sara preserves her dignity through stories, friendship, and acts of generosity. Next door, the invalid Tom Carrisford is unknowingly searching for her: he was Captain Crewe's partner, and the investment has recovered spectacularly. His servant Ram Dass sees Sara's hardship and secretly transforms her attic with food, warmth, and furnishings. When Sara returns Carrisford's escaped monkey, her identity is discovered. Her fortune is restored, she leaves the school with Becky as her companion, and Carrisford becomes her guardian. Sara then arranges for a bakery to feed other hungry children, carrying her experience forward as practical generosity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2302,7 +2302,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2315,7 +2315,7 @@
       "recaps": {
         "ending": "After years in refugee camps, Salva is chosen to resettle with a family in Rochester, New York. He learns English, studies, and eventually receives word that his father is alive in a clinic in Sudan. Their reunion confirms how severely unsafe water has harmed his family and gives Salva a purpose: he organizes a project to drill wells in rural Sudan. In Nya's village, the strangers who have been drilling finally reach clean water. The well removes the need for her twice-daily journey and makes a school possible, allowing girls such as Nya to attend. When Nya thanks the visiting leader of the project, she learns that he is Salva, a Dinka man helping a Nuer community despite the historic conflict between their peoples. The two timelines meet in a shared result: the endurance that once kept Salva walking now brings safe water and new opportunities to Nya's village.",
         "in_short": "In 1985, eleven-year-old Salva Dut flees fighting in southern Sudan and becomes separated from his Dinka family. He walks with other refugees toward Ethiopia, befriending Marial and finding protection with his uncle Jewiir, but both are killed during the journey. After years in an Ethiopian camp, Salva survives a forced river crossing and eventually reaches camps in Kenya. He is resettled in the United States, later finds his sick father alive in Sudan, and decides to bring wells to communities without safe water. In 2008, Nya, a Nuer girl, spends each day walking for contaminated water until a drilling team comes to her village. Their successful well permits a school to be built. The team's leader is Salva, whose long journey has become the foundation for work that transforms Nya's future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2441,7 +2441,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2454,7 +2454,7 @@
       "recaps": {
         "ending": "After Captain Forrester's death, Marian remains in Sweet Water with little money and no longer preserves the standards Niel associated with her house. Ivy Peters gains control over her business affairs, drains the Forrester marsh, and becomes intimate with her. Niel, unable to separate the living woman from the ideal he created, leaves in disillusionment. Marian eventually escapes both Ivy and Sweet Water. Years later, Niel hears that she went west, then to South America, where she married a wealthy Englishman and recovered comfort and social standing. She has died by the time the news reaches him. Distance softens Niel's judgment: he remembers her distinctive warmth and her power to make life seem fuller, recognizing that what he mourned was not simply her conduct but the passing of the pioneer world the Forresters had represented.",
         "in_short": "In Sweet Water, Nebraska, young Niel Herbert worships the gracious household of railroad pioneer Captain Forrester and his beautiful younger wife, Marian. As Niel matures, he discovers that Marian's charm coexists with secrecy and an affair with Frank Ellinger. The captain loses most of his fortune after protecting depositors in a failed bank, suffers declining health, and dies. The old railroad generation fades while the ruthless Ivy Peters rises, takes control of Marian's affairs, drains the beloved marsh, and becomes her lover. Niel leaves, bitter that the woman he idealized has accommodated herself to this new order. Marian later leaves Ivy, remarries a wealthy Englishman in South America, and dies in comfort. Looking back, Niel recovers affection for the vitality she brought to his youth while understanding that his lost lady was also his image of a vanished West.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2632,7 +2632,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2645,7 +2645,7 @@
       "recaps": {
         "ending": "Ove's neighbors unite to prevent the authorities from removing Rune from Anita's care. Their testimony, records, and Lena's ability to expose the case defeat the official's plan. During the confrontation Ove collapses, and the hospital discovers that his heart is enlarged and may fail without warning. He responds by returning to the community that has formed around him. Parvaneh gives birth to a son, and Ove becomes an honorary grandfather to her children. He teaches, repairs, watches over the neighborhood, and remains close to the cat and the friends who have claimed him. Several years later, after he fails to clear the snow outside his house, Parvaneh finds that he has died peacefully in bed with the cat beside him. Ove has left practical instructions for his funeral and provisions for those he loves. Far more people attend than the solitary ceremony he expected, demonstrating the extent of the community he built while insisting that he needed no one.",
         "in_short": "Widowed, forcibly retired, and determined to join his late wife Sonja, Ove repeatedly tries to end his life. Each attempt is interrupted by a neighbor who needs him. Pregnant Parvaneh and her family draw him into driving lessons, childcare, repairs, and friendship; a stray cat moves into his house; and younger neighbors seek his protection and practical knowledge. Memories reveal a life shaped by honest work, Sonja's love, bereavement, and repeated battles with indifferent institutions. In the present, Ove rallies the neighborhood to stop officials from taking his disabled former friend Rune away from Anita. The effort succeeds, but Ove's collapse reveals a dangerous heart condition. He abandons his suicide plans and becomes a grandfather figure within the improvised family around him. Years later he dies peacefully at home. His crowded funeral and the people he has provided for show that the isolated man became the center of a lasting community.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2776,7 +2776,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2789,7 +2789,7 @@
       "recaps": {
         "ending": "In the ancient city, Jarvis takes one of the unusual objects being handled by the barrel-shaped creatures, provoking a mass attack. Tweel could escape alone but returns to help him, confirming that their alliance is more than temporary convenience. The two hold off the creatures and flee together. Near the human expedition, approaching rescue separates them: Jarvis is recovered by his companions while Tweel disappears back into the Martian landscape rather than joining the humans. Jarvis completes his account aboard the Ares and produces the object he carried away, giving the expedition tangible evidence that the city's mechanisms and inhabitants warrant further study. Yet his strongest conclusion is personal rather than material. Despite radical differences in body, language, and thought, Tweel repeatedly reasoned, cooperated, risked himself for another being, and behaved as a friend. The crew can return for the scientific discovery, but Jarvis does not know whether he will ever find Tweel again.",
         "in_short": "On the first human expedition to Mars, Jarvis crashes a survey rocket far from the ship Ares and begins a long walk back. He befriends Tweel, an intelligent birdlike Martian with whom he can share only a few words. Traveling together, they encounter forms of life that defeat familiar Earth categories: silicon creatures that build pyramids through their life cycle, a predator that traps victims with wish-shaped illusions, and barrel-like beings operating a vast mechanism in an ancient city. Tweel repeatedly recognizes danger and saves Jarvis. When Jarvis takes an object from the city's procession, the barrel creatures attack; Tweel chooses to stand with him rather than escape alone. Jarvis eventually rejoins the human crew with the object, while Tweel vanishes into the Martian distance. The sample promises an important discovery, but Jarvis regards his lost cross-species friendship as the greater find.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2876,7 +2876,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2889,7 +2889,7 @@
       "recaps": {
         "ending": "The succession crisis breaks into violence in the capital, but it is resolved not by the ambitious general One Lightning seizing the throne but by the old Emperor Six Direction giving up his own life in a public act designed to trigger an orderly succession and deny the coup its opening. In the aftermath, his trusted ally Nineteen Adze takes the throne as the new ruler of Teixcalaan. Mahit, having pieced together that her predecessor Yskandr had tried to trade Lsel's memory-implant technology for imperial protection, and that her own implant was sabotaged by a faction back home to stop exactly that, manages to preserve Lsel's independence. She refuses to surrender the station's secret technology to the Empire and keeps the most dangerous truths hidden. Loving Teixcalaanli culture yet fearing being consumed by it, she decides she cannot stay, and parts from Three Seagrass, whose bond with her has deepened, with the door left open between them. She turns toward home carrying the knowledge that something unknown and threatening is moving at the edge of Lsel's space, a danger that will shape what comes next.",
         "in_short": "Mahit Dzmare arrives at the capital of the Teixcalaanli Empire as the new ambassador from tiny, independent Lsel Station, only to find her predecessor Yskandr dead and her implanted memory-copy of him, meant to guide her, failing. Aided by her sharp liaison Three Seagrass, she investigates his death and uncovers that Yskandr had secretly bargained with the aging Emperor Six Direction, offering Lsel's prized memory-implant technology in exchange for the Empire's protection. As a succession crisis erupts and the ambitious general One Lightning moves toward a coup, Mahit realizes her own implant was deliberately sabotaged from home by a Lsel faction opposed to that bargain, and that Lsel's independence and its secret technology are the true stakes. To halt the coup and force an orderly succession, Emperor Six Direction sacrifices his own life, and his ally Nineteen Adze rises to the throne. Mahit secures Lsel's continued independence, refuses to hand over its technology, and, unwilling to be swallowed by the culture she loves, chooses to return home, while an unknown threat stirs at the edge of Lsel's space.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3049,7 +3049,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3062,7 +3062,7 @@
       "recaps": {
         "ending": "A Memory of Light ends with the Shadow defeated and the world remade at terrible cost. The forces of the Light win Tarmon Gai'don, but many fall: Egwene al'Vere dies unleashing a power that turns the enemy's channelers against themselves; Gawyn Trakand, Siuan Sanche, and the great captain Gareth Bryne are among the dead; Lan Mandragoran slays the Forsaken Demandred in a duel and barely survives. The twisted peddler Padan Fain is killed by Mat. Perrin destroys the assassin Slayer and guards Rand in the world of dreams. At Shayol Ghul, Rand confronts the Dark One directly and chooses not to annihilate him, for a world stripped of the ability to choose evil would be a world of puppets; instead he seals the prison anew and closes the Bore. Bound soul to soul with his enemy Moridin, Rand walks out of the fighting in Moridin's healthy body while his own broken body is burned on a pyre. The world believes the Dragon dead, but he lives, anonymous and finally free, riding away alone. Min, Aviendha, and Elayne, who carries his children, keep his secret. The Wheel of Time turns onward into a new Age.",
         "in_short": "Tarmon Gai'don, the Last Battle, is fought at last. At the Field of Merrilor the nations bind themselves to the Dragon's Peace, and Rand goes to Shayol Ghul to face the Dark One while four great battlefronts hold the Shadow's armies of Trollocs, Sharans, and Forsaken. Lan holds Tarwin's Gap and, in single combat, kills the Forsaken general Demandred. Egwene falls destroying an army of Shadow channelers; Gawyn, Siuan, and the great captain Gareth Bryne are among the many dead. Mat, become the Light's supreme commander, turns the tide and the Horn of Valere is sounded to call the heroes of legend. In the Pit of Doom, aided by Nynaeve and Moiraine, Rand battles the Dark One in a contest of wills and visions, refusing to destroy him utterly because that would end humanity's freedom to choose, and instead reseals his prison. Rand's dying body is burned on a pyre, but his soul lives on in another man's body, and he slips away unknown, free at last, while Min, Aviendha, and Elayne, who carries his children, keep the secret. The Wheel turns, and a new Age begins.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3164,7 +3164,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3177,7 +3177,7 @@
       "recaps": {
         "ending": "The monster forces Conor to enter the recurring nightmare in which his mother hangs above a dark drop and he loses his grip on her. Conor finally admits that part of him deliberately let go because he wanted the strain and uncertainty of her illness to end. He has mistaken that involuntary wish for a desire that she die and has been punishing himself for it. The monster tells him that thoughts can contradict one another and are not the same as actions. Conor's grandmother finds him beneath the yew tree and rushes him to the hospital. He reaches his mother's bedside shortly before her death. Supported by the monster, he can at last tell her that he does not want her to go while also releasing his hold when the moment comes. He and his grandmother face the loss together, their shared grief replacing some of their hostility. The monster's stories have not cured his mother; they have enabled Conor to speak the truth and survive it.",
         "in_short": "Thirteen-year-old Conor O'Malley is struggling with his mother's worsening cancer, bullying at school, and a recurring nightmare he cannot face. At 12:07 a giant being formed from the nearby yew tree begins visiting him. It promises three morally unsettling tales, after which Conor must tell a fourth story: the truth of his nightmare. The monster's tales challenge simple divisions between heroes and villains, while their violence spills into Conor's life. He wrecks his grandmother's sitting room and seriously injures his bully, yet adults respond with pity rather than punishment. When his mother's last treatment fails, Conor finally relives the nightmare and admits that, exhausted by fear, he once wanted the waiting to end and let her fall. The monster teaches him that the thought does not mean he wanted her dead. Conor reaches the hospital in time to tell his mother he does not want her to go, then lets her die without hiding from his love or grief.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3358,7 +3358,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3371,7 +3371,7 @@
       "recaps": {
         "ending": "Miss Marple and Inspector Craddock expose the woman called Letitia Blacklock as Charlotte Blacklock, Letitia's sister. The real Letitia died abroad, and Charlotte assumed her identity so that she could inherit when the elderly Belle Goedler died. Rudi Scherz recognized Charlotte from a Swiss clinic and became part of a staged robbery that she converted into his murder. Bunny's old memories and habit of calling her Lotty threatened the disguise, so Charlotte poisoned her; Amy Murgatroyd was killed after recalling that Miss Blacklock had not been in the room during the shooting. A trap using Mitzi and Miss Marple provokes Charlotte into attacking again, and she is arrested. Phillipa Haymes and Julia Simmons are revealed as the heirs Pip and Emma, and they inherit after Charlotte's scheme collapses.",
         "in_short": "A newspaper notice announces that a murder will occur at Letitia Blacklock's house. Curious neighbours gather; the lights fail, an armed man appears, and the intruder Rudi Scherz is shot dead. Further deaths show that the event concealed an old identity secret tied to an inheritance. Miss Marple discovers that the household's supposed Letitia is actually her sister Charlotte. The real Letitia died abroad, and Charlotte took her place to receive money due after Belle Goedler's death. Rudi recognized her, Bunny remembered too much, and Amy Murgatroyd recalled that she was absent during the staged shooting, so Charlotte killed all three. Miss Marple and Inspector Craddock trap her during another attempted attack. Charlotte is arrested, while Phillipa and Julia are identified as Pip and Emma, the alternative heirs.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3515,7 +3515,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3528,7 +3528,7 @@
       "recaps": {
         "ending": "Smiley establishes that Fielding had let the boy Perkins see an examination paper in advance so that he would not be removed from the school, and that Stella Rode obtained proof of it, along with knowledge of an earlier disgrace which Fielding had spent his career living down. Instead of exposing him she kept the evidence and let him understand that she had it, which was the private cruelty she practised on many people while the town admired her charity. With retirement and his reputation in front of him, Fielding killed her, and dressed the crime to point at her husband, whom Carne would have been happy to believe capable of it. When Perkins begins to talk about the examination paper, Fielding kills him too, in what is arranged to look like a road accident. Confronted with the reconstruction, Fielding admits what he did, and is arrested. Jane Lyn, who was the town's preferred culprit, is cleared. Stanley Rode is left innocent of the murder but with the truth about his marriage and no place at the school he tried so hard to enter. Smiley goes back to London with Ailsa Brimley, having exposed a killing that the school would rather have blamed on an outsider.",
         "in_short": "Ailsa Brimley, editor of a small nonconformist weekly, receives a letter from a reader, Stella Rode, saying that her husband intends to kill her, and takes it to her old wartime colleague George Smiley. Before anything can be done, Stella is beaten to death at her house on the edge of Carne, an ancient public school where her husband teaches science. Smiley goes down, is admitted to the school through the housemaster Terence Fielding, and works alongside Inspector Rigby. Carne assumes the murderer is either Stanley Rode, an outsider by birth and manner, or a local vagrant woman found with the dead woman's belongings; physical evidence has been arranged to incriminate the husband. Smiley finds that Stella's reputation for saintliness concealed a talent for collecting and using other people's shameful secrets. She had proof that Fielding had shown an examination paper to a boy in his house, and knowledge of an older disgrace that would have destroyed him. Fielding killed her to end it, staged the scene against Rode, and later killed the boy when he began to talk. Confronted, he confesses, and Smiley returns to London.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/a-parade-of-horribles.json
+++ b/data/works-community/0/a-parade-of-horribles.json
@@ -352,7 +352,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -365,7 +365,7 @@
       "recaps": {
         "ending": "Carl's plan leaves Scolopendra alive but reduced to a level-1 crawler in his party. Her survival is essential because killing or abandoning her would trigger the rest of the Nine-Tier attacks. Nineteen established crawlers remain, with Penelope joining them as a new crawler. Hetty, Corcunda, Don Quixote, Dwight, and Osvaldo are among the dead. Tipid and Jamal survive after losing their legs, while Florin is carried to the stairwell badly injured. Samantha departs with the thunder deity, and the later fates of Louis, Chris, Brittany, and Pontiff remain unknown after they use the casino route. Carl has renounced his divine patron, bears the chaos goddess's unresolved mark, and discovers an unidentified tracking tag in his leg. With floor-collapse timers suspended until the Ascendancy has a winner, he unites the survivors and plans to stall that contest on floor 12 long enough to create a wider evacuation.",
         "in_short": "Carl and Donut lead their allies through seven lethal racing heats while seeking exits for crawlers and awakened dungeon residents. Li Na proves that volunteers can reach the Pineapple Cabaret, and others enter an uncertain casino portal. Only a small group reaches the eleventh-floor parade, where the AI explains the primal origins of itself, the dungeon’s inhabitants, and the Nine-Tier threat. In the arena, Carl refuses to kill Scolopendra because her death would unleash the remaining attacks. Donut instead transforms her into a level-1 crawler. The victory costs many lives, leaves Tipid and Jamal without their legs, and separates Samantha, Louis, Chris, Brittany, and Pontiff from the group. Carl reunites the survivors, adds Scolopendra to the party, and heads toward floor 12, planning to prolong the Ascendancy contest so the dungeon’s remaining population has time to escape.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -590,7 +590,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -603,7 +603,7 @@
       "recaps": {
         "ending": "Two years after the Marabar case, Aziz is serving as a doctor in the Hindu state of Mau and has turned away from British friendship. Fielding arrives with his wife, Stella, who is Mrs. Moore's daughter, and her brother Ralph. Aziz's old suspicion that Fielding married Adela is finally corrected. During Mau's religious festival, Aziz helps Ralph and recognizes in him something of Mrs. Moore's sympathetic spirit. A collision on the water throws the visitors and celebrants together amid the procession, softening the estrangement. Aziz and Fielding later ride out and recover their personal affection, but their political positions remain opposed: Aziz now imagines an independent India, while Fielding still belongs to British rule. When Fielding asks why they cannot be friends, the landscape and their diverging paths seem to postpone that friendship until the colonial relationship itself has ended.",
         "in_short": "In British-ruled Chandrapore, the Indian doctor Aziz befriends the visiting Mrs. Moore and the independent college principal Fielding. Hoping to show hospitality to Mrs. Moore and Adela Quested, Aziz organizes an expedition to the Marabar Caves. Mrs. Moore is spiritually overwhelmed by a cave's echo, while Adela becomes disoriented during a later climb and accuses Aziz of assault. The British community closes ranks and Aziz is jailed, but Fielding publicly supports him. At the trial Adela admits she was mistaken, and Aziz is acquitted. Resentment, misunderstanding, Mrs. Moore's death, and Aziz's false belief that Fielding married Adela then break the men's friendship. Years later in Mau, Fielding returns married to Mrs. Moore's daughter Stella. He and Aziz reconcile personally, yet Aziz's commitment to Indian independence and Fielding's place within British power prevent a complete friendship while colonial rule continues.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -779,7 +779,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -792,7 +792,7 @@
       "recaps": {
         "ending": "Two years after the Marabar case, Aziz is serving as a doctor in the Hindu state of Mau and has turned away from British friendship. Fielding arrives with his wife, Stella, who is Mrs. Moore's daughter, and her brother Ralph. Aziz's old suspicion that Fielding married Adela is finally corrected. During Mau's religious festival, Aziz helps Ralph and recognizes in him something of Mrs. Moore's sympathetic spirit. A collision on the water throws the visitors and celebrants together amid the procession, softening the estrangement. Aziz and Fielding later ride out and recover their personal affection, but their political positions remain opposed: Aziz now imagines an independent India, while Fielding still belongs to British rule. When Fielding asks why they cannot be friends, the landscape and their diverging paths seem to postpone that friendship until the colonial relationship itself has ended.",
         "in_short": "In British-ruled Chandrapore, the Indian doctor Aziz befriends the visiting Mrs. Moore and the independent college principal Fielding. Hoping to show hospitality to Mrs. Moore and Adela Quested, Aziz organizes an expedition to the Marabar Caves. Mrs. Moore is spiritually overwhelmed by a cave's echo, while Adela becomes disoriented during a later climb and accuses Aziz of assault. The British community closes ranks and Aziz is jailed, but Fielding publicly supports him. At the trial Adela admits she was mistaken, and Aziz is acquitted. Resentment, misunderstanding, Mrs. Moore's death, and Aziz's false belief that Fielding married Adela then break the men's friendship. Years later in Mau, Fielding returns married to Mrs. Moore's daughter Stella. He and Aziz reconcile personally, yet Aziz's commitment to Indian independence and Fielding's place within British power prevent a complete friendship while colonial rule continues.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -961,7 +961,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -974,7 +974,7 @@
       "recaps": {
         "ending": "Rachel and the other captives break the HAPA facility's control, stopping its immediate program of abduction, murder, and forced transformation. Winona survives despite the permanent physical effects of the experiments, and the people used as research material are no longer hidden inside the operation. The investigation exposes a functioning anti-Inderlander organization rather than a single isolated killer; its local project is damaged, but the hatred and network behind it are not erased. Rachel rejects the enchanted silver that has hidden her aura and blocked her magic. Reclaiming access to ley lines also means accepting that demons can locate her and that her public identity cannot be reduced to a safe fiction. She returns to Ivy and Jenks with her abilities restored and with a clearer willingness to call herself what she has become. Nina survives the case, but Felix's use of her deepens the danger in their bond and draws Ivy's attention. Rynn Cormel continues to expect Rachel to find a way to preserve vampire souls, leaving demon and vampire politics unresolved beyond the HAPA case.",
         "in_short": "After Pale Demon, Rachel is no longer shunned, but being legally treated as a demon has erased parts of her ordinary identity. She hides her aura with enchanted silver that also cuts her off from ley-line magic. The FIB asks her to consult when murdered witches are found with evidence of deliberate genetic alteration. The crimes lead to HAPA, a human-supremacist organization using captives and research connected to demon physiology in an attempt to weaponize transformations against Inderlanders. Working with Glenn, Ivy, Jenks, and living vampire Nina, Rachel investigates while resisting both FIB restrictions and the protection others impose on her. HAPA eventually captures Rachel and tries to use her unusual blood and genetics in its experiments. She joins forces with captive witch Winona, removes the silver, reclaims her magic, and helps break the facility's control. The local operation is stopped, though HAPA is not wholly eliminated. Rachel returns home openly accepting her power, while Nina's bond with undead vampire Felix and Rynn Cormel's demand concerning vampire souls remain dangerous.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1166,7 +1166,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1179,7 +1179,7 @@
       "recaps": {
         "ending": "Miss Marple identifies Lancelot Fortescue as the murderer. Before returning home, Lance cultivated the inexperienced Gladys Martin under a false romantic identity and persuaded her to put taxine into Rex's breakfast without understanding that it would kill him. Lance then murdered Adele with cyanide and strangled Gladys, arranging details from the nursery rhyme to make the deaths seem linked to an old grievance. His aim was control of the family wealth and the valuable possibilities attached to the Blackbird mine. Jennifer Fortescue is revealed as Ruby MacKenzie, but her private acts of revenge and concealment did not include the murders. A letter and photograph Gladys sent to Miss Marple expose Lance's deception. He is arrested, and Miss Marple grieves that Gladys's trust was used against her.",
         "in_short": "Financier Rex Fortescue is poisoned with taxine, with grains of rye found in his pocket. His wife Adele and the maid Gladys Martin are then killed in ways echoing a nursery rhyme. Inspector Neele investigates the family's money disputes and an old mining betrayal, while Miss Marple comes because she once trained Gladys. The rhyme and the MacKenzie grievance are partly camouflage. Rex's son Lancelot courted Gladys under a false name and induced her to place the poison in Rex's food; he then killed Adele and Gladys to secure the inheritance and prevent exposure. Gladys had mailed Miss Marple a photograph that reveals her supposed admirer as Lance. Jennifer Fortescue is separately exposed as Ruby MacKenzie, seeking redress for her father's ruin but not responsible for the murders. Lance is arrested.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1356,7 +1356,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1369,7 +1369,7 @@
       "recaps": {
         "ending": "At the university, Stephen separates himself from the institutions competing for his obedience. He refuses Davin's nationalism, rejects pressure to practice a faith he no longer accepts, and tells Cranly that he will risk isolation rather than surrender intellectual freedom. His thoughts about Emma and his arguments about art become part of the same effort to discover a voice of his own. The narrative shifts into Stephen's diary as he prepares to leave Ireland. His family is strained and his mother hopes he will learn what a life away from belief may mean, but he commits himself to exile, artistic work, and direct experience. The book closes before that future is realized: Stephen is poised to depart, invoking the mythic craftsman associated with his name and intending to transform the inherited materials of Irish life into art.",
         "in_short": "Stephen Dedalus grows from a fearful, imaginative child into a young man determined to become an artist. At school he learns both the force and fallibility of religious authority; at home he witnesses Irish politics dividing those he loves. Adolescence brings poverty, pride, sexual desire, and then an intense religious reaction after sermons frighten him into confession. He briefly organizes his life around devotion and considers the priesthood, but recognizes that his deepest allegiance is to beauty and artistic creation. At university he develops an aesthetic theory while resisting the claims of Catholicism, nationalism, family, and friends. His attachment to Emma remains largely imagined, and his growing independence carries loneliness as well as exhilaration. He finally decides to leave Ireland and accept exile, silence, and cunning as the conditions of making his own art, ending the novel ready to test that vocation in the world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1532,7 +1532,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1545,7 +1545,7 @@
       "recaps": {
         "ending": "Carter and his allies seize Zodanga, prevent Dejah Thoris's forced marriage to Sab Than, and help Helium defeat its enemy. Tars Tarkas exposes Tal Hajus's cruelty, kills him in single combat, and becomes jeddak of the Tharks. The green Martian alliance with Helium is confirmed, and Carter marries Dejah. Nine years later, with Dejah expecting their child, the machinery that maintains Barsoom's atmosphere fails. Carter reaches the sealed atmosphere plant by using the telepathic knowledge entrusted to him and starts the machinery, but loses consciousness before he can learn whether the planet is saved. He wakes in his physical body in the Arizona cave. Ten years pass on Earth without any sign from Barsoom, leaving him uncertain whether Dejah, their child, or the planet survived.",
         "in_short": "After an encounter in an Arizona cave, Civil War veteran John Carter is inexplicably transported to Barsoom, a drying world whose lower gravity gives him exceptional strength. Captured by the nomadic green Martian Tharks, he befriends Sola, Woola, and the warrior Tars Tarkas. He also meets Dejah Thoris, a red Martian princess of Helium, and falls in love with her. Carter escapes captivity, survives imprisonment by the Warhoons, and reaches Zodanga, whose prince intends to force Dejah into marriage while Zodanga attacks Helium. With Tars Tarkas and a green Martian army, Carter takes Zodanga, rescues Dejah, and helps Helium win the war. Tars becomes jeddak of the Tharks, and Carter and Dejah marry. Years later Barsoom's atmosphere machinery stops. Carter enters the plant and restarts it, then wakes on Earth before seeing the result. After ten years he still does not know whether Barsoom or his family survived.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1740,7 +1740,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1753,7 +1753,7 @@
       "recaps": {
         "ending": "Antium falls to the Karkauns because Keris Veturia withdraws her legions and lets it happen. In the ruin of the capital she has Helene's father and her sister Hannah killed in front of her, destroying House Aquilla except for Livia, who gives birth to a son during the siege. Marcus dies, and Keris declares herself Empress of the Martial Empire. Helene names the infant Zacharias Emperor, takes him and Livia out of the city with the legions still loyal to her, and withdraws north to Delphinium to fight a civil war she is not equipped to win. Laia learns that Cook is her mother, Mirra, the Lioness who led the Scholar resistance and was assumed dead for years. In the Waiting Place, Shaeva is gone and Elias is left holding the ghosts and the jinn's prison alone. Mauth, the power behind the Soul Catcher's work, will only serve him if he severs every human tie he has; he accepts the terms, sends Laia away and stops being Elias Veturius in any way that matters. It is not enough. The Nightbringer completes the Star, breaks the prison and frees the jinn, and his own kind name him the Meherya, the beloved. The Empire is left with two claimants, an unbound and vengeful jinn host, and no one who can stop them.",
         "in_short": "The Nightbringer, holding the last fragment of the Star, works toward freeing the jinn imprisoned beneath the Waiting Place, while Keris Veturia plans both the extermination of the Scholars and the seizure of the throne. Laia travels north to Adisa seeking a weapon or an ally against him, finds neither in the Mariner court but gains the Scholar spymaster Musa. Elias, bound to the Waiting Place, cannot make its magic answer him while he still loves anyone living. The Blood Shrike is sent to Navium, where Keris lets the city burn under a Karkaun assault to discredit her; Helene saves it and cannot prove the sabotage. The Karkauns then besiege Antium, Keris withdraws her legions, and the capital falls. Keris executes most of Helene's family, Marcus dies, and Keris takes the throne as Empress. Helene escapes with her sister Livia and Livia's newborn son, whom she declares Emperor. Laia discovers that the woman called Cook is her own mother. Shaeva dies, Elias surrenders his humanity to become the Soul Catcher in full, and the Nightbringer completes the Star and releases the jinn.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2187,7 +2187,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B007FUCA0Q",
@@ -2199,7 +2199,7 @@
       "recaps": {
         "ending": "Manticore and Haven complete their peace and mutual-defense treaty, with Grayson and Beowulf aligned beside them. Honor's combined Grand Fleet has destroyed or disabled most of the Solarian invasion after an externally compelled missile launch prevented the enemy's surrender. Haven and Beowulf begin supplying the industrial capacity Manticore needs to recover from the destruction of its shipbuilding base. The Solarian League remains hostile but recognizes that its wallers cannot meet the alliance in open battle. Its leaders choose disinformation, commerce raids, and pressure on Beowulf instead. Beowulf schedules a plebiscite on leaving the League, while its secret Mycroft defense network remains months from operation and Solarian planners consider a rapid seizure of the system. Simoes's evidence and the controlled death of the Solarian Navy chief make the Mesan threat increasingly credible, but the Alignment's structure is still obscure. Albrecht Detweiler accelerates Operation Houdini, Maya continues Sepoy, and Al-Fanudahi's covert group investigates the Mesa-linked pattern behind the League's disasters.",
         "in_short": "Manticore recalls its merchant fleet and closes key wormhole termini as the Solarian League prepares a massive attack. Zilwicki and Cachat deliver Dr. Herlander Simoes and his evidence of the Mesan Alignment to Haven, prompting Manticore and Haven to end their war and form an alliance with Grayson and Beowulf. Honor Harrington traps the 427-wall-ship Solarian invasion inside Manticore's hyperlimit and offers surrender, but external control forces a missile launch that turns capitulation into battle. Grand Fleet destroys or cripples most of the invaders. Haven ratifies the alliance and joins Beowulf in rebuilding Manticore. League leaders answer defeat with false propaganda and a commerce-raiding strategy. Beowulf responds to a treason inquiry by scheduling a secession vote, while the League explores seizing the system before its new defenses are ready. The Alignment accelerates Operation Houdini, and an internal Solarian inquiry begins tracing Mesa's role in the crisis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2330,7 +2330,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2343,7 +2343,7 @@
       "recaps": {
         "ending": "After the family's final fishing trip, Paul remains in Helena and continues gambling despite Norman's offer to help. Soon afterward, Norman is told that Paul has been beaten to death and left in an alley, with injuries concentrated on the hand that made his extraordinary casts. Norman and his father cannot explain what happened or how they might have prevented it. The minister asks Norman to describe Paul's last great fish, and the memory gives them a way to speak about someone they loved but could not save. In a late sermon, the father reflects that people may require help even when they cannot be understood and may refuse what is offered. Years later Norman has outlived the rest of his immediate family. He continues to fish alone, carrying their presence in memory and finding that the river binds grief, family, and the landscape together.",
         "in_short": "Norman Maclean recalls a Montana family shaped by Presbyterian faith and fly-fishing. His younger brother Paul becomes a superb fisherman and a talented newspaperman, but also a heavy drinker and gambler who resists his family's help. During a visit from Norman's unreliable brother-in-law Neal, Norman and Paul try to arrange a fishing outing and instead must retrieve Neal after a drunken disappearance. A later trip with their father briefly restores harmony: Paul lands a magnificent trout, and the family sees his art at its fullest. The achievement cannot protect him from his other life. Paul is soon beaten to death after remaining in Helena to gamble. Norman and his father are left with sorrow and the recognition that love does not guarantee understanding or rescue. In old age, Norman fishes alone and remembers his family through the river that once joined them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2498,7 +2498,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2511,7 +2511,7 @@
       "recaps": {
         "ending": "After ending her engagement to Cecil, Lucy still refuses to admit that she loves George. She arranges to travel to Greece with the Miss Alans, concealing from several people that her real aim is to escape Windy Corner and the Emersons. A chance conversation with Mr. Emerson breaks through her evasions. He tells her that love requires truth and persuades her to acknowledge both her feelings and the harm caused by denying them. Lucy chooses George despite the opposition and disappointment she expects from her family. The novel closes with Lucy and George married and back at the Pension Bertolini in Florence, occupying the room with the view. They are happy together but know that some relatives have not forgiven their decision. They also look back on Charlotte's conduct and wonder whether, beneath her caution and interference, she deliberately enabled Lucy's final meeting with Mr. Emerson and therefore helped the truth emerge.",
         "in_short": "While visiting Florence with her restrictive cousin Charlotte, Lucy Honeychurch meets the unconventional George Emerson. After George steadies her when she witnesses a killing, the two share an unexpected kiss in the countryside. Charlotte separates them and Lucy returns to Surrey, where she accepts the cultivated but controlling Cecil Vyse. Without knowing their history, Cecil helps the Emersons move into a nearby house. George reenters Lucy's life and declares that Cecil treats her as an ornament rather than a person. Lucy rejects George and forces him to leave, then recognizes enough truth in his criticism to end her engagement while still denying her love. Planning to flee to Greece, she meets George's father, who persuades her to stop lying to herself. Lucy chooses George, and the book ends with them married in Florence, accepting the family conflict caused by their decision but sharing the freedom and intimacy she had resisted.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2699,7 +2699,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2712,7 +2712,7 @@
       "recaps": {
         "ending": "After ending her engagement to Cecil, Lucy plans to escape the confusion by traveling to Greece with the Miss Alans. A chance conversation with Mr Emerson forces her to stop denying that she loves George. She abandons the journey and chooses George despite the opposition she expects from family and society. The novel closes with Lucy and George together at the Pension Bertolini in Florence, occupying the room whose view began their acquaintance. They understand that Charlotte, despite her earlier efforts to separate them, may deliberately have allowed Mr Emerson the meeting that brought Lucy to honesty. Their happiness is real, although they have married without Mrs Honeychurch's approval and still hope for eventual reconciliation with the family. Lucy's choice resolves the conflict between a life directed by convention and one grounded in emotional truth.",
         "in_short": "While touring Florence with her restrictive cousin Charlotte Bartlett, young Lucy Honeychurch meets the unconventional Mr Emerson and his son George. After George catches Lucy when she faints at a murder and later kisses her during a country outing, Charlotte removes Lucy to Rome. Back in Surrey, Lucy becomes engaged to the cultured but controlling Cecil Vyse. By chance, the Emersons rent a nearby cottage, and George's return unsettles Lucy's effort to treat Florence as a closed episode. When George kisses her again and argues that Cecil sees her as an ornament rather than an equal, Lucy rejects George but also recognizes enough truth to end her engagement. She then lies about her feelings and prepares to leave for Greece. Mr Emerson finally persuades her to admit that she loves George. Lucy chooses him, and the couple return to the Florence pension where they met, married but temporarily estranged from her family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2900,7 +2900,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2913,7 +2913,7 @@
       "recaps": {
         "ending": "After ending her engagement to Cecil, Lucy plans to escape the confusion by traveling to Greece with the Miss Alans. A chance conversation with Mr Emerson forces her to stop denying that she loves George. She abandons the journey and chooses George despite the opposition she expects from family and society. The novel closes with Lucy and George together at the Pension Bertolini in Florence, occupying the room whose view began their acquaintance. They understand that Charlotte, despite her earlier efforts to separate them, may deliberately have allowed Mr Emerson the meeting that brought Lucy to honesty. Their happiness is real, although they have married without Mrs Honeychurch's approval and still hope for eventual reconciliation with the family. Lucy's choice resolves the conflict between a life directed by convention and one grounded in emotional truth.",
         "in_short": "While touring Florence with her restrictive cousin Charlotte Bartlett, young Lucy Honeychurch meets the unconventional Mr Emerson and his son George. After George catches Lucy when she faints at a murder and later kisses her during a country outing, Charlotte removes Lucy to Rome. Back in Surrey, Lucy becomes engaged to the cultured but controlling Cecil Vyse. By chance, the Emersons rent a nearby cottage, and George's return unsettles Lucy's effort to treat Florence as a closed episode. When George kisses her again and argues that Cecil sees her as an ornament rather than an equal, Lucy rejects George but also recognizes enough truth to end her engagement. She then lies about her feelings and prepares to leave for Greece. Mr Emerson finally persuades her to admit that she loves George. Lucy chooses him, and the couple return to the Florence pension where they met, married but temporarily estranged from her family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3218,7 +3218,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0C544LFGX",
@@ -3230,7 +3230,7 @@
       "recaps": {
         "ending": "Malcolm is defeated, arrested, and publicly discredited after Anna, Damien, and Sebastien expose his financial crimes and staged dealings with the Raven Queen. The textile subcommission goes forward, leaving Sebastien with gold, shareholder papers, and a four-percent stake that can free her from dangerous side work. Oliver and the Verdant Stag survive the Architects of Kronos assault, but Knave Knoll, valuable property, and many defenders are lost. The real stolen book remains secure, and Katerine confirms that both copies of Siobhan's bloodprint vow have been destroyed. Tanya survives after helping Siobhan escape capture, though her loyalties and knowledge remain uncertain. Liza can oppose renewed blood scrying only at great cost, and the sleep-proxy spell remains viable but potentially lethal and ethically compromised. Newton remains dead, while the Red Guard's alteration of his family's memories destroys Sebastien's remaining trust in official institutions. Siobhan leaves Oliver without confronting him, resolved to verify whether he exploited her stolen-book predicament as cover for another secret. Thaddeus Lacer possesses the original ring connected to her father and asks Oliver to arrange a meeting with the Raven Queen.",
         "in_short": "Sebastien begins the term grieving Newton Moore and hiding that she is also Siobhan, the wanted Raven Queen. She deepens her study of light magic, works with Liza on a dangerous sleep-proxy spell, and joins Anna and Damien in a scheme that exposes Malcolm's corruption and secures Oliver Dryden's textile agreement. The Architects of Kronos attack the Verdant Stag and Knave Knoll to recover Siobhan's stolen book. Siobhan helps defeat the assault, though the prison is destroyed and her equipment is lost. Malcolm is arrested, Anna's position improves, and Sebastien gains a four-percent business share and financial independence. Yet renewed blood scrying, Red Guard manipulation of Newton's family, and the lethal costs of the sleep project remain unresolved. The book ends with Siobhan withholding trust from Oliver and deciding to investigate whether he used her crisis to conceal another secret, while Thaddeus Lacer holds the original ring tied to her father and seeks a meeting with the Raven Queen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3418,7 +3418,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3431,7 +3431,7 @@
       "recaps": {
         "ending": "The observation of Troy's fall becomes a catastrophe when the team is caught in the destruction of the city. Max experiences Leon's death during the mission along with other losses among those sent through time. Refusing to accept that outcome, she uses the exceptional opportunity implied by the title to return to the crisis and change the rescue, despite the danger of meeting events already lived. Leon is recovered alive in the resulting version of events, but the deaths, injuries, and trauma surrounding Troy are not reduced to a harmless reset. Ronan's continuing interference remains part of the threat facing St Mary's rather than a closed case. Max and Leon end the book reunited and given another chance at their life together, while the institute must reckon with the cost of a mission that brought its people inside the sack of a city.",
         "in_short": "Max and the St Mary's team undertake assignments involving Isaac Newton, Agincourt, the origins of the Tudor dynasty, and a hazardous encounter in Georgian society before attempting their most demanding project: a sustained observation of the Trojan War. The earlier missions confirm that celebrated historical moments are confusing and dangerous at ground level. At Troy the historians rotate teams across the long siege, gathering evidence behind the later legend while trying to remain outside events. The fall of the city overwhelms those safeguards. Members of the expedition are killed, and Max experiences Leon's death in the disaster. Given an extraordinary second opportunity, she returns to the crisis and changes the recovery, bringing Leon back alive while retaining the personal cost and consequences of what happened. Ronan's campaign against St Mary's remains unresolved, but Max and Leon finish the book reunited after the institute survives another devastating temporal operation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3605,7 +3605,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3618,7 +3618,7 @@
       "recaps": {
         "ending": "Finny breaks his leg a second time while fleeing Brinker's late-night inquiry into his first fall. Gene visits him before surgery and explains that he had acted blindly when he shook the tree limb, not from a settled wish to hurt him. Finny, after struggling with the betrayal, accepts that Gene had not understood his own action. During the operation, bone marrow enters Finny's bloodstream and stops his heart. Gene does not cry at the funeral because he feels that Finny's death is inseparable from the death of part of himself. The school year ends under the pressure of war. Leper remains damaged by his brief military experience, while Brinker chooses the Coast Guard and Gene prepares for naval training after graduation. Gene concludes that he fought his real war at Devon, against fear and imagined enemies within himself. He remembers Finny as the one person he knew who did not build identity around conflict and therefore never needed an enemy.",
         "in_short": "Years after the Second World War, Gene Forrester remembers his adolescence at Devon School and his friendship with the charismatic athlete Finny. Gene admires Finny but mistakes his generosity for rivalry. During a jump from a riverside tree, Gene shakes their shared branch and Finny falls, suffering an injury that ends his athletic future. Unable to face his motive, Gene first denies responsibility and then devotes himself to Finny, who trains him as a substitute athlete and insists the war is unreal. Their schoolmate Leper enlists, suffers a psychological collapse, and deserts. His return prompts Brinker Hadley to investigate Finny's accident. When the boys force the issue at a nighttime hearing, Finny runs away, falls down marble stairs, and breaks the same leg again. Gene and Finny reconcile before surgery, but Finny dies from a complication. Gene leaves Devon understanding that jealousy and fear, rather than Finny, had been his enemy, while Finny had possessed a rare freedom from the need to oppose anyone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3758,7 +3758,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3771,7 +3771,7 @@
       "recaps": {
         "ending": "At the crashed plane, Baxter reveals himself as a criminal rather than an FBI agent and kills Sheriff Jenkins. Hank shoots Baxter and arranges the scene to support a story in which the sheriff died confronting the man responsible for the crash. Jacob, broken by the deaths and convinced that suspicion will eventually settle on him, asks Hank to kill him. Hank does so and stages his brother's death as a suicide. He and Sarah are then told by genuine federal agents that the money was ransom from a kidnapping and that every bill's serial number is known. The fortune cannot be safely spent. Hank burns the remaining cash. He avoids prosecution and returns to his job and family, but the imagined better life never arrives. His brother and the others are dead, and he must continue an outwardly ordinary existence knowing that his choices caused the entire chain of violence.",
         "in_short": "Hank Mitchell, his troubled brother Jacob, and Jacob's friend Lou find a crashed plane containing a dead pilot and millions of dollars. They agree that Hank will hide the cash until they know no one is looking for it. Secrecy quickly demands violence: an accidental witness dies, Lou tries to force an early division, and Hank kills Lou and Lou's wife while staging the scene to hide the dispute. A supposed FBI agent later leads Hank, Jacob, and the sheriff back to the aircraft, where the agent proves to be a criminal connected to the money. Hank kills him after he murders the sheriff. Jacob asks Hank to kill him rather than face what they have done, and Hank complies. Genuine agents finally explain that the cash was recorded kidnapping ransom, making it impossible to use. Hank burns it and resumes ordinary life with Sarah, having gained nothing and lost his brother and moral security.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3898,7 +3898,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3911,7 +3911,7 @@
       "recaps": {
         "ending": "Old, deaf, and nearly blind, Félicité remains in Madame Aubain's decaying house after her employer dies. She keeps the stuffed Loulou near her bed, and her religious imagination increasingly associates the parrot with the Holy Spirit. During the local Corpus Christi observance, Loulou is placed on an outdoor altar as part of the display. Félicité lies dying while the procession passes below. As incense reaches her room, she imagines the heavens opening and an immense parrot hovering above her. She dies at that moment, her final vision joining the humble creature she loved to the sacred image through which she understands consolation.",
         "in_short": "Félicité, a poor countrywoman betrayed by her first suitor, becomes the servant of the widowed Madame Aubain and gives her life to caring for the household. She loves Madame Aubain's children, Paul and Virginie, and later her sailor nephew Victor, but separation and death repeatedly remove the people on whom she fixes her affection. In later years her chief companion is Loulou, a parrot. After the bird dies, she has it preserved and gradually connects its image with the Holy Spirit in her simple religious understanding. Madame Aubain also dies, the house declines, and Félicité becomes deaf and blind. As she dies during a religious procession, she experiences a final vision of a gigantic parrot in heaven, transforming the small remnant of her earthly love into a sacred consolation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4013,7 +4013,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4026,7 +4026,7 @@
       "recaps": {
         "ending": "After robbers destroy the two celadon vases he was carrying, Tree-ear gathers a single surviving shard and completes the journey to Songdo. Emissary Kim recognizes Min's mastery in the fragment and awards him a royal commission, arranging Tree-ear's return by ship. Back in Ch'ulp'o, Tree-ear learns that Crane-man died after an accident at the bridge during his absence. The loss leaves him without his oldest family, but Min and Ajima invite him into their home and give him a family name, Hyung-pil, honoring their own dead son. Min finally agrees to teach him to make pottery. Tree-ear's dream is therefore fulfilled through perseverance and integrity rather than through the intact masterpieces he had hoped to deliver, while the single shard becomes sufficient proof of both Min's art and the boy's devotion.",
         "in_short": "Tree-ear, an orphan living under a bridge with the wise Crane-man in twelfth-century Korea, longs to learn the renowned pottery of Ch'ulp'o. After accidentally breaking a piece made by master potter Min, he works to repay the loss and remains as Min's helper. He gathers clay and wood but is not allowed to use the wheel, while Min struggles to perfect a new inlay technique for a royal commission. Tree-ear volunteers to carry two finished celadon vases to the court at Songdo. Robbers destroy them on the journey, yet he takes a single shard to Emissary Kim, who sees enough in it to award Min the commission. Tree-ear returns home to learn that Crane-man has died. Min and his kind wife Ajima take the boy into their family, give him the name Hyung-pil, and promise to teach him pottery, turning his long apprenticeship and painful journey into a new beginning.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4205,7 +4205,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4218,7 +4218,7 @@
       "recaps": {
         "ending": "The Nightbringer's war ends at the jinn city, where his purpose is finally laid bare: the massacre of his people and the loss of his family a thousand years ago, and a grief he intends to resolve by unmaking the world that caused it. Laia, wielding Rehmat's light and the truth about what was really done to him and by whom, kills him. The Soul Catcher takes the jinn dead and their leader onward, which is the only mercy left to give. Keris Veturia is defeated and killed, and the Martial civil war ends. The victory is expensive: Avitas Harper is among the dead, and Helene comes out of the war with almost no one left of the family she began it with. Mauth's demand turns out to have been a distortion rather than a law; the work of ferrying the dead does not require an empty keeper, and Elias takes back his name and his feelings while remaining the Waiting Place's Soul Catcher. Helene stands at the head of what survives of the Empire, holding it for the child emperor Zacharias, with the enslavement of the Scholars ended and an alliance with them in its place. Laia leads her people into the first free generation they have had in five hundred years, and she and Elias find a way to have each other on the terms his binding allows.",
         "in_short": "With the jinn free, the Nightbringer burns his way across the human kingdoms while Keris Veturia, now Empress, prosecutes a war of extermination against the Scholars. Laia, stripped of her magic and her mother's armlet, builds a Scholar resistance in the free lands with her brother Darin, the spymaster Musa and her mother Mirra, and is contacted by Rehmat, a presence of light that can burn jinn and will not explain what it is. Elias, having surrendered his humanity to become the Soul Catcher, cannot keep pace with the dead the war produces and begins to feel again despite Mauth's punishment. The Blood Shrike holds the north for her infant nephew against Keris and the jinn both, and is forced into alliance with the Scholars she was raised to own. The war converges on the jinn city, where the Nightbringer's true purpose is revealed and Laia kills him. Keris is defeated and killed. Harper is among the dead. Mauth's bargain proves to have been a lie, and Elias keeps both his work and his name. Helene rules what is left of the Empire for the child emperor, the Scholars are freed, and Laia and Elias are left with a future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/a-storm-of-swords.json
+++ b/data/works-community/0/a-storm-of-swords.json
@@ -142,7 +142,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -155,7 +155,7 @@
       "recaps": {
         "ending": "House Stark's cause is broken by the Red Wedding, where Robb and Catelyn Stark are murdered under guest-right by the Freys and Boltons. Jaime Lannister, maimed and humbled, is back in King's Landing and increasingly estranged from his sister Cersei. Joffrey lies dead of poison at his own wedding, and his younger brother Tommen is crowned in his place; Tyrion, wrongly convicted of the murder, escapes into exile across the sea after killing his father Tywin, who is found slain on the privy. Sansa Stark hides in the Vale as the ward of Petyr Baelish, who has murdered his way to control there. Arya Stark, having wandered the ruined Riverlands with the outlaw known as the Hound, leaves him behind and takes ship for the free city of Braavos to begin a new life. Jon Snow, now Lord Commander of the Night's Watch, holds the Wall with Stannis Baratheon encamped nearby, the wildling threat blunted but the deeper danger to the north unresolved. Bran Stark reaches a hidden teacher beyond the Wall to learn the ways of greensight. In the far east, Daenerys rules the freed city of Meereen, refusing to march on until she has learned to govern. In a final, grim turn, the murdered Catelyn is drawn back from death by outlaws as a vengeful revenant.",
         "in_short": "The war reaches its bloodiest turns. Jaime Lannister, escorted south by Brienne of Tarth, loses his sword hand to captors and is changed by the ordeal. Robb Stark, having broken a marriage pact, seeks to mend his alliance with the powerful House Frey, but at a wedding meant to seal the peace he, his mother Catelyn, and his army are massacred in the treacherous slaughter that becomes known as the Red Wedding. In the capital, King Joffrey is poisoned and dies at his own wedding feast; Tyrion is blamed, condemned in a rigged trial, and, after his lover betrays him, kills both her and his father Tywin before fleeing the kingdom. Sansa Stark is spirited away by the schemer Petyr Baelish and hidden in the Vale under a false name. At the Wall, Jon Snow returns to the Night's Watch and helps repel a massive wildling assault; Stannis Baratheon sails to the Wall's relief, and Jon is chosen Lord Commander. Bran travels beyond the Wall in search of a green-seeing power, while Daenerys conquers the slaver cities of the east and settles as queen in Meereen to learn the hard work of ruling.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -272,7 +272,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -285,7 +285,7 @@
       "recaps": {
         "ending": "Weeks after Stanley assaults Blanche, Stella has given birth and Blanche has been told that she is going on a trip. In reality, Stella and Stanley have arranged for a doctor and attendant to take her to a psychiatric institution. Blanche has retreated into a fantasy that an old admirer will rescue her and initially mistakes the arriving doctor for him. When the attendant tries to restrain her, the doctor instead offers his arm and treats her with formal courtesy; Blanche trusts him and leaves. Stella breaks down as her sister is taken away, but Eunice urges her not to accept Blanche's accusation because doing so would make life with Stanley impossible. Stanley comforts Stella and their physical bond begins to reassert itself. Mitch, overcome by what has happened, cannot intervene. The household and poker game continue after Blanche's removal, leaving Stella with Stanley and their child at the cost of rejecting her sister's account.",
         "in_short": "After losing her Mississippi family home, Blanche DuBois moves into the small New Orleans apartment shared by her pregnant sister Stella and Stella's husband, Stanley Kowalski. Blanche hides the circumstances that ended her teaching career and hopes to build a future with Stanley's friend Mitch. Stanley resents her pretensions, investigates her past, and tells Mitch about her sexual history, destroying the match. As Blanche's hold on reality weakens, Stanley asserts control over the household and assaults her while Stella is giving birth. Stella cannot reconcile Blanche's accusation with her decision to remain with Stanley. After the baby comes home, she allows a doctor and attendant to remove Blanche to an institution. Blanche leaves by trusting the doctor's courtesy, while Stella stays with Stanley and their child and the surrounding domestic life resumes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -473,7 +473,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -486,7 +486,7 @@
       "recaps": {
         "ending": "In custody, Jefferson Hope gives a complete account of both deaths and shows no remorse for either. He explains that he tracked Enoch Drebber and Joseph Stangerson from Utah across America and then across Europe to London, took work as a cab driver so that he could follow them unnoticed, and offered each man a choice between two identical pills, one harmless and one poisoned, so that the outcome would be a judgement rather than a simple killing. Drebber took the poisoned pill and died in the empty house at Lauriston Gardens; Stangerson refused the choice and attacked him, and was stabbed. A nosebleed brought on by the strain accounts for the blood at the first scene, and the word scrawled on the wall was meant to send the police toward a political motive. Hope also reveals that he is dying of an aortic aneurysm, and on the night before he is to be brought before the magistrates he is found dead in his cell, so there is no trial. The newspapers report the case as a triumph of official detection by Gregson and Lestrade, and Holmes's name is not mentioned. Holmes takes this lightly and explains to Watson how he reasoned backward from the marks at Lauriston Gardens to the cabman. Watson, indignant on his friend's behalf, resolves to publish an account of his own, which is how the record of their partnership begins.",
         "in_short": "Doctor John Watson, invalided home from Afghanistan and short of money, is introduced to Sherlock Holmes and takes rooms with him at 221B Baker Street, where he learns that his companion is a consulting detective the police fall back on when they are baffled. Their first case together is the death of an American, Enoch Drebber, found unwounded in an empty house off the Brixton Road with the German word for revenge scrawled in blood on the wall; Drebber's secretary Stangerson is then stabbed in a hotel near Euston. Holmes reads the traces at the scene, ignores the false trails the Scotland Yard men pursue, and traps the killer in his own sitting room: a London cabman named Jefferson Hope. The story then turns back thirty years to Utah, where Hope's promised bride Lucy Ferrier was taken from him and forced into marriage with Drebber, and her adoptive father was killed; she died within weeks, and Hope spent the years since hunting the two men across two continents. He confesses fully, dies of a heart aneurysm before he can be tried, and the newspapers give the credit to the police.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -654,7 +654,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -667,7 +667,7 @@
       "recaps": {
         "ending": "The attack by the hostile future version of St Mary's is defeated, but only after the present-day institute is turned into a battlefield and people involved in the time-travel operations are killed. Max and Bairstow's staff prevent their opponents from replacing or controlling their organisation. The Princes in the Tower project has established that the accepted historical mystery concealed more complicated events than the record preserves, and the fate of young Richard becomes bound to St Mary's own survival. Ronan's involvement connects the assault to the enemy who escaped the previous book; the immediate incursion is stopped, but he is still not safely beyond reach. Max, Leon, Peterson, Guthrie, and the surviving staff remain together at a damaged St Mary's, aware that a threat can now come from their own future as readily as from the past.",
         "in_short": "After surviving Ronan's first attack, Max and St Mary's resume historical assignments while treating every anomaly as a security risk. Missions involving Victorian London, Thomas Becket, and displaced dodos combine comic disorder with lethal field conditions. The central project investigates the Princes in the Tower. Max's team observes Edward V and his younger brother Richard in 1483 and discovers that the familiar story does not account for what happens to both boys. Their choices around Richard create a connection between the royal mystery and St Mary's future. A hostile future version of the institute, linked to Ronan's continuing campaign, then attacks the present organisation. Max and her colleagues defend their home at significant cost and stop the immediate attempt to seize their timeline. The present St Mary's survives, but personnel die during the temporal operations and Ronan remains an unresolved enemy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -841,7 +841,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -854,7 +854,7 @@
       "recaps": {
         "ending": "Larry's lawsuit fails, but victory does not save the farm or the marriages built around it. Pete dies after driving into a flooded quarry, and Ginny's relationship with Ty collapses when he remains attached to the farm and cannot face what she tells him about Larry. After learning that Jess has also been Rose's lover, Ginny briefly tries to poison Rose, then leaves Iowa and supports herself as a waitress in Minnesota. Debt eventually consumes the thousand acres. Larry declines and dies; Rose's cancer returns, and Ginny comes back to care for her until Rose also dies. Ginny becomes responsible for Rose's daughters, Pamela and Linda. Looking back, she recognizes both her own capacity for harm and the buried history of abuse beneath the family's public image. The land that seemed permanent has passed out of their hands, while Ginny survives apart from it with the next generation in her care.",
         "in_short": "Iowa farmer Larry Cook suddenly transfers his thousand acres to his daughters Ginny and Rose and their husbands, excluding youngest daughter Caroline when she questions the plan. The gift turns into a struggle for control as Larry grows erratic and sues to recover the farm. Narrator Ginny, long dutiful and childless, begins an affair with returning neighbor Jess Clark and uncovers memories of Larry sexually abusing her and Rose as teenagers. Rose confirms the abuse but also reveals her own affair with Jess, shattering the sisters' alliance. Pete dies after driving into a quarry, Ginny leaves husband Ty, and mounting debt ultimately costs the family the farm despite Larry losing his lawsuit. Larry later dies, Rose's cancer returns, and Ginny cares for her until her death. Ginny ends the novel in Minnesota, raising Rose's daughters and reckoning with the violence, rivalry, and silence hidden beneath the family's prosperous surface.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1110,7 +1110,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1515933962",
@@ -1122,7 +1122,7 @@
       "recaps": {
         "ending": "Long Wu Ying survives the tournament and defeats both Lin Tsui and Yin Xue when they challenge for his newly awarded inner-sect position. He moves into a modest inner-sect villa with better cultivation resources while Li Liu Tsong uses medicinal food to help repair his damaged meridians. Tou He leaves on an expedition required by his sponsor, and the city guard lieutenant departs in search of renewed purpose while retaining the valuable sword taken from the dead bandit leader. Cheng Zhao Wan also leaves to continue his training after warning that Long Wu Ying's victories over noble disciples have exposed both him and his associates to retaliation. Fairy Yang Fa Yuan has formed a core and become an elder, but any future guidance from her remains uncertain. Yin Xue survives, Elder Mo's hostility is unresolved, and Long Wu Ying enters the inner sect close to another breakthrough but still recovering from severe injuries.",
         "in_short": "Seventeen-year-old Long Wu Ying is conscripted into Shen's war, survives a near-fatal stabbing, and earns entry to Verdant Green Waters after his warning prevents a surprise attack. Sect life combines cultivation, hard labor, rivalry with Yin Xue, and pressure from Elder Mo, whose dangerous wine assignment sends Long Wu Ying through fights with spirit beasts and bandits. A wandering core cultivator helps deepen his sword understanding, and Long Wu Ying later kills the pursuing bandit leader beside a city guard lieutenant who becomes his friend. He returns with authentic wine, receives training from Cheng Zhao Wan, and reaches the eighth level of Body Cleansing. Forced to contest a suspiciously low rank, he fights through the sect tournament, defeats Lin Tsui and Yin Xue, and secures an inner-sect place. He ends the book recovering in his new villa, warned that noble retaliation will threaten him and those near him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1390,7 +1390,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DPNBDLJN",
@@ -1402,7 +1402,7 @@
       "recaps": {
         "ending": "The newly advanced elder saves Long Wu Ying from the demonic beast's killing leap, then joins the expedition leader and injured pill-refining elder in destroying it. Wu Ying, Tou He, Li Liu Tsong, and the female martial specialist all survive. Wu Ying returns with badly torn legs and a broken sword, Li Liu Tsong's left arm is mangled, and Tou He faces serious spinal and hip injuries that may have lasting effects but can be treated at the sect. The party reaches Verdant Green Waters about a week and a half later, and the wounded enter the physician's hall. Three of the five saint-level breakthrough pills remain for later use at the sect. The winged spirit beast's recognition of Wu Ying and its warning about the mountain remain unexplained. Wu Ying is still at Body Cleansing eleven, but he now understands part of his Tao: he wants enough strength to retain meaningful choices during a crisis. He and his surviving mission partner claim their rewards, with their proposed dinner still pending.",
         "in_short": "Long Wu Ying searches for a sustainable place in the inner sect, developing as a martial specialist, herb harvester, and novice pill refiner while abandoning blacksmithing as a long-term path. Missions with Tou He and a female martial specialist build his experience before sect obligations draw them into a northern spirit-lands expedition for a rare flower. The expedition suffers casualties, becomes trapped by a peak Core demonic beast, and refines the flower into five saint-level breakthrough pills. Two elders attempt advancement on site, forcing the exhausted group into a desperate defense. Wu Ying, Tou He, and Li Liu Tsong are gravely injured, but one elder completes the breakthrough in time to save Wu Ying and help kill the beast. The survivors return to Verdant Green Waters. Still below Energy Storage, Wu Ying ends at Body Cleansing eleven with a partial understanding of his Tao: strength matters because it preserves the ability to choose when disaster strikes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1625,7 +1625,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1515933989",
@@ -1637,7 +1637,7 @@
       "recaps": {
         "ending": "Wu Ying's party returns Lord Wen's authentic family cultivation method after escaping Guetong and surviving the journey out of enemy territory. Lord Wen keeps his oath, allowing Wu Ying's family and village to relocate under his protection, though the villagers resent the upheaval and the war remains unresolved. The blacksmith teammate survives severe wounds, while the final fates of Tsui and the armored defender are not established. Yin Xue has changed his qi route, advanced within Energy Storage, and retained an unexplained jade token from the mausoleum. Back at Verdant Green Waters, Wu Ying and the female martial specialist mutually end their romance, with any future friendship uncertain. Tou He returns safely, but his dantian problem remains open. After recovering and working to repay contribution points, Wu Ying understands that defining himself only by his peasant origins has constrained him. He accepts his ambition as a cultivator and opens his first Energy Storage meridian.",
         "in_short": "After failing to enter Energy Storage, Long Wu Ying tries to protect his village from the expanding war with Wei. Lord Wen agrees to let the villagers relocate only if Wu Ying's party retrieves the Wen family cultivation method from besieged Guetong. The Shen army detains the group and forces it into a costly assault, then abandons the siege without taking the city. Wu Ying and his companions infiltrate Guetong by river, recover the method from a family mausoleum, and escape after severe fighting. Lord Wen verifies the method and honors his oath, but the displaced villagers remain unhappy. Wu Ying's romance with the female martial specialist ends after their return. Having recognized that his attachment to a limited peasant identity caused his earlier blockage, Wu Ying finally enters Energy Storage, while war, family tension, Tou He's cultivation danger, Yin Xue's secrets, and Wu Ying's debts remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1872,7 +1872,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DLLDPL3M",
@@ -1884,7 +1884,7 @@
       "recaps": {
         "ending": "The ruler of Tsui is overwhelmed when Wu Ying forces his consuming Dao to take in the collapsing world spirit ring and Fairy Yang cuts away the unequal karmic bonds supporting him. The disaster reshapes the border and becomes a sealed gateway to a new, hazardous mystical realm. Only fragments of the ruler are recovered, leaving a measure of uncertainty about his complete destruction, while the damaged Tsui fortress retreats. Wu Ying is alive but absent, with his immortal body, soul integration, core, and link to the ring catastrophically damaged. His wood-cultivator companion remains his committed partner and final rescuer. The sect head survives his wounds, and Fairy Yang becomes temporary right guardian. Only one Iron Pass swordsman survives, permanently injured, and joins Verdant Green Waters as a visiting elder to preserve his tradition. Wei's first prince is reported dead, the first prince of Shen is apparently lost, and regional succession and alliances remain unsettled. Yin Xue survives without his demonic arm and eye, but his meridians are failing. He secretly possesses the ruler's second demonic heart and must choose between death and a transformation that threatens his humanity and future rebirths. The assassins' sponsor also remains unknown.",
         "in_short": "Wu Ying survives the reconstruction of his body, but his soul remains imperfectly joined to it. He joins a Verdant Green Waters embassy seeking to unite Shen and Wei and avert Tsui's drought-driven war. An assassination attempt, divided Wei loyalties, and Tsui's coercive cultivation system expose the talks as a trap. Wei's first prince sides with Tsui, and the ruler of Tsui proves to be a half-immortal sustained by demonic power and his army's linked strength. Wu Ying sacrifices a clean ascension to summon tribulation, then destroys his world spirit ring inside the ruler's consuming Dao. Fairy Yang severs the ruler's unjust karmic support, and the resulting collapse defeats him while remaking the border into a sealed mystical realm. Wu Ying survives but disappears in grave condition. Tsui withdraws, Wei's succession is unstable, and Verdant Green Waters suffers heavy losses. Yin Xue secretly keeps the ruler's second demonic heart, which may save his ruined meridians only by transforming him into a demon.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2175,7 +2175,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CWPQ3Y42",
@@ -2187,7 +2187,7 @@
       "recaps": {
         "ending": "Several years after returning, Wu Ying remains at Verdant Green Waters as an established elder and head of a growing Department of Wandering Gatherers. Its first students now undertake supervised and independent fieldwork, and the political attempt to abolish it has failed. The rival gathering elder has lost influence and some control over valuable herbs. Wu Ying's medicinal baths have improved his condition without curing it, and strenuous travel can still trigger a relapse. His wood-cultivator partner continues to travel, gather with him when possible, and seek materials for his treatment. During enforced recovery, Wu Ying creates the Old Dragon form, a fourth sword form built around restrained motion and holding a position under pressure. He also settles on a coherent understanding of the Seven Winds, joining five earthly winds with heavenly authority and the corrective force of the thousand hells, though further advancement remains uncertain. Tou He is still sealed away attempting to rebuild his immortal soul. Fairy Yang's network continues exposing exploitation and tracking dark-sect remnants, while war and displacement worsen beyond the sect.",
         "in_short": "Wu Ying returns injured to Verdant Green Waters and survives a hostile judgment that ends with him leading a new Department of Wandering Gatherers. The unfunded school becomes both his obligation and his means of serving the sect while experimental baths slowly repair his unstable wind body. He recruits and tests a first class, confronts political opposition, and begins intelligence work as Tou He struggles against a heaven-driven purifying flame. The students complete a dangerous wilderness examination, but Tou He then seals himself away to reconstruct his immortal soul and an aging former guardian dies attempting Nascent Soul ascension. A later effort to dissolve Wu Ying's department fails, and the rival gathering elder loses influence. Over several years the department expands, Wu Ying develops the defensive Old Dragon sword form, and his bond with the traveling wood cultivator endures. He remains only partly healed, ending with a clearer understanding of the Seven Winds as regional instability grows.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2464,7 +2464,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0F4Y2SHZS",
@@ -2476,7 +2476,7 @@
       "recaps": {
         "ending": "At the mountain summit, Wu Ying accepts travel, learning, relationships, ordinary labor, and service as parts of one continually growing path. The elderly physician fails to complete the same transformation and dies, but Wu Ying unites his immortal soul and body, then survives three heavenly lightning strikes. He leaves the chained hunger-beast alive so the realm can continue testing future cultivators, although its restraints may fail in roughly fifty years. Outside, the badly injured Yang Mu preserves the portal through the demonic assault. Wu Ying returns with the physician's body, transfers his possessions to Yang Mu, and rises toward denser immortal chi and the Jade Emperor's summons. An elder dragon subsequently addresses him as kin and directs him onward. Yang Mu remains in the mortal realm, and reunion depends on her own eventual ascent. Tou He has returned to his duties at Verdant Green Waters. The war around Yang Mu's family manual, the unidentified sponsors of the attacks, the library's surviving principals, and the mountain realm's long-term danger remain unresolved.",
         "in_short": "After a failed ascent leaves Wu Ying's immortal soul and body tearing apart, Yang Mu and Tou He accompany him through temples, foreign archives, hostile realms, and repeated ambushes in search of a new path. Tou He reaches Nascent Soul, while Wu Ying learns to remove the incompatible remnants of a wind-centered identity without discarding the mortal experiences that shaped him. Yang Mu uncovers the widening danger around her family's stolen dual-cultivation manual and repeatedly protects their journey. At a mountain realm that consumes chi and false self-conceptions, Wu Ying realizes his Tao lies in perpetual growth through travel, learning, relationships, and contribution. An elderly physician attempting the same trial dies. Yang Mu holds the entrance against demonic attackers while Wu Ying completes his merger, survives heavenly lightning, and becomes immortal. He leaves the realm's chained hunger-beast alive, entrusts his possessions to Yang Mu, and ascends to answer the Jade Emperor, leaving their reunion and several mortal conflicts unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2729,7 +2729,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B08Q28RW15",
@@ -2741,7 +2741,7 @@
       "recaps": {
         "ending": "Wu Ying survives a sword thrust through his chest because Wang Min and the injured apothecary recover enough cure material to prepare a powerful medicinal bath. The treatment repairs his severe wounds and strengthens his body, though it does not advance his cultivation stage. Fa Yuan rejoins him after the authorities accept enough evidence to release her. Her tracking mark on the stolen Ben spirit stone leads the sect to a merchant connected with its sale, but the wider dark-sect organization remains unexposed. The surviving expedition members are sent toward sect support, and a sun lotus continues growing inside Wu Ying's living world spirit ring. Elder Cheng receives the antidote and rapidly recovers. He assumes responsibility for the expedition's debts and begins training Wu Ying more intensely for the trouble ahead. Tou He remains alive but may have meridian damage, while the apothecary's poisoned and badly damaged hand tendons still require treatment. Fa Yuan briefs the sect's senior leadership, and the broader Shen-Wei destabilization remains open.",
         "in_short": "Elder Cheng returns to Verdant Green Waters with a lethal poison, prompting Wu Ying, Fa Yuan, Tou He, and a small expedition to seek three rare cure materials. Their journey tests the group against spirit beasts, hostile cultivators, and a conspiracy using corrupted chi and sacrifice-based cultivation. After Fa Yuan kills a Heavenly Lake elder and is detained, Wu Ying leads the remaining party to secure sun lotus and a powerful Chan Chu heart. Enemy cultivators capture and torture the apothecary, steal key materials, and nearly kill Wu Ying. Wang Min and the apothecary save him with a lotus blossom, a Chan Chu heart, and costly medicines, while Fa Yuan's tracking mark provides a lead to the stolen stone. Elder Cheng receives the antidote and recovers. Wu Ying returns to harsher training with a strengthened body and a new sword, while the dark-sect network, Tou He's cultivation damage, and the apothecary's injured hands remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2976,7 +2976,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09416PMN1",
@@ -2988,7 +2988,7 @@
       "recaps": {
         "ending": "The attack on the host sect fails, but the tower and library suffer extensive damage and many defenders are lost. Wu Ying, Tou He, their former wandering companion, the Whistling Iron Monkey allies, and the library defenders hold long enough for the wounded formation elder to destroy a hostile Core cultivator's core. Two other enemy Core cultivators also die, as does one protector of the host sect. The noblewoman escapes amid fires in the tower, and the Dark Sect's wider network and internal collaborators remain unresolved.\n\nWu Ying spends almost two months healing. Five Winds Body has restored much of his condition and strengthened his bones and joints, but the exact nature of his dragon ancestry, his long-term health, and the soul method suited to him remain unsettled. Elder Huang rewards his warning and service with a personal copy of Seven Winds Body under a binding secrecy oath. Wu Ying leaves the sect with the former wandering cultivator and seeks a middle course between reckless intervention and ignoring harm. Tou He stays behind for a time to refill and stabilize his enlarged cultivation capacity and to assist reconstruction. Wu Ying's next challenge is reconciling Seven Winds with his bloodline while changing his soul cultivation path.",
         "in_short": "An awakened dragon bloodline has transformed Wu Ying's body but filled it with dangerous, self-renewing chi. He travels with Tou He and a former wandering cultivator to a sect that studies unusual constitutions, where he is told he may have only a year to live. While earning access to cultivation manuals, he uncovers victims of addictive Dark Sect aids and signs of an active conspiracy. Tou He successfully opens a second dantian, but Wu Ying nearly exhausts himself supporting the breakthrough. Wu Ying finally understands that Five Winds Body must balance his altered chi instead of removing it, restoring his strength in time to resist a coordinated assault on the host sect. The defenders repel the attack at severe cost, though the noblewoman and other conspirators escape. After nearly two months of healing, Wu Ying receives Seven Winds Body and leaves with his former wandering companion, while Tou He remains temporarily to recover and help rebuild.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3245,7 +3245,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09MR4KNBH",
@@ -3257,7 +3257,7 @@
       "recaps": {
         "ending": "Fa Yuan, her sister, and many other prisoners escape the compound, though the victory costs numerous rescuers and captives their lives. Tou He completes his Core Formation breakthrough. Yin Xue survives the loss of an eye, while the former wandering cultivator dies after torture by a Dark Sect elder. Elder Cheng saves the fleeing group but suffers a critical poisoning. He gives Wu Ying his sword manual, then enters deep meditation behind a waterfall under the cover of an apparent burial. Only Wu Ying and Fa Yuan know that his death is not certain. Months later, the survivors leave Wei after corruption within its royal family leads to a coup and the end of the war. Fa Yuan returns toward Verdant Green Waters with Wu Ying and Tou He, then withdraws in mourning. Wu Ying refuses a separate hunt for Dark Sect remnants. Verdant Green Waters formally exiles him for disobeying orders and for the rescue's costs. He accepts the judgment, returns his token, and departs to follow the wind and shape an independent Tao. Elder Cheng's survival, Wu Ying's Core Formation path, the lost land, and remaining Dark Sect influence stay unresolved.",
         "in_short": "While gathering herbs for Verdant Green Waters, Wu Ying learns that Dark Sect forces and internal traitors have devastated his sect and abducted Fa Yuan. He defies orders and leads an expanding rescue force into Wei. The prisoners are freed, but the breakout becomes a costly battle in which the former wandering cultivator is murdered, Yin Xue loses an eye, and many allies die. Tou He reaches Core Formation, while Wu Ying develops a dangerous wind technique rooted in his own understanding of karma. Elder Cheng abandons another mission to save his disciples, is critically poisoned, and enters concealed meditation beneath a waterfall while the world believes him dead. Wei's corrupted royal order falls in a coup and the war ends. Back at Verdant Green Waters, Wu Ying accepts exile for the unauthorized mission, surrenders his sect token, and leaves to pursue his own Tao.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3484,7 +3484,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CD87X8F3",
@@ -3496,7 +3496,7 @@
       "recaps": {
         "ending": "The ape's body is drained and destroyed, closing the immediate demonic gate, but the survivors find no proof of who created it. The expedition's alliance collapses when members of the special unit ambush Wu Ying, the wood cultivator, and Tou He. Linked escape formations carry the trio away, and Wu Ying kills the pursuing Nascent Soul raptor with his single-use slaughter formation. Tou He loses two fingers protecting him, while the wood cultivator exhausts herself powering their flight. During the following weeks, corrupted-beast activity declines as the source's influence fades. Wu Ying's hand heals into a painful scar, and his contact with heavenly wind leaves him frightened that further cultivation could erode his human identity. He and the wood cultivator affirm their romantic bond. More than a year and a half after Tou He began his mission, the three travel by boat toward Verdant Green Waters. Tou He has advanced another core layer, and Wu Ying chooses to announce his return by approaching the sect through its waterfall. The gate's maker, the surviving conspirators, Wu Ying's reception, and the danger within his Seven Winds path remain unresolved.",
         "in_short": "Wu Ying travels south with a gifted wood cultivator to trace corrupted beast cores and deepen his wind cultivation. They reunite with Tou He, whose dragon-altered flame can cleanse the taint, and join a mistrustful military expedition. After recovering a heart-like corruption splinter from a demon-held ruin, the party reaches a temple where a mutilated Nascent Soul ape serves as a demonic gate. Wu Ying completes his third Wandering Dragon cut and channels heavenly wind, while Tou He and the formation workers help destroy the gate at great cost. The colonel's faction then betrays the three outsiders. They escape, kill the pursuing raptor, and evade pursuit as the corruption recedes. Wu Ying and the wood cultivator become partners. Scarred and troubled by the loss of self implicit in heavenly wind, Wu Ying returns toward Verdant Green Waters with her and Tou He.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3744,7 +3744,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0B2X3NMH2",
@@ -3756,7 +3756,7 @@
       "recaps": {
         "ending": "Elder Cao's scheme ends when Wu Ying and two visiting sect elders wear down her defenses and Liu Ping, overtaken by grief and her unstable bloodline, kills her. Wu Ying identifies Cao as the person behind the murders, the fire, Liu Ping's abduction, and the effort to make independent tournaments and auctions appear unsafe. With the confinement formation destroyed, attendees are free to leave. The White Flower Merchant Association openly recruits for resistance to Zhao, but Liu Ping does not follow its leader. The guard captain dismisses anyone unwilling to face the consequences and remains to file an honest report, although he expects the government to retaliate. Three days later, Liu Ping wakes, still injured and changed by her brother's death. She accepts Pan Yin's offer to travel west with the Pan clan alongside Wu Ying and Pan Shui. Wu Ying departs Zhao as a wounded new Core Formation cultivator. His banishment from Verdant Green Waters, the stability of his wind core, his developing Tao, the secret of his world spirit ring, and the purpose of Zhao's kingdom-wide formations remain unresolved.",
         "in_short": "Banished from Verdant Green Waters, Wu Ying follows a spirit beast's cryptic guidance, crosses into Zhao, and forms a compressed but fragile wind core. Concealing his strength, he joins Liu Ping and Liu Jin at a Seven Pavilions tournament, where he meets Pan Shui, Pan Yin, and visiting sect cultivators. A sequence of murders traps the contestants inside the grounds. Liu Jin and Investigator Chu are among the dead, while evidence increasingly points to an advanced insider. Wu Ying draws out Elder Cao, who admits that she created the violence for Zhao to discredit independent gatherings. Wu Ying and two elders bring her close to defeat, and Liu Ping kills her in an uncontrolled bloodline state to avenge her brother. The White Flower Merchant Association then recruits openly for resistance, while the guard captain stays to report the truth. Recovering from the battle, Wu Ying leaves Zhao for the west with Liu Ping and the Pan sisters.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4056,7 +4056,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BTMSD5WT",
@@ -4068,7 +4068,7 @@
       "recaps": {
         "ending": "Wu Ying leaves the neutral mountain inn on foot and heads south toward the Dai Kingdom. The innkeeper has warned him that unusually large, corrupted demonic cores are emerging from the region's beast-filled forest, and Wu Ying accepts the task of finding and opposing the cause. He remains free to return to Verdant Green Waters because his banishment has ended, but continues his independent journey by choice.\n\nHis revised cultivation method, Cyclone's Breath, uses a broad external vortex to attune surrounding wind chi and greatly accelerate his cultivation, though its concealment has not yet been tested against real enemies. His compressed wind core, Seven Winds body, Heart of the Sword, and first two Wandering Dragon movements are stronger, while a third sword form remains unfinished. He carries a new saint-level jian, concealment and protective formations, two escape talismans, and a single-use slaughter formation. Buying them costs much of his store of cores and rare plants. Elder Cheng's recovery, Pan Yin's advancement, the future of Wu Ying's winter pupil, and the source of the southern corruption remain unresolved.",
         "in_short": "Newly advanced to Core Formation, Wu Ying spends years wandering beyond Verdant Green Waters. He helps the Pan clan clear a deadly snake from its mystic realm and gains the Heart of the Sword, trains a persecuted teenage swordsman to win his freedom, and repays an offense against a northern tribe through service and defense. After rejecting a dragon-bloodline path, he reaches Baixia, learns that his banishment has ended, and retrieves seven tribute pearls before helping kill a giant spirit octopus. Further years of coastal work, storms, and seclusion deepen his Seven Winds cultivation and Wandering Dragon style. At a neutral inn, three Nascent Soul cultivators redesign his continuous cultivation technique as Cyclone's Breath. Equipped with a saint-level jian, formations, and escape talismans, he leaves for Dai to investigate increasingly powerful corrupted demonic beasts.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/a-thousand-splendid-suns.json
+++ b/data/works-community/0/a-thousand-splendid-suns.json
@@ -103,7 +103,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -116,7 +116,7 @@
       "recaps": {
         "ending": "Mariam's life ends in sacrifice, and Laila's opens into hope. When Tariq reappears, alive after years of Rasheed's lie that he had died, Rasheed flies into a murderous rage and begins beating Laila to death. To save her, Mariam strikes and kills Rasheed with a shovel. Knowing that both women cannot escape, Mariam insists on taking sole blame; she surrenders to the Taliban authorities and is publicly executed, choosing her end freely and finding a kind of peace in having, at last, loved and been needed. Laila flees with Tariq and the children to Pakistan, where they live quietly until the Taliban regime collapses. Drawn home, Laila returns to Kabul and, on the way, visits Herat, where she learns of Mariam's childhood and receives a letter and a small inheritance her father had left for the daughter he failed. Laila and Tariq settle into the recovering city, and Laila takes up work helping to rebuild an orphanage and teach children. Pregnant again, she resolves that if the baby is a girl she will name her Mariam, keeping alive the woman who gave everything for her.",
         "in_short": "In Afghanistan, an illegitimate girl named Mariam is married off at fifteen to Rasheed, a much older Kabul shoemaker, after her mother's suicide and her father's rejection. When she cannot give him a living child, Rasheed turns cruel. Years later, Laila, a bright girl on the same street, is orphaned by a rocket in the civil war and, believing her childhood love Tariq dead, is taken in and married by Rasheed as a second wife. The two women, at first rivals, become like mother and daughter as they endure Rasheed's abuse and the harsh rule of the Taliban. Laila raises a daughter secretly fathered by Tariq and a son by Rasheed. When Tariq returns alive and Rasheed nearly beats Laila to death in his fury, Mariam kills him with a shovel to save her. Mariam gives herself up so that Laila can escape, and is executed by the Taliban. Laila reunites with Tariq, and after the Taliban fall she returns to a rebuilding Kabul carrying Mariam's memory forward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -265,7 +265,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -278,7 +278,7 @@
       "recaps": {
         "ending": "Ernst's leave ends, and he returns to the Eastern Front after marrying Elisabeth and experiencing a brief civilian life amid the ruins. The German retreat has become more chaotic, but ideological killing continues even when it has no military purpose. Steinbrenner prepares to murder Russian prisoners before the unit withdraws. Ernst finally refuses complicity: he shoots Steinbrenner and releases the captives. The humane decision does not protect him. One of the freed prisoners seizes a weapon and shoots Ernst as the Germans abandon the position. He dies just when messages from home have offered evidence that the relationships and future he found on leave might have continued. Elisabeth remains behind in the bombed city, having lost her imprisoned father and now her husband as well. Ernst's last act breaks with the murderous obedience represented by Steinbrenner, but the ending denies any simple moral reward; violence set in motion by the war reaches him through a man he has chosen to save.",
         "in_short": "German soldier Ernst Graeber receives leave from the collapsing Eastern Front and returns to find his home town bombed and his parents missing. Searching the ruins brings him to Elisabeth Kruse, whose father has been imprisoned by the Nazis. They fall in love during air raids, using borrowed rooms, food, and a few weeks of freedom to build a private life inside a criminal regime. Ernst's former teacher Pohlmann and the fugitive Josef force him to confront what obedience has supported, while Nazi acquaintance Alfons Binding demonstrates the comforts available through complicity. Ernst and Elisabeth marry, knowing his leave will end. Back at the front, the German retreat accelerates. When the fanatical Steinbrenner intends to kill Russian prisoners, Ernst shoots him and frees them. One prisoner then takes a weapon and shoots Ernst. The novel closes without rescue: the love found during leave changes Ernst's moral choices, but it cannot remove him or Elisabeth from the destruction created by the war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -483,7 +483,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -496,7 +496,7 @@
       "recaps": {
         "ending": "Kauf burns and its Scholar prisoners are freed, but Izzi is killed in the escape and Elias is close to death from the Commandant's poison. Helene, having found him and been unable to finish her orders, lets him go and returns to Antium with a version of events that will keep her family alive. North of the prison, Shaeva saves Elias the only way left to her: she binds him to the Waiting Place as her heir. He will live, and he will never again be able to leave the forest for long. He and Laia part with that understood. Laia takes Darin south, meaning to get him to safety and then to fight. Keenan asks her to give him her mother's armlet as proof that she trusts him; when she does, he sheds the shape he has worn for years and reveals himself as the Nightbringer. The armlet was the last fragment of the Star he has spent a thousand years gathering, and every step of Laia's flight, including the resistance that betrayed her, has served his purpose. In Antium, Marcus tightens his grip on the Blood Shrike by binding her sister Livia to the throne, while the Commandant, the Nightbringer's ally, moves openly toward power. Laia is left with her brother, no armlet, no magic she can control, and the knowledge that the man she trusted most is the oldest enemy her people have.",
         "in_short": "Laia, Elias, Izzi and Keenan flee Serra for Kauf prison in the far north to free Laia's brother Darin, hidden along the way by the Tribal trader Afya Ara-Nur. Elias is dying from a poison the Commandant gave him in the death cells, and Laia discovers she can vanish from sight when she is terrified. Behind them, Helene Aquilla, now Blood Shrike to the Emperor Marcus, is ordered to hunt Elias down with her family's lives as surety; she discovers a healing magic of her own and evidence that the Commandant is conspiring with something inhuman. At Kauf, Elias is captured and tortured by the prison's Warden while Laia finds her brother alive but broken. Helene reaches the prison, cannot bring herself to finish her orders, and helps them escape as Kauf burns. Izzi is killed. To save Elias's life the jinn Shaeva binds him to the Waiting Place as the next Soul Catcher, which means he can never leave it. Laia takes Darin south, and Keenan asks for her mother's armlet as a token of trust. When she gives it to him he reveals himself as the Nightbringer, the ancient jinn who has been collecting the pieces of the Star for a thousand years.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -630,7 +630,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -643,7 +643,7 @@
       "recaps": {
         "ending": "Joe returns from England after learning from Noel that Jean has gone to Australia. He and Jean are reunited and acknowledge that each had crossed the world looking for the other. They marry and make their future in Willstown rather than leaving for an established city. Jean uses her trust income, business judgment, and knowledge of what working women need to create employment and amenities, while Joe develops his cattle interests. The ice-cream shop is followed by further ventures, including local manufacturing and a swimming pool. These projects attract young women, families, and additional businesses, gradually turning the isolated settlement into the kind of viable community Jean had admired in Alice Springs. Noel eventually visits and sees both the transformed town and the settled life Jean and Joe have built. Jean's wartime promise to repay help in Malaya and her postwar hope of creating a town like Alice are both fulfilled through durable communities rather than private wealth.",
         "in_short": "London solicitor Noel Strachan tells how Jean Paget inherits a fortune and uses it to revisit the Malayan village that sheltered her during the war. As a Japanese prisoner, Jean had helped lead a group of women and children on a deadly march between camps. Australian prisoner Joe Harman aided them and was brutally punished after stealing food for them; each believed the other had died. In Malaya Jean learns that Joe survived, then travels to his remote Australian home, Willstown, only to find that he has gone to England looking for her. She stays and begins creating jobs and amenities that can make the settlement attractive to women and families. Joe learns where she is and returns. They reunite, marry, and continue developing local businesses, transforming Willstown from an isolated cattle outpost into the thriving town Jean imagined after seeing Alice Springs.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -795,7 +795,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -808,7 +808,7 @@
       "recaps": {
         "ending": "Max and Leon survive the pursuit that began with her arrival in his version of St Mary's. By confronting the forces policing the timeline instead of continuing to hide, they establish that Max cannot simply be treated as an intruder to be removed. Their allies at St Mary's help preserve both the institute and the life Max has entered. The immediate chase ends, and Max is able to remain with Leon rather than being forced back into the loss from which she arrived. The resolution does not erase the cost of Troy or make the wider struggle over time travel safe: Ronan is still beyond St Mary's control, and the existence of authorities capable of pursuing people across eras has permanently enlarged the danger around the institute. Max and Leon nevertheless finish together at St Mary's, choosing a shared future after spending the book running through the past.",
         "in_short": "A Trail Through Time begins at the point where Max has reached a different version of St Mary's and found Leon alive. Their reunion is complicated by the fact that this world had its own Max and by temporal authorities who regard the newcomer as an anomaly. When an attempt to settle the situation turns into a pursuit, Max and Leon escape in a pod and move between periods, finding that each refuge carries its own historical dangers and that their pursuers can follow them along the timeline. Flight eventually gives way to a plan to return to St Mary's and challenge the basis on which Max is being hunted. Bairstow and the surviving staff support them through the confrontation. Max is allowed to remain in the life she has reached, and she and Leon end together, although Ronan remains free and the conflict over who controls travel through history is not resolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -957,7 +957,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -970,7 +970,7 @@
       "recaps": {
         "ending": "After Eddie reports the undocumented immigrants, officers arrest Marco and Rodolpho, as well as two men hidden by another family. Catherine and Beatrice understand who betrayed them, and Marco publicly accuses Eddie, destroying the reputation Eddie hoped to protect. Alfieri arranges bail so Catherine and Rodolpho can marry, but Marco is released only after promising not to attack Eddie. On the wedding day Eddie refuses to attend and demands that Marco withdraw the accusation. Marco comes to the street, where Eddie advances on him with a knife. Marco turns the weapon back during their struggle, and Eddie is fatally wounded. Beatrice holds her dying husband as he calls for her. Catherine and Rodolpho are left to proceed with their marriage, Marco faces deportation, and Alfieri reflects on the destructive force of Eddie's unchecked passion.",
         "in_short": "Brooklyn longshoreman Eddie Carbone and his wife, Beatrice, shelter her undocumented Sicilian cousins Marco and Rodolpho. Eddie's orphaned niece Catherine falls in love with Rodolpho, provoking Eddie's possessiveness. He insists Rodolpho only wants citizenship and tries to discredit him, while lawyer Alfieri warns that there is no lawful basis for interference. Eddie finally reports the brothers to immigration officials. Marco identifies him as the informer, leaving Eddie shunned by the community. Although Catherine and Rodolpho prepare to marry and Marco is released on bail pending deportation, Eddie cannot accept the loss of his reputation. He confronts Marco with a knife outside the apartment. Marco turns the weapon during the struggle, and Eddie dies in Beatrice's arms, destroyed by the betrayal and violence his jealousy set in motion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1091,7 +1091,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1104,7 +1104,7 @@
       "recaps": {
         "ending": "Jamie tells Landon that she has leukemia and that treatment can no longer cure her. As her health declines, Landon remains with her and seeks ways to fulfill the hopes she once listed for her life. His estranged father uses his resources to arrange care at home, beginning a reconciliation between father and son. Landon finally understands that Jamie's greatest wish is to marry in the church where her parents were married, with the community present and her father officiating. He proposes, and she accepts. Though weak, Jamie walks down the aisle to Landon, and they marry. Speaking forty years later, Landon says their marriage lasted only a short time before her death. He has never removed his wedding ring and still loves her. He cannot prove that the miracle he prayed for occurred, but he regards the transformation of his own life and the love they shared as miraculous.",
         "in_short": "In 1958 Beaufort, North Carolina, high-school senior Landon Carter asks the kind but socially isolated minister's daughter Jamie Sullivan to the homecoming dance because he has no other date. Their connection grows when she recruits him for a Christmas play and for an effort to give the local orphans a better holiday. Landon moves from embarrassment about being seen with Jamie to admiration and love, while she helps him become more generous and sincere. Jamie then reveals that she has leukemia and is dying. Landon stays with her, reconciles with his distant father when the congressman arranges medical support, and searches for a way to grant Jamie's wishes. He proposes marriage. Jamie walks down the church aisle despite her weakness, and they wed with her father officiating. Forty years later, Landon remains faithful to her memory and understands their love—and the person it helped him become—as the miracle for which he prayed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1356,7 +1356,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0090Q9BM8",
@@ -1368,7 +1368,7 @@
       "recaps": {
         "ending": "A sniper kills Julia Sorenson as she, Reacher, and Karen Delfuenso approach Wadiah's concealed former military installation. Reacher sends Delfuenso to summon support and enters alone. Inside, he finds handwritten financial records and containers of nuclear waste used as the visible reserve behind Wadiah's paper currency. He locates Don McQueen alive but bound and held by Peter King. Reacher kills Peter, frees McQueen, and fights toward an exit. Delfuenso returns in time to kill the guards about to shoot Reacher, then drives them away before the Quantico force arrives. McQueen and Delfuenso survive, while Sorenson and Peter are dead. The installation and its records remain for the incoming FBI operation, and the man who used the Lester identity is identified as Wadiah's mole within the CIA. Peter was only second in command, so Wadiah's ultimate leader and the wider reach of the network remain unresolved. Reacher leaves before the FBI can debrief him.",
         "in_short": "Hitchhiking through Nebraska, Jack Reacher accepts a ride from Alan King, Don McQueen, and Karen Delfuenso as police investigate a killing at a pumping station. Apparent murders and abductions draw Reacher into an unsanctioned investigation with FBI agent Julia Sorenson. The case proves to be a concealed FBI operation against Wadiah: McQueen is undercover, Delfuenso is his secret backstop, and Alan King is dead. Tracking McQueen leads Reacher, Sorenson, and Delfuenso to a hidden former military installation, where a sniper kills Sorenson. Reacher infiltrates the site, discovers an illicit paper bank backed by stored nuclear waste, frees McQueen, and kills Peter King, Wadiah's second in command. Delfuenso saves both men from the remaining guards and drives them away before federal forces arrive. Wadiah's local operation is exposed, but its ultimate leader remains unknown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1511,7 +1511,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1524,7 +1524,7 @@
       "recaps": {
         "ending": "After Gerald learns that Lord Illingworth is his father, he wants to repair his mother's social position by making Illingworth marry her. Mrs Arbuthnot refuses: a marriage without love would only place her again under the power of the man who abandoned her. Hester rejects the house party's double standard and gives Mrs Arbuthnot the acceptance she had earlier denied to women with compromised reputations. She and Gerald declare their love and decide to marry and live in America with his mother. Illingworth arrives expecting to recover influence over Gerald, but Mrs Arbuthnot rejects his claims on their son. When he treats their past and Gerald with renewed arrogance, she strikes him with his own glove and sends him away. Gerald, Hester, and Mrs Arbuthnot leave the old scandal behind as a family, while Illingworth departs isolated and dismissed as insignificant.",
         "in_short": "At a country-house gathering, young Gerald Arbuthnot is delighted when the sophisticated Lord Illingworth offers him a prestigious secretaryship. Gerald's mother urgently opposes the plan because Illingworth, once known as George Harford, seduced and abandoned her years earlier and is Gerald's father. She has concealed the truth while bearing the social shame alone. Illingworth refuses to give up the young man, and Gerald mistakes his mother's fear for narrowness. When Illingworth makes an unwanted advance toward Hester Worsley, Gerald attacks him; Mrs Arbuthnot stops her son by revealing their relationship. Gerald then proposes that his parents marry, but his mother will not bind herself to the man who wronged her. Hester, chastened in her earlier moral severity, embraces Mrs Arbuthnot and agrees to marry Gerald. They plan a life together in America. Mrs Arbuthnot rejects Illingworth's final attempt to assert himself, strikes him with his glove, and dismisses him from their lives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1659,7 +1659,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1672,7 +1672,7 @@
       "recaps": {
         "ending": "After Meg is hurt escaping Camazotz, gentle furred creatures on the planet Ixchel nurse her back to health, and one she calls Aunt Beast comforts her. The three Mrs Ws appear and explain that Meg alone must go back for Charles Wallace, because she has a bond with him that no one else shares, and they can give her nothing but their love and one final clue: she possesses something IT does not have. Returning to Camazotz, Meg faces IT and her brother, who is still controlled by the brain's rhythm. She realizes the thing IT cannot feel is love, and by pouring out her fierce love for Charles Wallace she breaks IT's hold on him. He comes back to himself, and the two are caught up and tessered home. They land in the vegetable garden behind their house, reunited with their father, their mother, the twins, and Calvin. The three Mrs Ws appear one last time to say goodbye before hurrying off on further work of their own.",
         "in_short": "Meg Murry, an unhappy misfit, grieves her scientist father, who vanished during a secret experiment. Her gifted little brother Charles Wallace introduces her to three strange beings, Mrs Whatsit, Mrs Who, and Mrs Which, who, with their new friend Calvin O'Keefe, whisk the children across space by folding it, a tesseract. They learn that a growing darkness threatens the universe and that Mr. Murry is held on Camazotz, a planet enslaved to mindless conformity. There they confront the controlling brain called IT; Charles Wallace lets his mind be taken. The children free their father, but escaping, they must leave Charles Wallace behind, and Meg is injured passing through the dark. Nursed back to health on another world by gentle creatures, Meg realizes she alone can save her brother. She returns to Camazotz and defeats IT with the one power it lacks, love, freeing Charles Wallace so the family can return home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1847,7 +1847,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1860,7 +1860,7 @@
       "recaps": {
         "ending": "After the exposure of Guinevere and Launcelot's relationship, Arthur's realm collapses into civil war and the Church places Hank's modernized kingdom under an interdict. Arthur and Mordred kill one another, while the surviving forces of chivalry turn against Hank's small technical elite. Hank and Clarence retreat with loyal youths to a fortified cave protected by mines, guns, and electrified fences. At the Battle of the Sand Belt, their machinery annihilates the massed knights, but the victors are trapped behind heaps of bodies that spread disease and make escape impossible. Merlin enters the cave disguised as an old woman and puts Hank into an enchanted sleep meant to last thirteen centuries; while celebrating, Merlin accidentally touches an electric wire and dies. Hank wakes in his own nineteenth century, but Camelot remains more real to him than the present. On his deathbed he calls for Sandy and their child, believes he is back in Arthur's world, and dies reaching for the family and age he lost.",
         "in_short": "Connecticut engineer Hank Morgan is knocked unconscious and wakes in King Arthur's Britain. Using knowledge of an eclipse, explosives, communications, and manufacturing, he defeats Merlin's prestige and becomes the King's chief minister. With the young Clarence, he secretly builds schools, factories, telegraphs, and an educated technical class while publicly participating in knight-errantry. He marries Sandy and tries to teach Arthur about ordinary life by traveling with him in disguise; both are captured and nearly sold as slaves. Hank's reforms transform parts of the kingdom but depend on his personal control and cannot overcome its political and religious foundations. When the affair of Guinevere and Launcelot destroys the court, Arthur and Mordred die in civil war and the Church turns the country against Hank. His small modern force exterminates the attacking knights with mines, guns, and electric fences, then becomes trapped by the destruction. Merlin enchants Hank into a thirteen-century sleep. Returned to the nineteenth century, Hank dies longing for Sandy, their child, and the lost world of Camelot.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2075,7 +2075,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2088,7 +2088,7 @@
       "recaps": {
         "ending": "Ashford's attack on the Station provokes exactly the response Holden feared: the slow zone tightens its limits further, and everyone inside it will die if it is not stopped. In the fighting aboard the Behemoth, Bull, already crippled and running the ship from a chair, defeats Ashford's loyalists and holds the vessel together long enough for Holden to act, and dies of his injuries. Holden crosses to the alien Station with the Miller apparition guiding him, and Clarissa Mao follows to kill him. Inside, Holden learns what the Miller construct has been assembled to tell him: the civilization that built the protomolecule and the gates was destroyed a very long time ago by something else, something that is still out there and that the Station has been watching for. Holden convinces the Station to stop killing the people trapped inside it, and the slow zone releases them. Anna goes out in a suit and brings a dying Clarissa back alive rather than leave her, and afterward argues for mercy rather than execution; Clarissa is taken into custody and sent back to Earth to face trial. The surviving ships go home. The ring is no longer a single door: it opens onto more than thirteen hundred gates, each leading to another star system with habitable worlds behind it, and the human race is left staring at more room than it knows what to do with.",
         "in_short": "The alien structure grown out of Venus has become a ring beyond the orbit of Uranus, and fleets from Earth, Mars and the Outer Planets Alliance gather to study it. James Holden takes the Rocinante out under a documentary contract while an apparition of the dead detective Miller, visible only to him, pushes him toward the ring. Clarissa Mao, working under a false name as a technician, sabotages a United Nations ship, murders a colleague to cover it, and frames Holden for the attack. Fleeing the pursuit, the Rocinante passes through the ring, and the fleets follow into a vast enclosed space that enforces an absolute speed limit; the sudden deceleration kills and maims thousands. Trapped inside, the survivors gather around the OPA's huge ship Behemoth. Its captain, Ashford, decides to destroy the alien Station at the centre, which would kill everyone. Security chief Bull, executive officer Pa and the pastor Anna Volovodov move against him, and Bull dies stopping the attack. Holden reaches the Station, learns that whatever killed the protomolecule's builders still exists, and persuades it to let the fleets go. The ring then opens onto more than thirteen hundred other star systems.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2267,7 +2267,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2280,7 +2280,7 @@
       "recaps": {
         "ending": "News of Kurt Cobain's death devastates Ellie. During a trip with Marcus she breaks a record-shop window displaying Cobain's image and is arrested. The crisis brings together the network that has formed around Marcus: Will, Fiona, Rachel, and his father can all be called upon, so he no longer believes one fragile adult is his entire foundation. Fiona remains alive and connected to him rather than facing her depression alone. Ellie has to answer for the damage but is also seen as a distressed child rather than merely a frightening rebel. Will, meanwhile, has become capable of caring about events that do not directly serve his comfort. His relationship with Rachel is genuine, and his bond with Marcus persists after the lie about being a father is gone. Marcus grows more socially adaptable without wholly discarding his difference. Both protagonists finish with a broader, messier set of attachments: Marcus is less isolated because he has several people to rely on, while Will is less isolated because he has finally accepted responsibility for other people.",
         "in_short": "Will Freeman is a wealthy, idle London bachelor who invents a young son so he can join a single-parent group and meet women. The lie brings him into the life of twelve-year-old Marcus Brewer, an isolated boy whose mother Fiona is severely depressed. After Fiona attempts suicide, Marcus decides he needs another adult as protection against losing her and begins visiting Will. Will initially resists, then helps Marcus fit in and becomes genuinely involved. Marcus exposes the fictional son, but also helps Will when Will falls for the single mother Rachel and repeats the lie. Their widening circle includes Rachel's son Ali and Marcus's rebellious friend Ellie. When Kurt Cobain's death triggers Ellie's grief and arrest for breaking a shop window, Marcus discovers he now has several adults to call on. Fiona is supported, Will sustains real attachments, and Marcus becomes less vulnerable without needing to remake himself completely.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2468,7 +2468,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2481,7 +2481,7 @@
       "recaps": {
         "ending": "Quentin's reconstruction identifies Charles Bon as Thomas Sutpen's son by an earlier wife whom Sutpen abandoned after learning that she had Black ancestry. Sutpen later tells Henry that Bon is both Judith's half brother and, under the racial code Sutpen accepts, an unacceptable husband. Henry finally kills Bon at the gate of Sutpen's Hundred and disappears. Decades later Rosa and Quentin discover that the aged Henry has secretly returned to die in the ruined mansion. When Rosa brings an ambulance, Clytie assumes the authorities have come to take Henry and burns the house, killing herself and Henry. Jim Bond escapes and remains the sole surviving branch of Sutpen's line. At Harvard, Quentin finishes telling Shreve the story but cannot resolve what the South and its inherited violence mean to him; when Shreve asks why he hates the South, Quentin insists that he does not.",
         "in_short": "In 1909, Rosa Coldfield tells Quentin Compson how Thomas Sutpen arrived in Mississippi, built a plantation through slavery, married her sister Ellen, and destroyed his family while pursuing a dynasty. Quentin, his father, and Shreve McCannon repeatedly reconstruct the past from partial testimony. Sutpen's son Henry befriends Charles Bon, who courts Henry's sister Judith. Bon is eventually understood to be Sutpen's unacknowledged son from an earlier marriage, rejected because of his mother's ancestry. Henry kills his half brother to stop the marriage. Sutpen's later attempt to secure an heir through Milly Jones ends when Wash Jones kills him. In 1909 Rosa and Quentin discover Henry hidden at the decaying estate. Clytie burns the mansion rather than let outsiders remove him, killing them both, while Bon's grandson Jim Bond escapes. Sutpen's design ends not in the white dynasty he imagined but in ruin, uncertain memory, and a surviving descendant the family had marginalized.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2933,7 +2933,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -2946,7 +2946,7 @@
       "recaps": {
         "ending": "Felix returns from the breach as Harwatch's defenses are near collapse. The freed Dusk Dragon spends most of his remaining power opening the battlefield, then survives through a voluntary Draconic Bond with Vessilia Dayne and becomes a small golden wyrmling. Atar V'as and Alistair destroy two Hierocracy mana ships, and Zara Cyrene's shield prevents the first cannon strike from breaking the city. A High Guard swordmaster severs Pit's wings and damages his spirit, but Pit remains linked with Felix and takes a decisive role in completing Felix's nine-pillar formation. Felix then kills all four High Guard and wins the territorial challenge. Most surviving invaders are captured or routed. Pit remains converged with Felix while both recover from spirit wounds, and Vess and the wyrmling survive under healer care. Harwatch still has casualties, prisoners, incomplete defenses, and an expected Hierocracy response. Felix directs his allies to strengthen the city's shield with the Merc Enclosure ritual and concludes that the scattered Unbound must coordinate for the conflict ahead.",
         "in_short": "After claiming the Leviathan Depths, Felix Nevarre installs an Itten chancellor and departs as threats converge on Nagast and Harwatch. A fragment of divine regalia reveals that the Hierocracy controls another Unbound, Imara. Felix divides his expedition, sending Zara Cyrene to reinforce Harwatch while he aids the naga against the Fathom. Beneath the flooded hills, he discovers a failing ancient seal and learns that the Fathom is a Dusk Dragon possessed by a sliver of a night goddess. Felix and Vessilia Dayne free the dragon, destroy the sliver's hold over the Deep King, and return to Harwatch with new allies. During the siege, Vess bonds the dragon into a golden wyrmling, while a cursed High Guard blade severs Pit's wings. Pit helps Felix complete all nine core pillars, and Felix kills the four linked High Guard in a forced territorial challenge. Harwatch survives, but Felix and several companions are badly injured and the Hierocracy's retaliation remains imminent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3166,7 +3166,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3179,7 +3179,7 @@
       "recaps": {
         "ending": "Hetty is convicted of murdering her baby and sentenced to death. Dinah reaches her in prison and helps her confess the abandonment. As Hetty is taken toward execution, Arthur arrives with a reprieve that commutes the sentence to transportation. He accepts that his secret relationship with Hetty helped cause the disaster and leaves Hayslope for military service, while Adam gradually gives up the need to answer grief with blame. Dinah returns to Snowfield, but Adam later recognizes that his deepest attachment is now to her. She returns his love after overcoming her fear that marriage would displace her religious calling, and they marry. In the epilogue, years of family life have passed: Adam and Dinah have children, Seth remains part of their household, and Dinah no longer preaches publicly after Methodist authorities restrict women preachers. Hetty has died away from Hayslope. Arthur returns older and chastened, seeking to resume his responsibilities on the estate, and is received with sober reconciliation rather than restored innocence.",
         "in_short": "In rural Hayslope, respected carpenter Adam Bede loves Hetty Sorrel, the vain young dairymaid at Hall Farm. Hetty is secretly courted by Arthur Donnithorne, heir to the local estate, who knows their difference in rank makes lasting commitment impossible. Adam discovers them together and forces Arthur to end the relationship. Hetty then accepts Adam's proposal while concealing that she is pregnant by Arthur. She flees to find Arthur, gives birth alone, abandons the baby, and is arrested after the child dies. Methodist preacher Dinah Morris, loved by Adam's gentle brother Seth, comforts Hetty in prison and helps her confess. Hetty is condemned, but Arthur arrives with a last-minute commutation to transportation and leaves Hayslope burdened by responsibility for what happened. Adam's grief gradually becomes compassion. He and Dinah come to love one another and marry. Years later they have a family, Seth lives with them, Hetty has died away from home, and a chastened Arthur returns to take up his duties on the estate.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3290,7 +3290,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3303,7 +3303,7 @@
       "recaps": {
         "ending": "After learning that Griselle was killed when Martin refused her refuge, Max turns the correspondence itself into a weapon. He sends letters that appear to contain coded references to money, paintings, and an anti-Nazi conspiracy, despite Martin's increasingly desperate requests that he stop. Because German authorities monitor international mail, the harmless-looking messages make Martin seem like a secret agent working with a Jewish associate abroad. Martin's final pleas show that he expects arrest and punishment, but Max continues. At last one of Max's envelopes is returned from Germany stamped that the addressee is unknown. The same bureaucratic phrase that gives the novella its title confirms, without describing the event directly, that the regime has removed Martin. Max has avenged his sister by exploiting the surveillance and arbitrary terror Martin chose to support.",
         "in_short": "In 1932, Jewish American art dealer Max Eisenstein exchanges affectionate letters with his German friend and business partner Martin Schulse, who has returned from California to Munich. As Hitler gains power, Martin embraces the new regime, adopts its antisemitism, and asks Max to stop writing to him. Max nevertheless begs Martin to protect his actress sister Griselle, Martin's former lover, while she is in Germany. Griselle flees to Martin's home, but he turns her away and later reports that Nazi troops killed her. Max then begins sending Martin conspicuously cryptic business letters designed to look like evidence of a conspiracy. Martin understands that the monitored correspondence puts him in mortal danger and begs Max to stop, but Max persists. The final letter is returned marked that Martin is no longer known at his address, implying that the Nazi system he embraced has destroyed him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/advent.json
+++ b/data/works-community/0/advent.json
@@ -355,7 +355,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B07MB6K9GX",
@@ -367,7 +367,7 @@
       "recaps": {
         "ending": "The pit rescue leaves 228 survivors together, including many children, but their food and water are almost gone. Daryl's wife dies from her injuries and he buries her near the node before returning to scouting. Drew claims the buried DIA node, keeps it configured as a Dungeon Training Center, and begins converting it to produce Korath. The claim raises him to level two and sub-lieutenant, while making him responsible for defending a strategic site that future world bosses may seize. Sarah directs security, Katie remains among the defenders, and Major Hoffacker and Captain Snyder join the evacuation leadership. As corpses throughout the tunnels become wereghouls, a more aware wereghast appears to coordinate them. The survivors choose an immediate nighttime withdrawal toward the soccer-field camp and eventual stadium reunion, with Drew covering the rear. The node's defense, Robbi's secret contact and bridge plan, Drew's hazardous Retribution, and the aims of Ares and the wider orders remain unresolved.",
         "in_short": "When Advent transforms Earth-3, Coast Guard specialist Drew escapes an underground bunker with Katie Sabin and Sarah Rothschild after losing their first companions to hostile creatures. He meets Daryl, frees an initial group of captives from the Ashala at DIA, and builds a larger rescue force. A sleep-sink encounter with Cassius Felix Ares identifies Drew as an unusually early assault mage and directs him toward the primary nexus, while secretly arming him with Aeon. After a troll assault triggers the dangerous inner Retribution, Drew leads a tunnel operation that frees hundreds more prisoners, though Daryl's wife dies. Drew kills the troll shaman and claims the buried DIA node, learning that he is Drew Michalik III. He retains the node as a Dungeon Training Center and gains new rank and gravity abilities. The book closes with 228 survivors evacuating the tunnels at night as wereghouls gather behind them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -741,7 +741,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -754,7 +754,7 @@
       "recaps": {
         "ending": "Jiran and Lenton end the Sanctum coup by defeating the cardinal and the remaining Templari, but the cardinal’s death breaks the undead truce. A Tier X corruption beast attacks the city. Lenton drives it away, while Jiran survives its corruption by evolving Mana Transcendence and then develops a way to cleanse other victims. Olive takes command of the former Third Corps, and Jiran wins support for a battlefield academy defended by his allied peoples. Jiran, Mayalyn, and Olive commit to remaining together. Melania’s terror at seeing Jiran remains unexplained. In the epilogue, two emperors rupture reality because Tier 11 ascenders threaten the world’s weave. The fissure scatters them along with three accompanying high Rankers. One Ranker awakens alone, greatly weakened in a hostile jungle, while the identities, destinations, and survival of the others remain unknown.",
         "in_short": "Jiran completes the Tier 4 Challenger arena, forms an ice aspect, reaches Tier 5, and gains Mana Venom before becoming stranded in a wasteland controlled by the parasitic Found. He defeats a Seeker vessel, alters the captives’ memories, and returns home to learn that the Church has seized Olive. Jiran, Mayalyn, Niya, Cameron, Lenton, and their allies infiltrate Sanctum as the cardinal launches a coup using branded Templari, hidden beasts, implanted white bones, and green corruption. Olive escapes with new blood-based powers, while Jiran and Lenton kill the cardinal. His death ends the undead truce and releases a Tier X beast. Jiran survives its corruption through Mana Transcendence and learns to cleanse other victims. Olive takes military command, Jiran proposes an allied battlefield academy, and he, Mayalyn, and Olive form a committed relationship. Two emperors rupture reality, and the fissure scatters them and three accompanying high Rankers, leaving one Ranker weakened in an unknown hostile jungle.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1132,7 +1132,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1039402313",
@@ -1144,7 +1144,7 @@
       "recaps": {
         "ending": "Elaine finishes the Ranger round alive after helping end both Perinthus plagues, though Origen's murder remains a personal and practical loss. Her parents accept her reincarnation, the arranged marriage is cancelled, and a temple account gives her financial security. The temple judges her retained Earth knowledge harmless or useful, stores her original medical scrolls, and begins wider distribution. The review implies coercive or lethal consequences for god-touched people judged dangerous. Elaine is bound for two years at Ranger Academy, and Julius's leadership standing depends on her success. Squad 4 dissolves: Julius takes Team Six, Kallisto Team Eight, and Maximus Team Eleven. Arthur becomes the Toxic Sentinel, while Artemis retires to establish a school for mages. The final interlude shifts to Iona, whose accidental killing of her friend leads her into a Valkyrie's apprenticeship. She becomes a Page, Light and accepts a binding vow to protect vulnerable people and oppose those who prey on them.",
         "in_short": "Elaine develops her celestial healing and fire magic while traveling with Squad 4, survives an abduction, and advances from Firebug to Pyromancer. The Rangers enter quarantined Perinthus, where she proves that two plagues are present: cholera from contaminated water and a magical bleeding disease deliberately spread by a concealed plague classer. The killer murders Origen before the squad identifies and kills him, after which a town-wide treatment operation clears the crisis. Elaine later helps people harmed by an abusive slave operation, completes a combat test, and returns to Ranger Headquarters. Her parents accept her Earth reincarnation and independence, her arranged marriage ends, and the temple clears her retained knowledge for distribution. Squad 4 then separates: Artemis retires, Arthur becomes the Toxic Sentinel, and the other survivors receive new assignments while Elaine prepares for Ranger Academy. A closing interlude follows Iona, who causes her friend's death in a mine collapse and enters a Valkyrie's service under a binding protection vow.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1368,7 +1368,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1381,7 +1381,7 @@
       "recaps": {
         "ending": "After Latinus's city turns against the war, Turnus agrees to settle the conflict in single combat with Aeneas. Juno and Turnus's allies disrupt the truce, and fighting resumes until Aeneas attacks the city itself. Amata, mistakenly believing Turnus dead, takes her own life. Turnus finally confronts Aeneas and is defeated. He concedes and asks that his body be returned to his father. Aeneas is on the point of sparing him, but then sees the belt Turnus took from the slain Pallas. Remembering his duty to the young man's father, Aeneas kills Turnus in vengeance. The poem ends at that instant. The Trojan victory and Aeneas's marriage to Lavinia are assured by prophecy and by Juno's final agreement with Jupiter, but the promised settlement and the later rise of Rome occur beyond the narrated action.",
         "in_short": "After Troy falls, Aeneas leads surviving Trojans west in search of the Italian homeland promised by fate. A storm brings him to Carthage, where Queen Dido falls in love with him; he leaves at divine command, and she dies cursing his descendants. In Italy he visits the underworld, learns the future importance of Rome, and seeks an alliance with King Latinus through marriage to Lavinia. Juno incites Lavinia's former suitor Turnus and the Italian peoples to resist. Aeneas gathers Arcadian and Etruscan allies, but the war costs many lives, including Evander's son Pallas, killed and stripped by Turnus. After further battles and the death of the warrior Camilla, Aeneas and Turnus agree to duel. The truce collapses, but they finally meet; Aeneas defeats Turnus and considers mercy until he sees Pallas's belt on him. He kills Turnus, securing the Trojan cause while ending the poem on an act of vengeance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1512,7 +1512,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1525,7 +1525,7 @@
       "recaps": {
         "ending": "Aeneas secretly readies his fleet, then resists Dido's pleas and leaves Carthage under cover of night. Dido curses him and his descendants, asking for enduring hatred between their peoples. She mounts the pyre that Anna believed was intended for a ritual to end her love, takes Aeneas's sword, and kills herself. Anna arrives too late and holds her dying sister. Because Dido's death comes before its appointed time, her spirit struggles to depart until Juno sends Iris to release it. The book closes with the Trojan ships at sea and the queen of Carthage dead, turning the failed union into both a personal catastrophe and a legendary origin for future conflict between Carthage and Rome.",
         "in_short": "After hearing Aeneas recount Troy's fall and his wanderings, Dido falls helplessly in love with him. Anna encourages the match, while Juno engineers a storm during a hunt that leaves the pair together in a cave; Dido treats their union as a marriage. As the lovers neglect their public duties, the rejected Iarbas appeals to Jupiter. Mercury then orders Aeneas to remember his destiny in Italy. Aeneas prepares to leave, insisting that divine command gives him no choice. Dido's appeals, accusations, and attempt to use Anna as an intermediary cannot change his mind. After the Trojans sail, Dido curses Aeneas and calls for lasting enmity between their descendants. She climbs a pyre built around his abandoned possessions and kills herself with his sword, while the unsuspecting Anna reaches her too late.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1685,7 +1685,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1698,7 +1698,7 @@
       "recaps": {
         "ending": "After Tessa has reorganized her life around Hardin, Molly and the others reveal that his pursuit of her began as a wager: Hardin claimed he could make the inexperienced, attached Tessa fall for him and sleep with him, and he supplied his friends with humiliating proof. Hardin insists that the bet stopped mattering once his feelings became genuine, but Tessa understands that many moments she treated as private were part of a contest known to the group. The discovery destroys her trust in both him and the friends who watched the relationship develop. She leaves Hardin despite his pleas and turns to Landon, who confirms that Hardin loves her but does not excuse what he did. Tessa is left devastated and unsure how much of the relationship was real, while Hardin is forced to face the consequences of building genuine attachment on calculated cruelty. Their separation closes the book without resolving their bond.",
         "in_short": "Sheltered, ambitious Tessa Young begins college expecting to remain devoted to her boyfriend Noah and the future planned by her mother. Her tattooed roommate Steph introduces her to Hardin Scott, a hostile but magnetic British student whose love of literature gives them unexpected common ground. Their attraction develops through arguments, jealousy, and repeated reconciliations. Tessa ends her relationship with Noah, becomes intimate with Hardin, takes an internship at Vance Publishing, and moves with Hardin into an apartment as he gradually reveals the trauma behind his anger. She believes their difficult relationship has become a serious commitment. Near the end, however, Molly and Hardin's friends expose the wager that started his pursuit: he had set out to make Tessa fall for him and surrender her virginity, sharing evidence with the group. Although Hardin says he genuinely fell in love, Tessa sees the deception beneath their entire history and leaves him, ending the novel heartbroken and their relationship unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1883,7 +1883,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1896,7 +1896,7 @@
       "recaps": {
         "ending": "Poirot proves that Miss Gilchrist killed Cora Lansquenet. Before the funeral, she murdered Cora and then attended the family gathering disguised as her, relying on the relatives' long separation and Cora's familiar mannerisms to pass unnoticed. Her remark that Richard had been murdered was designed to make Cora's subsequent death look like the silencing of someone who knew a family secret. The inheritance disputes supplied several plausible suspects, while an arsenic-laced wedding cake sent to Miss Gilchrist helped present her as another target. Her real object was a painting among Cora's unfashionable purchases that she had recognised as a valuable Vermeer. Helen Abernethie had unconsciously noticed that Cora looked wrong at the funeral; when the memory began to return, Miss Gilchrist attacked her, but Helen survives. Poirot's reconstruction of the disguise, the painting, and the staged threats breaks the case. The surviving Abernethies are left to divide Richard's estate without the imagined murder conspiracy that had turned them against one another.",
         "in_short": "After wealthy Richard Abernethie's funeral, his estranged sister Cora unexpectedly says that he was murdered. The family dismisses her, but she is killed the next day, and solicitor Mr Entwhistle asks Poirot to investigate Richard's heirs. Their debts, ambitions, and resentments provide many possible motives; poison sent to Cora's companion, Miss Gilchrist, and an attack on Helen Abernethie deepen the apparent family plot. Poirot discovers that Richard died naturally. Miss Gilchrist had already murdered Cora, impersonated her at the funeral, and planted the murder suggestion so Cora's own death would appear connected to the inheritance. She wanted a valuable Vermeer hidden among Cora's cheap-looking pictures and staged an attack on herself to support the deception. Helen had half-recognised that the woman at the funeral was not Cora, prompting Miss Gilchrist's attempt to silence her. Helen survives, and Poirot exposes the disguise and the true motive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2099,7 +2099,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2112,7 +2112,7 @@
       "recaps": {
         "ending": "The collection closes with Junpei, Sayoko, and her daughter Sala drawing closer after the earthquake. When Sala's nightmares return, Junpei comforts her with another story about Masakichi the bear, then decides he no longer wants to postpone a life with Sayoko. He resolves to ask her to marry him and to protect both mother and daughter. He also imagines writing a different kind of story, one in which a person waits in darkness for the destructive dream to pass and someone they love comes to hold them. The final movement does not settle whether the wider damage represented by the earthquake can be repaired, but it gives Junpei a concrete answer to his own emotional paralysis: he chooses commitment, family, and the possibility of creating something that helps rather than merely observing from a distance.",
         "in_short": "Six stories follow people living in the emotional aftermath of the 1995 Kobe earthquake, even when they are far from the disaster itself. A deserted husband carries a mysterious package to Hokkaido; a runaway and an older man contemplate death beside a beach bonfire; a young man follows someone who might be his absent father; a doctor in Thailand confronts decades of anger; and an overlooked debt collector is recruited by a giant Frog to prevent another earthquake beneath Tokyo. In the final story, writer Junpei has long concealed his love for Sayoko, who married and divorced their mutual friend. As Sayoko's daughter suffers earthquake nightmares, Junpei's invented bear stories help soothe her. He finally chooses to build a life with them, ending the collection with a modest commitment to love and creation in the face of unseen destruction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2421,7 +2421,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0C6FLJTM8",
@@ -2433,7 +2433,7 @@
       "recaps": {
         "ending": "Scorandum's supposed sale of the radonium-production secret is revealed as a controlled deception arranged with Skippy. Task Force Black uses the recovered exotic material to disable two possible activation sites, forcing the intruder and its Maxolhx partners to concentrate at the last viable location. Valkyrie penetrates their distortion field and destroys the Elder ship along with most of the assembled fleet. The Sentinel activation is stopped, but the victory exposes the larger danger: the adversary is not an Elder AI. It is an external entity capable of converting itself into exotic energy, and it escapes the destruction of its host vessel. Skippy confirms that known Elder weapons can neither destroy nor imprison it. Valkyrie survives with extensive damage and requires shield and jump-drive repairs, though it is expected to regain jump capability. The rare canister is secure, but its accidental manufacturing process cannot be reconstructed, Maxolhx production capacity remains substantial, and the Rindhalu have not yet committed to the fight. Joe concludes that humanity must unite the senior species and their clients against the entity beyond the galactic barrier.",
         "in_short": "Joe Bishop is pulled from garrison duty when an unknown attacker hijacks humanity's attempt to activate a Sentinel for the Rindhalu. The same adversary raids Earth's lunar vault, steals exotic material, and compromises Sentinel defenses with technology beyond Skippy's understanding. Task Force Black follows the trail through an Elder space-dock wreck, a lunar-vault assault, and a race against the Maxolhx for a rare radonium canister. Skippy restores his impaired abilities, enabling Valkyrie to recover the canister and its surviving researcher. Scorandum's apparent betrayal proves to be a deception that channels the enemy toward one activation site. Valkyrie destroys the hostile Elder ship and much of its Maxolhx support fleet, preventing activation, but an external entity escapes as energy. Known Elder weapons cannot kill or contain it, leaving Joe to seek an alliance across the galaxy while the badly damaged Valkyrie begins repairs.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2558,7 +2558,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2571,7 +2571,7 @@
       "recaps": {
         "ending": "After Ned vanishes, Mary can find no evidence that he planned to leave or that any ordinary visitor departed with him. Parvis eventually comes from America and explains the fate of Robert Elwell, whose losses in the Blue Star mine dispute had driven him to attempt suicide. Elwell died after briefly rallying, at about the time Ned disappeared. When Mary is shown Elwell's likeness, she recognizes him as the subdued stranger she saw enter Lyng. She finally understands Alida Stair's warning: the house's ghost does not announce itself as supernatural, and recognition comes only afterward. Elwell's apparition came for Ned, who left with him and never returned. The haunting Mary once desired has already happened, but its meaning becomes clear only after it has taken her husband from her.",
         "in_short": "After making their fortune in America, Mary and Ned Boyne retire to Lyng, an old English house said to possess a ghost recognizable only after the encounter. Their life there seems peaceful, although Ned remains troubled by claims arising from his Blue Star mining business. Mary later sees a subdued stranger approach the house and assumes Ned receives him. Both men disappear, and every ordinary effort to trace Ned fails. An American visitor eventually tells Mary that Robert Elwell, financially ruined in a dispute with Ned, attempted suicide and later died. On seeing Elwell's likeness, Mary recognizes the stranger who came to Lyng. She realizes too late that Elwell's ghost collected Ned and that the house's legend was exact: its supernatural visitor could be understood only afterward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2715,7 +2715,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2728,7 +2728,7 @@
       "recaps": {
         "ending": "Cassandra enters the palace knowing that both she and Agamemnon will be killed. Agamemnon's death cry is heard from within, and Clytemnestra then displays the bodies. She admits that she trapped and killed her husband and also killed Cassandra, presenting the murders as punishment for Agamemnon's sacrifice of Iphigenia and for the inherited violence of his family. Aegisthus arrives and identifies another motive: revenge for the children of his father, Thyestes, whom Agamemnon's father served as food to their own father. The Argive elders reject Aegisthus's claim to rule and nearly come to blows with his guards. Clytemnestra restrains him and declares that they will now control the palace. Agamemnon's son Orestes remains absent, but the chorus anticipates that his return may bring another act of vengeance, leaving the family feud unresolved.",
         "in_short": "After ten years of war, a beacon announces Troy's fall to Argos. Queen Clytemnestra welcomes home her husband Agamemnon, commander of the victorious Greeks, while the city's elders recall that he sacrificed their daughter Iphigenia to launch the expedition and fear that old crimes will demand payment. Agamemnon returns with Cassandra, a captive Trojan prophet whose accurate warnings are never believed. Clytemnestra persuades the king to enter the palace in a display of dangerous magnificence. Cassandra foresees the murders awaiting them and the history of violence in Agamemnon's family, then goes inside. Clytemnestra kills both captives and publicly claims responsibility, invoking Iphigenia's death as justice. Her partner Aegisthus presents the murder as revenge for atrocities committed by Agamemnon's father against his own father. The pair take power despite the elders' resistance, while the absent Orestes remains a future threat to their rule.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2909,7 +2909,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2922,7 +2922,7 @@
       "recaps": {
         "ending": "Agnes and her mother establish a small school after Richard Grey's death, gaining financial independence through their own work. On a seaside walk Agnes unexpectedly meets Edward Weston, now the clergyman of a parish in the region. He renews the acquaintance that was cut short when she left Horton Lodge and begins visiting the Greys. His sustained attention confirms that the sympathy Agnes perceived between them was real. Weston asks Agnes to marry him, and she accepts. The conclusion looks back from several years into their marriage: they live contentedly in a home of their own, have three children, and remain attached to Agnes's mother and sister. Agnes's years as a governess have not produced social advancement through her employers; instead, endurance, useful work, family loyalty, and a relationship founded on shared moral values lead her to a secure life.",
         "in_short": "When a failed investment impoverishes her clergyman father, sheltered Agnes Grey becomes a governess to help her family. Her first employers, the Bloomfields, demand that she reform children who are cruel and undisciplined while denying her the authority to do so; they dismiss her and blame her for the failure. At Horton Lodge she teaches the wealthy Murray girls. Beautiful Rosalie uses admirers for amusement before marrying Sir Thomas Ashby for status, while Agnes remains socially invisible to the family. Agnes finds purpose in visiting poor parishioners and grows attached to the thoughtful curate Edward Weston. Her father's death brings her home before either can speak plainly. Agnes and her mother open a school, and Rosalie later admits that her grand marriage is miserable. Weston eventually finds Agnes at the seaside, renews their acquaintance, and proposes. Their marriage and family provide the mutual affection and moral companionship absent from the privileged households Agnes served.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3098,7 +3098,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3111,7 +3111,7 @@
       "recaps": {
         "ending": "After leaving Horton Lodge, Agnes joins her widowed mother in establishing a small school at a seaside town. The work gives them independence and a more respectful place in the community. A visit from the now-married Rosalie confirms that wealth and rank have brought her neither affection nor freedom. Edward Weston, having obtained a parish of his own, eventually finds Agnes during a walk by the sea. Their renewed acquaintance develops openly, and he asks her to marry him. Agnes accepts. In her concluding account, she describes a companionate marriage founded on shared convictions rather than status: she assists in Edward's parish work, remains close to her mother, and becomes the mother of three children. Her years as a governess end not with social triumph over her former employers but with useful work, economic stability, and the mutual regard she had long wanted.",
         "in_short": "When a disastrous investment reduces her clergyman father's income, eighteen-year-old Agnes Grey becomes a governess to help her family. Her first employers, the Bloomfields, expect her to discipline spoiled children without giving her authority and then dismiss her. At Horton Lodge she teaches the wealthy Murray girls, enduring Rosalie's manipulative flirtations and the family's disregard for servants and poor neighbors. Agnes finds purpose in visiting the cottager Nancy Brown and comes to admire Edward Weston, a curate whose conduct matches his religious principles. Rosalie marries the rich Sir Thomas Ashby but discovers that status cannot make an unloving marriage happy. After Agnes's father dies, Agnes and her mother open a school at the seaside. Weston, now responsible for a parish of his own, finds Agnes there and proposes. They marry, raise three children, and build the life of affection and useful service that Agnes could not find in the households where she worked.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3290,7 +3290,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3303,7 +3303,7 @@
       "recaps": {
         "ending": "After Natalie is again denied the education her family wants for her, Moose decides to ask the one powerful person on the island whom he has no legitimate way to approach. With Piper's help, he places a letter to Al Capone into the prison laundry, explaining Natalie's situation and asking the gangster to use whatever influence he has. Soon afterward the family learns that a new program for older children will admit Natalie. No one can prove that Capone caused the decision, but Moose finds a one-word message in the sleeve of a freshly laundered shirt indicating that the request has been completed. The reply convinces him that his letter reached its intended reader. Natalie leaves for the school, giving her a chance at greater independence and changing the burden the family has carried. Moose has also changed: he recognizes Natalie's abilities more clearly, understands the cost of his mother's relentless hope, and accepts that protecting his sister does not require pretending she is someone else. His friendship with Piper survives their conflicts, now tempered by his greater willingness to resist her schemes.",
         "in_short": "In 1935, twelve-year-old Moose Flanagan moves to Alcatraz because his father has taken prison work and his mother hopes a San Francisco school can help Moose's older sister, Natalie. Natalie needs strict routines and communicates differently, while her mother insists on presenting her as ten rather than sixteen. Moose struggles with new school, compulsory childcare, and the schemes of Piper, the warden's daughter, including an illicit service claiming that convicts such as Al Capone wash customers' clothes. As Moose spends time with Natalie and includes her in baseball, he becomes more attentive to her capabilities and less willing to treat her only as a burden. A dangerous encounter with a prisoner exposes the risks of island life. When Natalie is denied admission again, Moose secretly sends Capone a request for help through the laundry. Natalie is unexpectedly accepted into a new program, and a one-word reply hidden in Moose's shirt suggests that Capone intervened.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3484,7 +3484,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3497,7 +3497,7 @@
       "recaps": {
         "ending": "Months after the attack, Fort Repose has become a functioning but austere community under Randy's leadership. Its residents obtain salt, defend themselves against armed thieves, contain radiation hazards, and rely on farming, fishing, barter, and shared labor. Randy and Lib marry, while Helen accepts that Mark is unlikely to return. Air Force helicopters finally reach the town. Paul Hart confirms that Mark died during the war and explains that the United States survived but has been devastated, with national authority passing to a former cabinet secretary and vast regions still dangerous. Fort Repose is judged free of contamination, yet its residents decline evacuation because the town is now their home and their work remains there. When Paul asks whether the United States won the war, Randy can only answer that the country is still present. The closing exchange makes survival, rather than military victory, the meaningful outcome.",
         "in_short": "In 1959, Air Force colonel Mark Bragg warns his brother Randy that nuclear war is imminent and sends his wife Helen and their children to Randy's home in Fort Repose, Florida. A Soviet attack destroys major cities and military sites, leaving the town without power, communications, money, medicine, or outside government. Randy gathers family and neighbors into a cooperative household, while physician Dan Gunn and retired admiral Sam Hazzard preserve medical care and information. The survivors confront contaminated goods, hunger, illness, armed robbers, and the need to rebuild authority from local resources. Randy organizes defense, secures salt, and becomes the town's recognized leader; he and Lib McGovern marry. When Air Force helicopters finally arrive, Paul Hart reports that Mark has died and that the United States, though shattered, endures under a new president. Fort Repose is uncontaminated, but its residents choose to remain and continue the society they have improvised.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3789,7 +3789,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3802,7 +3802,7 @@
       "recaps": {
         "ending": "The collection closes with the defeat of Milady. After escaping English custody and arranging Buckingham's assassination, she returns to France and poisons Constance Bonacieux just before D'Artagnan can rescue her. D'Artagnan, Athos, Porthos, Aramis, and Lord de Winter capture Milady, present the crimes known to each of them, and have her executed. Richelieu arrests D'Artagnan, but Athos produces the cardinal's own authorization for actions taken in the state's interest. Impressed by their effectiveness, Richelieu gives D'Artagnan a lieutenant's commission. Athos, Porthos, and Aramis insist that he accept it. The friends then follow different paths: Porthos makes a wealthy marriage and leaves the service, Aramis turns toward religious life, and Athos eventually retires, while D'Artagnan continues his military career. Rochefort and D'Artagnan settle their long quarrel through repeated duels and become friends. Their shared campaign ends with D'Artagnan advanced but the original company beginning to separate.",
         "in_short": "This collection joins two stories of betrayal and fellowship. In The Count of Monte Cristo, Edmond Dantès is falsely imprisoned by jealous rivals and prosecutor Villefort. He escapes after fourteen years, finds a hidden fortune, and returns as the Count of Monte Cristo to reward the Morrels and destroy Danglars, Fernand, Villefort, and Caderousse. His plans succeed but harm innocents, so he finally pardons Danglars, reunites Valentine and Maximilien, and leaves with Haydée. In The Three Musketeers, young D'Artagnan befriends Athos, Porthos, and Aramis. They save Queen Anne from Cardinal Richelieu's scheme involving her diamond studs, then confront the cardinal's agent Milady de Winter during the siege of La Rochelle. Milady arranges Buckingham's murder and kills Constance before the companions capture and execute her. Richelieu rewards rather than destroys D'Artagnan, who becomes a lieutenant as his three friends begin to leave military life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4033,7 +4033,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4046,7 +4046,7 @@
       "recaps": {
         "ending": "The hypnotic voice claiming to be Mary Whitney offers an explanation for Grace's missing memory but no certainty: it may be possession, a divided personality, or a performance arranged with Jeremiah. Simon does not complete a definitive report. After becoming entangled with Rachel Humphrey, he leaves Canada, later serves in the American Civil War, and suffers a head injury that damages his own memory. Grace's supporters continue their campaign, and she is pardoned in 1872 after nearly three decades of confinement. She moves to New York State and is met by Jamie Walsh, whose testimony had helped convict her. He apologizes and asks her to marry him. Their life is materially safe, though his fascinated requests that she recount her sufferings make their intimacy uneasy. Grace believes she may be pregnant but is uncertain. She makes a Tree of Paradise quilt, incorporating cloth associated with Mary, Nancy, and her own prison dress. The three women are joined in the pattern, but Grace never supplies a final, verifiable account of the murders.",
         "in_short": "In 1859, convicted servant Grace Marks is interviewed by Dr. Simon Jordan, who hopes to recover her lost memory of the 1843 murders of Thomas Kinnear and Nancy Montgomery. Grace recounts poverty in Ireland, migration to Canada, her mother's death, and domestic service. Her beloved friend Mary Whitney dies after an illegal abortion, leaving Grace haunted by the idea that Mary's spirit sought entry into her body. At Kinnear's house, conflict among Nancy, Grace, and hired man James McDermott ends with Kinnear and Nancy dead. McDermott blames Grace; she describes coercion and gaps in memory. Under hypnosis, a voice identifying itself as Mary claims responsibility through Grace, but the episode remains open to supernatural, psychological, and fraudulent readings. Simon abandons the case and later loses much of his own memory in war. Grace is eventually pardoned, marries former witness Jamie Walsh, and makes a quilt joining fabric linked to herself, Mary, and Nancy. Her true degree of guilt remains unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4265,7 +4265,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4278,7 +4278,7 @@
       "recaps": {
         "ending": "Alice's first adventure ends when she rejects the Queen of Hearts's irrational trial court as no more than playing cards and wakes beside her sister. In the second adventure, she passes through a mirror into a land arranged as a chessboard and advances from white pawn to queen. Her coronation banquet becomes as disorderly as Wonderland's trial. Alice grabs and shakes the Red Queen, who changes into Kitty, and again finds herself at home. Although the mirror journey was a dream, its ownership remains uncertain: Tweedledum and Tweedledee had claimed that Alice existed in the sleeping Red King's dream, and Alice cannot decide whether she dreamed him or he dreamed her. She asks the kitten, but receives no answer.",
         "in_short": "Alice has two dreamlike adventures in worlds governed by altered logic. First she follows the White Rabbit underground, repeatedly changes size, and meets the Caterpillar, Duchess, Cheshire Cat, Hatter, Queen of Hearts, and other Wonderland figures. At the Knave's trial she grows to full size, dismisses the court as playing cards, and wakes beside her sister. Later she steps through a drawing-room mirror into a countryside laid out as a chessboard. Traveling as a white pawn, she meets the Red and White Queens, Tweedledum and Tweedledee, Humpty Dumpty, and the kindly White Knight. She reaches the eighth square and becomes a queen, but her coronation dinner collapses into chaos. When she shakes the Red Queen, the figure becomes her kitten and she wakes at home, still wondering whether the mirror world was her dream or the sleeping Red King's.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4470,7 +4470,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4483,7 +4483,7 @@
       "recaps": {
         "ending": "At the Knave of Hearts's trial, Alice challenges the court's meaningless evidence and the Queen's demand for punishment before a verdict. Now growing to her full size, she declares that the court is only a pack of cards. The cards rush at her, and she wakes beside her sister, discovering that Wonderland was a dream. She tells her sister what happened and returns home, while her sister imagines the dream and the adult Alice may become. In the companion poem, a warned young warrior waits for the monstrous Jabberwock, kills it with his sword, and carries its head home. The person who warned him greets the victory with delighted celebration.",
         "in_short": "Alice follows a talking White Rabbit down a hole into Wonderland, where doors, food, and drink continually change her size. Her search for the garden beyond a tiny door brings encounters with a Mouse, a Caterpillar, the Duchess, the Cheshire Cat, the Hatter's tea party, and the violent Queen of Hearts. After the Queen's chaotic croquet game and the Mock Turtle's account of his education, Alice attends the Knave of Hearts's trial for stealing tarts. She grows large, rejects the court's arbitrary rules, and wakes beside her sister as the cards fly at her. The companion poem tells of a young warrior who is warned about the Jabberwock, finds the creature, kills it, and returns with proof of his victory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4648,7 +4648,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4661,7 +4661,7 @@
       "recaps": {
         "ending": "After the White Knight escorts Alice to the final brook, she crosses into the eighth square and becomes a queen. The Red and White Queens test her with impossible questions, then fall asleep against her. Alice reaches a banquet supposedly held in her honor, but the guests and food refuse to follow ordinary rules and the celebration descends into confusion. She seizes the Red Queen, whom she holds responsible for the disorder, and shakes her. The Queen dwindles into Kitty, the black kitten, and Alice wakes in her drawing room. She wonders whether the experience was her own dream or the sleeping Red King's, leaving the question unresolved as she asks Kitty what it thinks.",
         "in_short": "Alice passes through the mirror above the fireplace into a reflected world of living chess pieces. The Red Queen tells her that she is a white pawn who can become a queen by reaching the far side of a landscape laid out as a chessboard. Traveling square by square, Alice rides a peculiar train, loses her name in a wood, meets Tweedledum and Tweedledee beside the sleeping Red King, encounters the backward-living White Queen, discusses language with Humpty Dumpty, and watches the Lion and Unicorn fight. A kindly White Knight guides her to the last brook. Alice crosses it and becomes a queen, but her coronation feast turns chaotic. When she grabs and shakes the Red Queen, the figure becomes her kitten and Alice wakes at home, uncertain whether she dreamed the Red King or existed in his dream.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4792,7 +4792,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4805,7 +4805,7 @@
       "recaps": {
         "ending": "Alice reaches the royal court, where the Knave of Hearts is tried for stealing the Queen's tarts. The proceedings ignore consistent rules: witnesses offer little useful evidence, and the Queen wants punishment before a verdict. Alice, who has begun growing again, finally rejects the court's authority and says that its members are only playing cards. When the pack rises against her, she wakes beside her sister and realizes that the journey through Wonderland was a dream. She tells her sister about it and leaves for tea, returning to the ordinary world while her sister remains behind imagining the strange people and creatures Alice described.",
         "in_short": "Alice follows a talking White Rabbit down a hole and enters Wonderland, where food and drink repeatedly alter her size. As she searches for a way onward, she meets creatures who turn conversation, manners, and familiar sayings into nonsense: a questioning Caterpillar, the vanishing Cheshire Cat, and the Hatter's tea-party companions. She eventually reaches the Queen of Hearts's court, survives a chaotic croquet game, and attends the Knave of Hearts's trial for stealing some tarts. The trial becomes increasingly arbitrary, and Alice grows large enough to challenge the Queen and dismiss the court as a pack of cards. The cards fly at her, but she wakes beside her sister and understands that Wonderland was a dream.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4992,7 +4992,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5005,7 +5005,7 @@
       "recaps": {
         "ending": "At the Knave of Hearts's trial, Alice is called as a witness just as she begins growing again. The King and Queen treat meaningless statements as evidence and try to manipulate the rules, while the Queen demands punishment before a verdict. Now full-sized and no longer intimidated, Alice tells the court that its members are only a pack of cards. The cards fly at her, and she wakes on the riverbank with her head in her sister's lap. She explains her extraordinary dream and runs home for tea. Her sister remains behind, imagines the people and sounds of Wonderland, and pictures Alice growing into an adult who will preserve the sympathy and imagination of childhood.",
         "in_short": "Bored beside her sister, Alice follows a waistcoated White Rabbit underground and reaches Wonderland, where food and drink repeatedly change her size. She meets a tear-pool full of animals, an advice-giving Caterpillar, the violent Duchess, the vanishing Cheshire Cat, and the Hatter's endless tea party. In the Queen of Hearts's garden she plays a chaotic game of croquet and sees how readily the Queen orders executions. The Gryphon and Mock Turtle describe their peculiar schooling before Alice is summoned to the Knave of Hearts's trial for stealing tarts. As the proceedings become increasingly irrational, Alice grows to her normal size, rejects the court's authority, and calls its members mere cards. They swarm at her, whereupon she wakes beside her sister and realizes that Wonderland was a dream.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5176,7 +5176,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5189,7 +5189,7 @@
       "recaps": {
         "ending": "The final spirit shows Scrooge that his unchanged life will end in an unmourned death, while Tiny Tim will die without greater support. Scrooge awakens on Christmas morning and acts immediately on what he has learned. He sends a large turkey to the Cratchits, gives generously to charity, joins Fred's celebration, raises Bob's pay, and becomes a dependable friend to the family. Tiny Tim survives, and Scrooge maintains his reformed way of living. The collection then turns to a sleeping household on Christmas Eve. Its observer sees Saint Nicholas arrive in a reindeer-drawn sleigh, fill the children's stockings, and depart through the chimney, calling a final seasonal greeting as he flies away.",
         "in_short": "In A Christmas Carol, the miser Ebenezer Scrooge rejects his nephew, charity collectors, and the needs of his clerk Bob Cratchit. The ghost of his former partner Marley warns him to change, and three Christmas spirits show him his lonely past, the generous celebrations occurring around him, and a future in which Tiny Tim dies and Scrooge's own death inspires relief rather than grief. Awakening on Christmas morning, Scrooge gives money and food, joins his nephew's dinner, improves Bob's circumstances, and becomes a loving supporter of the Cratchits; Tiny Tim lives. The companion poem shifts to a peaceful Christmas Eve, when a householder glimpses Saint Nicholas arrive with eight reindeer, enter by the chimney, fill the children's stockings, and fly away after wishing everyone a happy Christmas.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5313,7 +5313,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5326,7 +5326,7 @@
       "recaps": {
         "ending": "As the epidemic worsens, Aschenbach learns the truth from an English travel clerk but chooses neither to leave Venice nor to warn Tadzio's family. His restraint collapses into covert pursuit. After a disturbing dream, he lets a barber dye his hair and apply cosmetics, reproducing the false youth that had disgusted him on the voyage. Sick and exhausted, he continues following the Polish family and eats overripe strawberries in the infected city. On the nearly deserted beach, he watches Tadzio lose a struggle with another boy and then walk alone into the shallow sea. When Tadzio turns and gestures toward the horizon, Aschenbach imagines that the boy is beckoning him onward. He slumps in his chair and dies. The family departs, and the public receives news of the famous writer's death without knowing the private obsession and disintegration that preceded it.",
         "in_short": "Gustav von Aschenbach, a famous writer whose life is governed by discipline, yields to a sudden desire for travel and goes to Venice. At a hotel on the Lido he sees Tadzio, a beautiful Polish adolescent, and begins treating the boy as an embodiment of ideal form. When oppressive weather prompts him to leave, misplaced luggage gives him an excuse to return. His aesthetic admiration becomes an acknowledged infatuation, and he secretly follows Tadzio and his family. Meanwhile cholera spreads through Venice while authorities conceal it to protect tourism. Aschenbach discovers the danger but stays silent rather than risk the family's departure. Abandoning the dignity on which his public identity rests, he dyes his hair, wears cosmetics, and wanders the infected city after the boy. Ill and exhausted, he watches Tadzio from a beach chair, imagines the boy pointing him toward the horizon, and dies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5497,7 +5497,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5510,7 +5510,7 @@
       "recaps": {
         "ending": "Mina's psychic connection to Dracula lets Van Helsing's party track him as he flees toward his Transylvanian castle in a box of native earth. The hunters divide to intercept the routes taken by ship and overland. Near sunset outside the castle, Jonathan and Quincey reach the wagon carrying Dracula's box and fight its guards. Jonathan cuts Dracula's throat while Quincey drives a knife into his heart; Dracula's body crumbles, and the mark on Mina's forehead disappears, showing that his hold over her has ended. Quincey has been mortally wounded in the struggle and dies after seeing Mina freed. Seven years later, Jonathan and Mina have a son named Quincey, and the surviving friends reunite in Transylvania. Jonathan notes that their assembled records are the chief evidence of what happened, while Van Helsing says that the character of the friends and the life of the child honor the man who died helping them.",
         "in_short": "Solicitor Jonathan Harker visits Count Dracula in Transylvania and discovers that his host is a vampire preparing to move to England. Dracula reaches Whitby, preys on Lucy Westenra, and defeats the efforts of Van Helsing and Lucy's friends to save her. After Lucy becomes a vampire, they release her from that state and unite with Jonathan and Mina to hunt Dracula. They destroy his London refuges, but Dracula attacks Mina and forces her to drink his blood, creating a psychic bond and threatening to transform her. The bond also allows Mina to help track him as he retreats to Transylvania. Jonathan, Van Helsing, Seward, Arthur, and Quincey pursue him. Van Helsing destroys the three vampire women at the castle; Jonathan and Quincey intercept Dracula's box and kill him moments before sunset. Mina is freed, but Quincey dies from his wounds. Seven years later Jonathan and Mina return with their son, named for their fallen friend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5701,7 +5701,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5714,7 +5714,7 @@
       "recaps": {
         "ending": "Amy and Laurie return from Europe already married, and Jo accepts their happiness without regret. Beth's death has left Jo lonely but has also drawn her toward writing grounded in her own family experience. Friedrich Bhaer comes to visit, and Jo initially fears that he is interested in someone else. During a rainy walk they finally acknowledge their love and become engaged. Aunt March dies and leaves Plumfield to Jo. Jo and Friedrich marry and turn the large house into a school for boys, combining work, family, and education. Years later the extended March family gathers there for Marmee's birthday: Meg and John have built a durable marriage, Amy and Laurie have a daughter, and Jo and Friedrich are raising sons while running the school. Beth remains absent but central to their memory. The surviving sisters recognize that their adult happiness has taken forms different from their youthful ambitions but has grown from sustained work and affection.",
         "in_short": "The March sisters enter adulthood. Meg marries John Brooke, learns to manage a modest household, and becomes mother to twins. Amy travels in Europe, matures as an artist and woman, and eventually marries Laurie after he accepts Jo's refusal and abandons his idle habits. Jo works in New York, befriends Professor Friedrich Bhaer, and stops writing sensational fiction she no longer respects. She returns home to care for Beth, whose long illness ends in death. Grief leads Jo to write honestly about family life, and her work finds an audience. Friedrich follows her home and proposes. After Aunt March leaves Jo the estate of Plumfield, Jo and Friedrich marry and open a school there. The novel closes years later with the extended family together: Meg, Amy, and Jo have formed distinct households and vocations, while Beth's influence remains part of the life they share.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5924,7 +5924,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5937,7 +5937,7 @@
       "recaps": {
         "ending": "Jane returns to Thornfield and finds the house burned and abandoned. She learns that Bertha set the fire and died after leaping from the roof; Rochester saved the servants but was badly injured, losing a hand and his sight. Jane finds him living quietly at Ferndean. Now financially independent and able to meet him freely, she tells him that she has come to stay. They marry, with Adèle placed at a better school and remaining part of Jane's life. Rochester gradually recovers enough sight in one eye to see their first child. Jane reports ten years of an equal and happy marriage. Diana and Mary Rivers also marry, while St John continues his missionary work in India. His health is failing, and the novel closes with his unwavering expectation of death and spiritual reward. Jane's final position is the opposite of her childhood dependence: she has family, property, purpose, and a marriage entered by her own choice.",
         "in_short": "Orphaned Jane Eyre grows up mistreated by her aunt, then endures the harsh Lowood school, where her friend Helen dies and Jane later becomes a teacher. Seeking independence, she becomes governess at Thornfield Hall and falls in love with its troubled master, Edward Rochester. Their wedding is stopped by the discovery that Rochester already has a living wife, Bertha Mason, confined at Thornfield because of severe mental illness. Jane refuses to become his mistress and leaves with almost nothing. The Rivers siblings rescue her; she later learns they are her cousins and shares a large inheritance with them. She rejects St John Rivers's proposal that she marry him for missionary work and returns to Rochester. Bertha has burned Thornfield and died, while Rochester was blinded and maimed rescuing others. Jane reunites with him at Ferndean, marries him as an independent equal, and builds the loving home she had long lacked. Rochester eventually regains partial sight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6154,7 +6154,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6167,7 +6167,7 @@
       "recaps": {
         "ending": "The volume closes with the resolution of The Secret Garden. Mary, Dickon, and Colin have secretly restored the locked garden, while exercise, friendship, expectation, and time outdoors have restored Colin's strength. He progresses from standing to walking and plans to surprise his father. Susan Sowerby writes to Archibald Craven, whose years of wandering have begun to loosen their hold on him, and urges him to come home. He returns to the garden associated with his wife's death and meets Colin running from it, healthy and joyful. Father and son walk back to Misselthwaite together, astonishing the servants and ending the household's rule of grief and secrecy. Earlier in the volume, Jane Eyre also reached a settled ending: Bertha Mason died in the fire at Thornfield, Jane returned as an independent heiress to the injured Rochester, and they married; he later recovered enough sight to see their child. Both stories therefore end with damaged households reopened to attachment, though by different paths.",
         "in_short": "The volume pairs two stories of isolated children who make lives beyond the households that confine them. Jane Eyre survives abuse at Gateshead and hardship at Lowood, becomes a governess, and loves Edward Rochester. Their wedding is stopped because Rochester's wife Bertha is alive at Thornfield. Jane leaves, finds cousins and an inheritance, rejects St John Rivers's loveless proposal, then returns after Bertha has died in a fire and Rochester has been blinded and maimed. Jane and Rochester marry as more equal partners. The second story follows orphaned Mary Lennox to Misselthwaite Manor, where she discovers a garden locked since her aunt's death and her hidden, invalid cousin Colin. With Dickon Sowerby, Mary revives the garden and helps Colin replace fear and inactivity with friendship, exercise, and confidence. Colin learns to walk. When his grieving father Archibald returns, he finds the healthy boy running from the restored garden, and they go home together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6357,7 +6357,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6370,7 +6370,7 @@
       "recaps": {
         "ending": "In The Great Gatsby, Daisy kills Myrtle Wilson while driving Gatsby's car, and Gatsby protects Daisy by allowing suspicion to fall on him. Tom directs the grieving George Wilson toward Gatsby; George shoots Gatsby and then himself. Daisy and Tom leave without accepting responsibility, almost no party guests attend Gatsby's funeral, and Nick returns to the Midwest after recognizing the destructiveness beneath their wealth. In The Curious Case of Benjamin Button, Benjamin continues growing physically younger while his wife and son age normally. His achievements and adult relationships fall away as he passes through adolescence and childhood. Roscoe, embarrassed by him, eventually places him in kindergarten and leaves him in a nurse's care. Benjamin's memories and awareness contract with his body until sensation itself fades, and he dies as an infant with no remaining knowledge of the long reverse life he has lived.",
         "in_short": "This volume pairs two Fitzgerald stories about desire and time. In The Great Gatsby, narrator Nick Carraway befriends Jay Gatsby, who has built a fortune and a glittering public identity to recover his former love Daisy Buchanan. Daisy will not abandon her established life with Tom. After she kills Myrtle Wilson in Gatsby's car, Gatsby takes the risk on himself; Myrtle's husband murders him, while Daisy and Tom depart untouched. Nick leaves the East disillusioned. In The Curious Case of Benjamin Button, Benjamin is born with an old man's body and grows younger as everyone else ages. He marries Hildegarde, prospers, serves in war, and attends college, but reverse aging steadily separates him from wife, son, and adult identity. Reduced to childhood and then infancy, he loses his memories and dies in a nurse's care.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6536,7 +6536,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6549,7 +6549,7 @@
       "recaps": {
         "ending": "After James Vane dies accidentally during a hunt, Dorian believes the last immediate threat from his past has disappeared. He tells Lord Henry that he has begun reforming by sparing a country girl named Hetty Merton. Yet when Dorian examines the hidden portrait, he sees no improvement, only a new suggestion of hypocrisy. Hoping to destroy the sole record of his conscience, he takes the knife used to kill Basil and stabs the canvas. His servants hear a cry and find an aged, disfigured man dead on the floor with a knife in his chest, while the portrait has returned to its original image of Dorian's youthful beauty. They identify the body as Dorian only by its rings. His attempt to separate himself from the consequences recorded in the painting instead turns the accumulated corruption back onto his own body, ending the life that the portrait had unnaturally preserved.",
         "in_short": "Painter Basil Hallward introduces the beautiful young Dorian Gray to Lord Henry Wotton, whose celebration of youth and sensation makes Dorian dread aging. Dorian wishes that Basil's portrait would grow old in his place, and the wish comes true: after he cruelly rejects the actress Sibyl Vane and she dies by suicide, the painted face acquires the marks of his conduct while his body remains young. Over the following years Dorian pursues pleasure and ruins reputations, hiding the changing portrait in a locked room. When Basil confronts him, Dorian shows him the picture and murders him, then coerces Alan Campbell into destroying the body. Sibyl's brother James nearly takes revenge but dies accidentally. Dorian tries one outward act of mercy, yet the portrait reflects vanity rather than reform. He finally stabs the painting and is found dead, suddenly old and disfigured, while the portrait recovers its original beauty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6680,7 +6680,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6693,7 +6693,7 @@
       "recaps": {
         "ending": "After Pooh and Christopher Robin use an upturned umbrella as a boat to rescue Piglet from the flood, Christopher Robin holds a celebration in Pooh's honor. The Forest friends gather, Owl gives a speech, and Pooh receives a pencil case as a gift for his clever part in the rescue. When the party is over, Christopher Robin takes Pooh to a quiet place at the top of the Forest. The boy is beginning to understand that growing older and going to school may change how they spend their days. He asks Pooh to remember him and to remain his friend even when they cannot always play together. Pooh promises. The book closes with the child and bear still together in their special place, preserving their friendship against the changes Christopher Robin anticipates.",
         "in_short": "Across ten linked Forest adventures, Winnie-the-Pooh pursues honey, visits Rabbit and becomes stuck in his doorway, follows misleading tracks with Piglet, and restores Eeyore's missing tail. Pooh and Piglet's trap for an imagined Heffalump frightens Piglet instead, while Eeyore's birthday improves when he receives an empty honey pot and a burst balloon that fits inside it. Rabbit's attempt to drive away the newly arrived Kanga and Roo fails, and they join the community. During an expedition, Pooh accidentally supplies the stick that Christopher Robin names as the North Pole. Heavy rain later surrounds Piglet's home. Pooh reaches Christopher Robin, and they turn an umbrella into a boat and rescue Piglet. Christopher Robin celebrates Pooh's resourcefulness with a party. Afterward, he and Pooh share a private conversation about growing up, and Pooh promises that their friendship will endure even when Christopher Robin's life changes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6856,7 +6856,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6869,7 +6869,7 @@
       "recaps": {
         "ending": "Rashad leaves the hospital and decides that he will attend the protest, despite his unease at having become a symbol. Quinn has already broken publicly with the Galluzzos, made a statement about witnessing Paul's assault, and joined students demanding accountability. The school basketball team can no longer keep the conflict outside the gym: players show support for Rashad and take part in the action rather than pretending that unity means silence. At the march, a large crowd follows the route from the store toward police headquarters. Rashad and Quinn are both present, their separate decisions finally bringing them into the same movement. Participants stage a die-in and read the names of Black people killed during encounters with police, answering each name with a collective affirmation that the person has not been forgotten. The demonstration makes Rashad visible on his own terms and confirms Quinn's refusal to protect Paul through silence. Paul's legal fate remains unresolved at the close; the ending centers instead on witness, public memory, and the difficult beginning of sustained action.",
         "in_short": "Black high-school student Rashad Butler is wrongly accused of shoplifting and severely beaten by white police officer Paul Galluzzo. White classmate Quinn Collins sees the assault, but Paul is his best friend's brother and has acted as Quinn's surrogate older brother since Quinn's father died. While Rashad recovers in the hospital and turns to drawing, his family and friends debate publicity, policing, and protest. Graffiti announcing Rashad's continued absence spreads through the city and becomes a rallying phrase. Quinn gradually rejects the idea that loyalty requires silence, tells the truth about what he witnessed, and supports his Black teammates even as Guzzo ends their friendship. Rashad chooses to join the protest rather than let others define his experience. The two boys take part in a mass march and die-in where the names of Black victims of police violence are read aloud. No final ruling on Paul is given; the book ends with Rashad and Quinn committed to remembering, speaking, and acting.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -7035,7 +7035,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -7048,7 +7048,7 @@
       "recaps": {
         "ending": "Ann shows Kate a letter Larry wrote before his final flight. Larry had learned of the defective engine parts and said that shame over his father's actions had made him decide not to return alive. Chris no longer intends to send Joe to prison, but his disillusionment leaves the family without a moral way forward. When Joe reads Larry's letter, he finally accepts a responsibility extending beyond his household: the pilots who died were also, in a human sense, his sons. He goes inside, apparently to prepare to surrender, and shoots himself. Chris is overcome by guilt for forcing the confrontation. Kate, after years of preserving the family's denials, tells him not to blame himself and urges him to go on living with Ann. Joe is dead, Larry's fate is confirmed as suicide, and the family business and the future Joe built around it are morally shattered.",
         "in_short": "Several years after the war, manufacturer Joe Keller lives comfortably after being cleared in a case involving defective aircraft parts; his partner Steve Deever remains in prison. Joe's son Chris plans to marry Steve's daughter Ann, once engaged to Chris's missing brother Larry, while Kate Keller insists Larry is alive. Ann's brother George arrives convinced Joe ordered Steve to ship the parts. Kate accidentally undermines Joe's alibi, and Joe admits to Chris that he gave the order to protect the business, though twenty-one pilots died. Ann then produces Larry's final letter, which reveals that he intended to die after learning of his father's crime. Joe recognizes that his obligation included the dead pilots, not only his own family. He goes inside and shoots himself. Kate tells the devastated Chris to leave with Ann and live rather than carry Joe's guilt.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/all-quiet-on-the-western-front-a-bbc-radio-drama.json
+++ b/data/works-community/0/all-quiet-on-the-western-front-a-bbc-radio-drama.json
@@ -124,7 +124,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -137,7 +137,7 @@
       "recaps": {
         "ending": "By the autumn of 1918, Paul's closest comrades are dead or gone. Müller and Leer have been killed, Detering has been caught after deserting, and Kropp has lost a leg. Kat is struck in the leg while the two men search for food; Paul carries him toward medical help, only to discover that a second wound has killed him on the way. The loss leaves Paul almost entirely alone. Although the war appears close to ending and many expect an armistice, he can no longer imagine returning to civilian life as the person he once was. Paul is killed in October 1918 on a day when the military report records no significant action. His face appears calm, as though death has released him from a future for which the war has left him unprepared. The ending reduces the official record of the conflict to routine language while showing the complete destruction of one young man and nearly all the classmates who enlisted beside him.",
         "in_short": "Nineteen-year-old Paul Bäumer and his school friends enlist in the German army after being stirred by their teacher's patriotic appeals. Training under the bullying Himmelstoss strips away their respect for authority; trench warfare then destroys their remaining ideas about glory. Guided by the resourceful older soldier Katczinsky, they endure hunger, bombardment, close combat, and the deaths of friends. Home leave makes Paul feel estranged from civilians who cannot understand the front. On patrol he kills a French soldier at close range and is overwhelmed by the man's individuality, though military routine soon absorbs him again. Paul and Kropp are later wounded, and Kropp loses a leg. As 1918 approaches, Paul sees nearly every close comrade die or disappear, including Kat, who is killed while Paul carries him to safety. With peace apparently near, Paul has no sense of a life to which he can return. He is killed in October on an otherwise uneventful day, one more death barely visible in the official account.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -316,7 +316,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -329,7 +329,7 @@
       "recaps": {
         "ending": "By the autumn of 1918, Paul's closest comrades are dead or gone. Müller and Leer have been killed, Detering has been caught after deserting, and Kropp has lost a leg. Kat is struck in the leg while the two men search for food; Paul carries him toward medical help, only to discover that a second wound has killed him on the way. The loss leaves Paul almost entirely alone. Although the war appears close to ending and many expect an armistice, he can no longer imagine returning to civilian life as the person he once was. Paul is killed in October 1918 on a day when the military report records no significant action. His face appears calm, as though death has released him from a future for which the war has left him unprepared. The ending reduces the official record of the conflict to routine language while showing the complete destruction of one young man and nearly all the classmates who enlisted beside him.",
         "in_short": "Nineteen-year-old Paul Bäumer and his school friends enlist in the German army after being stirred by their teacher's patriotic appeals. Training under the bullying Himmelstoss strips away their respect for authority; trench warfare then destroys their remaining ideas about glory. Guided by the resourceful older soldier Katczinsky, they endure hunger, bombardment, close combat, and the deaths of friends. Home leave makes Paul feel estranged from civilians who cannot understand the front. On patrol he kills a French soldier at close range and is overwhelmed by the man's individuality, though military routine soon absorbs him again. Paul and Kropp are later wounded, and Kropp loses a leg. As 1918 approaches, Paul sees nearly every close comrade die or disappear, including Kat, who is killed while Paul carries him to safety. With peace apparently near, Paul has no sense of a life to which he can return. He is killed in October on an otherwise uneventful day, one more death barely visible in the official account.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -463,7 +463,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -476,7 +476,7 @@
       "recaps": {
         "ending": "GrayCris's attempt to kill the survey team fails. The SecUnit is nearly destroyed protecting Dr. Mensah in the final fight and has to be rebuilt; the company gunship arrives, the illegal operation is exposed, and the members of the team all come through alive. Because the corporation that owns the SecUnit would rather scrap a unit with a hacked governor module than explain one, Mensah buys the unit outright. Her plan is to take it home to Preservation Alliance, where constructs are not property, and where it would be free, looked after, and permanently in the company of people who like it. That is precisely what the SecUnit cannot face. It accepts the repairs, tells her in its own oblique way that it needs time, and then walks out of the station and leaves on a cargo transport, with her ownership of its contract left as a legal formality and her offer left open. It sets off with no plan beyond its own curiosity and one unresolved question: what actually happened at the mining installation where it is supposed to have killed the humans it was guarding, an event that was deleted from its memory.",
         "in_short": "A security construct leased to a scientific survey on an unexplored planet has secretly hacked the governor module that controls it, and uses its freedom mainly to watch entertainment serials. When a predator the company's hazard report never mentioned nearly kills one of its clients, the team discovers that their survey data was deliberately edited, and that the other survey group on the planet has been massacred by its own security units. The company GrayCris is running an illegal alien remnant salvage operation nearby and is erasing witnesses. Cut off, sabotaged and hunted, the team survives because the construct chooses to protect them, and because they decide to trust it once its secret is exposed. Both sides take heavy damage before a company gunship ends the fight. Dr. Mensah, the team's leader, buys the SecUnit to keep it from being destroyed and offers it freedom on Preservation. It leaves instead, alone, on a cargo transport.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -668,7 +668,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -681,7 +681,7 @@
       "recaps": {
         "ending": "After Finch disappears, Violet follows clues in his messages to the Blue Hole. She finds his clothes and belongings beside the water, and his body is recovered after he has drowned. The loss leaves Violet grieving and angry, and the public attention reduces Finch to a simple explanation that does not match the person she knew. She gradually realizes that Finch left directions to the remaining places on their wandering map. Visiting them lets her complete the project and find the farewell embedded in his choices. At the final site, a quiet swimming place, Violet enters the water and reflects on their relationship without treating his death as her responsibility or erasing what he gave her. She continues writing, reconnecting, and imagining a life beyond high school. Finch is dead, but Violet ends the novel moving toward a future she can choose rather than merely counting the days until escape.",
         "in_short": "Theodore Finch and Violet Markey meet on their high-school bell tower, each privately considering a fall. Finch protects Violet from gossip by letting everyone think she rescued him, then chooses her as his partner for a project exploring unusual places in Indiana. Violet is grieving her sister Eleanor's death in a car crash and has stopped writing, riding in cars, and planning a future; Finch's restless attention helps her begin doing those things again. Their wanderings become a romance, while Violet slowly recognizes that Finch's changes in energy and identity are signs of serious distress. After conflict at school and increasing isolation, Finch disappears. Violet deciphers his messages, finds his abandoned belongings at the Blue Hole, and learns that he has drowned. Devastated, she later follows the clues he left to complete their remaining destinations. The final journey does not remove her grief, but it helps her reject responsibility for his death and resume writing, swimming, and imagining a life of her own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -861,7 +861,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -874,7 +874,7 @@
       "recaps": {
         "ending": "Willie dies after Adam Stanton shoots him in the state capitol; Sugar-Boy immediately kills Adam. Jack later learns that Tiny Duffy, who succeeds Willie as governor, told Adam about Willie's affair with Anne and deliberately directed his anger toward Willie. Sadie admits that she gave Tiny the information out of jealousy. Jack considers using Sugar-Boy to avenge Willie but abandons the plan rather than continue the cycle of manipulation and violence. He and Anne marry, take responsibility for the ailing Ellis Burden, and prepare to leave Burden's Landing after Ellis dies. Lucy takes in the child whose mother had claimed Willie’s son Tom was the father, choosing to treat the boy as her grandson. Jack ends with a changed understanding of responsibility: the past cannot be escaped, and private choices remain connected to their consequences.",
         "in_short": "Jack Burden, a former reporter turned political operative, serves Willie Stark, a populist Southern governor who pursues public benefits through coercion and patronage. Asked to find leverage against Judge Irwin, Jack uncovers an old act of corruption and confronts him; the judge kills himself, after which Jack learns that Irwin was his biological father. Willie draws Jack's childhood friends Anne and Adam Stanton into his hospital project, while beginning an affair with Anne. Political pressure involving Willie's son Tom leads to a bargain that Willie finally rejects, but Tom suffers a fatal football injury. Adam, told of Anne's affair, shoots Willie and is killed by Willie's bodyguard. Jack discovers that Tiny Duffy and Sadie Burke helped set the murder in motion but chooses not to arrange revenge. He marries Anne and accepts that history, identity, and moral responsibility cannot be evaded.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1057,7 +1057,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1070,7 +1070,7 @@
       "recaps": {
         "ending": "Werner and Volkheimer escape the collapsed cellar during the bombardment. Werner goes to Etienne's house, where von Rumpel is hunting Marie-Laure and the Sea of Flames. Werner shoots von Rumpel and finds Marie-Laure in the attic. They share food, and Werner leads her out during a ceasefire. At the seaside grotto Marie-Laure places the diamond in the water and leaves the model-house key with it. She reunites with Etienne, who takes her back to Paris. Werner is captured and, feverish and disoriented, steps on a German mine and dies. Decades later Volkheimer sends Werner's recovered belongings to Jutta. She traces the little wooden house to Marie-Laure and visits Saint-Malo with her son, learning enough to understand that Werner helped save the French girl. Marie-Laure becomes a scientist and has a family of her own. In 2014 she walks through Paris with her grandson, reflecting on lives, memories, and signals that remain present though unseen; the diamond's final resting place beneath Saint-Malo is undisturbed.",
         "in_short": "As Allied bombs fall on Saint-Malo in 1944, blind French teenager Marie-Laure LeBlanc hides in her great-uncle's house while German radio technician Werner Pfennig is trapped beneath a nearby hotel. Their paths began years earlier: Marie-Laure fled Paris with her locksmith father, who was entrusted with a museum diamond or one of its decoys; orphaned Werner's brilliance with radios carried him into a brutal Nazi school and then a unit hunting resistance transmitters. In Saint-Malo, Marie-Laure and her great-uncle Etienne help broadcast clandestine messages. Werner locates their signal but conceals it, recognizing the educational broadcasts he loved as a child. Gem hunter Reinhold von Rumpel enters the house searching for the Sea of Flames. Werner escapes the rubble, kills him, and leads Marie-Laure to safety. She returns the diamond to the sea. Werner later dies after stepping on a mine; Etienne and Marie-Laure survive. Decades afterward Werner's sister Jutta learns that he saved Marie-Laure, whose long life continues into the twenty-first century.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1239,7 +1239,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1252,7 +1252,7 @@
       "recaps": {
         "ending": "John Grady returns to Texas with his own horse, Rawlins's horse, and the horse Blevins had stolen. Rawlins is glad to see him but declines to travel farther, and John Grady finds that his father has died. He seeks legal recognition of his ownership of the disputed horse and tells a judge the full story of the killing in prison and his actions in Mexico. Although the judge rules in his favor and later reassures him that his remorse is evidence of conscience, John Grady remains troubled by the violence and by his inability to return the horse to its unknown owner. He also returns the captain's pistol to the man from whom Blevins stole it. With the family ranch gone, Alejandra lost to him, and no stable home left in Texas, John Grady attends the funeral of the family's longtime servant Abuela. He then rides west with the recovered horses, crossing a landscape in which his ideal of the old horseman's world is receding.",
         "in_short": "After his family's Texas ranch is sold, sixteen-year-old John Grady Cole rides into Mexico with his friend Lacey Rawlins. A reckless younger runaway, Jimmy Blevins, briefly joins them and leaves behind trouble tied to a stolen horse and pistol. John Grady and Rawlins find work on Don Héctor Rocha's hacienda, where John Grady proves a gifted horseman and begins a forbidden affair with Don Héctor's daughter Alejandra. The Americans are arrested, Blevins is executed, and John Grady and Rawlins survive a brutal prison before Alejandra's great-aunt buys their release in exchange for Alejandra's promise to end the relationship. After a final meeting, Alejandra keeps that promise. John Grady recovers the horses at gunpoint and returns to Texas, but his father has died and the ranch is gone. Unable to restore the life he imagined, he rides west carrying both his devotion to horses and the moral burden of the violence he survived.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1456,7 +1456,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1469,7 +1469,7 @@
       "recaps": {
         "ending": "After years of preparation compressed into months of training and dangerous transport, the dragonriders carry the colony ships' great engines to their calculated positions on the Red Star. The coordinated operation succeeds: the detonations alter its orbit enough to prevent the future close approaches that bring Thread to Pern. The current generation still has responsibilities during the remaining fall, but future Passes will no longer recur. Opponents of AIVAS attack the project and abduct Robinton, but he is recovered and the plan survives their interference. Once the orbital change is confirmed, AIVAS declares its original purpose fulfilled and shuts itself down, leaving its students with extensive recovered knowledge and the responsibility to choose how Pern will use it. Robinton, already weakened by age and the strain of the crisis, dies soon afterward. His death joins the triumph with a profound personal loss for Menolly, Sebell, Lessa, F'lar, Jaxom, and their allies. Pern ends the story with Thread's ultimate defeat secured, but without the two guiding voices that made the victory possible.",
         "in_short": "After Jaxom, Piemur, and their companions awaken AIVAS at ancient Landing, the computer reveals a plan to end Thread permanently by changing the Red Star's orbit. AIVAS teaches science to selected riders, Smiths, and Harpers, restores access to the original colony ships, and trains dragons to travel between to positions in space. Jaxom and Ruth, F'lar, Lessa, and leaders from all the Weyrs coordinate the dangerous operation while conservative Craft leaders resist the social changes surrounding the new knowledge. The dragonriders ultimately move and deploy the ships' engines on the Red Star; their detonation shifts its path so future close passes will not bring Thread to Pern. Anti-AIVAS conspirators abduct Robinton but fail to stop the mission. With its task complete, AIVAS shuts itself down. Robinton dies soon afterward, leaving his friends to grieve even as Pern celebrates freedom from the ancient cycle. The survivors inherit both a safer world and the recovered knowledge needed to reshape it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1899,7 +1899,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1914,7 +1914,7 @@
       "recaps": {
         "ending": "The Others' attack on Sol is defeated when Riker recognizes that the Jokers' near-light-speed nuclear detonations can produce a lethal radiation strike. The victory costs most of the Bob fleet, and an earlier zap kills 150,000 people in Cuba. Bellerophon escapes with everyone else from Earth, including six million awake passengers housed in its cargo bays. Humanity heads toward three viable worlds in 82 Eridani, while Earth is left to recover over millennia. Icarus and Daedalus destroy GL-877, and Bill confirms that every known Others unit in Sol is gone, though patrols continue to search for survivors or other nests. The Pav are secure and increasingly autonomous, Poseidon is governed by Gina's elected administration, and Howard and replicated Bridget share life and research in Odin's cloud cities. Mac still cannot account for Medeiros's hidden industrial support. After Archimedes dies, Bob leaves Camelot and retires the Robert identity. The Bob network establishes that help to humanity will be voluntary, and Bob sets out to explore beyond his old commitments while building relays back to BobNet.",
         "in_short": "As the Others threaten every inhabited system, the Bobs pursue several survival plans at once. Bob tries to end violence between two Deltan settlements, Marcus overturns Poseidon's authoritarian Council, Howard secures Bridget's lawful replication, and Mac defeats a Medeiros probe at 82 Eridani. Herschel and Neil convert an Others carrier into Bellerophon, which ultimately evacuates everyone remaining on Earth except 150,000 people killed in Cuba. Riker and Bill lead a costly defense of Sol, while Icarus and Daedalus destroy the Others' home system. The Pav establish an autonomous refuge with a path toward restoring their former world. Archimedes dies, prompting Bob to leave Camelot. With the known Others forces gone, the Bobs reject any automatic obligation to serve humanity. Earth is abandoned for recovery, its survivors head toward new worlds, and Bob begins an independent journey while maintaining relay links to BobNet.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2165,7 +2165,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2178,7 +2178,7 @@
       "recaps": {
         "ending": "The Fellowship of the Sun destroys the summit. Bombs planted through the hotel bring the building down in daylight, when the vampires are helpless in their rooms, and the death toll among the assembled kings, queens, sheriffs and their human staff is enormous. Sookie and Barry, who felt the plot forming in human minds too late to stop it, get some people out beforehand and then spend the day walking the rubble, using their telepathy to find survivors buried in it. Jake Purifoy, the werewolf made vampire against his will, turns out to have helped the Fellowship get its people and its devices into the building, and he does not survive. Sophie-Anne Leclerq lives, but she loses her legs and what remained of her power; her legal victory over Arkansas is worth very little in the ruins. Andre is found injured in the wreckage and killed there by Quinn, which quietly ends the threat he represented to Sookie. Bill is badly burned pulling people out of the rubble, and tells Sookie plainly that he loves her; she does not take him back. Eric and Pam survive. Sookie goes home alive, paid, and bound by blood to Eric Northman, able to feel his moods across a distance and unable to undo it. Quinn is injured and their relationship is intact but strained, the vampire hierarchy of the whole country has been gutted, and the Fellowship of the Sun has proved it can kill vampires by the hundred.",
         "in_short": "Weeks after a hurricane destroys New Orleans and ruins the Queen of Louisiana, Sookie is hired as her telepath for a vampire summit in the northern city of Rhodes, where Sophie-Anne must answer a charge of murdering her husband, the King of Arkansas. Sookie works the summit alongside Quinn, who is running the event, and Barry, the only other telepath she knows, reading human minds for the Queen's advantage. The vampire pressing the case is found slaughtered in her suite, and the remaining Arkansas witness is shot dead with an arrow while testifying; the Queen is cleared and awarded Arkansas. Meanwhile Andre tries to force a blood exchange to bind Sookie to Louisiana forever, and Eric takes his place, leaving Sookie blood-bonded to Eric instead. On the last day, Sookie and Barry sense a plot in human minds: the Fellowship of the Sun has bombed the hotel. The building collapses with hundreds of vampires helpless inside. Sookie and Barry search the rubble for survivors, Sophie-Anne loses her legs, Andre is killed in the wreckage by Quinn, and Bill is burned rescuing people. Sookie goes home alive and permanently tied to Eric.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2367,7 +2367,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2380,7 +2380,7 @@
       "recaps": {
         "ending": "The Bureau of Genetic Welfare decides to end the uprising in the city by releasing a serum that will erase everyone's memories, including those of Tobias's family and friends. Tris and her group resolve to stop it by turning the memory serum on the Bureau's own staff instead. The plan requires someone to enter a heavily guarded Weapons Lab protected by a lethal death serum. Caleb, seeking to atone for betraying Tris, volunteers for what is meant to be a suicide mission, but at the last moment Tris takes his place. She endures the death serum and succeeds in releasing the memory serum, resetting the Bureau, but David, the Bureau's director, shoots her before it can take him. Tris dies. Tobias, shattered by grief, works to prevent all-out war in the city and helps bring Evelyn to give up her hold on power, easing the conflict between the factionless and the Allegiant. Uriah, gravely injured earlier, dies of his wounds. In an epilogue set more than two years later, the survivors have begun to rebuild a freer life, and Tobias scatters Tris's ashes by zip-lining over the city, honoring her.",
         "in_short": "After the city's founding secret is revealed, it fractures under Evelyn's harsh factionless rule, and a group loyal to the old factions, the Allegiant, forms to obey the message urging people to go outside. Tris, Tobias, Caleb, Christina, Peter, and others escape beyond the wall and reach the Bureau of Genetic Welfare, where they learn the truth: long ago, attempts to genetically engineer away human flaws produced people deemed genetically damaged, and the walled cities are experiments meant to restore genetically pure humans over generations. Divergents are the genetically healed. Tris is judged genetically pure while Tobias is called damaged, which shakes him. When the Bureau prepares to wipe the memories of everyone in the rebelling city with a serum, Tris and her friends resolve to turn that serum on the Bureau instead. Caleb volunteers for the deadly mission, but Tris takes his place, survives the death serum, and releases the memory serum, only to be shot and killed by David. Tobias, devastated, helps broker peace in the city, and after Uriah dies of his injuries, the survivors slowly rebuild. Years later, Tobias scatters Tris's ashes over the city she helped free.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2539,7 +2539,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2552,7 +2552,7 @@
       "recaps": {
         "ending": "At the French court, Bertram denies giving Diana his ancestral ring and becomes entangled in contradictions about a second ring that belonged to Helena. Diana refuses to explain how she obtained it until the widow and Helena arrive. Helena reveals that she took Diana's place during the secret meeting with Bertram: she therefore possesses his ring and is pregnant by him, satisfying the two conditions he had declared impossible before he would accept her as his wife. Faced with the proof, Bertram promises to love Helena if she can demonstrate the truth of her account, and she assures him that the evidence is genuine. The king accepts the resolution and turns to arranging Diana's future marriage. Parolles, already exposed as a coward and rejected by Bertram, receives food and shelter from Lafew. The announced reconciliation closes the legal and dynastic problem, though Bertram's sudden change of heart leaves the emotional future of the marriage dependent on conduct not shown in the play.",
         "in_short": "Helena, the physician's daughter and ward of the Countess of Roussillon, loves the countess's son Bertram. She cures the King of France and claims Bertram as her promised reward, but he rejects the unequal match, goes to war in Florence, and says he will recognize her only if she gains his ancestral ring and bears his child. Helena follows in disguise and befriends Diana, the woman Bertram is trying to seduce. Diana obtains his ring and secretly sends Helena to meet him in her place, allowing Helena to fulfill both conditions. Meanwhile, Bertram's fellow officers expose his companion Parolles as a coward. Believing Helena dead, Bertram returns to France, where conflicting claims about the rings bring him under suspicion. Diana delays the explanation until Helena appears alive and pregnant, carrying Bertram's ring. Bertram accepts her and promises love, while the king acknowledges that the conditions have been met.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2716,7 +2716,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2729,7 +2729,7 @@
       "recaps": {
         "ending": "Shadow discovers that the war between old and new gods was never real. Wednesday, who is the American Odin, secretly conspired with the trickster Loki, who had been posing as both Shadow's old cellmate and the new gods' cold leader Mr. World, to provoke a battle in which the deaths of gods on both sides would become a great sacrifice, feeding the two of them and restoring their power. Wednesday's own murder was staged as the spark. Having died on the world-tree and returned from the dead, Shadow understands the con and confronts the gods massing for battle at Lookout Mountain, laying the whole scheme bare so that the assembled powers, cheated of their war, disperse rather than slaughter one another. Loki's plot collapses and both conspirators are undone. Shadow also learns the truth of his own origins: Wednesday fathered him as part of the long game, so the con man he served was his father. Afterward Shadow returns to Lakeside and solves its mystery, revealing that the beloved old Hinzelmann is a kobold who has kept the town safe and prosperous for generations by taking the life of one child every winter; exposed, Hinzelmann's hold ends. Freed of the gods' schemes and his grief for Laura settled, Shadow leaves America and travels to Iceland, where he meets the older, original Odin and, in a small final gesture, hands over a token, walking away lighter than he came.",
         "in_short": "Released from prison to the news that his wife Laura has died in a car crash, Shadow Moon takes a job as bodyguard for a charismatic con man calling himself Mr. Wednesday. Traveling America, Shadow discovers that the odd old people Wednesday visits are gods brought over by generations of immigrants, now faded and forgotten, and that Wednesday is Odin, rallying them for war against a rising pantheon of new gods of media, technology, and money. Laura returns from the grave, uncannily animate thanks to a magical coin Shadow was given, and repeatedly protects him. For his safety Shadow hides in the pleasant lakeside town of Lakeside, whose prosperity conceals a grim secret. When Wednesday is killed during a parley with the new gods, the old gods rally for battle, and Shadow keeps a death-vigil bound to a great tree, dying and passing to the land of the dead before returning. There he realizes the whole war is a con: Wednesday and his hidden partner Loki, disguised as the new gods' leader Mr. World, engineered it so the slaughter would be a sacrifice feeding them both. Shadow exposes the grift to the assembled gods and stops the battle. He also learns Wednesday was his father. He then returns to Lakeside and uncovers that the kindly old Hinzelmann has kept the town prosperous by sacrificing a child each winter, ending the arrangement before leaving to find a kind of peace abroad.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2895,7 +2895,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2908,7 +2908,7 @@
       "recaps": {
         "ending": "At the Levovs' dinner, the Swede silently carries knowledge that destroys his picture of his family and friends. Merry is alive but has reduced herself to an emaciated Jain ascetic in a filthy Newark room; she says she was responsible for further deaths after the bombing, and Seymour cannot bring himself either to expose or abandon her. He knows that Sheila once hid Merry and never told him, and learns that Dawn and William Orcutt are lovers while Dawn plans a new house and a life beyond the family's catastrophe. The gathering erupts when Jessie Orcutt drives a fork into Lou Levov's face. The novel does not restore the pastoral order or resolve Merry's fate. Instead, Zuckerman's reconstruction closes on Seymour trapped among secrets, betrayals, and violence beneath the respectable surface he spent his life preserving. Because the central narrative is Zuckerman's imaginative version of another man's private life, even this devastation remains an attempt to understand the unknowable person behind the Swede's public image.",
         "in_short": "At a school reunion, novelist Nathan Zuckerman reflects on Seymour “the Swede” Levov, the Jewish sports hero who appeared to embody postwar American success. Zuckerman imagines the life behind that image: Seymour inherits his father's Newark glove factory, marries former Miss New Jersey Dawn Dwyer, and raises their daughter Merry on a farm in Old Rimrock. During the Vietnam era, Merry's anger hardens into extremism, and a bomb she plants kills a local man. She disappears, leaving Seymour vulnerable to an intermediary named Rita Cohen and consumed by the need to find her. Years later he discovers Merry living as a starved Jain ascetic; she claims responsibility for more deaths. He also learns that therapist Sheila Salzman once sheltered her, and that Dawn is having an affair with their neighbor William Orcutt. A disastrous family dinner exposes still more disorder. Merry's future remains unresolved, and the ideal life Seymour tried to preserve is revealed as a fragile story concealing violence, estrangement, and betrayal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3077,7 +3077,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3090,7 +3090,7 @@
       "recaps": {
         "ending": "After Dike recovers, Ifemelu returns to Lagos and begins an affair with Obinze. He says that he will leave Kosi, but his hesitation and attempts to preserve both households anger Ifemelu, who refuses to remain his secret and ends the relationship. Obinze finally confronts the life he has chosen for respectability. Despite Kosi's pleas that they maintain the marriage, he decides that continuing it dishonestly would damage all of them, including Buchi. He leaves the family home and later appears at Ifemelu's door. Acknowledging that his situation is complicated and that he cannot promise an easy resolution, he tells her that he is pursuing her and asks for a chance to try. Ifemelu lets him in. The novel closes with their relationship reopened on adult, uncertain terms rather than restored to an idealized version of their youth.",
         "in_short": "Ifemelu and Obinze fall in love as teenagers in Lagos but are separated when university strikes and immigration restrictions send her to the United States while he later enters Britain without secure status. Ifemelu endures poverty, depression, and the discovery that America has made her Black in a new social sense. She finds work, dates the wealthy Curt, builds a celebrated blog about race, and later lives with Black academic Blaine. Obinze is deported from London, returns to Nigeria, becomes rich, and marries Kosi. Thirteen years after leaving, Ifemelu closes her blog and returns to Lagos. She starts a Nigerian blog, reconnects with Obinze, and travels back to America when her cousin Dike attempts suicide. On returning again, she and Obinze begin an affair, but she rejects his half-measures. Obinze finally leaves his marriage and comes to her door asking to build a life together; she lets him in.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3237,7 +3237,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3250,7 +3250,7 @@
       "recaps": {
         "ending": "Roy returns to Atlanta expecting that his exoneration should restore his marriage, but Celestial's emotional life has changed during the five years the state took from him. She and Andre acknowledge their love and intend to build a life together. Roy initially treats Andre as the man who stole his wife, and the two fight, but the confrontation cannot settle a choice that belongs to Celestial. Roy and Celestial finally face the mixture of love, anger, obligation, and grief between them. Their physical and emotional reunion shows that the old marriage cannot be recreated by force of history or duty. Roy releases Celestial from the promise he hoped she would keep, and she chooses Andre. The later exchange of letters confirms that Roy and Celestial divorce without denying that their marriage mattered. Celestial and Andre marry, while Roy makes a new life with Davina, whose acceptance offers a relationship not governed by waiting for his former self to return. Roy remains innocent and free, but the ending does not pretend that legal correction can return the lost years or undo the damage to everyone involved.",
         "in_short": "Newly married Roy Hamilton Jr. and Celestial Davenport are building careers in Atlanta when Roy is falsely accused of rape during a visit to his parents in Louisiana. Although Celestial knows he was with her, Roy is convicted and sentenced to twelve years. Their letters preserve intimacy for a time, but prison changes Roy while Celestial's art succeeds and her life continues. She grows close to Andre, her lifelong friend and the man who introduced them. Roy's conviction is overturned after five years, and he returns home expecting to reclaim his marriage. Celestial loves Andre and cannot become the wife Roy remembers. Roy's grief and anger lead to a confrontation with Andre and a painful final reckoning with Celestial. Roy ultimately accepts that injustice created obligations love cannot fulfill. He and Celestial divorce; she marries Andre, and Roy builds a future with Davina. His freedom is real, but neither exoneration nor love can restore the years and possibilities the conviction destroyed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3423,7 +3423,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3436,7 +3436,7 @@
       "recaps": {
         "ending": "The jury convicts Clyde of first-degree murder, accepting the prosecution's account that he deliberately killed Roberta. Appeals and pleas for clemency fail. In prison Clyde cannot settle whether the death resulted from an act he fully intended or from his failure to save Roberta after recoiling from the plan. His mother's efforts and the counsel of a visiting minister bring only uncertain religious comfort. Sondra sends no personal rescue, and the wealthy Griffithses keep their distance. Clyde is executed in the electric chair. The closing return to his family's street mission shows another generation being raised amid the same poverty and promises of salvation, while Clyde's pursuit of status has ended in death rather than arrival.",
         "in_short": "Clyde Griffiths grows up ashamed of his poor missionary parents and becomes a hotel bellboy, where money and pleasure encourage his hunger for status. After fleeing a fatal car accident, he eventually works in his wealthy uncle's factory in Lycurgus. He secretly seduces employee Roberta Alden, then gains entry to fashionable society through Sondra Finchley. When Roberta becomes pregnant and insists on marriage, Clyde imagines removing her so he can pursue Sondra. He takes Roberta to an isolated lake intending to drown her, falters, but strikes or startles her as the boat overturns and swims away without saving her. Investigators reconstruct his preparations, and a sensational trial ends in conviction. His appeals fail, his rich relatives withdraw, and his attempts at repentance never resolve his own uncertainty about his guilt. He is executed, while his family's mission continues its cycle of poverty and hope.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3636,7 +3636,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3649,7 +3649,7 @@
       "recaps": {
         "ending": "Noriko's marriage to Taro Saito has succeeded, and Ono's feared social disgrace has not prevented the match. When Setsuko later visits, she does not confirm his memory that she urged him to take precautionary steps about his past; she suggests instead that he may have made too much of his reputation. Ono also visits the ailing Matsuda, who now regards their political ambitions as misguided but limited, the work of ordinary men rather than the decisive national force Ono sometimes imagines. These conversations leave Ono's grander account of both guilt and influence uncertain. He recalls the marriage meeting at which he openly acknowledged that some of his wartime work had been harmful, yet even this apparent confession remains enclosed within his selective narration. In the rebuilt city, he watches young office workers gather where his old pleasure district once stood and imagines that they face a hopeful future. He ends neither fully absolved nor fully self-condemned: his family has moved forward, his cultural world has vanished, and the scale of his past importance remains unresolved.",
         "in_short": "In four postwar reflections, retired painter Masuji Ono considers whether his former support for Japanese nationalism threatens his younger daughter Noriko's marriage prospects. Prompted by remarks from his elder daughter Setsuko, he revisits old associates and remembers his career: training under Mori-san in the art of the pleasure district, adopting the political ideas of Chishu Matsuda, gaining influence, and breaking with the gifted pupil Kuroda, who suffered after Ono acted against him. At Noriko's marriage meeting, Ono acknowledges that his wartime work was a mistake. The match nevertheless succeeds. Later, Setsuko questions the premise that she ever considered his reputation a serious obstacle, while Matsuda minimizes the influence they once imagined they possessed. Ono is left as an unreliable judge of both his guilt and stature. Watching a younger generation occupy the rebuilt city, he accepts that his world has passed and offers cautious hope for what follows.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3879,7 +3879,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3892,7 +3892,7 @@
       "recaps": {
         "ending": "The ship carrying Jamie back from Scotland is lost, and he is reported drowned. Claire reaches Philadelphia with Jenny Murray as a widow, and the city is under British occupation with her name on more than one list. Lord John Grey marries her, chiefly to put an English officer's name between her and arrest, and the arrangement is barely a day old when the truth of William's parentage breaks open: William learns that James Fraser is his natural father, that Lord John has known it all his life, and that everything about his own name is a fiction. He turns on his stepfather and rides out. Into the middle of this walks Jamie, alive, wet and unannounced, to find his wife married to his oldest friend. Elsewhere, Young Ian has declared himself to Rachel Hunter, Denzell Hunter is committed to the Continental army, and William is at large and furious. In the twentieth century the family's half of the story ends worse: Jem is taken by Rob Cameron and disappears near the tunnel at the hydroelectric dam. Roger, with William Buccleigh MacKenzie for company, goes through the stones after him, and comes out in the wrong century entirely, leaving Brianna alone in 1980 with Amanda and with a man who knows what her family is.",
         "in_short": "The American war closes over the Frasers. Jamie, Claire and Young Ian leave the burned Ridge behind, travel north through a country in revolt, and end up with the Continental garrison at Fort Ticonderoga, where Jamie raises a militia company and Claire runs a surgery. The fort is abandoned before Burgoyne's advance, and the retreat carries them into the Saratoga campaign, where the British army is beaten and surrenders. Charged with taking a dead British general home for burial, Jamie sails for Scotland with Claire and Ian, buries his brother-in-law at Lallybroch, and starts back with his widowed sister Jenny. The ship is lost and Jamie is reported drowned. Claire, arriving in occupied Philadelphia as a widow, is married by Lord John Grey to protect her, and within a day William discovers that Jamie Fraser is his real father and storms out of his own life. Jamie then walks in alive. In 1980 Scotland, Roger and Brianna's son Jem is abducted, and Roger goes through the stones after him and lands in the wrong century.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4108,7 +4108,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4121,7 +4121,7 @@
       "recaps": {
         "ending": "The final Trial is Loyalty: each Aspirant is ordered by the Augurs to kill the person dearest to them. Marcus kills his twin Zak and is crowned Emperor. Helene cannot bring herself to kill Elias, and Marcus binds her to him as his Blood Shrike, the second in the Empire and his personal enforcer, holding her family's safety over her. Elias is condemned and taken to the execution block, but Laia, Izzi, Keenan and Cook engineer his rescue, and he escapes Serra through the catacombs with them. Laia has learned that the resistance leader Mazen sold her to the Commandant and never intended to free Darin, and that her brother is alive in Kauf, the Empire's northern prison. She, Elias, Izzi and Keenan set out for it, a journey of months across the Empire. Helene's first order from her new Emperor is to hunt Elias down and kill him. Keris Veturia keeps her command of Blackcliff and her own unexplained plans, including the shadowed figure Laia once glimpsed her meeting. Elias leaves Serra carrying the poison his mother saw administered to him in the death cells, which nobody in his party yet understands.",
         "in_short": "In the Martial Empire, where the conquered Scholar people are kept enslaved and illiterate, a young Scholar named Laia watches soldiers kill her grandparents and take her brother Darin for the drawings of Martial weapons hidden in his room. She runs, then bargains with Serra's Scholar resistance: they will free Darin if she spies on the commandant of Blackcliff Military Academy from inside the woman's household. At Blackcliff, Elias Veturius is days from graduating as a Mask and intends to desert, until the Empire's Augurs announce that the imperial line has failed and name him one of four Aspirants who must compete in supernatural Trials for the throne, alongside his best friend Helene and the brothers Marcus and Zak. The Trials cost the lives of Elias's friends. Laia is beaten, spied on and finally betrayed by the resistance leader who traded her away. The last Trial demands each Aspirant kill the one they love. Marcus kills Zak and takes the throne; Helene refuses and is made his Blood Shrike; Elias is condemned, then broken out by Laia. They flee north together to free Darin from Kauf prison, with Helene ordered to hunt them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4271,7 +4271,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4284,7 +4284,7 @@
       "recaps": {
         "ending": "After the public meeting, the Stockmann home is attacked, Thomas loses his post at the baths, Petra is dismissed from her school, and their landlord orders the family out. Captain Horster also suffers for giving Thomas a venue. Morten Kiil then reveals that he has used the money Katherine and the children expected to inherit to buy cheap shares in the baths. He demands that Thomas retract his accusation, since the family will otherwise lose the investment and the tanneries may bear the blame. Hovstad and Aslaksen mistakenly treat the purchases as evidence that Thomas engineered the controversy for profit and offer the newspaper's help in return for support; he drives them away. Although leaving for another country remains possible, Thomas decides to stay. He plans to continue proving his case, educate his sons at home, and teach poor children to think independently. With Katherine and Petra beside him, he accepts isolation and concludes that a person who stands alone for the truth can possess a different kind of strength.",
         "in_short": "Doctor Thomas Stockmann discovers that the water supplying his town's celebrated baths is contaminated by industrial waste. The press and local reformers initially support him, but his brother Peter, the mayor, explains that rebuilding the system will be expensive and require a long closure. Once property owners fear higher taxes, the newspaper and civic leaders reverse themselves. Denied publication and an orderly hearing, Thomas speaks at a turbulent public meeting, broadening his attack from the baths to the complacent majority that suppresses uncomfortable truths. The town declares him an enemy of the people. His windows are broken, he and his daughter lose their jobs, and his family faces eviction. His father-in-law further traps him by investing the family's expected inheritance in the baths. Rejecting both pressure and opportunistic offers, Thomas chooses to remain in town, educate his children, and continue the fight with the support of his family and Captain Horster.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4406,7 +4406,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4419,7 +4419,7 @@
       "recaps": {
         "ending": "After Inspector Goole leaves, Arthur, Sybil, and Gerald concentrate on whether the investigation was genuine, while Sheila and Eric insist that the family's behavior remains shameful regardless. Gerald learns that the local police force has no inspector by that name. Telephone calls to the infirmary find no record of a recent suicide, and the older Birlings conclude that they have been deceived, perhaps by being shown different photographs and led to confuse several women. Their relief widens the moral division in the family: Sheila and Eric have accepted responsibility, but their parents are chiefly grateful that scandal may be avoided. Then the telephone rings. Arthur is told that a young woman has just died after taking disinfectant and that a police inspector is on the way to question the family. The promised real inquiry repeats the situation at the point when the unrepentant characters believe they have escaped it.",
         "in_short": "In 1912, wealthy manufacturer Arthur Birling celebrates his daughter Sheila's engagement to Gerald Croft. Inspector Goole interrupts the dinner to investigate the suicide of Eva Smith, a working-class woman. His questioning reveals a chain of harm: Arthur dismissed Eva for seeking better pay; Sheila cost her another job in anger; Gerald made her his dependent mistress and then left her; Sybil's charity refused her aid; and Eric, who had made her pregnant, stole money in an attempt to help. The Inspector argues that people share responsibility for one another and departs. Gerald and the older Birlings discover signs that he may not have been a real policeman and that no suicide has yet reached the infirmary, but Sheila and Eric reject this as an excuse. Just as the others celebrate avoiding scandal, a telephone call reports that a young woman has died from disinfectant and that an inspector is coming to question them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4502,7 +4502,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4515,7 +4515,7 @@
       "recaps": {
         "ending": "Farquhar seems to survive the hanging, swim away under gunfire, cross a forest, and reach the gate of his plantation. His wife comes toward him, and he is about to embrace her when he feels a crushing blow at the back of his neck and sees a burst of light. The escape has taken place only in his mind during the instant of his fall. Peyton Farquhar is dead, his neck broken, and his body hangs beneath Owl Creek Bridge.",
         "in_short": "Union soldiers prepare to hang a civilian saboteur from an Alabama railroad bridge during the American Civil War. The prisoner is Peyton Farquhar, a Confederate sympathizer who acted after a disguised Federal scout told him the bridge was vulnerable to burning. When the plank drops, Farquhar experiences an extraordinarily vivid escape: the rope breaks, he plunges into the creek, evades gunfire, and makes an exhausting journey home. As he reaches for his wife at the plantation gate, the vision ends. His apparent flight occurred in the last instant of consciousness; his neck has broken and his body hangs dead beneath Owl Creek Bridge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4670,7 +4670,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4683,7 +4683,7 @@
       "recaps": {
         "ending": "Henry's forged evidence is exposed; he confesses and dies in prison. The collapse of the army's case leads to Dreyfus being returned from Devil's Island for a new court-martial at Rennes, but the military judges again find him guilty, this time with supposed extenuating circumstances. He accepts a presidential pardon to regain his freedom while continuing to seek legal vindication. Picquart, also released and restored to public life, sees the campaign continue until France's highest court fully annuls Dreyfus's conviction in 1906. Dreyfus is reinstated in the army and awarded the Legion of Honour. Picquart is promoted to general and becomes minister of war. Their public vindication comes after years of imprisonment, exile, professional destruction, and political conflict, and it confirms that the documents used to sustain the original verdict were false.",
         "in_short": "French officer Georges Picquart takes command of army intelligence after Alfred Dreyfus has been convicted of spying and sent to Devil's Island. A recovered message leads Picquart to Ferdinand Esterhazy, whose handwriting matches the document central to Dreyfus's conviction. Picquart also learns that the original case relied on irrelevant and later forged secret evidence. His superiors refuse to reopen it, transfer him abroad, and eventually imprison him, while Esterhazy is acquitted. Picquart passes his findings to civilian allies; Émile Zola's public accusation turns the affair into a national crisis. Major Henry's forgery is finally exposed, but a second court-martial still convicts Dreyfus. A pardon frees him, and in 1906 the courts fully clear him. Dreyfus returns to the army, while Picquart becomes a general and minister of war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4877,7 +4877,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4890,7 +4890,7 @@
       "recaps": {
         "ending": "After Nabi's letter reaches Markos, he locates Pari in France and tells her that she was born in Afghanistan and had an older brother, Abdullah. Pari travels to the United States to meet him. Abdullah has built a family and named his daughter Pari after the sister he never stopped mourning, but age and dementia have taken away much of his ability to recognize or explain the past. The younger Pari gives her aunt a box containing a feather that Abdullah preserved from childhood. Its meaning confirms the enduring bond between the siblings even though the reunion comes too late for full recognition. The elder Pari gains the family history she had long sensed was missing and remains connected to Abdullah's household while accepting that much of their shared past cannot be recovered. The separated pair are physically reunited, but time has made restoration incomplete.",
         "in_short": "In 1952 Afghanistan, ten-year-old Abdullah's beloved little sister Pari is sold to the wealthy, childless Wahdatis in Kabul, a decision driven by the poverty of their father, Saboor, and arranged through their uncle Nabi. Nila Wahdati takes Pari to France and raises her without knowledge of Abdullah, while Nabi remains to care for the disabled Suleiman. Across decades, the consequences of sacrifice and abandonment echo through linked lives: Parwana's guilt toward her twin, Afghan expatriates confronting suffering in Kabul, a Greek surgeon shaped by his friendship with the scarred Thalia, and children discovering truths hidden by powerful adults. Nabi eventually records Pari's origin in a letter to Markos. After Nila's death, Pari learns the truth and finds Abdullah in America. He has named his own daughter after her but now has dementia. A saved feather from their childhood restores a fragment of their connection, though their long separation cannot be undone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/and-then-there-were-none.json
+++ b/data/works-community/0/and-then-there-were-none.json
@@ -103,7 +103,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -114,7 +114,7 @@
       "recaps": {
         "ending": "The novel ends with every one of the ten people on Soldier Island dead and the crime seemingly impossible to solve. The last survivor, Vera Claythorne, alone and broken by guilt after shooting Philip Lombard, returns to the house to find a noose set out for her in keeping with the nursery rhyme and, in a trance of despair, hangs herself. When the police arrive, they are faced with ten corpses, a missing set of little soldier figurines, and no living suspect or explanation. The solution comes only afterward, through a confession the killer wrote and cast into the sea in a bottle. It reveals that the murderer was Justice Lawrence Wargrave, a dying judge who wished both to punish people he was certain had escaped justice for causing deaths and to commit one flawless, undetectable crime. He chose his ten targets, drew them to the island, and killed them one by one in the order of the rhyme, faking his own death partway through with the unwitting help of Dr. Armstrong so the others would stop suspecting him. After the rest were dead, he staged his final suicide to look like another murder, ensuring the police would find the case unsolvable, and confessed only so that the cleverness of his scheme would one day be understood.",
         "in_short": "Ten strangers are each tricked into visiting an isolated mansion on Soldier Island, where their absent host, the untraceable \"U. N. Owen,\" is never seen. On the first night a recording accuses every one of them of having caused a death and escaped justice. One by one the guests then die, each killing echoing a nursery rhyme about ten soldier boys, and small soldier figurines vanish with every death. Cut off by a storm, the survivors realize the murderer must be among them, but they cannot identify who, and even the calm retired judge Wargrave is found apparently dead. In the end all ten perish; the last survivor, Vera Claythorne, wracked by guilt, hangs herself. Police find the island strewn with bodies and no killer, an impossible crime. A confession later recovered in a bottle reveals the truth: Justice Wargrave, terminally ill and driven to punish the guilty and stage a perfect murder, orchestrated everything, faked his own death with the doctor's unwitting help, killed the rest, and finally took his own life to leave the case unsolvable.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -285,7 +285,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -298,7 +298,7 @@
       "recaps": {
         "ending": "Langdon and Vittoria discover that the supposed Illuminati plot was orchestrated by Camerlengo Carlo Ventresca. He murdered the pope after learning that the pontiff had fathered a child through artificial insemination, then arranged Leonardo Vetra's death, the antimatter theft, and the cardinals' murders to manufacture a crisis in which he could appear divinely chosen. Kohler had recorded Ventresca's confession, and the surviving evidence reaches the conclave. Ventresca learns that he himself was the pope's child, conceived without breaking the pope's vow of celibacy, and publicly burns himself to death. Cardinal Mortati is elected pope. The antimatter has exploded harmlessly high above Rome after Langdon survives the fall from the helicopter with a parachute-like cover. Vittoria and Langdon leave the Vatican together, and Mortati gives Langdon the final Illuminati diamond brand on indefinite loan.",
         "in_short": "CERN scientist Leonardo Vetra is murdered and a canister of antimatter is stolen, leading symbologist Robert Langdon and Vetra's daughter Vittoria to Vatican City during a papal conclave. A caller claiming to represent the Illuminati threatens to kill four leading cardinals along an ancient Path of Illumination, then destroy the Vatican at midnight. Langdon and Vittoria follow clues through Roman churches but cannot prevent the ritual deaths. Camerlengo Carlo Ventresca appears to locate the antimatter through divine inspiration and carries it aloft in a helicopter before it explodes, saving the city. Langdon survives the blast, and evidence left by CERN director Maximilian Kohler reveals that Ventresca engineered the entire conspiracy. He had killed the pope and used the Illuminati legend to create a miracle that would renew the Church. After learning he was secretly the pope's son, Ventresca kills himself. Cardinal Mortati becomes pope, and Langdon and Vittoria leave Rome together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -432,7 +432,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -445,7 +445,7 @@
       "recaps": {
         "ending": "The Illuminati threat is exposed as a fabrication staged from within the Church. The camerlengo, Carlo Ventresca, is revealed to be the mastermind behind everything: he poisoned the Pope, arranged the theft of the antimatter, hired the assassin, and staged a false revival of the Illuminati so that he could appear to save the Church and be swept to power. His climactic rescue of the antimatter, flying it above the city and parachuting to apparent glory while Langdon survives a fall into the Tiber, is part of the performance, including a wound he inflicts on himself to seem divinely marked. On the verge of being acclaimed the next Pope, he is undone when it emerges that the Pope he murdered was his biological father, conceived through artificial insemination so that the pontiff never broke his vow of chastity. Devastated by this truth, Ventresca sets himself ablaze before the crowds in St. Peter's. The elderly Cardinal Mortati, who uncovers and reveals the truth, is elected the new Pope. Langdon and Vittoria survive, and the Church quietly buries the scandal, preserving the illusion of a miracle for the faithful.",
         "in_short": "Harvard symbologist Robert Langdon is summoned to CERN after a scientist is murdered and branded with the ancient symbol of the Illuminati, a secret brotherhood long thought extinct. A vial of antimatter, capable of a devastating explosion, has been stolen and hidden somewhere in Vatican City, set to detonate at midnight, just as the cardinals gather to elect a new Pope. With the physicist Vittoria Vetra, Langdon races through Rome following a trail of Illuminati clues hidden in Renaissance art and architecture, while a hired assassin murders four kidnapped cardinals one by one. The seemingly heroic camerlengo, the late Pope's chamberlain, rallies the Church and, in an apparent act of divine courage, flies the antimatter high above the city so it explodes harmlessly in the sky, and Langdon survives a fall from the aircraft. But it is revealed to be an elaborate deception: the camerlengo himself orchestrated the entire plot, murdering the Pope and staging the Illuminati threat to make himself the Church's savior, only to learn that the Pope he killed was secretly his own father. Exposed, the camerlengo takes his own life by fire, and a new Pope is chosen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -595,7 +595,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -608,7 +608,7 @@
       "recaps": {
         "ending": "Bosch's inquiry joins Howard Elias's murder to the truth Elias was preparing to reveal in the Michael Harris civil case. Harris did not murder Stacey Kincaid; the original investigation concentrated on him while evidence inside the Kincaid family was ignored, and Stacey's father was responsible for her death. Internal Affairs investigator John Chastain killed Elias to prevent the full chain of misconduct and concealment from emerging, with Catalina Perez becoming an additional victim of the attack. Frankie Sheehan, though implicated in the abusive interrogation of Harris, is not the simple answer to Elias's murder. Chastain dies amid the violence surrounding the case before Bosch can deliver an ordinary arrest and trial. The facts therefore emerge into a city already primed to distrust the LAPD, leaving both the department and Bosch unable to claim a clean resolution. At home, the damage is also final: Eleanor Wish leaves Bosch and Los Angeles after their marriage collapses under secrecy, distance, and his absorption in the case.",
         "in_short": "Civil-rights lawyer Howard Elias and bystander Catalina Perez are shot aboard the Angels Flight railway just before Elias is to try a police-brutality suit for Michael Harris. With Los Angeles close to unrest and LAPD officers the obvious suspects, Harry Bosch leads Kiz Rider and Jerry Edgar through Elias's files, the conduct of Bosch's former partner Frankie Sheehan, and the old murder of twelve-year-old Stacey Kincaid. The inquiry shows that Harris was tortured during a failed case and that Elias had uncovered both the real source of Stacey's death and misconduct that kept attention away from her family. Internal Affairs investigator John Chastain killed Elias to stop those discoveries from coming out, while Perez died because she was present. Chastain dies during the resulting disorder before he can be prosecuted. Bosch solves the linked crimes but cannot contain their civic consequences. His marriage also breaks: Eleanor Wish leaves Los Angeles after Bosch is unable to bridge the distance the case and their private losses have created.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -781,7 +781,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -794,7 +794,7 @@
       "recaps": {
         "ending": "Prior reaches Heaven and rejects the Angels' demand that humanity stop moving and changing. He returns their prophetic book and asks for more life despite pain, loss, and the certainty of death. On Earth, Roy Cohn dies after tricking Ethel Rosenberg into confirming his disbarment; Belize has Louis recite the Jewish prayer for the dead over Roy's body, and Ethel joins unseen. Harper finally leaves Joe, taking his credit card and flying west to begin an independent life. Joe, abandoned by both Harper and Louis and separated from Roy's promised future, does not join the final gathering. Five years later, Prior is alive though still ill. He sits at the Bethesda Fountain with Belize, Louis, and Hannah, an unlikely chosen family shaped by the epidemic and their shared history. Prior addresses the audience with hope for more life and imagines the fountain restored, offering a blessing that does not deny suffering or mortality. The characters do not achieve a clean cure or political resolution, but survival, change, and mutual care defeat the Angels' ideal of static safety.",
         "in_short": "In 1985 New York, Prior Walter develops AIDS and is abandoned by his frightened boyfriend, Louis Ironson. Louis begins a relationship with Joe Pitt, a closeted Mormon lawyer whose Valium-dependent wife Harper retreats into hallucinations. Joe's patron, the powerful conservative lawyer Roy Cohn, also has AIDS but denies the identity and uses influence to secure scarce medication. An Angel selects Prior as a prophet and commands humanity to stop migrating and changing, claiming human restlessness drove God away. Prior refuses the mission and ultimately returns the prophetic book to Heaven, choosing painful life and change over stillness. Joe's relationship with Louis collapses after Louis learns of his connection to Roy; Harper leaves Joe to build a life of her own. Roy is disbarred and dies, watched by Ethel Rosenberg's ghost, while Belize and Louis give him a final prayer. Five years later Prior remains alive, supported by Belize, Louis, and Joe's mother Hannah, and closes with a blessing of survival and hope.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -941,7 +941,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -954,7 +954,7 @@
       "recaps": {
         "ending": "The revolution has come full circle into a new tyranny. Napoleon rules Animal Farm as an absolute dictator, protected by his dogs and served by Squealer's lies, while the working animals are as poor, hungry, and exploited as they were under the humans. Boxer, who trusted the pigs to the last, has been sold to a horse slaughterer and his death disguised as a peaceful passing. The idealistic Seven Commandments have been erased and replaced by the single principle that all animals are equal but some animals are more equal than others. The pigs now wear clothes, walk on two legs, carry whips, and trade and dine with the neighboring farmers. In the closing scene Napoleon hosts the humans at a banquet, announces that the farm will be called Manor Farm once more, and falls to quarreling with a guest over a game of cards. The other animals, peering in from outside, look from the pigs to the men and back again and can see no difference between them. The ruling pigs have become indistinguishable from the oppressors the animals rose up to overthrow.",
         "in_short": "The mistreated animals of an English farm, inspired by the dying boar Old Major, drive out their neglectful owner and take the farm for themselves, vowing that all animals are equal. The clever pigs take the lead, and two of them, the inventive Snowball and the ruthless Napoleon, become rivals until Napoleon uses a pack of dogs he has secretly raised to seize sole power and expel Snowball. Under Napoleon the pigs steadily grant themselves more privileges while the other animals, above all the loyal cart-horse Boxer, work themselves to exhaustion. Napoleon rules by fear, staging false confessions and executions and blaming every failure on Snowball, while Squealer's propaganda quietly rewrites the founding Commandments to excuse each new betrayal. When Boxer can work no more, he is sold to a slaughterer. Years later the pigs walk upright, do business with humans, and reduce their code to the claim that some animals are more equal than others, until the other animals can no longer tell them apart from the men they once rebelled against.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1047,7 +1047,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1060,7 +1060,7 @@
       "recaps": {
         "ending": "Two days after Anna tells the truth about her past, Chris returns prepared to accept her, though he still distrusts the sea and the man she loves. Mat also comes back. His first demand for an oath of purity angers Anna, but when she swears that she has never loved another man, he accepts her account and renews his commitment to her. The reconciliation is uneasy rather than idealized: Mat and Chris discover that both have signed onto the same vessel bound for South Africa, leaving Anna to wait ashore for their return. Anna and Mat plan to marry after the voyage. Chris sees the coincidence as another sign that the sea governs their lives, and the play closes with all three facing a future that repeats some of the separations they had hoped to escape.",
         "in_short": "Anna Christie reunites with her seafaring father, Chris, after years of hardship she does not initially explain. A restorative stay on his coal barge leads to her meeting Mat Burke, an Irish stoker rescued from a wreck, and they fall in love. Chris objects because he wants Anna kept away from sailors, while Mat idealizes her and proposes marriage. Forced between their competing assumptions, Anna reveals that she was assaulted while living with relatives and later survived through prostitution. Both men initially abandon her in anger and confusion. They return two days later, and Mat accepts Anna after she insists that her love for him is genuine. He and Chris then learn they have signed onto the same ship. Anna agrees to wait for Mat and marry him when he returns, while the men's departure confirms that the sea still shapes all their lives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1204,7 +1204,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1217,7 +1217,7 @@
       "recaps": {
         "ending": "Anna's affair with Vronsky, once ecstatic, curdles into suspicion and misery. Ostracized by society for abandoning her marriage, separated from her beloved son, and unable to secure a stable new life, she becomes consumed by jealousy and the conviction that Vronsky no longer loves her as he once did. In a spiral of despair she goes to a railway station and throws herself beneath a passing train, ending her life. Vronsky, shattered by her death, goes off to war seeking his own destruction. In deliberate contrast, Levin and Kitty settle into married life on his estate with their child; after long wrestling with despair and the question of how to live, Levin comes to a simple, hard-won faith that gives his life meaning. The book closes on his private resolve to live for goodness, setting his quiet spiritual renewal against the tragedy of Anna's fall.",
         "in_short": "Anna Karenina, the graceful wife of the cold St. Petersburg official Karenin, falls into a consuming love affair with the cavalry officer Count Vronsky. She leaves her husband and young son to be with Vronsky and bears his child, defying the moral code of her society, which then shuns and isolates her. Cut off from her son and from respectable company, and increasingly tormented by jealousy, insecurity, and the fear that Vronsky's love is cooling, Anna sinks into despair and finally throws herself under a train. Her story runs in counterpoint to that of the landowner Konstantin Levin, who wins and marries Kitty Shcherbatskaya, works his estate, and struggles with doubts about the meaning of life until he arrives at a quiet religious faith. The novel contrasts Anna's destruction by passion outside the bounds of society with Levin's slow, imperfect discovery of purpose in love, family, work, and belief.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1385,7 +1385,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1398,7 +1398,7 @@
       "recaps": {
         "ending": "After Anna's death, Vronsky gives their daughter into Karenin's care and leaves as a volunteer for the war in Serbia, indifferent to whether he survives. Stiva continues seeking advancement, while Koznyshev and others are swept up in public enthusiasm for the Slavic cause. On his estate, Levin remains disturbed by his inability to reason his way into religious certainty. A conversation with a peasant helps him recognize that a meaningful life can be directed toward goodness rather than self-interest. This insight does not make him flawless or remove every doubt, but it gives him a basis for living. During a storm he fears that Kitty and their infant son have been killed by a falling tree; finding them safe sharpens his sense of gratitude. He decides that his new understanding may remain private even from Kitty, and that ordinary family life will continue with quarrels and mistakes, yet can now possess a moral meaning he had been unable to see.",
         "in_short": "Anna Karenina, the wife of a prominent official, begins an affair with the cavalry officer Vronsky and eventually leaves her husband and son to live with him. Their exclusion from respectable society, Vronsky's continuing freedom, and Anna's mounting jealousy make their shared life increasingly desperate. Unable to secure a divorce or trust his love, Anna dies by suicide beneath a train, leaving Vronsky broken. In a parallel story, the landowner Levin is rejected by Kitty, then later marries her. They endure family illness, jealousy, and the difficult birth of their son, while Levin searches for a way to reconcile honest thought with faith. After Anna's death, Vronsky goes to war. Levin finally understands that life need not be justified by abstract proof: it gains meaning through an imperfect but deliberate commitment to goodness, family, and responsibilities beyond the self.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1597,7 +1597,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1610,7 +1610,7 @@
       "recaps": {
         "ending": "Miss Lavendar Lewis and Stephen Irving are married at Echo Lodge on an August afternoon, with Anne and Diana as bridesmaids, Charlotta the Fourth weeping with joy, and Paul delighted to be given a mother he already likes. The couple leave for the United States, taking Charlotta with them, and Paul goes too, so Anne loses her favourite pupil. Echo Lodge is to be kept up and opened again in the summers, so it is not shut for good. Mr. Harrison and his wife are settled and reconciled, and the Avonlea Village Improvement Society has begun to change the look of the village. At Green Gables the twins have become a fixture, Davy no more docile but a good deal more affectionate. Mrs. Rachel Lynde, left alone in the world after her husband's death, comes to live at Green Gables and take over the housekeeping and the twins, which frees Marilla and settles the question that has hung over Anne for two years. Anne and Gilbert are able at last to go to Redmond College in the autumn, and part from Avonlea on a September evening with their studies ahead of them and their friendship unchanged.",
         "in_short": "At sixteen Anne Shirley teaches the Avonlea school while keeping house at Green Gables with Marilla, and finds that her pupils, her neighbours, and her own quick temper all resist improvement. She quarrels with the irascible new neighbour Mr. Harrison, sells his Jersey cow by mistake, and ends by becoming his confidante. With Gilbert and Diana she founds a village improvement society whose first triumph is a hall painted a hideous blue. Marilla takes in six-year-old orphan twins, Davy and Dora Keith, and Davy's mischief keeps Green Gables lively. Anne loses her temper once, whipping her most difficult pupil, and is ashamed of it; she also gains a devoted scholar in the dreaming Paul Irving. Losing her way one afternoon, she discovers Miss Lavendar Lewis living alone at Echo Lodge, and gradually learns that Miss Lavendar was once engaged to Paul's widowed father. Their old quarrel is mended and they marry. Mrs. Lynde, widowed, comes to Green Gables to keep house, freeing Anne and Gilbert to leave for Redmond College.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1814,7 +1814,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1827,7 +1827,7 @@
       "recaps": {
         "ending": "Anne finishes her year at Queen's Academy in a single year instead of two, wins the Avery scholarship for English, and comes home to Green Gables expecting to go on to Redmond College in the autumn. Gilbert Blythe takes the gold medal. That summer Matthew, whose heart has been failing, dies suddenly after learning that the bank holding the Cuthberts' savings has failed. Marilla is left alone with a farm she cannot work and eyes that are failing her; the doctor warns that she will lose her sight altogether unless she gives up close work and worry, and she speaks of selling Green Gables. Anne gives up the scholarship and Redmond, arranges to board at home, and takes a teaching post so that she and Marilla can keep the farm. When she finds that the Avonlea school has been promised to her, she learns that Gilbert has withdrawn his own application and taken the school at White Sands so that she could stay near Marilla. Meeting him at the gate, Anne finally puts an end to the quarrel she has kept up for five years, and the two part as friends with plans to study together. Anne sets out on a narrower road than the one she had imagined, and finds she is content with it.",
         "in_short": "Elderly brother and sister Matthew and Marilla Cuthbert of Green Gables, on Prince Edward Island, send for an orphan boy to help on the farm and are sent eleven-year-old Anne Shirley instead. Marilla means to return her, but relents, and the talkative, imaginative, red-haired child stays. Anne makes a bosom friend of Diana Barry, begins a five-year feud with Gilbert Blythe after he teases her about her hair, and stumbles through a series of scrapes: an accidental dose of currant wine, a dyed-green head, a broken ankle on a dare. She also grows into the village's affection, saving Diana's little sister from croup and winning over her sternest critics. Marilla, who cannot say what she feels, comes to love her; Matthew, who never could say anything, quietly always did. Anne takes the entrance examinations for Queen's Academy, ties with Gilbert for first place, and wins a scholarship. Then Matthew dies and Marilla's sight begins to fail. Anne gives up the scholarship, takes a country school, and stays at Green Gables, making peace with Gilbert at last.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2019,7 +2019,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2032,7 +2032,7 @@
       "recaps": {
         "ending": "Matthew dies suddenly after learning that the bank holding the Cuthberts' savings has failed. Soon afterward Marilla's worsening eyesight threatens to force her to sell Green Gables, because she cannot manage the farm alone. Anne, who has won the Avery Scholarship and planned to continue her education at Redmond College, gives up the scholarship so she can remain with Marilla and teach nearby. Gilbert has been appointed to the Avonlea school, but he quietly gives up the post so Anne can take it and accepts a more distant school himself. His generosity ends their long estrangement, and Anne finally offers the friendship he has wanted. Green Gables is preserved, Marilla is no longer alone, and Anne faces a smaller life than she expected but sees it as a beginning rather than a defeat.",
         "in_short": "Marilla and Matthew Cuthbert intend to adopt a boy to help at Green Gables, but a mistake sends them Anne Shirley, an imaginative red-haired orphan. Matthew immediately cares for her; Marilla gradually decides to keep her and grows to love her. Anne's temper and romantic ideas cause repeated disasters, yet she finds a devoted friend in Diana Barry, proves resourceful in a crisis, and wins a place in Avonlea's community. She treats Gilbert Blythe as an enemy after he mocks her hair, and their academic rivalry drives both toward Queen's Academy. Anne earns the Avery Scholarship, but Matthew dies and Marilla's failing eyesight endangers Green Gables. Anne gives up further study to stay home and teach. Gilbert surrenders the Avonlea school for her benefit, and she finally reconciles with him, accepting an altered future rooted in the home she once feared she would lose.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2202,7 +2202,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2215,7 +2215,7 @@
       "recaps": {
         "ending": "Anne completes her year at Queen's Academy, ties with Gilbert for first-class honors, and wins the Avery scholarship, which would allow her to attend college. Her plans change after Matthew dies suddenly and Marilla learns that her eyesight may fail if she continues working too hard. Anne decides to remain at Green Gables and teach nearby so Marilla will not have to sell their home. Gilbert has already received the Avonlea school but gives it up for Anne, accepting a more distant post himself. His generosity ends their long estrangement, and they finally agree to be friends. Anne's future is narrower than the ambitious route she had expected, yet she regards it as purposeful rather than defeated: Green Gables is secure for the present, Marilla will have her support, and education and writing remain open to her in new forms.",
         "in_short": "Matthew and Marilla Cuthbert intend to adopt a boy to help at Green Gables but receive imaginative, red-haired Anne Shirley instead. Marilla keeps her after learning how precarious the orphan's alternatives are, and Anne gradually becomes central to both Cuthberts' lives. Her impulsiveness causes comic disasters, while her loyalty, courage, and eagerness to learn win over Avonlea. She forms a deep friendship with Diana Barry and a fierce academic rivalry with Gilbert Blythe after he mocks her hair. Guided by the progressive teacher Miss Stacy, Anne earns a place at Queen's Academy and wins a scholarship. Matthew then dies, and Marilla's failing eyesight threatens the loss of Green Gables. Anne gives up immediate college plans to remain with Marilla and teach locally. Gilbert surrenders the Avonlea post so she can stay near home; Anne forgives him, and their rivalry becomes friendship as she accepts a changed but still hopeful future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2428,7 +2428,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2441,7 +2441,7 @@
       "recaps": {
         "ending": "Anne's fear that Gilbert has stopped loving her comes to a head when they attend a dinner in town where Christine Stuart, an old acquaintance of his college days, is among the guests. Anne dresses carefully and spends the evening watching the two of them, wretched with an unhappiness she has never felt before. On the drive home Gilbert speaks of Christine with amused indifference, remarking on how much she has changed and how glad he is to be going home, and the whole structure of Anne's jealousy collapses. His distraction, it turns out, was nothing but overwork and worry over a difficult case. The two are entirely at ease with each other again. Aunt Mary Maria has long since taken herself off, and Ingleside is its own household once more. Each of the children's troubles has been survived and mostly outgrown: Jem is full of plans, Walter is writing, the twins have finished with their unsuitable friendships, and Rilla is out of babyhood. The book ends on a quiet summer night at Ingleside with the whole family asleep under one roof and Anne content, the family established for the books that follow.",
         "in_short": "Anne Blythe is settled at Ingleside, the doctor's house at Glen St. Mary, with Gilbert's country practice, the redoubtable housekeeper Susan Baker, and a family of children: Jem, Walter, the twins Nan and Di, Shirley, and, born in this book, the youngest, Rilla. The story is a sequence of domestic episodes rather than a single plot. Gilbert's Aunt Mary Maria arrives for a short visit and stays for months, spreading gloom and criticism until she takes offence and leaves of her own accord, to the household's relief. Each child has a chapter of their own troubles: Jem loses his dog, Walter is frightened into walking home alone in the night by a story that his mother is dying, Nan convinces herself she was exchanged in infancy and goes to find her supposed real mother, and Di is twice taken in by a friend who lies to her. Anne, turning forty, begins to fear that Gilbert has grown indifferent to her, a fear that a dinner party attended by an old acquaintance of his makes almost unbearable, until his own words on the way home show it to be groundless.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2651,7 +2651,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2664,7 +2664,7 @@
       "recaps": {
         "ending": "Anne takes her degree at Redmond, refuses Royal Gardner when he finally proposes because she discovers she has only been in love with an idea of him, and comes home to Avonlea for good. Philippa Gordon marries Jonas Blake and goes with him to his poor shore parish in a fishing village, entirely happy. Patty's Place is given up and Aunt Jamesina goes home. In Avonlea, Anne finds Gilbert changed and distant and hears that he is expected to marry Christine Stuart. Then Gilbert falls dangerously ill with typhoid fever, and during the night when the crisis is expected to kill him Anne understands that she has loved him all along and that her refusal of him was the great mistake of her life. He recovers, and when he is strong enough the two meet in the woods above Avonlea. Gilbert learns that Christine was never anything but a friend engaged to another man, and he asks Anne again. She accepts. They agree to wait three years while he completes his medical training, and Anne takes a teaching post to fill the time. Diana is married to Fred Wright, Green Gables is unchanged, and Anne ends the book engaged and at home.",
         "in_short": "Anne leaves Avonlea at eighteen for four years at Redmond College in Kingsport, where she makes friends with the frivolous, clever Philippa Gordon and eventually keeps house with her college friends at Patty's Place under the chaperonage of Aunt Jamesina. Childhood ends around her: Diana becomes engaged to Fred Wright, Anne refuses two absurd proposals and one serious one when Gilbert Blythe asks her to marry him, and her old schoolfellow Ruby Gillis dies of consumption. Estranged from Gilbert, Anne is courted by the handsome, poetic Royal Gardner and drifts into accepting his attentions, only to refuse him when he proposes, realizing that she wanted the romance rather than the man. She takes her degree, sees Philippa married to a poor divinity student, and returns to Avonlea. There Gilbert nearly dies of typhoid fever, and in the fear of losing him Anne discovers that she has loved him for years. He recovers, asks her again, and this time she accepts, on the understanding that they will wait three years for his medical course to end.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2872,7 +2872,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2885,7 +2885,7 @@
       "recaps": {
         "ending": "Anne finishes her third year as principal of Summerside High School and resigns to be married. The Pringle clan, long since won over, is sorry to lose her. Katherine Brooke, whose bitterness Anne dissolved by taking her home to Green Gables for Christmas, has left teaching for work she actually wants and has become a real friend. Little Elizabeth's future is settled: Anne brings her father, Pierce Grayson, to see her, the misunderstanding that kept them apart is cleared up, and Elizabeth goes to live with him, so that the Tomorrow she has been waiting for arrives at last. Anne makes her farewells at Windy Poplars, where Rebecca Dew and the two widows part from her with real grief, and she leaves Spook's Lane for the last time. Miss Minerva Tomgallon's house, the Summerside gossip, the school, and the three years of letters are behind her; ahead is her wedding to Gilbert Blythe, who has finished his medical course, and the house by the sea they will begin their marriage in. The book closes with Anne's Summerside chapter shut and her married life about to begin.",
         "in_short": "Engaged to Gilbert Blythe and waiting out his medical course, Anne Shirley spends three years as principal of Summerside High School, boarding at an old house called Windy Poplars with two elderly widows and their outspoken help, Rebecca Dew. The story is told largely through her letters to Gilbert. Her first year is a quiet war with the Pringles, the clan that dominates the town and resents her appointment, until an old family diary comes into her hands and the opposition collapses. She wears down the hostility of the embittered vice-principal Katherine Brooke by taking her home to Green Gables for Christmas, and befriends a lonely, strictly reared child next door, little Elizabeth Grayson, who is waiting for a father she has never met. Between these threads Anne meddles benevolently in Summerside's romances, feuds, and family histories. At the end of the three years she reunites Elizabeth with her father, resigns her post, and leaves Summerside to be married.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3070,7 +3070,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3083,7 +3083,7 @@
       "recaps": {
         "ending": "The truth about Leslie Moore's husband frees her: the man she nursed for years was Dick Moore's cousin George, and the real Dick died abroad long ago, so her marriage never existed. Owen Ford returns to Four Winds and the two become engaged. Anne and Gilbert's son, James Matthew, is born safely and thrives, with Susan Baker installed to help in the house. Captain Jim's life-book, written up by Owen from the old man's stories, is published; Captain Jim reads his copy through on a quiet evening at the light and is found dead in his chair, having gone out as easily as a ship crossing the bar, with the First Mate beside him. Miss Cornelia Bryant, after a lifetime of denouncing men, marries Marshall Elliott, who shaves at last. Leslie and Owen marry and take the little house on the shore as their own summer home, so it stays in loving hands. Gilbert's practice has grown too large for the cottage, and he and Anne move up to a big house at Glen St. Mary called Ingleside, taking Susan and the baby with them. Anne leaves her house of dreams with real grief and with the certainty that the happiness it held goes with her.",
         "in_short": "Anne Shirley marries Gilbert Blythe at Green Gables and goes to keep house in a small cottage on Four Winds Harbour, where Gilbert has taken over a country practice. Her neighbours are the old lighthouse keeper Captain Jim, the outspoken Miss Cornelia Bryant, and Leslie Moore, a beautiful young woman married at sixteen to a man who came home from sea with his wits gone and who has nursed him ever since. Anne wins Leslie's friendship slowly, and their first real closeness comes after Anne's baby daughter is born and dies within a day. A writer named Owen Ford comes to board with the Moores, takes down Captain Jim's life story for a book, and falls in love with Leslie, which seems hopeless. Gilbert then argues that Leslie's husband might be cured by surgery. The operation reveals that the man is not Dick Moore at all but his cousin; the real Dick died years before, and Leslie is free. Leslie and Owen marry, Anne's son Jem is born, Captain Jim dies the night he reads his finished book, and the Blythes move to a larger house at Glen St. Mary.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3246,7 +3246,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3259,7 +3259,7 @@
       "recaps": {
         "ending": "Ida finally tells Vivaldo about her affair with Ellis and about the compromises, anger, and humiliation bound up with it. Her confession forces both of them to face how often their relationship has depended on partial truths and on Vivaldo's confidence that love alone can erase racial difference. Cass admits her relationship with Eric to Richard, leaving their marriage badly shaken but no longer protected by silence. Eric, having offered intimacy to both Cass and Vivaldo during his return, goes to meet Yves when the young man arrives from France. Their reunion closes the novel on a fragile possibility of tenderness rather than a settled resolution. Rufus remains the absent center of the group: his death cannot be repaired, and the surviving characters carry forward the conflicts over race, desire, guilt, and honesty that he exposed.",
         "in_short": "In New York, Black jazz drummer Rufus Scott falls into poverty and despair after his destructive interracial relationship with Leona ends, and he dies by suicide. His death binds together and unsettles those around him: his white friend Vivaldo begins a difficult relationship with Rufus's sister Ida; married Cass Silenski confronts the emptiness beneath her husband Richard's literary success; and actor Eric Jones returns from France while awaiting his lover Yves. As the characters seek intimacy across divisions of race, sex, and social power, they repeatedly conceal what they most need to say. Cass and Eric become lovers, Eric also shares a charged encounter with Vivaldo, and Ida becomes involved with the influential television producer Ellis while trying to advance as a singer. Ida eventually confesses the affair to Vivaldo, and Cass tells Richard the truth. Their relationships remain uncertain. Eric meets Yves on his arrival in New York, ending the novel with reunion and hope shadowed by the damage the group has done and endured.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3382,7 +3382,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3395,7 +3395,7 @@
       "recaps": {
         "ending": "In the mountain house, Equality reads books from the lost individualist civilization and finally encounters the word that his society erased: I. He understands that a person is not merely a fragment of a collective and adopts the name Prometheus. Liberty chooses the name Gaea. Prometheus plans to remain in the house, learn its knowledge, cultivate the land, and raise a family whose members will never surrender their identities. Once the house is secure, he intends to return to the city and rescue International and any others capable of choosing freedom. He imagines building a defended community for them in the mountains. The story closes with his recognition that the liberty of the individual is the value for which the forbidden word stands.",
         "in_short": "Equality 7-2521 lives in a collectivist future that has abolished personal names, choices, love, and unsupervised inquiry. Assigned to street sweeping despite his intelligence, he secretly studies in an old underground tunnel and rediscovers electric light. He also forms a forbidden bond with Liberty 5-3000, whom he calls the Golden One. When the World Council of Scholars recoils from his independent invention and threatens to destroy it, Equality escapes into the Uncharted Forest. Liberty follows him, and together they find a mountain house surviving from the lost age. Its books teach Equality the concept and word that his society eliminated: I. Renaming himself Prometheus and Liberty as Gaea, he decides to make the house a refuge, recover old knowledge, rescue selected friends, and establish a society founded on individual freedom.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3528,7 +3528,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3541,7 +3541,7 @@
       "recaps": {
         "ending": "Creon orders Antigone sealed in a cave, then belatedly goes to release her after the Chorus warns that he has pushed the punishment too far. He arrives after Antigone has hanged herself. Haemon, found holding her body, rejects his father and kills himself. A messenger brings the news to Eurydice, who quietly withdraws and cuts her throat. Creon is left alive after losing his wife, his son, and his niece. He returns to the administrative work of the state because, unlike Antigone, he has accepted the duty of continuing. The guards resume their card game, untouched by the royal family's destruction, and the Chorus closes the play on the silence that follows tragedy.",
         "in_short": "After the sons of Oedipus kill each other in a civil war, Creon honors Eteocles and forbids burial of Polynices. Their sister Antigone secretly covers Polynices' body with earth and is arrested when she returns to perform the rite again. Creon tries privately to save his niece, arguing that rule is practical work and revealing that neither brother deserves her idealized loyalty. Antigone nearly accepts life but rejects the compromised happiness he offers and insists on owning her act. Creon condemns her to be sealed in a cave. She hangs herself before he can reverse course; her fiancé Haemon, Creon's son, kills himself beside her, and Creon's wife Eurydice takes her own life after hearing the news. Creon survives and returns alone to governing while the indifferent guards carry on with their routine.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3646,7 +3646,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3659,7 +3659,7 @@
       "recaps": {
         "ending": "Tiresias warns that the gods hold Creon responsible for leaving Polynices unburied and confining Antigone alive. Shaken at last, Creon arranges the burial and goes to release Antigone, but his reversal comes too late. Antigone has hanged herself in the tomb. Haemon, grieving beside her, attacks his father and then kills himself. When Eurydice hears that her son is dead, she also takes her own life, cursing Creon as responsible. Creon returns carrying Haemon's body and learns of his wife's death. His decree has not secured his family or the city; it has left him alive, stripped of wife and son, and conscious that his own obstinacy caused the ruin. The elders close on the lesson that proud judgment without reverence brings punishment and that wisdom is learned through suffering.",
         "in_short": "After civil war in Thebes, the new king, Creon, orders that Eteocles be honored but that his brother Polynices be left unburied as a traitor. Their sister Antigone obeys religious and family duty instead, performs burial rites, and openly accepts responsibility when caught. Creon rejects the pleas of Ismene, his son Haemon, and the Theban elders, sentencing Antigone to be sealed alive in a rocky tomb. The prophet Tiresias warns that the gods reject Creon's treatment of the dead and that his own household will pay for it. Creon finally yields, buries Polynices, and goes to free Antigone, but she has already hanged herself. Haemon dies by suicide beside her, and his mother Eurydice kills herself after hearing the news. Creon survives to recognize that his inflexible assertion of authority has destroyed his family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3773,7 +3773,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3786,7 +3786,7 @@
       "recaps": {
         "ending": "Tiresias warns that Creon's treatment of Polyneices and Antigone has offended the gods. Creon finally yields and goes first to bury Polyneices, then to release Antigone from the stone chamber. The reversal comes too late. Antigone has hanged herself. Haemon, grieving beside her, attacks his father unsuccessfully and then kills himself. When Eurydice hears that her son is dead, she withdraws into the palace and takes her own life, condemning Creon for the deaths of their children. Creon returns carrying Haemon's body and learns of his wife's death. Having lost his family through the decree he defended as necessary to the state, he recognizes his own responsibility and asks to be led away. The Chorus closes by linking wisdom with reverence for divine law and by presenting suffering as the punishment that teaches the proud.",
         "in_short": "After Oedipus's sons Eteocles and Polyneices kill each other fighting over Thebes, the new king Creon honours Eteocles but forbids burial of Polyneices as a traitor. Their sister Antigone believes divine and family duties require burial and performs the rites despite the threat of death. Creon refuses appeals from Antigone, Ismene, the Theban elders, and his son Haemon, who is pledged to marry her. He orders Antigone sealed in a rocky chamber. The prophet Tiresias then warns that the gods reject Thebes' sacrifices because Creon has left a corpse exposed and entombed a living person. Creon finally reverses course, buries Polyneices, and goes to free Antigone, but she has killed herself. Haemon dies beside her, and his mother Eurydice kills herself after hearing the news. Creon survives to recognize that his rigidity destroyed his family, while the Chorus identifies humility and respect for divine law as the wisdom purchased by his suffering.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3945,7 +3945,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3958,7 +3958,7 @@
       "recaps": {
         "ending": "The witnesses' contradictory accounts are revealed as a collective effort to protect the bank robber, a frightened mother rather than the dangerous criminal imagined outside. Jack reconstructs the escape and finds that Jim reached her first. Jim, moved by her situation and by his own family pain, let her go; Jack ultimately accepts his father's choice instead of making an arrest. The strangers leave the apartment connected by the compassion they showed under pressure. Zara finally reads the letter left by the man whose loan she rejected and begins loosening her grip on years of guilt, with Lennart becoming part of her life. Anna-Lena tells Roger the truth about hiring Lennart, and the admission opens a more honest phase of their marriage. Julia and Ro continue toward parenthood, supported by people who are no longer quite strangers. Estelle's grief for her late husband is acknowledged, and the apartment becomes a possible refuge for the robber and her daughters. The supposed hostage drama ends without a villain: its lasting consequences are forgiveness, new relationships, and several people choosing to keep one another from falling.",
         "in_short": "After a desperate parent fails to rob a cashless bank, the would-be robber runs into an apartment viewing and accidentally creates a hostage drama. The captives are an ill-matched group carrying private fears: combative retirees Roger and Anna-Lena, expectant mothers Julia and Ro, solitary bank director Zara, widowed Estelle, hired disruptor Lennart, and a real estate agent. Their hostility gives way to recognition that the robber is terrified, nonviolent, and trying to prevent the loss of a home and children. Outside, police officers Jack and his father Jim struggle to understand witness statements deliberately designed to conceal an escape. The case intersects with an old suicide from a bridge, Zara's guilt over refusing the dead man a loan, and the rescue that shaped psychologist Nadia's life. Jim finds the robber but lets her go; Jack discovers this and accepts the merciful decision. The witnesses' deceptions protect a vulnerable family, while the crisis pushes several of them toward honesty, forgiveness, and lasting friendship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4101,7 +4101,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4114,7 +4114,7 @@
       "recaps": {
         "ending": "After surviving the clash on Lexington Green and joining the attacks on the British column returning from Concord, Adam comes home physically exhausted and emotionally older. Moses is dead, and Adam must face Sarah, Levi, Granny, and Ruth with the knowledge that the morning's public history is also his family's private catastrophe. The community prepares its dead for burial while trying to understand that a political quarrel has become a war. Adam no longer needs the abstract recognition he wanted from his father: carrying fear, responsibility, and grief has forced adulthood upon him. At the same time, the novel does not make combat glorious. Adam's new maturity consists largely in knowing its cost and in accepting that ordinary life, family duties, and his relationship with Ruth must continue after irreversible loss.",
         "in_short": "On April 18, 1775, fifteen-year-old Adam Cooper of Lexington longs for his stern father Moses to recognize him as a man. Their household arguments unfold while the town debates resistance to British authority. Adam signs the militia muster roll, and during the night riders warn that British regulars are approaching. On Lexington Green the local militia faces the column in a confused confrontation. A shot is fired, the British volley, and Moses is killed. Adam escapes in terror, then meets the experienced Solomon Chandler and joins colonists firing on the British retreat from Concord. The day's fear and violence replace Adam's romantic ideas about courage with direct knowledge of death and responsibility. He returns to Sarah, Levi, Granny, and Ruth as the community mourns. The war has begun, Moses is gone, and Adam has acquired the adult standing he wanted in a form he never imagined and cannot celebrate.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4234,7 +4234,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4247,7 +4247,7 @@
       "recaps": {
         "ending": "Dussander's collapse while trying to dispose of a murdered vagrant places him in a hospital, where Morris Heisel, a camp survivor, gradually recognizes him. The report reaches Nazi hunter Isaac Weiskopf, and Dussander realizes that his assumed identity is about to fail. He kills himself with stolen medication before he can be taken into custody. Independently, Ed French checks the family story Todd and Dussander used to explain Todd's academic recovery. He discovers that the supposed grandfather was an impostor and confronts Todd. Todd murders French, takes a rifle and ammunition, and chooses a position overlooking a highway. He fires at passing motorists until police surround and kill him after several hours. The murders committed separately by Todd and Dussander, along with the body hidden at Dussander's house, leave physical evidence of the violence their association encouraged. Neither coercer nor captive exposes the other through their prepared safeguards; their own escalating acts bring about both endings.",
         "in_short": "Thirteen-year-old Todd Bowden recognizes elderly Arthur Denker as Kurt Dussander, a fugitive Nazi camp commandant. Rather than report him, Todd demands detailed accounts of the camps. Their coercive relationship revives Dussander's cruelty and intensifies Todd's violent fantasies. When Todd's grades collapse, Dussander poses as his grandfather to deceive counselor Ed French; blackmail and forged records keep Todd's parents unaware. Both Todd and Dussander begin murdering vulnerable strangers. After Dussander suffers a heart attack during one killing, a hospitalized camp survivor recognizes him and alerts investigators. Dussander takes a fatal overdose as exposure closes in. French separately uncovers the false-grandfather scheme and confronts Todd. Todd kills him, then shoots at motorists from above a highway until police kill him. The pair's elaborate threats and concealments do not protect them: the habits of domination they cultivate eventually destroy them both.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/are-you-there-god-its-me-margaret-movie-tie-in-edition.json
+++ b/data/works-community/0/are-you-there-god-its-me-margaret-movie-tie-in-edition.json
@@ -130,7 +130,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -143,7 +143,7 @@
       "recaps": {
         "ending": "Margaret's maternal grandparents visit after years of estrangement and immediately frame her religious identity as something to be claimed. Sylvia arrives during the confrontation, and the adults' competing expectations leave Margaret angry and alienated. She rejects the idea that anyone else can decide what she believes and temporarily stops speaking to God. Her school project concludes without a formal religious choice; instead, she honestly tells Mr Benedict that the search has left her confused. Friendship also becomes less idealized as Margaret recognizes Nancy's dishonesty and regrets joining in cruel gossip about Laura Danker. At the close, after months of waiting and worry, Margaret gets her first period. Barbara helps her with calm affection. Margaret's joy and relief restore the private relationship that mattered throughout her search: she speaks to God again, grateful for the change and assured that she has not been forgotten.",
         "in_short": "Eleven-year-old Margaret Simon moves from New York City to New Jersey and joins a new circle of sixth-grade girls led by Nancy Wheeler. Their private club discusses bras, boys, and the periods they are all waiting to begin. At school, Margaret chooses religion as a yearlong project. Her Christian mother and Jewish father have raised her without a formal faith, so she visits different services and tries to discover where she belongs, continuing a private conversation with God throughout. Competing expectations from her two extended families turn the search into a painful conflict, and she decides no label can be forced on her. Margaret also learns that social confidence can hide dishonesty and that gossip has hurt Laura Danker. She finishes the year without choosing a religion, but with a more independent sense of herself. When her first period finally arrives, she is delighted and resumes speaking to God with gratitude.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -275,7 +275,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -288,7 +288,7 @@
       "recaps": {
         "ending": "Alex is launched into orbit and reaches Ark Angel with Tamara Knight, and aboard the station he changes what Drevin has set in motion. Instead of coming down on Washington, the station is put on a course that breaks it up over open ocean, and the city is never hit. Drevin's scheme collapses with it, and he is killed. Getting home is the last problem: Alex leaves the station and falls back through the atmosphere, coming down in the sea off the coast of Australia, where he is picked up alive. Force Three is finished, Kaspar dead, and Drevin's empire and his fraud both exposed. Paul Drevin is left orphaned and disgraced by association with a father he never suspected of anything. Alex, having been shot months earlier and told to rest, has now been in space and back, and MI6 have again used him with no intention of stopping.",
         "in_short": "Recovering in a London hospital from the bullet Scorpia put in him, Alex is mistaken for Paul Drevin, the son of a Russian billionaire in the next room, and abducted by an environmental group calling itself Force Three. He escapes, and the incident brings him into the Drevins' orbit and, inevitably, into MI6's plans. Nikolai Drevin is building Ark Angel, the first hotel in space, and Force Three has been attacking the project; Alex goes with Paul to the family's Caribbean island, where the launch site is. There he finds that the project is bankrupt, that Drevin is under criminal investigation, and that Force Three was created and funded by Drevin himself as cover. Drevin's plan is to bring Ark Angel out of orbit onto Washington, DC, destroying the case against him along with a large part of the city. Alex is launched into space, reaches the station, and diverts it so that it breaks up over open ocean. Drevin is killed, and Alex falls back to Earth and comes down in the sea off Australia.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -450,7 +450,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -463,7 +463,7 @@
       "recaps": {
         "ending": "Zack concludes that the apparently genocidal conflict is a test of whether humanity can resist fear, imitation, and the impulse to answer force with greater force. Admiral Vance remains committed to the military response even when it risks extending the destruction. Zack defies that logic, communicates a refusal to continue the cycle, and persuades others to stop fighting. The alien force ends its attack, confirming that survival depended on choosing restraint rather than winning a conventional battle. Xavier dies during the defense after Zack has only briefly recovered the father he believed dead, leaving Zack to absorb both the truth of Xavier's long secret service and a second, real loss. The contact brings humanity access to transformative alien knowledge rather than conquest. Zack returns to a changed Earth and maintains his relationship with Alexis Larkin while taking a role in the new order created by open extraterrestrial contact. His gaming skill helped him reach the crisis, but his decisive achievement was recognizing and rejecting the scenario the games had trained everyone to accept.",
         "in_short": "Teenager Zack Lightman is an elite player of Armada, an alien-combat game, and worries he has inherited his late father's obsession with a hidden extraterrestrial war. A real craft recruits him into the Earth Defense Alliance, which reveals that Armada and its companion game have secretly trained drone pilots for an imminent attack. Zack joins other gamers, meets technician Alexis Larkin, and discovers that his father Xavier is alive and serving the defense under the handle RedJive. During devastating battles, Zack notices that the enemy and the EDA keep reproducing familiar game and film patterns. He comes to believe the war is a test of humanity's willingness to stop escalating rather than a simple invasion. Xavier dies in the defense, but Zack opposes Admiral Vance's drive for retaliation and initiates a peaceful response. The aliens halt the attack and share advanced knowledge with Earth. Zack survives to help build the post-contact world, carrying both his father's loss and the lesson that training for a fight need not determine the choice to fight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -735,7 +735,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774241285",
@@ -747,7 +747,7 @@
       "recaps": {
         "ending": "The wormhole chain sends the Earth-bound Maxolhx battle group beyond the galaxy, where corrupted mathematical libraries crash its ship AIs. The Flying Dutchman and Valkyrie then impersonate the missing star carriers at Goalpost, extending the deception about their route. Earth gains time but remains isolated behind the Gateway blockade and cannot be warned. Avalon still holds Chang, Simms, Chotek, the commissioners, scientists, and security personnel as a possible refuge, though it has not received final approval. The mobile force retains two damaged ships. Nagatha remains aboard the Flying Dutchman, while Valkyrie's resident AI is hostile and requires Skippy's supervision. Desai, Giraud, and twenty-five other people are dead. Adams remains comatose, Smythe is gravely injured and not lucid, and the surviving STAR force is severely depleted under Kapoor. Skippy has lost access to both the ship-slicing and wormhole-chain tactics. Possible enemy Elder AIs, the unexplained barrier around the Milky Way, future Maxolhx forces, the unfinished Paradise evacuation, and the unresolved recovery of the wounded remain open threats.",
         "in_short": "Joe Bishop leads the Flying Dutchman on a search for a refuge beyond the Milky Way and finds Avalon, but a Maxolhx battle group is soon dispatched toward Earth. Bishop saves time by framing the Bosphuraq for the loss of two Maxolhx cruisers, causing devastating reprisals, then uses manipulated wormholes to seize sections of senior-species warships and assemble Valkyrie. A raid for essential power devices kills Desai, Giraud, and many others while leaving Adams comatose and Smythe gravely injured. Skippy infects the approaching battle group's AI libraries, chains wormholes to strand the force beyond the galaxy, and helps the two human ships impersonate its missing carriers at Goalpost. Earth is temporarily safer but remains blockaded, unreachable, and unwarned. Avalon is still only a refuge candidate, Valkyrie's resident AI remains hostile, the human force is badly depleted, and Skippy can no longer repeat either decisive wormhole tactic.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1076,7 +1076,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07SZHH5BG",
@@ -1088,7 +1088,7 @@
       "recaps": {
         "ending": "Leggett escapes Armor World after McGill gives the Skay a working dose of the Mogwa bio-terminator and its formula. The bargain saves Legion Varus and Earth, but equips a powerful enemy of the Mogwa and leaves humanity exposed if the two galactic powers contest Province 921. Carlos and Kivi are among those killed during the Armor World mission. Galina is revived after Armel's mutiny, while Armel remains dead.\n\nAt Earth, Sateekas has also been revived and convenes a tribunal over his assassination, the deaths of his retinue, and the human cover-up. McGill claims Armel served the Skay and reframes the poison as part of their campaign against the Mogwa. Sateekas accepts the defense, treats McGill's killing of Armel as evidence of loyalty, and closes the immediate case after demanding a sample. Galina survives later investigations, keeps her rank, and is acquitted, but she is not restored as Imperator. Etta remains at Central, Barton and Mills have ended their relationships with McGill, and McGill returns to Waycross before reconciling with Galina. The Skay threat, Mogwa relations, and the spread of the bio-terminator remain unresolved.",
         "in_short": "A moon-sized Skay vessel attacks Earth, converts Hamilton's population into machine-biotic troops, and retreats to 51 Pegasi. Legion Varus follows, discovers the same conversion process among the Pegs, and sees Sateekas's fleet destroyed. Armel murders Galina Turov during a failed mutiny and identifies a Mogwa-specific bio-terminator before McGill kills him. When the Skay captures Leggett, McGill learns that Armor World is itself a single machine intelligence and trades it the poison and its formula for the ship, the legion, and Earth's safety. Back on Earth, a revived Sateekas prosecutes the human leadership over his killing and the cover-up. McGill casts Armel as a Skay agent, and Sateekas ends the case in exchange for his own sample. Galina is acquitted but does not regain the title of Imperator, while McGill returns to Waycross and reconciles with her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1240,7 +1240,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1253,7 +1253,7 @@
       "recaps": {
         "ending": "Bluntschli's return exposes the difference between the Petkoffs' romantic poses and their real desires. The inscription on Raina's photograph reveals that he was the enemy soldier she sheltered, while Sergius's pursuit of Louka makes his own engagement impossible to defend. Sergius and Raina release each other without lasting hostility. Louka insists that Sergius treat her as an equal, and he agrees to marry her; Nicola steps aside and turns his attention to a future business opportunity. Raina admits that Bluntschli's clear sight and practical nature attract her more than heroic display. He initially resists because he believes she is a sheltered girl, but proposes after learning that she is twenty-three. News that he has inherited his father's hotel business makes him an unexpectedly substantial match. The play closes with the two new engagements replacing the idealized pairing with relationships grounded in a more honest view of each person.",
         "in_short": "During the Serbo-Bulgarian War, idealistic Raina Petkoff hides Bluntschli, a Swiss officer fighting for Serbia, when he escapes into her bedroom. His sweets, exhaustion, and practical account of combat challenge her worship of military heroism. Months later her fiancé Sergius returns as a celebrated cavalry officer, but he is privately disillusioned and attracted to the servant Louka. Bluntschli comes to return the coat used in his escape and proves far better than the officers at solving a logistical problem. His presence gradually exposes both couples' poses: Raina prefers his honesty to Sergius's performance, and Sergius cannot reconcile his engagement with his desire for Louka. Raina and Sergius separate. Sergius agrees to marry Louka, while Raina accepts Bluntschli after he learns she is old enough to make her own choice. The original romantic engagement gives way to two less conventional but more candid matches.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1402,7 +1402,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1415,7 +1415,7 @@
       "recaps": {
         "ending": "Fogg reaches London believing he has arrived five minutes too late and has lost the wager. Fix has arrested him at Liverpool, only to release him when the real bank robber is found, and the resulting delay appears fatal. Back home, Fogg faces financial ruin with his customary composure. Aouda, believing his misfortune has left him alone, asks him to marry her, and he joyfully agrees. Passepartout goes to arrange the wedding and learns that it is Saturday rather than Sunday: by traveling eastward around the globe, the party crossed every meridian and gained a calendar day. Fogg races to the Reform Club and enters moments before the deadline, winning the wager. The expenses leave him little monetary profit, but he shares what remains with Passepartout and Fix. His true gain is Aouda, whom he marries.",
         "in_short": "Phileas Fogg wagers his Reform Club companions that he can circle the world in eighty days and leaves London with his new servant Passepartout. Detective Fix, wrongly convinced Fogg robbed the Bank of England, follows and obstructs them. Crossing India, Fogg delays his schedule to rescue Aouda from a funeral pyre; she continues with them through Hong Kong, Japan, and the United States. Missed ships, storms, legal trouble, an attack on the American train, and Fix's eventual arrest of Fogg repeatedly consume their margin. Fogg returns to London apparently five minutes late and accepts defeat. When Aouda proposes marriage, Passepartout discovers that their eastward journey gained a day. Fogg reaches the Reform Club just before the actual deadline and wins. He makes little money after his costs but marries Aouda, finding happiness rather than profit.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1580,7 +1580,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1593,7 +1593,7 @@
       "recaps": {
         "ending": "Fogg reaches London believing that delays and Fix's mistaken arrest have cost him the wager. Having spent much of his fortune and withdrawn from public view, he nevertheless offers to marry Aouda after she declares her love for him. When Passepartout visits a clergyman to arrange the ceremony, he discovers that the date is Saturday rather than Sunday. By traveling eastward around the globe, the party crossed the international date line and gained a calendar day without realizing it. Passepartout races back with the news, and Fogg reaches the Reform Club seconds before the agreed deadline, winning the wager. His travel costs leave little financial profit, which he shares with Passepartout and Fix, but the journey has brought Aouda into his life. Fogg and Aouda marry, making their relationship - not the money - the lasting result of the voyage.",
         "in_short": "Phileas Fogg wagers members of London's Reform Club that new transport links make it possible to circle the world in eighty days. He leaves at once with his French servant Passepartout. Detective Fix mistakes him for a bank robber and follows while awaiting a warrant. In India, Fogg sacrifices time to rescue Aouda, who then travels with the party. Missed ships, storms, Passepartout's separation, a railway attack in America, and an improvised Atlantic crossing repeatedly consume their margin. Fix finally arrests Fogg in Liverpool, only to release him when the real robber is identified. Fogg reaches London believing he is late and ruined. After Aouda proposes that they marry, Passepartout learns that eastward travel across the date line has gained them a day. Fogg arrives at the Reform Club just before the deadline and wins. He gains little money after expenses, but marries Aouda.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1776,7 +1776,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1789,7 +1789,7 @@
       "recaps": {
         "ending": "Fogg reaches London believing he missed the Reform Club deadline by five minutes and has lost both his wager and most of his fortune. Aouda, unwilling to leave him in despair, proposes marriage, and Fogg accepts. When Passepartout visits a clergyman to arrange the ceremony, he discovers that the date is Saturday rather than Sunday. By traveling continuously eastward, the party crossed the International Date Line and gained a calendar day without recognizing it. Passepartout races home, and Fogg reaches the Reform Club with seconds remaining, winning the wager. His expenses leave him little financial profit, which he shares with Passepartout and Fix. His real gain is Aouda: they marry, and the journey ends with companionship replacing the rigid solitude of his former life.",
         "in_short": "Exacting London gentleman Phileas Fogg wagers his Reform Club companions that he can circle the world in eighty days and leaves at once with his new French servant, Passepartout. Detective Fix follows because he mistakes Fogg for a bank robber and repeatedly tries to delay him. Across India, Fogg interrupts his schedule to rescue Aouda from a forced death, and she joins the journey. Missed ships, storms, an opium den, a circus, a Sioux attack, and broken transport force Fogg to improvise while remaining outwardly calm. He reaches Liverpool only to be wrongly arrested, then arrives in London believing he is five minutes late. After Aouda proposes marriage, Passepartout discovers that eastward travel across the International Date Line has gained them a day. Fogg reaches the Reform Club just before the deadline and wins. He makes little money after expenses, but he and Aouda marry.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1981,7 +1981,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1994,7 +1994,7 @@
       "recaps": {
         "ending": "After Leora dies of plague on St. Hubert, Martin abandons the controlled trial Gottlieb required and distributes his phage treatment broadly. The epidemic subsides, but the experience leaves him uncertain whether he acted as a humanitarian, failed as a scientist, or both. He returns to New York as a public hero and later marries the wealthy Joyce Lanyon. Their life gives him status, comfort, and a son, yet it also pulls him toward the kind of polished career he distrusts. When the McGurk Institute offers further advancement, Martin instead leaves Joyce and joins Terry Wickett at an isolated Vermont laboratory. The novel closes with the two men pursuing research on their own terms, short of money but free from institutional publicity and social obligation. Martin has not resolved the conflict between science and ordinary human loyalties; he has chosen the laboratory again, at considerable personal cost.",
         "in_short": "Martin Arrowsmith enters medicine wanting both worldly success and the austere experimental truth taught by bacteriologist Max Gottlieb. Marriage to the loyal Leora accompanies him through rural practice, public-health work, a fashionable clinic, and finally the McGurk Institute, where he develops a bacteriophage treatment. Sent to plague-stricken St. Hubert, Martin plans a controlled trial but breaks the protocol after Leora contracts the disease and dies. He treats everyone who remains, returns famous, and eventually marries the wealthy Joyce Lanyon. Comfort and reputation again threaten to displace research. Martin ultimately leaves Joyce and their child to work with Terry Wickett in a primitive Vermont laboratory, choosing scientific independence while leaving unresolved the damage that his single-mindedness causes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2164,7 +2164,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2177,7 +2177,7 @@
       "recaps": {
         "ending": "The police finally recognize Jonathan as a wanted murderer and take him into custody, while Dr. Einstein slips away. Teddy's commitment papers are completed, but Abby and Martha decide that he should not enter the sanitarium alone and arrange to accompany him. They also reveal that Mortimer was adopted and is therefore not biologically related to the Brewsters, freeing him from his fear that the family's madness is hereditary. Mortimer joyfully reclaims his engagement to Elaine. As the household prepares to disperse, Mr. Witherspoon mentions that he is an unmarried man with no close family. Abby and Martha respond with renewed hospitality and offer him their prepared elderberry wine, showing that their lethal vocation may claim one final guest before they leave.",
         "in_short": "Drama critic Mortimer Brewster visits his charitable aunts Abby and Martha to announce his engagement to their neighbor Elaine, only to discover a dead lodger hidden in their window seat. The sisters serenely admit that they poison lonely men and have their deluded brother Teddy bury them in the cellar. Mortimer tries to contain the secret and arrange Teddy's commitment, but his murderous brother Jonathan arrives with the frightened surgeon Dr. Einstein and another corpse. Jonathan plans to kill Mortimer, while inattentive police officers repeatedly pass through the house. The police eventually arrest Jonathan, and Teddy is bound for a sanitarium with Abby and Martha choosing to join him. The aunts disclose that Mortimer was adopted, so he abandons his fear of inherited insanity and reunites with Elaine. Their final offer of poisoned wine to the lonely sanitarium superintendent suggests that the sisters have not quite retired.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2290,7 +2290,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2303,7 +2303,7 @@
       "recaps": {
         "ending": "Tlacey is dead, killed by the ComfortUnit she owned once the SecUnit removes the governor module holding it; the freed construct takes what it needs from her operation and goes its own way. The surviving technicians, Tapan and Maro, recover their work and leave the installation with enough to start again. The SecUnit has its answer about RaviHyral: it did cause the deaths, but through a catastrophic system failure rather than a decision, and the corporation that owned it deleted the record and resold it rather than account for the conditions that produced it. The knowledge does not absolve it, and it concludes that it does not need to be absolved. Back aboard the research transport, ART repairs it and offers to keep it on permanently, since ART's own crew are not due back for a while and it would rather not be alone. The SecUnit refuses. It has read in the newsfeeds that Dr. Mensah and Preservation are locked in a legal fight with GrayCris, the company that tried to kill her team, and that GrayCris is dangerous to her. It takes a fresh fabricated identity and leaves to gather proof of what GrayCris was really doing, with the friendship left open rather than finished.",
         "in_short": "Traveling alone after leaving the survey team, the SecUnit heads for RaviHyral, the mining installation where the record says it killed the humans it was guarding before its memory was erased. It hitches a ride on a university research transport whose bot pilot, which it nicknames ART, is far more capable than it expected; ART trades help for company, alters its body so scans read it as an augmented human, and joins the investigation. To get down to the mine, the SecUnit takes a job protecting three young technicians whose former employer, Tlacey, stole their work. The exchange she offers is a trap, one of the three is killed, and the SecUnit stops pretending to be human: it dismantles Tlacey's security, frees the ComfortUnit she keeps under a governor module, and that construct kills her. Underground, the SecUnit recovers the lost memory and learns that it did cause the deaths, but through a system failure rather than a choice, and that its owners erased the evidence and resold it. It parts from ART and sets off to find evidence against GrayCris for Dr. Mensah.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2492,7 +2492,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2505,7 +2505,7 @@
       "recaps": {
         "ending": "The Bundrens finally reach Jefferson and bury Addie, but the journey has damaged nearly everyone except Anse. To avoid being sued for the barn fire, the family helps seize Darl, who is taken by train to the state hospital in Jackson while laughing and speaking of himself from outside his own identity. Cash's broken leg has been encased in concrete, leaving the skin injured and the limb shortened; Peabody condemns the treatment. Dewey Dell again seeks an abortion, but pharmacy assistant MacGowan deceives and sexually exploits her instead of helping. Anse then takes the ten dollars she had guarded for the procedure. He uses the trip to acquire false teeth and, after borrowing shovels from a Jefferson woman for Addie's burial, quickly returns with that woman as his new wife. He introduces her to the children as the new Mrs. Bundren. Addie is buried as promised, yet Anse converts the family's ordeal into a means of satisfying his own wants, while Darl is institutionalized and the other children carry the journey's physical and emotional consequences.",
         "in_short": "As Addie Bundren dies on her family's poor Mississippi farm, her husband Anse prepares to honor her request for burial in Jefferson. Their children Cash, Darl, Jewel, Dewey Dell, and Vardaman join a wagon journey delayed by flood and driven by private motives: Cash wants tools, Dewey Dell seeks an abortion, and Anse wants new teeth. A flooded river kills the mules, breaks Cash's leg, and nearly sweeps away the coffin. Anse sacrifices Jewel's beloved horse to obtain another team, while the family crudely encases Cash's leg in concrete. Addie's own narration reveals her alienation from Anse and her affair with minister Whitfield, which produced Jewel. Darl later burns a barn in an attempt to end the degrading journey, but Jewel rescues the coffin. The family reaches Jefferson, buries Addie, and commits Darl to an asylum to avoid liability. Dewey Dell is exploited by a pharmacy clerk, and Anse takes her money, buys teeth, and immediately introduces a new Mrs. Bundren.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2706,7 +2706,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2719,7 +2719,7 @@
       "recaps": {
         "ending": "Rosalind, still directing events through her disguise as Ganymede, promises to resolve the forest's crossed romances. She returns as herself and marries Orlando. Celia marries the reformed Oliver; Phebe, unable to marry Ganymede once Rosalind's identity is known, honors her promise to accept Silvius; and Touchstone marries Audrey. The exiles also regain their political home. Duke Frederick had entered Arden intending violence against Duke Senior, but a religious hermit persuades him to abandon that purpose and renounce the dukedom. Duke Senior is restored, and Orlando and Oliver recover their proper places in the de Boys family. Most of the company prepares to return from the forest to court. Jaques chooses a different path, leaving to learn from the newly converted Frederick rather than joining the weddings. Rosalind closes by addressing the audience and asking their favor for the play.",
         "in_short": "After the usurping Duke Frederick banishes Rosalind, she escapes to the Forest of Arden with her cousin Celia and the fool Touchstone, disguised as a young man named Ganymede. Orlando, mistreated by his brother Oliver, also flees to Arden and joins the exiled Duke Senior. He covers the forest with poems to Rosalind. Still disguised, Rosalind offers to cure his lovesickness by having him court Ganymede as if Ganymede were Rosalind. Around them, Touchstone woos Audrey, Silvius pursues the scornful Phebe, and Phebe falls for Ganymede. Orlando saves Oliver from danger; Oliver repents and immediately falls in love with Celia. Rosalind arranges the resolution: she reveals herself and marries Orlando, Celia marries Oliver, Phebe accepts Silvius, and Touchstone marries Audrey. Duke Frederick abandons his attack on the exiles after meeting a hermit, restoring the dukedom to Duke Senior. The forest has transformed political exile, family hatred, and confused courtship into reconciliation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2900,7 +2900,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2913,7 +2913,7 @@
       "recaps": {
         "ending": "At Trofimovsk, the prisoners face polar darkness with almost no food, medicine, or adequate shelter. Scurvy and other illnesses spread. Elena, already weakened by labor, hunger, and grief, dies despite Lina's care. Jonas also becomes gravely ill, and Lina continues drawing and writing even when she is close to collapse. Dr. Samodurov arrives at the settlement and confronts the neglect there, bringing medical knowledge and supplies that save many of those still alive, including Lina and Jonas. The closing frame moves to Lithuania in 1995, where workers uncover papers Lina buried in a jar decades earlier. Her written account explains that she and Jonas survived and eventually returned home, while the preservation of her drawings fulfills her determination to leave a record of the deportees. It also confirms that Andrius survived; the bond formed between him and Lina was not erased by their forced separation. The discovered testimony turns the family's private struggle into evidence of the wider Soviet persecution of Lithuania.",
         "in_short": "In 1941, Soviet officers remove fifteen-year-old Lithuanian artist Lina Vilkas, her mother Elena, and her young brother Jonas from their home. Lina's father has already vanished into the prison system. Packed into a cattle car with other deportees, the family crosses the Soviet Union and is put to forced labor in the Altai region. Lina secretly records the journey through drawings and grows close to fellow prisoner Andrius Arvydas. After months of hunger, coercion, and hard labor, Lina learns that her father has been killed. She, Elena, and Jonas are then sent still farther north to Trofimovsk above the Arctic Circle, while Andrius remains behind. The prisoners build shelters from scraps and endure a lethal winter. Elena dies, and Lina and Jonas nearly follow her, but the arrival of Dr. Samodurov brings treatment that keeps them alive. A 1995 frame reveals Lina's buried writings and confirms that she, Jonas, and Andrius survived, preserving testimony that the Soviet authorities tried to silence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3342,7 +3342,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0030U3IKG",
@@ -3354,7 +3354,7 @@
       "recaps": {
         "ending": "Honor survives the Blackbird attack after using her runabout to shield Grayson I, saving Queen Elizabeth and Protector Benjamin. Queen Adrian is destroyed, killing Duke Cromarty, the foreign secretary, Michelle Henke's father and brother, and the other people aboard. Mueller is impeached, tried, and executed for enabling the beacon plot, while the wider extremist network and the full chain of responsibility remain unresolved. The resulting opposition government compels Elizabeth to accept Saint-Just's proposal for a ceasefire in place, suspending Earl White Haven's advance near Lovett and leaving each side in possession of the systems it occupies. Michelle Henke inherits the title Countess Gold Peak and carries the truce offer home. Saint-Just plans to use the pause to rebuild State Security authority and counter Manticore's weapons, but his attempted purge of regular Navy commanders triggers resistance. Shannon Foraker destroys the State Security force sent against Tourville, and Theisman leads a coordinated coup in the capital. The book closes with Pierre and McQueen dead, Saint-Just captive at Theisman's gunpoint, the Havenite power structure in revolt, and the peace settlement still to be negotiated. Honor remains a major Manticoran and Grayson leader, with her physical recovery and the new treecat signing project still developing.",
         "in_short": "Honor Harrington returns alive from Hades with thousands of freed prisoners, then rebuilds her body and career while helping the Alliance prepare its next offensive. Manticore's new light attack craft, missile pods, and electronic warfare systems transform the war, allowing Earl White Haven's Operation Buttercup to shatter Havenite defenses and advance almost to Lovett. On Grayson, Honor's family develops sign language for treecats, opening direct communication between the species. A covert extremist network blackmails Samuel Mueller into placing beacons in ceremonial memory stones, guiding missiles toward Queen Elizabeth and Protector Benjamin. Honor saves their yacht, but the other strike kills Duke Cromarty and his government. The replacement ministry accepts Saint-Just's ceasefire proposal, halting Buttercup while both sides retain their conquests. Saint-Just then attempts to tighten State Security control, but Shannon Foraker defeats the purge aimed at Tourville and Theisman seizes Saint-Just, leaving Haven in revolt as negotiations begin.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3580,7 +3580,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3593,7 +3593,7 @@
       "recaps": {
         "ending": "Clerres is destroyed. Fitz poisons, burns and cuts his way through the fortress, the Four are killed, the school and its records go up, and Dwalia and Vindeliar both die there. Bee is found alive, and father and daughter are reunited in the ruins of the place that took her. Prilkop is freed. Paragon keeps his side of the bargain, carries the survivors clear, and is then allowed to become what his timbers always were, separating into dragons and leaving the sea. The party comes home the long way, by liveship to Bingtown and up the Rain Wild River, and Bee is acknowledged as a Farseer, a princess of the Six Duchies in her own right. Fitz does not recover. The Silver, the Skill and the wounds he took at Clerres have used him up, and he is dying by inches; the Fool, who has spent his life spending Fitz, cannot mend him this time. Fitz goes to the Mountain Kingdom, to the quarry where Verity carved his dragon, and gives himself to the stone as the Skilled have always been able to do, pouring his memories and his self into it and finding his wolf waiting there. Bee goes home to Withywoods with the Fool, who stays to raise her, and with Nettle, Riddle, Lant, Spark and Perseverance around her. The Servants are finished, the prophecies they farmed are over, and Bee is left with her father's journals, her own dreams, and a wolf in the woods.",
         "in_short": "Believing Bee dead, Fitz sails south with the Fool, Lant, Spark and Perseverance to destroy the Servants of Clerres, taking passage on the mad liveship Paragon with Althea and Brashen Trell. Bee, meanwhile, is alive: recovered at Kelsingra among the Elderlings, then dragged away again by Dwalia and shipped across the world to Clerres, where the Servants examine her as the fulfilment of their prophecies. Fitz's party crosses the Pirate Isles and the southern sea, Paragon bargaining for a future of his own in exchange for the voyage, and reaches the island fortress. Fitz and the Fool go in and take it apart: poison, fire and murder, the ruling Four killed, the school destroyed, Dwalia and Vindeliar dead. In the ruins Fitz finds Bee alive. Paragon carries them clear and is released to become dragons; the survivors sail home by way of Bingtown and the Rain Wild River, and Bee is acknowledged as a Farseer princess. But Fitz is dying of what the Silver and the Skill and Clerres cost him. He goes to the Mountain quarry where Verity carved his dragon, gives his memories and himself into the stone, and finds his wolf there. Bee goes home to Withywoods with the Fool to raise her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3817,7 +3817,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3830,7 +3830,7 @@
       "recaps": {
         "ending": "Verity finishes his dragon by pouring the last of himself into it, and the black stone rises as a living creature carrying him. Kettle gives herself to the unfinished dragon she has spent her life owing a debt to, and other members of the party pay their own prices. Fitz kills Will, taking the coterie's Skill knowledge as he does it, and then reaches into Regal's mind and rewrites him, binding him to serve Queen Kettricken and stripping out his hatred of Fitz entirely, which ends the civil war without another battle. Fitz then wakes the old stone dragons sleeping in the Six Duchies by feeding them memories of his own, and the dragons drive the Red Ships from the coast and end the raiding war. Kettricken returns to Buckkeep as reigning queen, carrying Verity's heir, with Chade and Patience to help her rebuild a stripped and half-ruined kingdom. Verity does not come back as a man. Fitz, still officially dead, makes the choice the whole book has been pushing him towards and stays dead: Molly has a life with Burrich and a daughter who calls Burrich father, and Fitz will not walk into it and break it. He parts from the Fool, keeps Nighteyes, and disappears to a quiet place to write the histories of the war nobody knows he fought. The Farseer line is secure, the coast is free, and the man who bought all of it has given up every claim on his own name.",
         "in_short": "Fitz comes back from the grave half a wolf and spends a winter being coaxed into a man again by Burrich and Chade, then leaves them both to go inland and kill Regal. The attempt fails, and in the middle of it Verity reaches him through the Skill with a single overriding command, to come to him. Compelled, Fitz travels to the Mountain Kingdom with the minstrel Starling and an old pilgrim woman, Kettle, who knows far more about the Skill than she admits, and finds Kettricken and the Fool. The party takes the ancient Skill road beyond the mountains and finds Verity in a stone quarry, carving a dragon and pouring his life into it: the Elderlings of legend are stone dragons, quickened by the people who make them. Through the Skill Fitz sees that Molly is living with Burrich and has borne his daughter, and gives them up. Verity fathers an heir on Kettricken using Fitz's body, then completes his dragon and flies. Fitz kills Will, Skill-commands Regal into loyalty, and wakes the sleeping dragons of the Six Duchies, who end the Red Ship war. Kettricken rules; Fitz stays dead and disappears with his wolf.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4402,7 +4402,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0030F1LP0",
@@ -4414,7 +4414,7 @@
       "recaps": {
         "ending": "Operation Beatrice devastates both sides. Sebastian D'Orville's Home Fleet is destroyed but cripples Lester Tourville's Second Fleet and prevents its controlled advance on Sphinx. The second Haven force traps and nearly annihilates Third Fleet; Alistair McKeon's Apollo squadron is destroyed and McKeon dies, while Alice Truman assumes command of the few survivors. Honor arrives with Eighth Fleet, uses Apollo to break Fifth Fleet, and compels Tourville to surrender his remaining ships and intact databases. Manticore survives, but Alliance deaths approach six hundred thousand and Haven's losses are still greater. Three weeks later, Eighth Fleet is redesignated Home Fleet and Honor becomes its acting fleet admiral because the capital cannot risk sending away the only concentrated Apollo force. She remains with Hamish, Emily, Raoul, Catherine, and Nimitz. Pritchart and Theisman retain power in Haven, but the war continues. Giancola is strongly implicated in the original diplomatic fraud, while Mesa or Manpower remains the unproved suspect behind the later attacks. Zilwicki's search for evidence, the location of Bolthole, and any route back to peace are still open.",
         "in_short": "Renewed war finds Manticore outnumbered, so Honor Harrington leads Eighth Fleet in deep raids while building a family with Hamish and Emily. Haven's own leaders discover that Arnold Giancola probably falsified the diplomacy that restarted the conflict, but cannot prove it. A hidden Mesa-Manpower campaign blocks a peace summit by framing Haven for assassinations and a massacre on Torch. Honor reluctantly executes Operation Sanskrit and uses Apollo, Keyhole-2, and Mistletoe to destroy Lovett's defenses. Fearing those weapons will soon become widespread, Pritchart and Theisman launch Operation Beatrice against Manticore. Home Fleet and almost all of Third Fleet are destroyed, killing Sebastian D'Orville and Alistair McKeon, but their resistance delays the invaders until Honor arrives. Apollo shatters Fifth Fleet and forces Lester Tourville to surrender Second Fleet. Manticore survives at enormous cost. Eighth Fleet becomes Home Fleet under acting Fleet Admiral Honor, while the war, the hidden instigators, and Haven's secret Bolthole complex remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4593,7 +4593,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4606,7 +4606,7 @@
       "recaps": {
         "ending": "After Diamond's family has found greater security, the narrator becomes personally acquainted with the boy and hears more about his friendship with North Wind. Diamond questions her about the suffering connected with her work, but she will not reduce it to a simple explanation; he continues to trust that what appears destructive may belong to a larger good. Diamond later grows ill. One night North Wind comes for him again, and he leaves the ordinary world for the place he had once reached behind her. His family discovers that he has died, while the narrator presents his death as the completion of the journey Diamond had long expected rather than the defeat of his hopeful vision.",
         "in_short": "Diamond, the young son of a coachman, befriends North Wind, a vast female figure who carries out both gentle and destructive tasks in the world. She takes him over London and the sea and finally brings him to the peaceful country behind the north wind. After returning, Diamond applies the compassion learned on his journeys to everyday life. As his family loses its secure position and his father becomes a cab driver, the boy helps with the cab, befriends the poor crossing-sweeper Nanny, attracts the support of Mr. Raymond, and brings comfort to strangers. Stories, dreams, illness, and practical hardship mingle with his further encounters with North Wind. The family's prospects eventually improve, but Diamond remains physically frail. He becomes ill and dies after North Wind takes him back to the country behind her, a close that treats his death as entry into the home he had already glimpsed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4780,7 +4780,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4793,7 +4793,7 @@
       "recaps": {
         "ending": "In 1999, Briony is a celebrated novelist facing the onset of vascular dementia. She has completed the final version of the book that recounts the events begun at the Tallis estate. She reveals that the scene in which she visited Cecilia and Robbie and promised to retract her accusation did not happen. Robbie died of septicemia at Bray Dunes before the Dunkirk evacuation, and Cecilia died later that year in the bombing of Balham Underground station. Lola and Paul Marshall remained married and became influential public figures; because they are still alive, Briony cannot publish an account naming them without legal danger. Her novel gives Robbie and Cecilia the shared future reality denied them. She regards that imagined reunion as the only reparation her art can now make, while recognizing that an author who controls the story cannot grant herself an objective pardon.",
         "in_short": "At a country estate in 1935, thirteen-year-old Briony Tallis misreads the developing love between her sister Cecilia and Robbie Turner, the housekeeper's educated son. After Briony's cousin Lola is assaulted in the dark, Briony confidently identifies Robbie, although she did not see the attacker's face. Robbie is imprisoned while the actual assailant, Paul Marshall, later marries Lola. During the war Robbie joins the army and retreats toward Dunkirk; Cecilia becomes a nurse and rejects her family, and Briony also trains as a nurse while trying to confront what she did. A later account of Briony visiting the reunited lovers and promising to recant is revealed as fiction. Robbie died in France and Cecilia died months later in a London bombing. The elderly Briony has written their story as an act of atonement, giving them in art the life together they never had.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4949,7 +4949,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4962,7 +4962,7 @@
       "recaps": {
         "ending": "Lincoln finally stops reading Beth and Jennifer's messages, leaves the surveillance job, and builds a life no longer organized around his old heartbreak or his mother's house. Beth ends her long relationship with Chris after accepting that affection without a shared future is not enough. Her comments about the handsome stranger at work have meanwhile allowed Lincoln to realize that he was the man she noticed, but he cannot approach her while concealing how much he knows. After he has gone from the Courier, Beth recognizes him at a movie theater. Their first honest conversation includes the uncomfortable truth that he was the security employee who read the flagged emails. Rather than erasing the attraction between them, the confession lets them meet as two people who already know they have imagined one another. They kiss and begin a relationship. Jennifer and Mitch also move forward together after grief and fear force them to speak more plainly about parenthood. The close leaves all three central characters choosing uncertain participation in life over the safer routines that had kept them stuck.",
         "in_short": "In 1999, Lincoln O'Neill takes a night job at an Omaha newspaper and discovers that he is expected to read employee emails caught by a monitoring program. He becomes absorbed in the funny, intimate correspondence of friends Beth Fremont and Jennifer Scribner-Snyder and falls for Beth without having met her. Beth, unhappy that her musician boyfriend Chris will not commit to a shared future, has meanwhile nicknamed an unknown newsroom visitor her attractive stranger; neither she nor Lincoln initially realizes she means him. Jennifer confronts her fear of motherhood and a painful pregnancy loss, while Lincoln slowly leaves his mother's house, renews friendships, and recognizes that reading the emails is both a refuge and a violation. He quits before approaching Beth, and she ends her stagnant relationship with Chris. When Beth later recognizes Lincoln at a cinema, he admits that he was the employee who read the messages. She accepts the awkward truth, they kiss, and they choose to begin a real relationship rather than continue loving imagined versions of each other.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5129,7 +5129,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5142,7 +5142,7 @@
       "recaps": {
         "ending": "Nick proves that the body hidden in Clyde Wynant's workshop is Wynant himself, identifiable by an old leg injury. Clyde therefore could not have written the recent letters that kept him apparently alive. Herbert Macaulay, the trusted lawyer handling Clyde's affairs, killed him to conceal financial theft and created the illusion that the inventor was traveling. Julia Wolf knew enough to endanger the scheme, so Macaulay killed her as well; Nunheim's attempt to profit from what he knew made him another victim. Nick lays out the case at a dinner gathering, using the false chronology and physical evidence to strip away Macaulay's respectable role, and the police arrest him. The unrelated secrets of Mimi's second husband are also exposed, adding to the Wynant family's upheaval. Dorothy and Gilbert are left to absorb the truth about their father and the adults around them. Nick and Nora finish the holiday together, their marriage intact and playful, while Nick again insists that solving one case does not mean he has returned permanently to detective work.",
         "in_short": "Retired detective Nick Charles and his wealthy wife Nora spend Christmas in New York, where Dorothy Wynant asks Nick to find her missing father, eccentric inventor Clyde Wynant. Clyde's secretary and former lover Julia Wolf has been murdered, and letters supposedly from Clyde make him the obvious suspect. Nick is drawn in as police, criminals, and Clyde's unstable family pass through the Charleses' crowded holiday. Further violence silences a man connected to Julia, while a body discovered in Clyde's workshop changes the problem. Nick identifies the remains as Clyde himself, proving that the recent letters were forged. At a dinner for the suspects, he shows that trusted lawyer Herbert Macaulay murdered Clyde to hide financial wrongdoing, maintained the fiction that Clyde was alive, and killed Julia and a blackmailer who threatened the deception. Macaulay is arrested. The Wynant family's other secrets remain painful, but the central murders are solved, and Nick and Nora return to their holiday partnership rather than to a conventional detective-and-client relationship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5321,7 +5321,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5334,7 +5334,7 @@
       "recaps": {
         "ending": "After the funeral dinner, every attempt to hold the Weston family together collapses. Johnna stops Steve when he makes a sexual advance toward Jean, but Karen chooses to preserve her planned marriage and leaves with him. Bill takes Jean back to Colorado and rejects Barbara's attempt to reconcile. Ivy and Little Charles prepare to leave together until Barbara tells Ivy that Beverly, not Charlie, was Little Charles's father, making them half-siblings; Ivy leaves in fury. Violet then admits that Beverly contacted her before his suicide and that she delayed responding while securing the family's money. Barbara recognizes that her mother knowingly left Beverly unaided and finally drives away. Violet calls for her daughters after all three have gone, leaving only Johnna to comfort her in the empty house. Barbara escapes the home but has no settled destination, while Violet is left with the isolation her cruelty and choices helped create.",
         "in_short": "When Oklahoma poet Beverly Weston disappears, his three adult daughters return to the family home, where their mother Violet is ill with cancer, dependent on pills, and ready to expose every weakness around her. Beverly is found dead by suicide, and the funeral dinner becomes a sustained family battle. Eldest daughter Barbara tries to take control while her marriage to Bill fails; Ivy plans to leave with her cousin Little Charles; and Karen insists that her fiance Steve offers a new beginning. Violet's attacks and the family's hidden resentments destroy the gathering. Steve targets Barbara's teenage daughter Jean, Bill leaves with Jean, and Karen departs with Steve despite learning what he did. Ivy discovers that Beverly secretly fathered Little Charles, making them half-siblings. Violet finally admits that she delayed acting after Beverly contacted her before his death. Barbara leaves, as her sisters already have, and Violet ends abandoned in the house with only Johnna, the caregiver Beverly hired, remaining beside her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5712,7 +5712,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0F2TRCNNC",
@@ -5724,7 +5724,7 @@
       "recaps": {
         "ending": "Ilea completes the evacuation of Erendar's 53 awakened survivors, delivering them to Hallowfort and securing Catelyn's protection for their four peoples. She then returns to help Endless Meadow close the realm gate. Ilea and the ancient ice elemental defend the closure monolith against two Daughters of Cephalon, and the resulting storm devastates the attacking spirits. Michael's copies die after documenting the event, leaving two notebooks with Ilea. The ice elemental remains in Erendar, while Ilea transports Endless Meadow to Elos in a reduced stone form. The gate disappears without residue. Hallowfort accepts Endless Meadow as an ally and gives it a mana-rich cavern between the settlement and the Descent. Ravenhall's Medic Sentinels and Taleen research continue, but Kyrian remains unreachable. Eve's murder, Helena's wider agenda, the Order of Truth's remaining plans, Baralia's war, the active Taleen production site, and Erendar's surviving dangers remain unresolved.",
         "in_short": "Back in Ravenhall, Ilea expands the Medic Sentinels, trains her resistances, saves Riverwatch from an invading slave-taking army, and becomes eligible for a third class. She chooses a Fae-and-Valkyrie path centered on space and creation flame, then joins Helena's elite mission against the Order of Truth's city-killing rituals. The mission stops several attacks but leaves a stable fissure to Erendar. There, Ilea meets Endless Meadow, guardian of 53 awakened survivors threatened by an eclipse and astral spirits. After months of training, she moves every refugee to Hallowfort. Ilea returns for the gate closure, battles the Daughters of Cephalon beside an ancient ice elemental, and carries the weakened Endless Meadow to Elos. Hallowfort accepts the refugees and their guardian, while Kyrian, Eve's murder, the Taleen gates, Baralia's war, and the larger ambitions of the Golden Lily and Order of Truth remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -6255,7 +6255,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DMQ2WP9F",
@@ -6267,7 +6267,7 @@
       "recaps": {
         "ending": "Ilea returns to Ravenhall after the Fae saves her from an Ascended in an ancient transport facility. She is level 345 in both classes, has reached several new third-tier resistances, and is nearing another class choice. The small Fae is part of a larger collective and carries Ilea's Sentinel Mark, which lets the Fae signal Ilea and provides its location, although its home conceals the exact position. Claire, Trian, and their partners continue Ravenhall's plans for self-rule, the Medic Sentinel Corps, and research into the Taleen Gate Key. Kyrian remains missing but is believed alive. Stormbreach is rebuilding, the Gray Company has been destroyed, and Hallowfort has survived the immediate Descent outbreak. The Ascended remains active, while the Fae collective's account connects the ruined North and the loss of Elos's third sun to an ancient extraction project. Inter-realm travel, Ilea's connection to Earth, the wider purpose of the facilities, and the Golden Lily investigation remain unresolved.",
         "in_short": "Ilea returns from the North with ancient wealth and a Taleen Gate Key, helps establish Ravenhall's independence project and the Medic Sentinel Corps, and enables Aki to inhabit a Guardian body. In Riverwatch she liberates Stormbreach, exposes the Gray Company's trade in captives, clears Kevin, and links cursed Serethil hunters with a possible trade partner. A corruption emergency then draws her into the Descent. She traces the outbreak to Project Animus, rescues a Fae, reunites with Catelyn's expedition, and helps an uncorrupted magma creature destroy the corrupted sand elemental. Continuing deeper with the Fae, she disperses a mana-concentrating system and barely escapes an Ascended. The Fae collective attributes Elos's lost third sun and the North's devastation to an ancient Ascended extraction project. Ilea returns to Ravenhall at level 345 in both classes, while Kyrian, the Ascended, inter-realm travel, and several ancient systems remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/azarinth-healer-book-one.json
+++ b/data/works-community/0/azarinth-healer-book-one.json
@@ -306,7 +306,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -319,7 +319,7 @@
       "recaps": {
         "ending": "Ilea leaves besieged Dawntree to check on people farther south and finds Salia destroyed. She reunites with Roland and Lily, helps stabilize the survivors, and fights beside a shadow-clad mercenary squad to kill the three elves pursuing her. Roland and Lily depart east with the refugees. Ilea reaches level 200 in both classes and evolves from Azarinth Healer into Azarinth First Hunter, gaining stronger healing, defenses, senses, and tracking. Dale and Earl remain alive in Riverwatch, while Walter and the Vultures' Brotherhood remain friendly contacts. Jasper Horim, Lorcan Agor, Jeremy, and Rin survived the Taleen expedition, but the Praetorians still control the throne room. Alice Forkspear's betrayal and her family's search for Ilea remain unresolved, as do the poisons used during the expedition, the Taleen artifacts, and Ilea's arrival from Earth. Edwin Redleaf, Felicia Redleaf, and Aliana remain beyond a Taleen gate. Ilea accepts the Dagger of Akelion as a willing companion and travels east, reaching the mercenary order's fortress city to seek training, allies, and information about the Redleaf party.",
         "in_short": "Ilea Spears wakes in the wilderness of Elos, survives an ancient Azarinth awakening, and becomes a formidable fighter-healer. After reaching Riverwatch, she rescues Alice Forkspear, survives an elven assault, escapes through Calys Dungeon, and develops fire and ash powers alongside her healing class. A caravan disaster takes her to Salia before Alice sends her into a Taleen ruin on a fabricated mission. Ilea explores the ruin with Edwin Redleaf, Felicia Redleaf, and Aliana, then alone and under the alias Lilith with a Forkspear expedition. Taleen Praetorians devastate that expedition, though Ilea rescues several survivors. She returns to find Dawntree besieged and Salia destroyed, reunites with Roland and Lily, and helps mercenaries kill three pursuing elves. After evolving into an Azarinth First Hunter, she confirms Dale and Earl survived in Riverwatch, renews her friendship with Walter, and befriends the Dagger of Akelion. She ends the book entering the eastern mercenary order's fortress city in search of training and the missing Redleaf party.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -675,7 +675,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0GJFN4C4Q",
@@ -687,7 +687,7 @@
       "recaps": {
         "ending": "Ilea closes the volume as Arcane Eternal level 503, Ashen Titan level 500, and Fae and Valkyrie level 465. She establishes a transfer anchor on the Crawon Isles, leaves a modified gate key with the dragonling elf, and returns to her seaside home to seek Endless Meadow's help training her new abilities and space magic. Kyrian has returned from two years of isolation, reunited with Claire and Trian, and begun rebuilding a life in Ravenhall, though he continues hunting on the isles. Iana, Christopher, and Endless Meadow possess an intrusion key, a partial map of the Taleen network, and a key locator, but the buried capital remains beyond their strength and still demands three keys or key wardens. Zoe's trail, the other keys, the gate-like ruins, and the ocean Leviathan remain unresolved. Ilea also postpones any action against Michael after learning that he killed Eve following Eve's attack on Prim. Isalthar's hunters remain opposed to the Taleen machines and the elven domains, while Ravenhall's Medic Sentinels continue expanding.",
         "in_short": "Ilea strengthens Ravenhall's Medic Sentinels, joins Isalthar's exiled hunters, and helps uncover the buried Taleen capital, where a hostile guardian demands three keys or key wardens before granting deeper access. Iana, Christopher, and Endless Meadow later breach part of the gate network, allowing Ilea to find Kyrian alive after two years in the far north. He returns to Ravenhall and begins readjusting with Claire and Trian. Ilea also ends a rot crisis, frees captives from a Baralian fort, learns that Michael killed Eve after Eve killed Prim, and survives new four-mark threats in the ocean and on the northern isles. Victories over a sealed Terror and the Scorching Worm carry her through two level-500 evolutions, first from Azarinth Sentinel to Arcane Eternal and then from Kin of Ash to Ashen Titan. She leaves Kyrian and the dragonling elf hunting on the Crawon Isles and returns home to train with Endless Meadow, while the Taleen keys, Zoe's trail, the capital, and several ancient gate mysteries remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1295,7 +1295,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -1308,7 +1308,7 @@
       "recaps": {
         "ending": "Ilea ends the book above level 300 as an Azarinth Sentinel and Kin of Ash. She has freed Tremor's ancient necromancer-king, recovered the key to his treasury, helped repel attacks on two Awakened settlements, and joined her northern allies in destroying two level-600 Taleen Praetorians. The queen remains bound while Hallowfort allies work on her enchantments. The elven mentor and three young hunters survive, with the mentor now accepting hunter status, and the dwarven companion remains with Ilea. In Ravenhall, Claire continues supporting the search for Kyrian, Trian stays with his surviving household, Aki pursues answers about its nature, and Weavy and his apprentice have refuge. Ilea holds a Taleen Gate Key that may provide a route to Kyrian, who remains missing after Arthur Redleaf's unstable gate scattered the assault party. She plans to finish exploring Tremor's vaults before returning south, possibly with the necromancer-king. Eve's killer, the Golden Lily, Adam Strand's motive, the queen's release, the Taleen control mystery, and the widening northern war all remain unresolved.",
         "in_short": "After helping Trian punish the Birmingham members responsible for his household's massacre, Ilea joins an assault on Arthur Redleaf and loses Kyrian when Arthur's unstable Taleen gate scatters the group. She leaves Ravenhall for the North to gain enough strength to search for him. There she establishes allies in Hallowfort, explores Tremor and the Descent, frees an imprisoned Fae, discovers an active Taleen factory, and learns that Tremor's ancient royal couple remain bound to the city's undead machinery. Ilea reaches level 300, evolving into an Azarinth Sentinel and Kin of Ash, then defeats the Kingsguards and frees the necromancer-king. With northern allies, she repels coordinated attacks on Awakened settlements and destroys two Taleen Praetorians. A hidden Great Hall chamber yields a Taleen Gate Key, giving her the first practical lead toward Kyrian. She intends to finish Tremor's vaults and return south while the queen, the Golden Lily, the Taleen mystery, and the northern war remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1641,7 +1641,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -1654,7 +1654,7 @@
       "recaps": {
         "ending": "The Shadow's Hand clears Ravenhall after Ilea kills Bane of the Deep and the defenders break the demons' Mind Weaver command, but the powerful winged demon escapes. Dagon and Sulivhaan negotiate cooperation with the Empire, giving the Hand a larger role in the city's reconstruction. Claire joins the new administration and takes responsibility for Cless. Trian plans to check on his family after learning that demon attacks have spread, while the Golden Lily remains tied to that family. Eve kills a poison druid during her separate investigation but leaves the fight critically wounded and without healing supplies, so her immediate safety is unresolved. Weavy proves his allegiance but is still feared by humans. Ilea leaves for Riverwatch with Kyrian and Weavy. Adam Strand remains missing, the one-way demon-spawn lake still requires containment, the winged demon remains at large, and the mysteries surrounding Aki, Taleen technology, Cless's father, and travel between Earth and Elos remain open.",
         "in_short": "Ilea joins the Shadow's Hand and helps turn Team 34 into a capable unit alongside Claire, Eve, Kyrian, and Trian. Their missions lead to Cless, a child apparently displaced from Earth, before a Hand elder's rune plot unleashes demons across Ravenhall. Ilea and Trian are stranded in the Great Salt, ally with a Mind Weaver whom Ilea names Weavy, and use an ancient facility to return after Ilea rejects a possible route to Earth in favor of Elos. They find Ravenhall fallen and reunite surviving Hand forces under Dagon and Sulivhaan. Ilea, her allies, and Weavy break the demons' command structure and retake the city, though a winged demon escapes. Claire enters Ravenhall's new Hand-Imperial administration and cares for Cless. Trian turns toward his family, Eve is critically wounded after killing a poison druid linked to her investigation, and Ilea departs toward Riverwatch with Kyrian and Weavy while Adam Strand and the wider demon crisis remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1858,7 +1858,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1871,7 +1871,7 @@
       "recaps": {
         "ending": "After ending her engagement, Lucy plans to escape the emotional consequences by traveling to Greece with the Alan sisters. A final conversation with Mr. Emerson breaks through the explanations she has given herself and others: she admits that she loves George and has been denying it out of fear. Lucy and George marry and return to the Pension Bertolini, occupying the room with the view that the Emersons once surrendered to Lucy and Charlotte. Their happiness has cost them some family approval, and Mr. Beebe is disappointed by Lucy's choice, but they have rejected the social evasions that kept them apart. George also concludes that Charlotte, despite her warnings and apparent opposition, deliberately allowed Lucy to meet Mr. Emerson before leaving for Greece. Her action suggests a concealed sympathy with the match and gives the couple reason to remember her with gratitude rather than simple resentment.",
         "in_short": "While visiting Florence with her chaperone, Charlotte Bartlett, Lucy Honeychurch meets the unconventional Mr. Emerson and his troubled son George. Lucy and George share two intense encounters, culminating in a kiss that Charlotte interrupts. Back in Surrey, Lucy becomes engaged to the cultivated but controlling Cecil Vyse. A housing prank by Cecil unexpectedly brings the Emersons into her neighborhood, and renewed contact with George exposes how artificial her engagement has become. After George kisses her again, Lucy sends him away and denies her feelings, but she also recognizes Cecil's habit of treating her as an object and ends their engagement. She plans to flee to Greece until Mr. Emerson persuades her to speak honestly. Lucy admits that she loves George. The two marry and return to the Florence pension where they met, accepting estrangement and disapproval as the cost of choosing a life based on truth rather than convention.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2050,7 +2050,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2063,7 +2063,7 @@
       "recaps": {
         "ending": "Peter brings Wendy, John, Michael, and the Lost Boys back to the Darling nursery, where Mr. and Mrs. Darling joyfully receive them. The Darlings adopt the Lost Boys, who gradually grow into ordinary adult lives. Peter refuses adoption because it would mean school, work, and adulthood. He returns to Neverland and soon forgets many of his old companions. Years later he comes back for Wendy, only to discover that she has grown up and has a daughter, Jane. Peter takes Jane to Neverland to do spring cleaning and hear stories; when Jane grows up, her daughter Margaret follows. The pattern continues while Peter remains forever young, separated by his choice from the people who remember and love him.",
         "in_short": "Peter Pan visits the London nursery of Wendy, John, and Michael Darling and teaches them to fly to Neverland. Wendy becomes a motherly storyteller to Peter and the Lost Boys, while the children encounter fairies, mermaids, Tiger Lily, and Captain Hook's pirates. Hook captures Wendy and the boys after poisoning Peter's medicine, but Tinker Bell drinks it and survives when children affirm their belief in fairies. Peter boards the pirate ship, defeats Hook, and sends him to the waiting crocodile. Wendy decides that she and her brothers must return home, and the Lost Boys go with them. The Darling parents welcome the children and adopt the Lost Boys, but Peter refuses to grow up. He later returns to find Wendy an adult, then takes her daughter Jane to Neverland; succeeding generations repeat the visit while Peter remains unchanged.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2221,7 +2221,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2234,7 +2234,7 @@
       "recaps": {
         "ending": "Jeeves returns to command and resolves the deadlock with a fabricated telegram implying that Anatole has been offered a position elsewhere. The prospect of losing the chef induces Tom Travers to give Dahlia the money her magazine needs, while the same crisis draws Tuppy and Angela back together. Jeeves also arranges for Gussie and Madeline to reconcile, freeing Bertie from Madeline's promise to marry him if her engagement failed. The various hungry and angry residents finally receive dinner, and Brinkley Court returns to order. Bertie recognizes that his own interventions created most of the disaster and restores Jeeves to his former advisory role. The white mess jacket that began their disagreement is ruined while supposedly being pressed. Bertie accepts its loss and acknowledges the valet's victory.",
         "in_short": "Bertie Wooster returns from Cannes determined to resist Jeeves's influence and to solve several friends' troubles himself. At Brinkley Court, Gussie Fink-Nottle cannot declare his love to Madeline Bassett, while Tuppy Glossop and Angela Travers have broken their engagement. Aunt Dahlia also needs money from her husband to keep her magazine afloat and cannot risk losing the chef Anatole. Bertie's remedies depend on alcohol, jealousy, and denying people dinner. They produce Gussie's scandalous school speech, multiple broken engagements, Anatole's threatened resignation, and a hungry household furious with Bertie. Madeline even decides she must marry him when she separates from Gussie. Jeeves finally uses a false job offer for Anatole to bring Tom Travers, Dahlia, and both couples into line. Bertie escapes marriage, concedes that Jeeves was right, and discovers that Jeeves has disposed of his disliked white jacket.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2396,7 +2396,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2409,7 +2409,7 @@
       "recaps": {
         "ending": "Virginia returns through the hidden panel carrying jewels and leads her family to a concealed chamber, where Sir Simon's chained skeleton lies beside the evidence of his long imprisonment. The Otises arrange a formal funeral, and Virginia places flowers on his grave after helping his spirit reach peace. Mr. Otis tries to return the valuable jewels to Lord Canterville, but Lord Canterville insists that Virginia keep them as the ghost intended. Years later Virginia marries Cecil, now Duke of Cheshire. When they revisit Sir Simon's grave, she tells her husband that the ghost taught her the meaning of life and death and why love is stronger than either. She will not disclose exactly what she saw during her absence, and Cecil accepts the private bond she keeps with Sir Simon.",
         "in_short": "American minister Hiram Otis buys the haunted Canterville Chase and moves in with his practical family. The resident ghost, Sir Simon, expects to terrify them, but Mr. Otis offers lubricant for his chains, Washington repeatedly cleans the supernatural bloodstain, and the twins answer every apparition with traps and missiles. His dignity and health ruined, Sir Simon withdraws. Virginia Otis eventually finds him grieving and learns that he longs to die but cannot reach peace. A prophecy says an innocent child must weep and pray for him, and Virginia agrees to accompany him into a supernatural darkness. She returns hours later with jewels and reveals the chamber containing his remains. After Sir Simon is buried, the haunting ends. Virginia later marries the Duke of Cheshire and keeps secret the details of what she experienced, saying only that Sir Simon taught her about love, life, and death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2521,7 +2521,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2534,7 +2534,7 @@
       "recaps": {
         "ending": "After leaving the Van Tassel gathering disappointed, Ichabod rides home through places associated with local ghost stories. A large rider joins the road behind him and pursues him toward the bridge by the church. Ichabod sees that the figure appears to be headless. As he crosses the bridge, the pursuer hurls what looks like a severed head, knocking him from his horse. Ichabod is gone the next morning. Searchers find Gunpowder, Ichabod's hat, and a shattered pumpkin, but not Ichabod. Brom Bones later marries Katrina and reacts knowingly whenever the pumpkin is mentioned, suggesting that he staged the apparition. A later traveler reports that Ichabod survived, left the district, studied law, and entered public life. The established residents prefer a supernatural explanation, and the schoolhouse is eventually said to be haunted by the missing teacher's voice. The story leaves the horseman's identity formally unresolved while giving strong evidence for Brom's prank.",
         "in_short": "In the secluded New York community of Sleepy Hollow, superstitious schoolmaster Ichabod Crane courts Katrina Van Tassel, the daughter of a prosperous farmer, and imagines the comfortable future her inheritance could provide. His rival is the athletic prankster Brom Bones. After a harvest gathering rich in food and ghost stories, Ichabod speaks privately with Katrina and leaves dejected. Riding home through the dark on a borrowed horse, he is pursued by a rider who appears to be the legendary Headless Horseman. At the church bridge, the figure throws its head at him. By morning Ichabod has disappeared; only his hat and a broken pumpkin are found. Brom soon marries Katrina and seems amused by references to the pumpkin, implying that he impersonated the ghost to frighten his rival away. A later report says Ichabod survived and made a career elsewhere, but Sleepy Hollow preserves the more supernatural version of his disappearance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2678,7 +2678,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2691,7 +2691,7 @@
       "recaps": {
         "ending": "The Persian and Raoul enter the cellars beneath the Opera but fall into Erik's mirrored torture chamber. Erik gives Christine a choice represented by a scorpion and a grasshopper: agree to marry him or allow an explosion to destroy the Opera and everyone above them. Christine chooses the scorpion to save the others. Her compassion then reaches Erik where force has failed. She allows him to kiss her and returns a kiss to his disfigured face, the first he has received. Overcome, he frees Raoul and the Persian and permits Christine to leave with Raoul. Christine later returns his ring as promised. Erik tells the Persian what happened and asks that his death be announced. Christine and Raoul disappear together. Erik dies soon afterward and is secretly buried beneath the Opera; the later discovery of his skeleton and ring supports the narrator's account of the ghost as a brilliant, tormented human being.",
         "in_short": "At the Paris Opera, soprano Christine Daaé becomes famous after secret lessons from a voice she believes is the Angel of Music promised by her dead father. Her childhood friend Raoul learns that the teacher is the Opera Ghost, a masked man named Erik who lives beneath the theater and enforces his demands with ingenious violence. Erik abducts Christine to his underground home; she pities him but loves Raoul, and the pair plan to flee. Erik seizes her again during a performance. Guided by a Persian who knows Erik's past, Raoul reaches the cellars but is trapped in a torture chamber. Erik threatens to destroy the Opera unless Christine agrees to marry him. She consents to save everyone and responds to his misery with genuine compassion. Moved by her kiss, Erik releases Christine, Raoul, and the Persian. Christine leaves with Raoul, while Erik dies soon afterward beneath the Opera, having surrendered the woman he could not compel to love him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2855,7 +2855,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2868,7 +2868,7 @@
       "recaps": {
         "ending": "In Calais, Percy stays ahead of Chauvelin through disguise and misdirection. Appearing as an old Jewish cart driver, he draws Chauvelin and the soldiers away and endures their contempt while arranging the fugitives' escape. Chauvelin believes he has trapped the Scarlet Pimpernel at Père Blanchard's hut, but Percy's signals and concealed route allow Armand St. Just and the de Tournay party to reach the waiting schooner. Marguerite, who has followed despite the danger, is also saved. The supposed cart driver is revealed as another of Percy's disguises, leaving Chauvelin defeated and the rescued party beyond French reach. Marguerite and Percy finally speak without the pride and misunderstanding that had divided them. She understands both his hidden courage and the pain her past secrecy caused him, and he accepts the loyalty that brought her after him. They return to England reconciled. Sir Andrew Ffoulkes and Suzanne de Tournay are also free to marry, while the League's leader remains able to continue his rescues.",
         "in_short": "During the French Revolution, a secret band of Englishmen repeatedly rescues aristocrats from the guillotine under the direction of the elusive Scarlet Pimpernel. French agent Chauvelin coerces Marguerite Blakeney into helping identify him by threatening her brother Armand. Marguerite reluctantly passes on a clue, then discovers that the Pimpernel is her own husband, Sir Percy, whose foolish public manner is a disguise. Realizing she has placed him and Armand in danger, she follows Percy to Calais with League member Sir Andrew Ffoulkes. Chauvelin prepares an ambush around a hut where Armand and other fugitives are waiting, but Percy uses disguises, false trails, and secret signals to misdirect the soldiers and get the party aboard his schooner. Marguerite is rescued as well. She and Percy overcome the secrecy and wounded pride that had estranged them, returning to England reconciled, while Chauvelin is left behind after failing to capture either the fugitives or his enemy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3026,7 +3026,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3039,7 +3039,7 @@
       "recaps": {
         "ending": "Badger leads Mole, Rat, and Toad through a hidden passage into Toad Hall while the weasels and stoats are holding a banquet. The four friends surprise the occupiers, drive them from the house, and restore Toad to his home. Toad initially wants a grand public celebration of his victory, but his friends curb his boasting and arrange a smaller dinner. He sends compensation and apologies to people he wronged during his escape, and publicly credits Mole, Rat, and Badger for recovering the Hall. The inhabitants of the riverbank come to regard Toad as reformed and modest, although his closest friends know that his improved behavior still requires encouragement. Mole and Rat return to their familiar life by the river, with their friendship intact and Toad Hall once again in its owner's hands.",
         "in_short": "Mole leaves his underground home and discovers the river, where Rat introduces him to boating and friendship. Their wealthy companion Toad becomes obsessed with motorcars, repeatedly crashes them, and rejects every attempt by Rat, Mole, and Badger to restrain him. Convicted after stealing and recklessly driving a car, Toad escapes prison in disguise and makes a difficult journey home. Meanwhile, Mole learns to value both adventure and his own neglected home, Rat resists a sudden urge to wander abroad, and the friends share encounters that reveal the wonder and danger of the countryside. Toad returns to find that weasels and stoats have seized Toad Hall. Badger guides the four friends through a secret tunnel, and they drive out the occupiers during a banquet. Restored to his home, Toad apologizes for some of his misconduct and behaves with greater humility, while Mole and Rat resume their life beside the river.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3173,7 +3173,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3186,7 +3186,7 @@
       "recaps": {
         "ending": "After reaching Oxford, the party begins the return journey in worsening weather. Continuous rain strips the river of its earlier charm, so the men spend a miserable evening in the boat trying to pretend that they are comfortable. George's attempt at music only deepens the gloom. When the next day is equally wet, he suggests leaving the boat at Pangbourne and taking the train to London. J. and Harris briefly object in the name of perseverance, then admit that they want exactly the same thing. Back in London, the three men eat a satisfying supper and go on to the Alhambra. Harris raises a toast to their escape from the boat, and Montmorency gives an approving bark. The holiday ends not with the planned completion of the return voyage, but with the friends contentedly abandoning it for warmth, food, and city life.",
         "in_short": "Convinced that they are overworked and unwell, J., George, and Harris plan a fortnight's boating holiday on the Thames with J.'s fox terrier, Montmorency. They travel upstream from Kingston toward Oxford, repeatedly turning simple jobs such as packing, towing, cooking, opening tins, and putting up canvas into elaborate difficulties. The journey is interspersed with J.'s memories, comic histories, and observations on river life. The friends quarrel with equipment, weather, other boats, musical instruments, and their own uneven willingness to work, but also enjoy old towns and stretches of peaceful countryside. At Oxford the weather breaks. On the return journey, relentless rain defeats their determination, and they leave the boat at Pangbourne for a train to London. Restored by supper and an evening's entertainment, they toast the fact that all three men, and the dog, are safely out of the boat.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3359,7 +3359,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3372,7 +3372,7 @@
       "recaps": {
         "ending": "Ben Gunn has already found Flint's treasure and moved it from its burial pit to his cave, so the mutineers discover only an empty hole. When they turn on Silver and Jim, Livesey, Gray, and Gunn attack from concealment and defeat them. The survivors transfer the treasure to the Hispaniola, leaving three mutineers supplied but marooned on the island. Silver remains useful during the escape and is allowed aboard, but at a later port he slips away with a small bag of coins. Jim, Livesey, Trelawney, Smollett, Gray, and Gunn return safely to England and divide their shares. Gray uses his money responsibly and Gunn quickly spends his. Jim says that no reward could persuade him to return to the island; in dreams he still hears the surf and Silver's parrot crying about pieces of eight.",
         "in_short": "Jim Hawkins acquires the map to Captain Flint's buried treasure after pirates descend on his family's inn. Doctor Livesey and Squire Trelawney organize a voyage aboard the Hispaniola, unaware that their engaging cook, Long John Silver, has recruited much of Flint's old crew and plans a mutiny. Jim overhears the plot, and the loyal party occupies an old stockade on Treasure Island. He meets the marooned Ben Gunn, survives several independent adventures, and eventually falls into Silver's hands. Silver protects Jim while trying to retain control of his wavering men. The treasure pit proves empty because Gunn moved the hoard years earlier. Livesey's party routs the mutineers, loads the treasure, and sails for home, marooning the surviving rebels. Silver escapes at a port with a small share, while Jim and his companions return to England wealthy but permanently marked by the voyage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3524,7 +3524,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3537,7 +3537,7 @@
       "recaps": {
         "ending": "Madame de la Rougierre returns under Silas's protection and helps arrange what Maud believes is a journey to France. Instead, Maud is isolated at a remote house and drugged so that Dudley can murder her and secure the Ruthyn inheritance. The plan fails when Madame occupies Maud's bed and Dudley kills the governess by mistake. Maud survives the night, escapes the conspirators' control, and is restored to the protection of Lady Monica and Doctor Bryerly. Silas's scheme and his complicity in the danger are exposed; he dies after its collapse, while Dudley flees and is later reported dead abroad. Maud inherits and eventually describes a secure married life. Her adult perspective does not erase the terror of Bartram-Haugh, but it confirms that the guardianship intended to make her helpless did not determine the rest of her life.",
         "in_short": "Young heiress Maud Ruthyn grows up at Knowl under her secretive father Austin, fascinated and frightened by stories about his disgraced brother Silas. A sinister governess, Madame de la Rougierre, spies on the household and is dismissed. When Austin dies, his will makes Silas Maud's guardian in an attempt to demonstrate his trust and clear the family name. At decaying Bartram-Haugh, Maud befriends Silas's daughter Milly but faces pressure to marry his violent son Dudley. She refuses, and evidence emerges that Dudley is already married. Silas and Dudley, desperate for Maud's fortune, bring Madame back and plot Maud's murder during a supposed trip to France. Drugged and confined, Maud survives because Dudley mistakes Madame for her and kills the governess. Maud escapes to her allies, Silas dies after the plot fails, and Dudley flees. Maud inherits and later builds a peaceful adult life beyond her relatives' control.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3714,7 +3714,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3727,7 +3727,7 @@
       "recaps": {
         "ending": "After pressure from Zenith's respectable set isolates George, Myra becomes seriously ill and needs surgery. Fear of losing her ends his attempt to build a separate life, and their reconciliation restores him to both his family and the city's approval. He joins the Good Citizens' League and resumes the public conformity expected of him. The final disturbance comes from Ted, who elopes with Eunice Littlefield and announces that he wants technical work rather than the professional career his parents planned. Relatives gather to condemn the marriage, but George refuses to make his son surrender. He admits that he has not lived as freely as he once hoped and tells Ted that he supports the young couple. George has not escaped Zenith or remade himself, yet his defense of Ted preserves a small act of independence and gives his son the permission he could not give himself.",
         "in_short": "George F. Babbitt is a successful Zenith real-estate broker whose public confidence in business, consumption, and civic boosterism conceals a longing for another life. He seeks status among the city's elite while depending emotionally on his unhappy friend Paul Riesling. After Paul shoots his wife Zilla and goes to prison, George's dissatisfaction deepens. He rebels against his circle, befriends liberal Seneca Doane, and begins an affair with the widow Tanis Judique, but the freedom he finds is shallow. Business associates punish his independence until Myra's grave illness draws him home. Reconciled with her, he returns to social respectability and joins the conservative Good Citizens' League. When his son Ted elopes with Eunice and rejects a conventional career, however, George resists the family's outrage and supports him, hoping Ted may make the choices George could not sustain.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3840,7 +3840,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3853,7 +3853,7 @@
       "recaps": {
         "ending": "Farmer Hogget enters Babe in the sheepdog trials despite the disbelief his decision causes. In the final test, the unfamiliar sheep initially refuse to move for a pig. Fly learns the sheep's traditional password from the flock at home and passes it to Babe, allowing him to establish trust with the trial flock. Once they recognize that he approaches them respectfully, the sheep follow his requests through the course. Babe completes the work with extraordinary precision and receives the highest possible score. The spectators' mockery turns to astonishment and applause, while Hogget accepts the result with his usual restraint. Babe has secured his place as a working member of the farm rather than as an animal being raised for the table, and the partnership between the farmer and his sheep-pig is publicly confirmed.",
         "in_short": "Farmer Hogget wins a piglet at a fair and brings him home, where the sheepdog Fly adopts him and calls him Babe. Babe admires Fly's work but discovers that sheep obey dogs mainly from fear. By addressing the flock courteously and listening to the old ewe Maa, he learns to herd through cooperation. Hogget recognizes Babe's talent after the pig helps protect the sheep and proves he can guide them. When stray dogs attack the flock and kill Maa, Hogget briefly suspects Babe, but Fly finds evidence that clears him. The farmer then enters the pig in a sheepdog trial. The strange sight draws ridicule, and the unfamiliar trial sheep will not initially respond. With help from Fly and a password shared among sheep, Babe wins their trust, guides them flawlessly through the course, and earns a perfect score. His achievement makes him Hogget's valued working partner and saves him from his expected fate as food.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4012,7 +4012,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4025,7 +4025,7 @@
       "recaps": {
         "ending": "Robin, Victoire, and their allies occupy Babel and stop the silver bars that support Britain's infrastructure, hoping national disruption will force Parliament to abandon war with China. Workers and radicals rally to them, but the government refuses their demand and prepares to retake the tower. Letty, unable to accept the revolution, betrays the group, and Ramy is shot and killed. As soldiers close in, Robin concludes that only destruction can prevent Babel's knowledge from returning to imperial control. He stays in the tower and sabotages its resonant structure, causing Babel to collapse and killing himself along with the remaining defenders and much of the stored silver. The wounded Victoire escapes Oxford carrying the memory of her friends and the task of continuing resistance elsewhere. Britain loses Babel's central stockpile and expertise, but the novel leaves the larger struggle against empire unresolved rather than presenting the sacrifice as a complete victory.",
         "in_short": "Robin Swift, a Chinese orphan raised by the severe Oxford professor Richard Lovell, enters Babel with Ramy, Victoire, and Letty. They study translation and magical silver bars whose power drives British industry and empire. Robin's half-brother Griffin recruits him into Hermes, a secret anticolonial society, and Robin gradually sees that Babel extracts languages and resources from the peoples Britain subjugates. On an expedition to Canton, Babel supports the opium interests pushing Britain toward war. Robin kills Lovell during their return and joins Ramy and Victoire in open resistance. Letty betrays them, and Ramy is killed. The survivors seize Babel, halt Britain's silver network, and demand an end to the planned war. When the government chooses force, Robin brings down the tower rather than return its knowledge to imperial hands, dying in the collapse. Victoire escapes to carry the resistance forward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4241,7 +4241,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4254,7 +4254,7 @@
       "recaps": {
         "ending": "Marco commits the Free Navy to a decisive battle at the ring gate rather than accept that his authority is evaporating. The allied fleet gives him the fight he wants on terms Naomi has calculated: the gates destroy anything that passes through them carrying too much mass and energy at once, and the Free Navy's ships transit together at speed. Most of the fleet, the Pella and Marco Inaros with it, is annihilated in the crossing. Filip is not aboard; he had already broken with his father and walked away, and he ends the book working an ordinary berth under a name that is not Inaros. With the Free Navy gone, the surviving powers build a Transport Union to govern traffic through the ring gates and to give the Belt permanent standing in the settlement of the new worlds, with Belter leadership at its head and Medina Station as its seat. Fred Johnson's holdings, willed to Holden, are folded into it. Earth begins the long work of feeding itself again with Prax's engineered strains; Michio Pa's faction is absorbed into the new order; Ceres survives as a ward of the alliance. The Rocinante takes contract work for the union with Bobbie Draper added to the crew, and Holden and Naomi, having spent a decade at the center of every catastrophe, are left with the unfamiliar prospect of ordinary work.",
         "in_short": "In the aftermath of the Free Navy's asteroid attacks, Marco Inaros holds Ceres, Medina Station and the ring space while Earth starves and the inner planets rebuild a fleet. His movement decays from within: his squadron commander Michio Pa defects and turns pirate, seizing Free Navy cargo and giving it away to Belt stations; Ceres is stripped and abandoned, handing the alliance a station full of starving people and handing the Belt a lesson about who Marco actually serves; Medina's own work crews turn against the occupation; and his son Filip, raised as the movement's heir, finally sees his father clearly. Fred Johnson dies and leaves his authority to Holden. Earth, Mars, Pa's ships and the Outer Planets Alliance combine, and Naomi works out how to use the ring gates themselves as a weapon. Baited into a mass transit of the ring, most of the Free Navy is destroyed and Marco with it. Filip, who left before the battle, survives anonymously. The powers that remain create a Transport Union to govern the gates and give the Belt a permanent place in the settlement of the new worlds.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4347,7 +4347,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4360,7 +4360,7 @@
       "recaps": {
         "ending": "Thomas succeeds in protecting Harry from the danger closing around him without ever revealing the existence of the Oblivion War. Harry survives the night largely unaware of how close the threat came or of the hidden conflict his brother is bound to. The secret of the war is preserved, Thomas's loyalties remain concealed, and the quiet, one-sided vigilance he keeps over his brother continues as it did before.",
         "in_short": "Told from the point of view of Thomas Raith, this novella follows him as he works to protect his half-brother, the wizard Harry Dresden, from a danger Harry cannot be allowed to learn about. Thomas is secretly part of the Oblivion War, an ancient, hidden effort to erase the names of certain old and terrible beings from human memory so they can never again be called into the world. Harry has stumbled unknowingly into the edges of this war, drawing the attention of a faction that wants to exploit what he has touched. Because the rules of the war forbid revealing it to outsiders, Thomas must guard Harry without telling him what is truly at stake, maneuvering alone against supernatural enemies. Through a night of danger he manages to shield his brother and blunt the threat, keeping both the secret and Harry intact.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4653,7 +4653,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audiosilo-meta:work:bad-luck-and-trouble",
@@ -4665,7 +4665,7 @@
       "recaps": {
         "ending": "Jack Reacher hides aboard Allen Lamaison's helicopter and intervenes as Lamaison's associates prepare to throw Karla Dixon and David O'Donnell from the aircraft. He frees both captives, sends the two associates out of the helicopter, kills Lamaison, and later kills the pilot after forcing a landing at Edward Dean's remote home. Azhari Mahmoud arrives expecting Dean to demonstrate how to arm the stolen Little Wing systems. Reacher and Frances Neagley capture Mahmoud, restrain the arriving truck driver, and alert a Pentagon contact. Federal authorities take control of Mahmoud, the missile shipment, and the evidence before any of the 650 systems are armed. Dixon administers the recovered financial instruments and diamonds, establishing support for the victims' families, Tony Swan's dog charity, expenses, and the surviving investigators. Reacher, Neagley, Dixon, and O'Donnell separate at LAX. Weeks later, Dixon deposits Reacher's $111,822.18 share in his account. The amount encodes both mission accomplished and her Greenwich Village ZIP code, leaving him an invitation while he continues travelling. The final dispositions of Curtis Mauney, Lennox, and Parker are unstated.",
         "in_short": "After Calvin Franz is murdered, Frances Neagley summons Jack Reacher and reunites him with former special-investigations colleagues Karla Dixon and David O'Donnell. Their search links the deaths of Franz, Tony Swan, Jorge Sanchez, and Manuel Orozco to New Age Defense Systems. Security chief Allen Lamaison has coerced employees into falsely rejecting 650 working electronics packs for Little Wing missiles and arranged their sale to Azhari Mahmoud. Sheriff Curtis Mauney is exposed as Lamaison's partner, while Dixon and O'Donnell are captured. Reacher boards the conspirators' helicopter, rescues them, and kills Lamaison. Reacher and Neagley then capture Mahmoud before the missile shipment can be armed for attacks in the United States. Federal authorities receive the prisoner, shipment, and evidence. The recovered assets support the victims' families, Tony Swan's dog charity, expenses, and the surviving investigators. The four survivors separate, and Dixon later sends Reacher his share with a coded invitation to Greenwich Village.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4810,7 +4810,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4823,7 +4823,7 @@
       "recaps": {
         "ending": "The passengers persuade Élisabeth to submit to the Prussian officer by presenting her sacrifice as patriotic, moral, and necessary for everyone. The officer then allows the coach to leave. On the renewed journey, the other travelers immediately restore their social distance from her. Having secretly prepared food for themselves, they eat while refusing to share with Élisabeth, who had fed them during the first stage of the trip and had no time to provision herself after yielding for their sake. Cornudet whistles and sings a republican anthem as the coach moves on. Isolated among people who used her courage and generosity, Élisabeth begins to cry. No one acknowledges her tears, and the respectable passengers' relief rests upon the degradation of the person they continue to despise.",
         "in_short": "During the Franco-Prussian War, ten travelers leave occupied Rouen in a coach. The respectable merchants, aristocrats, two nuns, and republican Cornudet initially scorn their fellow passenger Élisabeth Rousset, a sex worker called Boule de Suif, but hunger leads them to accept the meal she generously shares. At an inn controlled by the Prussians, an officer refuses to let the coach continue unless Élisabeth sleeps with him. She rejects him out of patriotism. As the delay continues, her companions become angry at the cost of her refusal and collectively pressure her, dressing their self-interest as moral and religious argument. She finally yields. Once the coach is released, the others shun her again and eat provisions they have concealed without offering her any. Hungry and humiliated after sacrificing herself for them, Élisabeth weeps while her companions ignore her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4931,7 +4931,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4944,7 +4944,7 @@
       "recaps": {
         "ending": "While Luo is away visiting his sick mother, the Little Seamstress tells the narrator that she is pregnant. Because she and Luo are too young to marry legally, the narrator secretly finds a gynecologist willing to perform an abortion and secures his help by promising him a forbidden Balzac novel. The procedure succeeds. During Luo's absence the Seamstress has continued reading, altered her clothes and appearance, and reached conclusions that Luo did not anticipate. She decides that beauty, education, and self-possession can give her a life beyond the mountain. Without waiting for either young man, she cuts her hair and leaves for the city. Luo and the narrator try unsuccessfully to stop or follow her. Devastated by the outcome of the education he meant to control, Luo burns the stolen books. The narrator watches the pages and imagined worlds disappear in the fire, while the Seamstress carries their transforming influence away with her into an unknown independent future.",
         "in_short": "During China's Cultural Revolution, two educated teenage boys from Chengdu are sent to a poor village on Phoenix Mountain for re-education through labor. The unnamed narrator brings a violin; his friend Luo survives through wit and storytelling. They befriend a tailor's daughter known as the Little Seamstress and discover that another exile, Four-Eyes, hides a suitcase of banned Western novels. After stealing it, the boys devour Balzac and other authors, retell their stories, and try to use literature to broaden the Seamstress's life. Luo becomes her lover and imagines himself as her teacher. When she becomes pregnant while he is away, the narrator arranges an illegal abortion by trading a treasured book to a doctor. Reading has meanwhile changed the Seamstress on her own terms: she adopts a new appearance and decides to seek a life in the city. She leaves both boys behind. Luo, unable to accept that his project has freed her from him as well as from the mountain, burns the books.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5093,7 +5093,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5106,7 +5106,7 @@
       "recaps": {
         "ending": "The Great Prince completes Bambi's education by leading him to the body of a dead human, proving that the hunters who terrorize the forest are mortal rather than all-powerful. Bambi grows into a solitary, self-reliant stag. When the old Prince has become weak, he acknowledges Bambi as his son, tells him that he has loved him, and departs alone, leaving Bambi to occupy the mature place for which he has been prepared. Later Bambi encounters two young fawns calling for their mother. He turns them away from dependence much as the Prince once did with him, while privately recognizing that the male fawn shows promise. The close returns to the pattern of one generation teaching the next: Bambi is no longer the frightened youngster seeking protection but an experienced stag who understands danger, loss, and the necessity of standing alone.",
         "in_short": "Bambi is born in a forest and learns its creatures, seasons, and dangers under his mother's care. He befriends his cousins Faline and Gobo, observes the authority of the solitary Great Prince, and gradually understands that human hunters are the animals' greatest threat. During a winter drive his mother is killed, forcing him toward independence. As a young stag he reunites with Faline and defeats rival males, but happiness is shadowed by Gobo's return from captivity among humans. Gobo believes his human keeper has made him safe; that trust leads him to approach a hunter and be killed. Guided by the Great Prince, Bambi survives a gunshot and learns to evade pursuit. The Prince later shows him a dead human, breaking the belief that humanity is invincible. In old age the Prince acknowledges Bambi as his son and leaves him. Bambi, now a solitary mature stag, encounters a new pair of fawns and assumes the stern, protective role once held by his father.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5283,7 +5283,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5296,7 +5296,7 @@
       "recaps": {
         "ending": "The Great Prince completes Bambi's education by leading him to the body of a dead human, proving that the hunters who terrorize the forest are mortal rather than all-powerful. Bambi grows into a solitary, self-reliant stag. When the old Prince has become weak, he acknowledges Bambi as his son, tells him that he has loved him, and departs alone, leaving Bambi to occupy the mature place for which he has been prepared. Later Bambi encounters two young fawns calling for their mother. He turns them away from dependence much as the Prince once did with him, while privately recognizing that the male fawn shows promise. The close returns to the pattern of one generation teaching the next: Bambi is no longer the frightened youngster seeking protection but an experienced stag who understands danger, loss, and the necessity of standing alone.",
         "in_short": "Bambi is born in a forest and learns its creatures, seasons, and dangers under his mother's care. He befriends his cousins Faline and Gobo, observes the authority of the solitary Great Prince, and gradually understands that human hunters are the animals' greatest threat. During a winter drive his mother is killed, forcing him toward independence. As a young stag he reunites with Faline and defeats rival males, but happiness is shadowed by Gobo's return from captivity among humans. Gobo believes his human keeper has made him safe; that trust leads him to approach a hunter and be killed. Guided by the Great Prince, Bambi survives a gunshot and learns to evade pursuit. The Prince later shows him a dead human, breaking the belief that humanity is invincible. In old age the Prince acknowledges Bambi as his son and leaves him. Bambi, now a solitary mature stag, encounters a new pair of fawns and assumes the stern, protective role once held by his father.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5650,7 +5650,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00309OTU0",
@@ -5662,7 +5662,7 @@
       "recaps": {
         "ending": "Cordelia's raid recovers Miles's uterine replicator, but Kareen is killed while trying to turn on Vordarian. Bothari executes Vordarian, and his death breaks the coup's leadership. Loyalists retake the capital, Gregor is publicly restored as emperor, and Aral remains Regent. The Council makes Aral and Cordelia Gregor's guardians, with Cordelia responsible for his household and education. Koudelka and Droushnakovi marry, Lady Vorpatril and Ivan survive, and Lord Vorpatril, Captain Negri, Kareen, Vordarian, and Avon Vorhalas are dead. Miles survives treatment and birth but remains very small, physically deformed, and vulnerable to fractures. Bothari, aided by better medication but still carrying severe trauma, becomes his bodyguard. Five years later, Miles is active and determined. After a riding fall breaks his arm, Cordelia permits supervised lessons, and Piotr begins to replace his rejection of Miles with guarded involvement.",
         "in_short": "Cordelia Naismith and Aral Vorkosigan enter Barrayaran public life as Aral becomes Regent for the child emperor Gregor. A revenge attack exposes their unborn son Miles to a bone-damaging poison treatment, and Cordelia transfers him to a uterine replicator. Vidal Vordarian then launches a coup, captures Kareen and the replicator, and falsely claims the throne. Cordelia leads Bothari and Droushnakovi into the capital, where Kareen dies after learning Gregor is alive and trying to kill Vordarian. Bothari executes Vordarian, Miles is recovered, and the rebellion collapses. Gregor returns as emperor under Aral and Cordelia's guardianship. Miles is born alive with severe skeletal damage and brittle bones. Five years later, his energy and desire to ride begin a cautious reconciliation with Piotr, who had rejected him at birth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5840,7 +5840,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5853,7 +5853,7 @@
       "recaps": {
         "ending": "Barry's attempt to found a lasting aristocratic house ends with his fortune exhausted, his wife alienated, and his son Bryan dead. Lord Bullingdon returns to defend his mother and challenges Barry; their confrontation leaves Barry badly wounded and removes the physical power on which much of his dominance rested. Lady Lyndon escapes his control, and creditors close in. Barry is allowed an income in exchange for staying away, but he cannot live quietly within it and resumes the schemes and demands that ruined him. Bullingdon eventually has him arrested, and Barry spends the remaining years of his life in the Fleet Prison. His mother continues to care for him as long as she can, but neither her loyalty nor his claims of noble conduct restore his position. An editorial conclusion corrects the triumphant tone of Barry's memoir: the worldly gentleman he has described finishes as an impoverished prisoner, while the rank and estate he tried to seize return to the family he displaced.",
         "in_short": "Redmond Barry, an impulsive Irish youth, flees home after a supposed duel over his cousin Nora. Robbed on the road, he joins the British army, deserts, is forced into Prussian service, and then becomes a spy. Instead of betraying the Irish adventurer Chevalier de Balibari, he joins him and learns to live by gambling and cultivated deceit. Seeking permanent rank and wealth, Redmond courts the married Lady Lyndon; after her elderly husband dies, he marries her and takes the name Barry Lyndon. He spends her fortune pursuing a title, mistreats her son Lord Bullingdon, and indulges their own son Bryan. Bryan's death and Bullingdon's return destroy the household Barry claims to govern. Wounded, indebted, and separated from Lady Lyndon, Barry loses his income through further schemes and is imprisoned for debt. He dies in the Fleet Prison, still represented by his own memoir as a wronged gentleman, while the editorial frame exposes the ruin produced by his vanity and aggression.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5972,7 +5972,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5985,7 +5985,7 @@
       "recaps": {
         "ending": "After the lawyer moves his practice to escape an impossible standoff, Bartleby remains in the old building and refuses either to leave or adopt another occupation. The new occupants eventually have him arrested as a vagrant and taken to the Tombs. The lawyer visits, pays a food contractor to look after him, and tries to reassure him, but Bartleby rejects food as he rejected work and movement. On a later visit the lawyer finds him dead in the prison yard. Some time afterward, the lawyer hears an unconfirmed report that Bartleby once worked in the Dead Letter Office, handling messages that could never reach their recipients. The rumor gives him a possible image for Bartleby's desolation but no complete explanation. He closes by linking grief for this solitary man with grief for humanity more broadly.",
         "in_short": "A cautious Wall Street lawyer hires Bartleby as a copyist. Bartleby initially works with remarkable intensity, then calmly refuses to proofread documents, perform errands, copy, or leave the office. The lawyer discovers that Bartleby lives there and alternates among pity, irritation, charity, and fear of public embarrassment. Unable to persuade or force him out, he moves his own firm, leaving Bartleby behind. The building's new occupants have the silent former scrivener arrested and sent to the Tombs. The lawyer visits and pays for better food, but Bartleby refuses to eat and dies in the prison yard. A later rumor says that he once worked with undeliverable mail in the Dead Letter Office. The narrator cannot verify that history or solve Bartleby's withdrawal, but it deepens his sense that the scrivener's fate reflects a wider human isolation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6090,7 +6090,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6103,7 +6103,7 @@
       "recaps": {
         "ending": "After the lawyer moves his practice to escape an impossible standoff, Bartleby remains in the old building and refuses either to leave or adopt another occupation. The new occupants eventually have him arrested as a vagrant and taken to the Tombs. The lawyer visits, pays a food contractor to look after him, and tries to reassure him, but Bartleby rejects food as he rejected work and movement. On a later visit the lawyer finds him dead in the prison yard. Some time afterward, the lawyer hears an unconfirmed report that Bartleby once worked in the Dead Letter Office, handling messages that could never reach their recipients. The rumor gives him a possible image for Bartleby's desolation but no complete explanation. He closes by linking grief for this solitary man with grief for humanity more broadly.",
         "in_short": "A cautious Wall Street lawyer hires Bartleby as a copyist. Bartleby initially works with remarkable intensity, then calmly refuses to proofread documents, perform errands, copy, or leave the office. The lawyer discovers that Bartleby lives there and alternates among pity, irritation, charity, and fear of public embarrassment. Unable to persuade or force him out, he moves his own firm, leaving Bartleby behind. The building's new occupants have the silent former scrivener arrested and sent to the Tombs. The lawyer visits and pays for better food, but Bartleby refuses to eat and dies in the prison yard. A later rumor says that he once worked with undeliverable mail in the Dead Letter Office. The narrator cannot verify that history or solve Bartleby's withdrawal, but it deepens his sense that the scrivener's fate reflects a wider human isolation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6217,7 +6217,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6230,7 +6230,7 @@
       "recaps": {
         "ending": "The collection closes with The Bell-Tower. Bannadonna secretly builds a mechanical figure to strike the great bell at the appointed hour. When the tower is opened for its public unveiling, officials find the inventor dead beside his creation: absorbed in his final preparations, he failed to move clear of the automaton's blow. The project that was meant to establish mastery over art, labor, and time instead kills its maker. The bell is later destroyed and the tower falls, completing the ruin of Bannadonna's monument. The preceding stories end with similar reversals: Bartleby dies in prison after refusing food, while the lawyer is left with only a rumor about his past; the lightning-rod salesman is driven away when the householder refuses to let manufactured terror govern him.",
         "in_short": "Three stories examine isolation, fear, and destructive certainty. In Bartleby the Scrivener, a Wall Street lawyer hires a copyist who gradually refuses all work and will not leave the office. The lawyer alternates between accommodation and escape, but Bartleby is eventually removed to prison and dies after declining food; a rumor that he once handled undeliverable letters offers only a possible explanation. In The Lightning-Rod Man, a salesman visits during a storm and tries to frighten a householder into buying his protection, but the householder rejects his claims and expels him. In The Bell-Tower, the proud inventor Bannadonna builds a magnificent tower, bell, and automated striker. His machine kills him before the unveiling, and the monument subsequently collapses.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/bastion.json
+++ b/data/works-community/0/bastion.json
@@ -274,7 +274,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -287,7 +287,7 @@
       "recaps": {
         "ending": "Scorio passes his second trial during the final gauntlet, becomes a Tomb Spark, and advances slightly farther than Jova Spike. The Academy declares him the winner, but he refuses further training and every House offer. Jova honors their wager, rejects Praximar's attempt to give her the victory, and shares a journal entry written by Scorio's incarnation 233 years earlier. The message warns against the Houses, Imperators, and herdsmen, says the cycle can be broken only by attaining a named ultimate role, and insists that Scorio will need allies. Jova agrees to help investigate. Naomi, Leonis, Lianshi, Juniper, and Zala also join Scorio, creating a seven-person fellowship. Helena and Feiyan have contacted Manticore to assist their escape, and the group plans to meet at the Western Gates before heading toward the Rascor Plains. Praximar remains hostile, Scorio's heart is still fractured, Imogen remains at large, and Bastion is politically unstable amid organized resistance to Great Soul rule.",
         "in_short": "Scorio awakens without memories, survives a lethal rebirth gauntlet, and is condemned by Bastion's Academy for crimes from forgotten lives. After escaping the Warrens, he trains under Naomi, reunites with Leonis and Lianshi, and forces his way back into the Academy. His dangerous pursuit of advancement fractures his heart, while Imogen's attack exposes Bastion's weakness and deepens public unrest. Scorio rejects Praximar's blackmail and House Camara's support, then uses Nox's imperial gel and Naomi's mana to become an Emberling. He enters the final gauntlet with Naomi, Leonis, and Lianshi, reaches Tomb Spark after they fall, and narrowly surpasses Jova Spike to win. Scorio and Jova reject the Academy and Houses. A journal from Scorio's former self warns them not to trust the institutions governing the cycle. They join Naomi, Leonis, Lianshi, Juniper, and Zala in planning to leave Bastion for the Rascor Plains and investigate the truth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -486,7 +486,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -497,7 +497,7 @@
       "recaps": {
         "ending": "Chicago stands, at a terrible price. Ethniu is not killed - she is bound: battered by the combined assault of Mab, the Erlking, Vadderung, River Shoulders, Lara, Marcone, and Harry's friends, the Titan is dragged down at the lakeshore and imprisoned in Demonreach's crystal cells by the island's power, with Harry as her jailer. The Fomor host is shattered and the city saved, but tens of thousands are dead, the skyline is broken, and the mortal world can no longer entirely pretend: the masquerade is cracked, with officialdom papering over what millions glimpsed. Karrin Murphy is dead - killed not by the enemy but by Rudolph's panicked, negligent gunshot - and only Butters, invoking who Murphy was, stopped Harry from murdering Rudolph on the spot; Harry is later given reason to believe her spirit has gone on to a warrior's reward. John Marcone stands revealed as host of the fallen angel Thorned Namshiel, a Denarian with a baron's army and a decade of preparation. The White Council formally expels Harry, leaving him Winter's creature in the world's eyes. The Thomas affair finally shows its roots: visiting the pregnant Justine, Harry realizes she has long been possessed by Nemesis - the adversary coerced Thomas into the Etri assassination - and the infected Justine escapes, carrying Thomas's child. And Mab, sealing Winter's new alliance, decrees that Harry will marry Lara Raith. Grieving, expelled, engaged against his will, and jailer to a Titan, Harry buries Murphy as the book ends.",
         "in_short": "Ethniu, the Last Titan, and King Corb's Fomor armies rise out of Lake Michigan to destroy Chicago in a single night. The Eye of Balor blacks out the city, and an alliance of everything Harry has ever befriended or bargained with - Winter's legions under Mab, Marcone's einherjar and Valkyries, the White Court, svartalves, Wardens, the Knights Sanya and Butters, River Shoulders' Forest People, and Chicago's own defenders - fights block by block against giants, kraken, and warrior-priests. Karrin Murphy, fighting despite her injuries, is killed by a panicked gunshot from Detective Rudolph; Butters barely stops Harry from murdering him. The allies bleed the Titan, Marcone is revealed as the host of the fallen angel Thorned Namshiel, and at the lakeshore the assembled powers batter Ethniu until Harry can bind her into Demonreach's prison. Chicago survives, half-broken, with the supernatural half-exposed to the world. In the aftermath the White Council expels Harry; he learns Justine has long been possessed by Nemesis - the true hand behind Thomas's crime - and she escapes; and Mab decrees Harry's engagement to Lara Raith. The book ends at Murphy's funeral.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -678,7 +678,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -691,7 +691,7 @@
       "recaps": {
         "ending": "Maya's accusation divides Beartown between the truth of what Kevin did and the town's desire to protect its hockey team. Amat eventually states that he saw Maya and Kevin after the assault, supporting her account despite threats and the loss of his place among teammates. The case does not deliver the clean public justice Maya's family hoped for, and Kevin's family prepares to leave. Maya confronts Kevin in the woods with a gun, makes him believe he will die, and then reveals that it was not loaded; she leaves him alive but no longer untouched by fear. Peter survives an effort to remove him from the club when unexpected members back his leadership. The junior team's old unity is broken. David pursues his career elsewhere, while Sune and Peter begin imagining a team built around Amat and players whom the old hierarchy dismissed. Benji refuses the demand that loyalty to Kevin require denial of Maya's suffering and steps away from the life the team prescribed. The town remains damaged and divided, but acts of testimony and solidarity create the possibility of a different hockey culture and a future not controlled by Kevin's talent.",
         "in_short": "Beartown, an isolated community in decline, invests its hopes in a gifted junior hockey team led by star player Kevin Erdahl. Club manager Peter Andersson, coach David, veteran Sune, and sponsors all understand victory as economic and emotional rescue. Amat, a poor and unusually fast younger player, is promoted for a crucial match and gains entry to the team's privileged circle. After a victory party, Kevin sexually assaults Peter's daughter Maya. Amat sees enough to corroborate her, but the club's dependence on Kevin turns the accusation into a test of communal loyalty. Maya and her family face disbelief and hostility; Peter's job is threatened, and Amat is intimidated into silence before finally telling the truth. Kevin avoids a decisive legal reckoning and leaves town, but the team and its myths fracture. Maya confronts him with an unloaded gun so he experiences fear without being killed. Peter retains support, and a new hockey future begins to form around Amat and players excluded by the old order.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -838,7 +838,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -851,7 +851,7 @@
       "recaps": {
         "ending": "Beauty realizes that the Beast's life is failing after she overstays her promised visit home. She returns to the castle, finds him near death, and admits that she loves him. Her choice breaks the enchantment: the Beast becomes the human prince he was before a sorcerous curse transformed him, and the castle and its household are restored with him. Beauty also discovers that the magic had prevented her from seeing herself clearly; she has grown into the beauty her family already recognized. The castle's influence has brought Robert Tucker safely back to Grace, resolving the loss that shadowed the family. Beauty marries the prince, while her father, sisters, Gervain, and Robert join the renewed life around the castle. The conclusion makes Beauty's freely given love, rather than compliance with a bargain or attraction to appearances, the act that ends the curse.",
         "in_short": "After a merchant loses his fortune, his three daughters begin a simpler life in the country. His youngest, Honour, has long been called Beauty despite considering herself plain; she works hard, loves horses, and refuses to let the family face hardship alone. Lost in an enchanted forest, her father shelters in a mysterious castle and plucks a rose, provoking its master, the Beast. Beauty voluntarily takes her father's place. At the castle she finds courtesy, books, invisible servants, and a Beast who asks her to marry him each night. Affection grows, but she repeatedly refuses. Allowed to visit home, Beauty delays until a magical vision shows the Beast dying. She rushes back and declares her love, breaking the curse that made him a beast. He is restored as a prince, Beauty recognizes her own maturity and beauty, and the castle's magic reunites her sister Grace with her missing fiancé. Beauty and the prince marry with both families restored around them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1017,7 +1017,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1030,7 +1030,7 @@
       "recaps": {
         "ending": "A thunderstorm breaks up Opal and Gloria's party, and Winn-Dixie disappears. Opal and the Preacher search through Naomi in the rain. Opal accuses her father of giving up on both the dog and her mother; the Preacher finally admits that he tried to keep her mother from leaving and still grieves for her. Their shared honesty brings them closer. Returning to Gloria's house, they discover that Winn-Dixie had hidden under a bed because of his terror of storms and had been safe there all along. The guests regroup indoors, Otis plays his guitar, and everyone sings together. Opal privately names ten things she knows about Winn-Dixie, echoing the list her father gave her about her mother. She accepts that her mother is not coming back, recognizes the friends the dog helped her find, and tells Winn-Dixie that she will always love him. The Dewberry boys are included in the gathering, and Opal begins a more hopeful friendship with Dunlap.",
         "in_short": "Ten-year-old India Opal Buloni, lonely after moving to Naomi, Florida, adopts a stray dog she names Winn-Dixie. His friendliness draws her toward a circle of people carrying private sorrows: librarian Miss Franny Block, nearly blind Gloria Dump, quiet pet-shop manager Otis, grieving Amanda Wilkinson, and others. Their stories teach Opal that sweetness and sadness often remain together, and she plans a party to unite them. When a storm interrupts the gathering and Winn-Dixie vanishes, Opal and her father search for him and finally confront their pain over the mother who abandoned them. Winn-Dixie is found hiding safely at Gloria's house. The party resumes indoors, with former strangers singing together. Opal accepts that her mother will probably not return and sees that, because of Winn-Dixie, she now has friends, a more honest relationship with her father, and a place in her new town.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1214,7 +1214,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1227,7 +1227,7 @@
       "recaps": {
         "ending": "Abyssinia's campaign collapses in the final conflict, and both she and Caisson die, ending the restored leader's attempt to build a future around her son and her claimed dynasty. Valkyrie obtains what she needs to replace the missing part of Alice's soul, and Alice is made whole. The cure does not bring Valkyrie peace: evidence about her family reveals that their bloodline descends from the Faceless Ones rather than from the Ancients as they had believed. Alice's remarks about a future confrontation identify her as the potential Child of the Faceless Ones and leave that destiny unresolved. Sebastian Tao and the Darquesse Society complete their own mission and bring Darquesse back into the world, believing she will be needed against what is coming. China remains under political pressure in Roarhaven, Crepuscular Vies continues manipulating President Flanery, and Valkyrie moves forward with Skulduggery and Militsa while still relying on unhealthy ways of containing her trauma.",
         "in_short": "Valkyrie searches for a way to restore the missing part of Alice's soul while she and Skulduggery confront Abyssinia's growing campaign. The search leads through the institution where Caisson was held and into buried secrets about souls, family lines, and the older sorcerers who shaped Abyssinia's life. Roarhaven faces political and religious pressure as China Sorrows and Damocles Creed compete for influence, while Crepuscular Vies quietly guides President Flanery. Abyssinia gathers Caisson into her plans, but their bid for power ends with both mother and son dead. Valkyrie succeeds in making Alice's soul whole, only to learn that her family descends from the Faceless Ones, not the Ancients; Alice may be the prophesied Child of the Faceless Ones. Separately, Sebastian Tao's society succeeds in bringing Darquesse back. The immediate family crisis is repaired, but Darquesse's return, Alice's future, and the struggle for control of Roarhaven remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1379,7 +1379,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1392,7 +1392,7 @@
       "recaps": {
         "ending": "On the seventh version of Cupid Day, Sam understands that escape is not the point; she has been given repeated chances to see her life clearly and choose what she leaves behind. She spends the day expressing love, gratitude, and forgiveness, and she makes peace with Lindsay while recognizing the fear beneath her friend's cruelty. At Kent's party she tells him how much he matters and then follows Juliet. When Juliet runs into the road, Sam pushes her clear of the approaching vehicle and is struck instead. Sam dies, but this final death differs from the first crash because it is a deliberate act that saves another person. In her last awareness, the day's memories gather around her and she understands that her life is measured by the moments of connection she created. Juliet survives and thanks her, while Sam accepts the end she has chosen.",
         "in_short": "Popular high-school senior Samantha Kingston dies in a car crash after a Cupid Day party, then wakes to discover that the same date has begun again. Trapped through seven versions of the day, she first tries to avoid the collision, then tests whether actions have consequences, withdrawing, lashing out, and chasing experiences she once thought important. The repetitions show her how casually she and her friends hurt other students, especially the isolated Juliet Sykes, and how little satisfaction she finds in her boyfriend Rob or in popularity itself. Sam reconnects with her family, recognizes Kent McElroy's genuine care, and learns that Lindsay's persecution of Juliet grew from an old humiliation and lie. She eventually realizes that Juliet's attempted suicide is the event she must change. On the final day Sam says meaningful goodbyes, follows Juliet from the party, and pushes her out of an oncoming vehicle's path. Sam dies in Juliet's place, accepting her death because her last choice saves a life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1608,7 +1608,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1621,7 +1621,7 @@
       "recaps": {
         "ending": "Marlowe goes ahead with the Eye at his exhibition of the American future, and the breach it opens is far worse than he promised: the dead come through in force and the King of Crows is strengthened by it. The Diviners put their gifts together and force the tear shut, but the night ends in disaster. Mabel Rose is killed, and Marlowe and the newspapers hand the blame for the deaths to the Diviners, naming them anarchists and murderers rather than admit what his machine did. Will finally tells the whole truth about Project Buffalo: that he, Sister Walker, Marlowe and the colleague he loved dosed pregnant women during the war to manufacture Diviners, that the young people around him are its children, and that the door they opened at Hopeful Harbor was never properly closed. Sister Walker's warnings are vindicated far too late. Theta's reckoning with Roy leaves her unable to pretend the fire is under control. Jericho's dependence on Marlowe's serum has become a hold Marlowe can pull. Sam is left with what he learned about his mother and no way to act on it. With the law, the press and Marlowe's money against them, the group scatters and runs, hunted, grieving, and carrying the knowledge that the King of Crows is raising the dead across the whole country and that stopping him will mean leaving New York behind.",
         "in_short": "New York, autumn 1927. Evie's radio fame is fading when a visit to the asylum on Ward's Island puts the Diviners in front of the restless dead, who are no longer only ghosts: they rise, they attack, and they are being called by the man in the stovepipe hat, the King of Crows. Following the dead back to their source, the group finally learns the whole of Project Buffalo, the wartime programme run by Will Fitzgerald, Sister Walker and Jake Marlowe that dosed pregnant women to manufacture Diviners and tore something open at the estate called Hopeful Harbor. The Diviners are its children. While Marlowe prepares to demonstrate the Eye, a machine that draws power through that same breach, Mabel is drawn into a radical circle, Theta's violent husband finds her, and Bill Johnson's own part in the programme comes out. At Marlowe's exhibition the Eye tears the breach wide open, the dead pour through, and the Diviners close it at terrible cost: Mabel is killed, Will confesses everything, and Marlowe pins the deaths on the Diviners, who scatter and go on the run as wanted criminals.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1798,7 +1798,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1809,7 +1809,7 @@
       "recaps": {
         "ending": "Before They Are Hanged ends with all three campaigns in ruins. Bayaz's company reaches the island at the edge of the World only to find the Seed beyond their reach; the quest that justified everything fails outright, and the magus's ruthless, ancient nature is now plain to those who travelled with him. Jezal returns disfigured and humbled, bound uneasily to Ferro. In the South, Dagoska falls to the Gurkish and Glokta escapes with his life, carrying the knowledge that the banking house Valint and Balk owns the Union's debts - and, through blackmail, owns him. In the North, Prince Ladisla's army has been destroyed; Collem West has survived only by joining the Dogman's crew, but at the cost of beating the prince to death after Ladisla tried to rape the woman Cathil, a killing he must now conceal. Rudd Threetrees is dead and the Dogman leads what remains of the old crew. Every party turns back toward Adua: the quest empty-handed, a city lost, a royal army wiped out, and a prince secretly murdered. The Union is weaker, its enemies bolder, and Bayaz's true purpose - and the price of it - still hidden as the final book opens.",
         "in_short": "The three roads opened at the end of the first book run to bitter ends. Bayaz leads Logen, Jezal, Ferro and the rest west across the ruined Old Empire to the edge of the World in search of the Seed, enduring pursuit and starvation; Jezal is humbled and scarred and grows closer to Ferro, but the quest fails and the weapon is never recovered, while the darker truth of the magus becomes harder to deny. In the South, Glokta struggles to hold Dagoska against the Gurkish with threats, bribes and Cosca's mercenaries, uncovers treachery within, and learns that a hidden banking house, Valint and Balk, secretly controls the Union and now controls him; Dagoska falls and he barely escapes. In the North, Prince Ladisla's army is annihilated, and West, cast into the wilderness with the Dogman's crew, beats the cowardly prince to death after Ladisla attacks a woman under their protection. Threetrees is killed and the Dogman becomes chief. Battered and empty-handed, all of them turn back toward Adua and a Union sliding toward collapse.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1918,7 +1918,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1931,7 +1931,7 @@
       "recaps": {
         "ending": "After Benjamin Rand's death, the powerful men attending his funeral discuss possible candidates for the next presidential ticket. Chauncey Gardiner, whose past cannot be found and whose public appearances have been interpreted as evidence of rare judgment, emerges as an attractive choice. None of them understands that he is Chance, an illiterate gardener with no political knowledge or documented history. Chance wanders away from the funeral gathering into the grounds. Coming to a pond, he steps onto the water and continues across it, testing the surface with his umbrella. The extraordinary closing image leaves him moving beyond the ordinary limits that everyone else assumes while the political world prepares to elevate the identity it invented for him.",
         "in_short": "Chance, an illiterate gardener who has never left his employer's Washington home, is abruptly evicted when the owner dies. After a car belonging to Elizabeth Eve Rand strikes him, his introduction as Chance the gardener is mistaken for the name Chauncey Gardiner. Eve and her dying financier husband, Benjamin Rand, assume he is a discreet businessman. Chance's literal remarks about gardens are treated as insight into the economy by Rand, the President, television audiences, and diplomats. Each new observer supplies the intelligence and background that Chance lacks, while the absence of any record of him makes him seem important and secretive. By Rand's funeral he is being discussed as a potential vice-presidential or presidential candidate. Unaware of the political design forming around him, Chance walks away and apparently crosses the surface of a pond without sinking.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2096,7 +2096,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2109,7 +2109,7 @@
       "recaps": {
         "ending": "Duroy exposes Madeleine with Laroche-Mathieu and uses the legally witnessed adultery to obtain a divorce, while the disgraced minister loses office. He then persuades Suzanne Walter to run away with him, making scandal the means of forcing her parents to accept their marriage. Madame Walter, who had become desperately attached to Duroy, cannot prevent her daughter from marrying him and attends the ceremony in anguish. At the grand church wedding, Duroy appears before Paris as Georges du Roy, wealthy, celebrated, and connected to the Walters' fortune. The crowd and the city's political future seem open to him, and he imagines a path toward public office. Yet his exchange with Clotilde de Marelle as he leaves the church shows that his old affair may continue even after this advantageous marriage. He finishes not morally transformed but triumphant: every friendship, romance, and public institution he has encountered has become material for his rise.",
         "in_short": "Penniless ex-soldier Georges Duroy enters Paris journalism through his former comrade Charles Forestier. Although unable to write well, he advances through appearance, nerve, and relationships: he begins an affair with Clotilde de Marelle, relies on Madeleine Forestier's political intelligence, and turns the newspaper world into a ladder. After Charles dies, Duroy marries Madeleine and adopts the grander name du Roy, but resents her independence. La Vie Française profits from colonial intrigue, while its owner Walter makes a fortune that Duroy envies. Duroy seduces Walter's wife, then shifts his ambition to their wealthy daughter Suzanne. He catches Madeleine with the minister Laroche-Mathieu, secures a divorce, and induces Suzanne to elope, forcing the Walters to approve their marriage. He ends the novel celebrated at a magnificent wedding, contemplating political power and renewing his private understanding with Clotilde. His success rests on manipulation rather than talent or loyalty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2303,7 +2303,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2316,7 +2316,7 @@
       "recaps": {
         "ending": "Government soldiers enter the residence through a tunnel and launch a sudden rescue. The long separation between captors and captives collapses back into the official categories of terrorists and hostages. The young guerrillas are killed, including César and Ishmael. Carmen is shot, and Hosokawa is also killed when he moves toward her rather than remaining safely apart. The surviving hostages are freed, but the private community created during the siege is destroyed. In the epilogue, Gen Watanabe and Roxane Coss marry in Italy. Messner attends and understands that their marriage is bound to the people they loved and lost: Gen mourns Carmen, and Roxane mourns Hosokawa. The union is real, but it also gives the survivors a way to carry grief that cannot be explained to the outside world. The siege ends with political force, while the relationships and changed selves it created continue beyond the house.",
         "in_short": "At a birthday party for Japanese executive Katsumi Hosokawa in an unnamed South American country, guerrillas seize the vice president's residence intending to kidnap the president, who is absent. They hold the international male guests and soprano Roxane Coss while releasing most others. A short crisis becomes a months-long siege. Translator Gen Watanabe connects people who share no language, Roxane's daily singing gives the household structure, and captors and hostages gradually form a community. Hosokawa and Roxane fall in love; Gen and the young guerrilla Carmen begin a secret relationship; Roxane trains César, another guerrilla with an exceptional voice. Negotiations stall while the government secretly tunnels toward the house. Soldiers finally storm it and kill the guerrillas. Carmen dies, and Hosokawa is shot when he goes to her. In the aftermath, Roxane and Gen marry in Italy, joining two survivors whose future remains shaped by their love for Hosokawa and Carmen and by the world they briefly shared inside the residence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2493,7 +2493,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2506,7 +2506,7 @@
       "recaps": {
         "ending": "Denver leaves 124 to seek help, work, and human contact, while Sethe gives all her attention and dwindling resources to Beloved. The women of the community gather outside the house to pray and sing. Their presence breaks Beloved's hold. When Edward Bodwin arrives to collect Denver for work, Sethe mistakes him for a returning captor and rushes at him with an ice pick; the women stop her, and Beloved disappears. Paul D later returns to find Sethe grieving and physically depleted. He tells her that she, not the lost child around whom she built her life, has value. Denver is moving into an independent future, and Beloved fades from communal memory, though the damage of slavery and the need to reckon with it remain.",
         "in_short": "In 1873, Sethe and her daughter Denver live in an Ohio house haunted by the baby Sethe killed eighteen years earlier when slave catchers found the family after their escape from Kentucky. Paul D, who knew Sethe at Sweet Home, arrives and attempts to build a future with her. A mysterious young woman calling herself Beloved then enters the household and appears to embody the dead child. Beloved draws out suppressed histories, seduces Paul D, and becomes the center of Sethe's life after Paul D learns the truth and leaves. As Sethe tries to make endless amends, Beloved consumes the household and Denver finally turns outward for help. Local women confront the haunting together, Beloved vanishes, and Paul D returns. Denver begins an independent life, while Sethe is left to understand that her own life is also worthy of care.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2699,7 +2699,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2712,7 +2712,7 @@
       "recaps": {
         "ending": "At Jerusalem, Judah sees that Jesus will not lead the armed national revolt he had expected. During the arrest, trial, and march to crucifixion, Judah recognizes the condemned teacher as the stranger who once gave him water when he was an enslaved boy. He offers help but cannot prevent the execution. Jesus's death and the accompanying darkness and earthquake convince Judah that the promised kingdom is spiritual rather than a restored military monarchy. Before the crucifixion, Jesus heals Miriam and Tirzah of leprosy, allowing the family to reunite openly. Balthasar dies with his long search fulfilled. Judah abandons his plans for war, embraces the new faith, and marries Esther. In later years they use the surviving Hur fortune to assist persecuted believers, carrying the consequences of Judah's transformed loyalty into the early Christian community.",
         "in_short": "Judah Ben-Hur, a Jewish nobleman of Jerusalem, is falsely condemned after an accident injures the Roman governor and his former friend Messala refuses to protect him. His mother and sister disappear into prison while Judah becomes a galley slave. He saves the Roman commander Quintus Arrius in battle, gains freedom and adoption, then returns east seeking his family and revenge. In Antioch he recovers the loyalty and fortune preserved by Simonides, befriends Esther, and defeats Messala in a dangerous chariot race. Back in Judea, Judah prepares followers for the political king he expects Jesus to become, while his mother and sister, released with leprosy, hide from him. Jesus heals them. At the crucifixion Judah recognizes that Jesus's kingdom is spiritual, abandons armed revolt, reunites with his family, marries Esther, and devotes his wealth to the early Christian movement.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2884,7 +2884,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2897,7 +2897,7 @@
       "recaps": {
         "ending": "As German control of northern Italy collapses, Pino can finally act openly against the regime whose uniform he has worn as cover. General Leyers attempts to escape the Allied advance, but Pino helps deliver him into American custody, ending their dangerous driver-and-commander relationship. Liberation does not bring a clean or joyful resolution. Anna, who worked in German surroundings and is mistaken for a collaborator, is seized and shot by Italian partisans before Pino can save her. Her death leaves him devastated just as Milan celebrates the end of occupation. Pino survives the war and is reunited with members of his family, but the losses and compromises of his hidden service cannot be publicly erased. Leyers lives beyond the immediate defeat, while Pino must continue without recognition equal to what he risked. The closing historical perspective presents his wartime actions as a largely unknown contribution: he helped refugees cross the Alps, passed German intelligence to the resistance, and endured being judged by the enemy uniform that enabled his espionage.",
         "in_short": "After Allied bombing and German occupation shatter his youth in Milan, Pino Lella is sent to a church refuge in the Alps. Trained by Father Re, he guides Jewish refugees over dangerous mountain routes into neutral Switzerland. At eighteen, his parents push him into German service as the least deadly option available. An injury leads to an assignment driving General Hans Leyers, a senior Nazi official in Italy. Pino secretly reports Leyers's movements and military information to the resistance while maintaining the appearance of a loyal German soldier. He also renews his bond with Anna Marta, who works within the general's household. As the German position collapses, Pino helps turn Leyers over to the Americans. Liberation brings tragedy when partisans mistake Anna for a collaborator and kill her. Pino survives with his family and his secret record of rescue and espionage, but victory cannot restore the people lost during the occupation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3016,7 +3016,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3029,7 +3029,7 @@
       "recaps": {
         "ending": "Once Benito Cereno leaps into Delano's departing boat, Babo follows with a dagger and the concealed revolt becomes visible. Delano's crew overpowers Babo and retakes the San Dominick. Cereno's later legal deposition explains that Babo led the enslaved captives in seizing the ship, killing their owner Alexandro Aranda and much of the Spanish crew, and forcing the survivors to perform a false story of illness and disorder while Delano was aboard. Aranda's skeleton had been mounted on the ship as a threat. Babo refuses to defend himself at trial and is executed; his head is displayed in the port. Cereno never recovers from the ordeal. He withdraws to a monastery and dies a few months after Babo, psychologically following the murdered Aranda even after legal safety has been restored.",
         "in_short": "American captain Amasa Delano finds the battered Spanish ship San Dominick drifting near an island and boards to help. Its captain, Benito Cereno, appears gravely ill and is constantly attended by an enslaved man named Babo. The ship's loose discipline, depleted Spanish crew, and unsettling incidents trouble Delano, but his racial prejudices keep him from imagining that the Africans aboard control the vessel. When Delano prepares to leave, Cereno suddenly jumps into his boat. Babo attacks, exposing the truth. Delano's men recapture the ship, and Cereno's deposition reveals that Babo organized a revolt, killed the captives' owner Alexandro Aranda, and forced Cereno and the surviving sailors to stage the appearance of ordinary command during Delano's visit. Babo is tried and executed. Cereno, unable to recover from what happened, enters a monastery and dies soon afterward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3114,7 +3114,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3127,7 +3127,7 @@
       "recaps": {
         "ending": "After the haircut, Bernice discovers that the daring gesture has not made her glamorous. The severe bob looks unflattering, the young men respond with embarrassment rather than admiration, and Mrs. Harvey worries about the offense to Bernice's conservative mother. Bernice agrees to leave on an early train. Before going, she quietly enters the sleeping Marjorie's room, cuts off her cousin's two braids, and takes them with her. As she heads toward the station, she throws the braids onto Warren's porch and leaves town delighted by her private revenge. Marjorie has won their social contest, but Bernice's final act shows that she has acquired a capacity for boldness that her cousin did not anticipate.",
         "in_short": "During a summer visit, shy Bernice learns that her popular cousin Marjorie considers her a burden at dances. Marjorie teaches her to attract attention through teasing conversation and the appearance of daring. Bernice becomes popular, especially after repeatedly suggesting that she might bob her hair, and Warren McIntyre begins preferring her company to Marjorie's. Jealous, Marjorie publicly challenges Bernice to prove that her claim is genuine. Bernice goes through with the haircut, only to find that it looks bad and shocks her aunt. Ordered home early, she takes revenge before leaving by cutting off Marjorie's braids and tossing them onto Warren's porch.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3308,7 +3308,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3321,7 +3321,7 @@
       "recaps": {
         "ending": "At Trofimovsk, the prisoners face polar darkness with almost no food, medicine, or adequate shelter. Scurvy and other illnesses spread. Elena, already weakened by labor, hunger, and grief, dies despite Lina's care. Jonas also becomes gravely ill, and Lina continues drawing and writing even when she is close to collapse. Dr. Samodurov arrives at the settlement and confronts the neglect there, bringing medical knowledge and supplies that save many of those still alive, including Lina and Jonas. The closing frame moves to Lithuania in 1995, where workers uncover papers Lina buried in a jar decades earlier. Her written account explains that she and Jonas survived and eventually returned home, while the preservation of her drawings fulfills her determination to leave a record of the deportees. It also confirms that Andrius survived; the bond formed between him and Lina was not erased by their forced separation. The discovered testimony turns the family's private struggle into evidence of the wider Soviet persecution of Lithuania.",
         "in_short": "In 1941, Soviet officers remove fifteen-year-old Lithuanian artist Lina Vilkas, her mother Elena, and her young brother Jonas from their home. Lina's father has already vanished into the prison system. Packed into a cattle car with other deportees, the family crosses the Soviet Union and is put to forced labor in the Altai region. Lina secretly records the journey through drawings and grows close to fellow prisoner Andrius Arvydas. After months of hunger, coercion, and hard labor, Lina learns that her father has been killed. She, Elena, and Jonas are then sent still farther north to Trofimovsk above the Arctic Circle, while Andrius remains behind. The prisoners build shelters from scraps and endure a lethal winter. Elena dies, and Lina and Jonas nearly follow her, but the arrival of Dr. Samodurov brings treatment that keeps them alive. A 1995 frame reveals Lina's buried writings and confirms that she, Jonas, and Andrius survived, preserving testimony that the Soviet authorities tried to silence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3705,7 +3705,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -3718,7 +3718,7 @@
       "recaps": {
         "ending": "Fa Ram begins its expanded harvest with Jin and the pregnant Meiling remaining at its center. Bi De has returned with Yin, Miantiao, and a damaged crystal that preserves fragments of an ancient land-empowering formation and its catastrophe. Jin supports a careful investigation, Cai Xiulan plans to seek relevant material in her sect library, and Miantiao accepts useful work and treatment at Fa Ram, although his spinal injuries remain. Tigu is healthy in human form but has found no way to become a cat again. Wa Shi can shift into a dragonlike form, and the rest of the household has gained new infrastructure, responsibilities, and family ties. Cai Xiulan, now in the Profound Realm, departs for the Dueling Peaks tournament with Tigu, Gou Ren, Ri Zu, and Yun Ren. Lu Ri's network has traced Jin Jue to Verdant Hill without confirming Jin's identity, while Lu Ban commands Fangtip Fortress from Zang Li's stolen body and retains a hidden cultivation scroll. The ancient wound in the Azure Hills and the attention gathering around Jin therefore remain unresolved.",
         "in_short": "Newly married, Jin and Meiling expand Fa Ram while Cai Xiulan struggles with guilt from the battle against Sun Ken. The household's care helps her recover and reach the Profound Realm. Bi De leaves to study scattered shrines, gains Yin and Miantiao as companions, and discovers that the Azure Hills contain a broken five-element formation. Wa Shi returns from hidden training able to take a dragonlike form, while Tigu survives a tribulation and becomes human. Meiling learns she is pregnant, heals a contamination crisis in Verdant Hill, and returns home. Lu Ri's search for Jin Jue reaches the region without exposing Jin, while Lu Ban remains concealed in Zang Li's stolen body. Bi De brings an ancient damaged crystal back to Fa Ram, and Jin agrees to help investigate it. At harvest, Cai Xiulan leads Tigu, Gou Ren, Ri Zu, and Yun Ren away toward the Dueling Peaks tournament, leaving Jin and Meiling with the growing household.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4082,7 +4082,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -4095,7 +4095,7 @@
       "recaps": {
         "ending": "The Shrouded Mountain assault is settled through reparations, rebuilding, and withdrawal rather than further retaliation. Lu Ban is confirmed dead, though an unidentified infiltrator preserves a trace of his grudge for possible future harm. Cai Xiulan's internal injury is healed, but her cultivation remains reduced and she chooses to rebuild on gentler terms. Tigu accepts both her human and tiger forms, and her bonds with Ri Zu, Loud Boy, Rags, and the Hermetic Iron young master widen Fa Ram's circle. Loud Boy and Rags leave to seek restoration of his cultivation, while Liu Bowu travels to Fa Ram for treatment. Jin refuses a return to the Cloudy Sword Sect but retains Gramps' letter, gift, and favor. He and Meiling await their child and accept that Fa Ram is now known to powerful outsiders. The ancient recording, the earth spirit's damaged past, the politically sensitive Dueling Peaks archive, and a possible southern trading expedition remain open. Liu Xianghua formally asks Gou Ren's parents for permission to court him.",
         "in_short": "Jin takes Fa Ram's extraordinary harvest to market while Tigu, Cai Xiulan, and their companions attend the Dueling Peaks tournament. The journey uncovers Jin's commercial importance, a message from Gramps, and an ancient crystal record linked to broken formations. Cai Xiulan wins the tournament over Tigu, but Lu Ban and the Shrouded Mountain Sect abduct Tigu and attack her allies. The Azure Hills cultivators unite in resistance, Jin defeats Lu Ban, and he prevents a wider war by demanding compensation and reconstruction. Cai Xiulan survives severe cultivation damage and receives further healing from Fa Ram's earth spirit. The household returns home intact but newly exposed to provincial politics. Jin refuses to rejoin the Cloudy Sword Sect, Tigu forms new friendships, and Liu Xianghua begins openly courting Gou Ren. Lu Ban is dead, yet an unknown woman retains a residue of his grudge, while the ancient formation, the Dueling Peaks archive, and Fa Ram's broader responsibilities remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/beware-of-chicken-4-a-xianxia-cultivation-novel.json
+++ b/data/works-community/0/beware-of-chicken-4-a-xianxia-cultivation-novel.json
@@ -314,7 +314,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -327,7 +327,7 @@
       "recaps": {
         "ending": "Fa Ram enters spring intact after the devil storm, with Jin and Meiling raising their healthy but formally unnamed son, nicknamed Little D. Their household continues its farming, medicine, machinery, glassmaking, mining, and greenhouse work. Liu Bowu is fully mobile, Gou Ren and Liu Xianghua remain together without settled marriage plans, and Bi De intends to travel while continuing to defend the farm.\n\nTianlan awakens with much of her body restored and a domain extending across Hong Yaowu toward Verdant Hill. She learns that the ancient farmer-emperor broke the corrupted formation to save her, not to betray her, and begins recovering with the household's shared chi. Bi De remains the crystal spirit's preferred heir but has rejected one-person rule in favor of teaching several caretakers.\n\nThe empire has defeated the exposed demon force at severe cost, although surviving infiltration and future attacks remain possible. The Cloudy Sword Sect has renewed imperial service, Lu Ri keeps peaceful contact with Jin, and Jin's wounded grandfather plans to visit. The southern trade expedition, Shrouded Mountain scrutiny, Tianlan's ancient injuries, and the unidentified snow-guardian crystal remain open.",
         "in_short": "Jin expands Fa Ram while preparing for the political consequences of the Dueling Peaks conflict. Meiling restores Liu Bowu's leg, Jin learns politics and a less destructive approach to combat, and the household strengthens its ties to Hong Yaowu and Verdant Hill. An ancient crystal shows Bi De how a farmer bonded with the earth spirit Tianlan, overthrew a tyrant, and became emperor before demonic sabotage shattered the Azure Hills. Bi De refuses to inherit solitary rule and instead seeks shared stewardship. As an imperial force narrowly defeats a major demon incursion, Meiling safely gives birth to a son. After a severe winter storm, Tianlan wakes substantially healed by Fa Ram's freely given labor and chi. A recovered recording proves that the ruler she remembered as a betrayer destroyed the fatal formation to save her. She grieves, joins the household, and begins moving forward, while demons, ancient damage, and Fa Ram's growing public importance remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -731,7 +731,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -744,7 +744,7 @@
       "recaps": {
         "ending": "Jin and Shen Yu end their dispute with a durable understanding. Jin will remain bound to Tianlan and will not trade his chosen life for ordinary ascension, while Shen Yu accepts both his decision and the family he has created. Jin stays at Fa Ram with Meiling, their son, Tianlan, Gou Ren, Liu Bowu, Miantiao, Chun Ke, and other residents. They begin enlarging the farmstead so that it can support future generations and welcome the travelers home.\n\nCai Xiulan's oath-bound fellowship leaves to reconnect the sects of the Azure Hills with their duty to protect the region. Yin travels in a stable human form while seeking her own purpose. Shen Yu leads Bi De, Ri Zu, Yun Ren, and Yun Ren's white fox companion north to investigate demons. Lu Ri departs to report to the Cloudy Sword Sect and acquire better warding materials.\n\nThe memory crystal is being copied rather than monopolized, and Jin knowingly accepts the foundational contract joining his restored soul to Tianlan. Several threats remain active. Vajra's growing hive watches for black-lance creatures, a Shrouded Mountain elder sends a covert party toward the Azure Hills, and a demonic commander tracks the investigator destroying his hidden bases.",
         "in_short": "During the third spring at Fa Ram, Jin's grandfather Shen Yu arrives expecting Jin to resume a conventional cultivator's path. Their confrontation instead confirms Jin's commitment to his family, his farm, and his bond with the injured earth spirit Tianlan. Shen Yu accepts that choice, recognizes Jin's awakened animals as family, and takes Bi De as a disciple. An ancient memory crystal reveals how demons devastated the Azure Hills, leading Cai Xiulan to share its knowledge and form a cross-sect fellowship. She, Tigu, Liu Xianghua, Yin, Zheng Fei, Loud Boy, Rags, and the Hermetic Iron Sect young master depart to protect and reunite the region. Shen Yu, Bi De, Ri Zu, Yun Ren, and a white fox leave separately to investigate northern demons. Jin remains with Meiling and the others to expand Fa Ram into a lasting home. The close introduces converging dangers: black-lance creatures still probe the farm, Shrouded Mountain agents head toward the Azure Hills, and a demonic commander begins hunting an investigator who destroyed one of his facilities.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1104,7 +1104,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -1117,7 +1117,7 @@
       "recaps": {
         "ending": "Jin and Meiling complete their marriage at Fa Ram and begin spring together. Meiling awakens usable chi and discovers that the living land responds to her as it does to Jin. Bi De, Chun Ke, Pi Pa, Ri Zu, Tigu, and Wa Shi remain by choice as the household's animal students and defenders. Yun Ren and Gou Ren have also awakened chi without abandoning family or work, and Gou Ren plans to spend the summer at the farm. Cai Xiulan preserves Fa Ram's secrecy, still owes Jin and Meiling a life debt, and receives permission to stay temporarily as a learner. Chow Ji and Sun Ken are dead, with Cai Xiulan publicly credited for Sun Ken's defeat. Luban and a confined Shrouded Mountain disciple remain unresolved dangers, while the vast solstice fire formation remains unexplained. Beneath these human concerns, Fa Ram's long-injured land spirit has recovered enough to become self-aware. It trusts Jin and Meiling and begins exploring its domain in a joyful but incomplete new form.",
         "in_short": "An outsider awakens in the dying body of Jin Jue and rejects sect life, settling as Jin on a farm he names Fa Ram. His practical use of chi makes the land flourish and awakens several animals, led by the rooster Bi De. Jin becomes part of Hong Yaowu and falls in love with its healer, Meiling. The household survives Chow Ji's attempt to corrupt Bi De and Sun Ken's raid, while Jin accepts the animals as free students and protectors. Meiling and Jin save Cai Xiulan, who conceals Fa Ram's power and accepts public credit for Sun Ken's death. The Song brothers awaken chi but retain their ordinary commitments. Jin and Meiling marry at Fa Ram, where Meiling gains chi and a bond with the land. The closing revelation is that Jin's care has healed the farm's ancient wounded spirit enough for it to awaken as a weak, benevolent consciousness linked to the couple.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1249,7 +1249,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1262,7 +1262,7 @@
       "recaps": {
         "ending": "Ashamed of the secret engagement he has accepted, Anton denies it when fellow officers confront him. The denial reaches Edith and confirms her fear that his devotion was pity rather than love. Anton recognizes the damage almost immediately and confesses to his colonel, who treats the matter seriously but helps arrange a transfer and an attempt to correct the lie. History intervenes: the assassination at Sarajevo and military mobilization disrupt communications and carry Anton away before he can repair what he has done. Edith throws herself from the tower of her father's home and dies from the fall. War gives Anton a socially honored form of escape. He fights with conspicuous courage and receives decorations, yet understands that bravery in battle cannot cancel the cowardice that harmed Edith. Years later he sees Doctor Condor with his blind wife at a public performance. Afraid that the doctor will recognize and judge him, Anton withdraws. He remains haunted by the knowledge that guilt can survive both public honor and the passage of time.",
         "in_short": "In 1913, young cavalry officer Anton Hofmiller accidentally asks Edith von Kekesfalva to dance, not knowing that she is paralyzed. Mortified, he sends flowers and begins visiting her wealthy father's estate. His wish to ease embarrassment becomes a habit of pity that Edith, isolated and desperate for ordinary life, interprets as love. Doctor Condor warns Anton that sentimental sympathy without responsibility can be dangerous, but Anton continues offering reassurance and allows hope of a possible treatment to become certainty. When Edith declares her love, he cannot honestly return it yet cannot bear to hurt her. Pressured by her distress and her father's pleading, he accepts a secret engagement. He then denies it before fellow officers out of shame. Before he can retract the denial, wartime mobilization interrupts communication; Edith learns of it and kills herself. Anton serves bravely in the First World War and is decorated, but public courage never frees him from guilt over the moral cowardice of his conduct toward her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1648,7 +1648,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09L5BBJ6X",
@@ -1660,7 +1660,7 @@
       "recaps": {
         "ending": "Elaine survives the disaster above Nolgrad but is stranded in an abandoned mine with four dwarves, no known route out, an amputated arm, damaged armor, and much of her equipment gone. Lula died protecting her, and the dwarf who opened the escape route is missing. Hunting had already left to seek a stronger human party, while delayed reports lead Julius to record Elaine as Missing in Action, Presumed Alive. The Formorian queens and organized hive threat are gone, but Arthur's persistent poison remains dangerous, a managed frontier settlement is still proposed, and Remus faces a likely coup that the Sentinels and Ranger Command will not enter. Contact with Nolgrad and the discovery that Remus lies inside an experience-suppressing dead zone remain unresolved. In the closing shift, Iona destroys Alfie's pirate operation and its former captives escape. She reaches Julie d’Audrey, who chooses to remain at the Abbey while reaffirming their relationship. Iona must still decide whether to aid the oath-bound healer in the Great Tang, return to the depleted Valkyries, or seek a companion. Alfie's shark also remains loose in the sea.",
         "in_short": "A Formorian breach sends Elaine and the Sentinels into a desperate campaign against the queens. Divine aid, poison, an earthquake, and mass healing secure victory, but Priest Deimos, Catastrophe, Sentinel Sky, and the barrier specialist die, while Magic remains missing. Elaine becomes the Dawn Sentinel, then joins the grieving Hunting to verify the hives are finished. Their expedition discovers that Remus lies inside an experience-suppressing dead zone and makes first contact with Nolgrad. After Hunting leaves for reinforcements, Elaine travels toward the dwarf capital, only for a dragon and several Guardians to devastate the region. Lula dies protecting her, Elaine amputates a burning arm, and she ends trapped in a mine with four dwarves while Remus lists her Missing in Action, Presumed Alive. The final chapters follow Iona, who destroys Alfie's pirate base, frees its captives, and visits Julie d’Audrey. Julie remains at the Abbey, while Iona leaves to choose among the Valkyries, a threatened healer, and finding a companion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1813,7 +1813,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1826,7 +1826,7 @@
       "recaps": {
         "ending": "The death withheld all along is Perry Wright's, and the truth of his life is the book's real revelation. Behind his charming public image, Perry has for years been violently abusing his wife Celeste, who has kept it hidden even as she plans to leave him. Separately, the man who raped Jane years before, whom she knew only by a false name, is revealed to be Perry, meaning he is the biological father of her son Ziggy. These threads converge at the school's Trivia Night. When Jane recognizes Perry and Celeste's situation comes to a head, Perry attacks Celeste in front of Madeline, Jane, and Renata. Bonnie, Nathan's wife, who as a child watched her father abuse her mother, is triggered by the sight and pushes Perry hard; he falls down the stairs and is killed. The women present agree to tell the police that Perry tripped and fell accidentally, and their united account largely holds, though Bonnie eventually admits to the police what she did and receives a light sentence of community service. In the aftermath the friendships endure, Celeste and her sons begin a safer life, Jane finds peace and a new relationship, and the community's polished surface is shown to have hidden real violence all along.",
         "in_short": "In the seaside town of Pirriwee, three mothers whose children are starting kindergarten, spirited Madeline, beautiful Celeste, and shy newcomer Jane, become close friends while a schoolyard feud over an alleged bullying incident divides the parents. The book is framed by police-interview fragments confirming that someone will die at the school's fundraising Trivia Night, but withholds who is killed and who kills. Beneath the comic social drama run darker currents: Celeste's marriage to her charming husband Perry conceals his ongoing physical abuse of her, and Jane is a survivor of a rape years earlier whose attacker fathered her son. At Trivia Night these secrets collide when Jane realizes that Perry is the man who assaulted her, and that he is her son's biological father. When Perry turns violent on Celeste in front of the others, the women intervene, and Bonnie, whose own childhood was scarred by watching her father beat her mother, shoves Perry away; he falls down a flight of stairs and dies. The women agree to tell the police it was an accident, closing ranks to protect one another.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1943,7 +1943,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1956,7 +1956,7 @@
       "recaps": {
         "ending": "Jack's attempted refuge has become the setting for a severe alcoholic and psychological collapse. At the cabin with Billie and Elliott, he is unable to keep the commitments he has made or to control his fear, jealousy, and confusion. Ordinary events and remembered images take on threatening meanings, and the sound of the Pacific seems to speak of suffering and death. His friends recognize that he needs help and get him away from the canyon. As the crisis begins to pass, Jack experiences a moment of exhausted clarity: the terrors he has been reading into the world come from his own distressed mind, while the natural scene remains indifferent and complete. He leaves Big Sur physically depleted and without a simple cure for his alcoholism or fame. The closing vision offers temporary acceptance rather than a repaired life, and the appended sea poem turns the coast's sounds into a final record of the mind that confronted them.",
         "in_short": "Overwhelmed by literary fame, constant visitors, and alcoholism, writer Jack Duluoz borrows Lorenzo Monsanto's isolated cabin at Big Sur. He hopes solitude will restore him, but the difficult journey, darkness, ocean noise, and withdrawal expose his anxiety. He returns to San Francisco and resumes drinking with old friends, including Cody Pomeray, before making further trips to the coast. Jack begins a relationship with Billie, who expects him to marry her and care for her son Elliott, yet he becomes jealous, evasive, and increasingly ill. At the cabin his sleeplessness and heavy drinking develop into paranoia and delirium; memories, nature, and his friends' actions appear charged with death. The group gets him back from the canyon. Jack's final insight is not a lasting recovery but a brief recognition that his mind has created much of the surrounding horror. He leaves exhausted, with the sea and landscape continuing beyond his crisis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2036,7 +2036,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2049,7 +2049,7 @@
       "recaps": {
         "ending": "Nick fishes downstream until the river approaches a dark, swampy stretch where the water is deep and the banks make landing a fish difficult. He imagines the strain and uncertainty of fishing there and decides he does not need to enter it today. Instead, he cleans his trout, keeps them cool in a sack, and prepares to return to camp. The swamp is not conquered or permanently rejected; Nick tells himself that there will be many later days when he can fish it. The story closes on that postponement, with his carefully managed day having brought effort and satisfaction without forcing him beyond the limits he has chosen.",
         "in_short": "Nick Adams steps off a train at Seney to find the town burned away, then walks beyond the damaged landscape into living country beside the Big Two-Hearted River. Alone, he makes camp with deliberate care, cooks, remembers an old companion, and sleeps. The next morning he prepares bait and tackle and wades into the cold river. He loses one large trout, lands two others, and moves downstream through increasingly difficult water. When he reaches the edge of a deep, shadowed swamp, he decides not to fish it yet. He cleans his catch and turns back with the knowledge that he can return on another day.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2185,7 +2185,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2198,7 +2198,7 @@
       "recaps": {
         "ending": "A drumhead court accepts that Billy did not intend treason or Claggart's death, but Captain Vere insists that wartime naval law judges the fatal act rather than his innocent motive. Billy is condemned and hanged at dawn. His final blessing of Vere is echoed by the assembled crew, and his body is committed to the sea. Vere later dies from wounds received in action, speaking Billy's name. The public record does not preserve the moral truth of the case: a naval report reverses the characters, describing Claggart as a loyal officer killed by a dangerous mutineer. Sailors preserve a different memory, treating the spar from Billy's execution as a relic and composing a ballad that imagines his last hours. Billy becomes a legend of innocence destroyed by the institution he served.",
         "in_short": "Billy Budd, a handsome and openhearted young sailor, is impressed from a merchant ship into the Royal Navy during a period of anxiety about mutiny. He wins the Bellipotent's crew but attracts the hidden hatred of master-at-arms John Claggart. After a suspicious sailor tries to draw Billy into a secret scheme, Claggart falsely accuses him of planning mutiny. Captain Vere confronts accuser and accused in his cabin. Unable to speak under stress, Billy strikes Claggart once and kills him. Vere convenes a drumhead court and argues that, regardless of Billy's innocence and lack of intent, wartime discipline requires death for killing a superior. Billy is hanged after blessing Vere. Vere later dies in battle, while an official report falsely casts Billy as a mutineer. The sailors' ballad preserves a more sympathetic memory of him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2344,7 +2344,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2357,7 +2357,7 @@
       "recaps": {
         "ending": "A drumhead court convicts Billy of striking and killing a superior officer, despite accepting that he acted without murderous intent and had been falsely accused. Vere presses the officers to apply wartime naval law, and Billy is sentenced to hang at dawn. Before the crew, Billy blesses Captain Vere rather than condemning him, and the sailors echo the blessing. His body shows none of the expected convulsion when he dies, and he is buried at sea. Vere is later wounded in battle and dies after murmuring Billy's name. An authorized newspaper account reverses the moral facts, presenting Claggart as a loyal official murdered by a dangerous mutineer. Among sailors, however, Billy becomes a revered figure; a foretopman composes a ballad imagining his final hours, and a piece of the spar associated with his execution is kept like a relic.",
         "in_short": "During the wars with revolutionary France, the Royal Navy impresses the innocent and well-liked Billy Budd from a merchant ship into service aboard the Bellipotent. Billy thrives among the sailors, but master-at-arms John Claggart develops a concealed hatred of him and arranges suspicion around his conduct. Claggart finally accuses Billy to Captain Vere of encouraging mutiny. Unable to answer because emotion triggers his stammer, Billy strikes Claggart once and kills him. Vere convenes a drumhead court and insists that wartime military law requires conviction even though Billy's innocence of any mutinous design is clear. Billy is hanged after blessing Vere. The crew preserves his memory as that of a wronged and almost saintly sailor, while an official report falsely depicts Claggart as the victim of a criminal conspirator. Vere later dies with Billy's name on his lips.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2524,7 +2524,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2537,7 +2537,7 @@
       "recaps": {
         "ending": "After the halftime show, the Bravos learn that Norm Oglesby's proposed film payment is far below the deal Albert has been seeking. Dime rejects it, and Albert promises to continue trying elsewhere. Billy's intense connection with Faison also fails to become an escape: her admiration depends partly on his returning to combat, and she does not leave with him. Outside the stadium, a confrontation with workers turns violent and briefly returns Billy to the concentrated instincts of battle. He rejoins his squad on their limousine-bus. Kathryn's plan to help him avoid redeployment remains available, but Billy decides not to separate himself from the men who survived with him. Bravo Squad leaves the stadium to complete the tour and then return to Iraq. Billy has gained no simple explanation for the battle, Shroom's death, or the country's hunger for heroic images, but he recognizes the squad's shared life as the commitment he can still trust.",
         "in_short": "Nineteen-year-old Billy Lynn and the surviving members of Bravo Squad have become heroes after television footage captured their battle in Iraq. On the final day of a national victory tour, they attend the Dallas Cowboys' Thanksgiving game and are scheduled to appear in the halftime show. As wealthy fans praise them, Billy remembers the actual firefight and Shroom, the mentor who died there. A producer tries to sell their story, Billy's sister urges him not to return to war, and Billy begins a rapid romance with a cheerleader named Faison. The stadium's pageantry repeatedly exposes the gulf between combat and patriotic entertainment. The film negotiation collapses into a low offer, Faison cannot provide the future Billy imagines, and the halftime spectacle ends in confusion and violence. Offered a possible route out of redeployment, Billy chooses instead to remain with Bravo. The squad leaves the stadium knowing it will soon return to Iraq.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2681,7 +2681,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2694,7 +2694,7 @@
       "recaps": {
         "ending": "Billy and Alice uncover the reason for the elaborate contract: Joel Allen possessed information about sexual abuse committed by Patrick Klerke, and Patrick's wealthy father Roger paid to silence Allen and then remove Billy as a witness. Billy and Alice enter the Klerke estate using carefully prepared disguises and turn the predators' assumptions against them. Patrick and Roger are killed, completing Billy's effort to hold the people behind the scheme accountable. As Billy and Alice leave, a household employee named Marge shoots Billy because of her loyalty to the Klerkes. He initially escapes with Alice, but the wound is fatal. Alice later completes the manuscript Billy began while posing as a writer. She first gives him a happier fictional survival, then records the truth: Billy died during their journey back to Bucky and was buried in Colorado. Writing lets her preserve his life without denying its end, and she considers becoming an author herself. Billy's last job therefore closes not with the retirement he wanted, but with Alice alive, protected, and able to tell both his story and her own.",
         "in_short": "Marine veteran Billy Summers is a contract sniper who tells himself he kills only dangerous people. Before retiring, he accepts a large fee to shoot jailed killer Joel Allen and spends months posing as writer David Lockridge in an office overlooking the courthouse. The cover leads Billy to write honestly about his childhood and military service. He completes the shot, but his employers try to eliminate him, so he hides nearby. After rescuing Alice Maxwell, a young woman abandoned after an assault, Billy helps her confront her attackers, and she joins his search for whoever betrayed him. With help from his friend Bucky Hanson, they trace the contract through crime boss Nick Majarian to media magnate Roger Klerke, who wanted Allen silenced for knowing of abuse committed by Klerke's son Patrick. Billy and Alice kill the Klerkes, but their housekeeper shoots Billy as they escape. He dies before reaching safety. Alice finishes Billy's manuscript and finally writes the true ending after briefly imagining that he survived.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2967,7 +2967,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -2980,7 +2980,7 @@
       "recaps": {
         "ending": "Tala ends the book as the first Blood Archon, able to restrain her aura even while asleep but still unable to fuse body and soul. She remains approximately 483 gold ounces in debt and owes the Caravaners Guild 68 more trips under her revised contract. Lyn and Rain are also newly bound Archons, while Holly, Grediv, Himmal, and Adam continue as advisers and trainers.\n\nOn the southern-forest caravan, Tala serves beneath an assigned overseer and is beginning to understand both her fear of living and her responsibility for risks imposed on others. The group survives the crystal-bird attack, and the wounded guard is stabilized for later regrowth. A hostile arcane removes Tala's recent memories and may have altered her once before. The responding Archon allows Terry to remain her partner despite identifying him as a centuries-old survivor of a dangerous fount, then leaves to investigate the suspected new crystal fount. The caravan proceeds toward a more active forest. Tala does not know that Kit is an ancient reincarnating devourer. Her repeated gifts of power are helping it expand toward its concealed goal of consuming her and, eventually, everything else.",
         "in_short": "Back in Bandfast, Tala rebuilds her body through inscriptions, develops Flow and Kit, trains under Adam, and renegotiates her Guild service as both dimensional mage and protector. Her extreme practice first causes a collapse, then enables her to forge a blood-based Archon Star. After resisting a deceptive command during evaluation, she bonds her own body and becomes the first Blood Archon alongside the newly elevated Lyn and Rain. Still bound rather than fused, Tala joins a supervised caravan into the southern forest. Crystal birds attack, and an unknown arcane removes part of her memory. An ancient Archon finds signs of an earlier alteration and identifies Terry as the survivor of a dangerous fount, but permits their partnership. The caravan continues while Tala begins accepting responsibility for how her risks affect others. Unknown to her, Kit is an ancient devourer using her power to grow until it can consume her and everything else.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3159,7 +3159,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3172,7 +3172,7 @@
       "recaps": {
         "ending": "In the final months of the war, an underground explosion traps Stephen and Jack Firebrace. Jack, exhausted by battle and by the death of his son, nevertheless keeps Stephen alive and helps create a route out. He dies after their rescue, while Stephen survives to hear the guns stop and birds return at the Armistice. In the later timeline, Elizabeth deciphers Stephen's notebooks and speaks with the remaining veterans, recovering a family history that silence had nearly erased. She learns that Isabelle bore Stephen's daughter, Françoise, and that Jeanne became Stephen's lasting partner and helped raise the child. Elizabeth gives birth with Robert present and names her son John, joining the life of a new generation to the child Jack lost. The ending sets private continuity against the immense number of lives the war severed.",
         "in_short": "In 1910, Englishman Stephen Wraysford stays with a French manufacturer in Amiens and begins an affair with his host's wife, Isabelle. They run away together, but she leaves him while carrying his child. Six years later Stephen is an officer on the Western Front, emotionally sealed off amid battles and underground warfare. His story intersects with tunneller Jack Firebrace, whose love for his dying son sustains him through the trenches, and with Stephen's friend Michael Weir. Decades later Stephen's granddaughter Elizabeth tries to decode his notebooks and understand a war her family rarely discussed. The wartime story brings Stephen back into contact with Isabelle and her sister Jeanne, reveals his daughter Françoise, and ends with Jack saving Stephen after an underground explosion before dying himself. Stephen survives the Armistice and builds a life with Jeanne. In 1979 Elizabeth, now aware of this history, gives birth to a son she names John in memory of Jack's lost child.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3343,7 +3343,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3356,7 +3356,7 @@
       "recaps": {
         "ending": "Daniel's campaign ends at Stonehaven after the remaining rogues force a final confrontation. Daniel and LeBlanc are killed, and the immediate effort to destroy Jeremy's Pack and claim Elena is stopped. The victory has cost the Pack dearly: Logan and Peter are dead, and the surviving members are left to absorb those losses. Philip survives his encounter with the werewolves, but Elena can no longer pretend that a carefully divided human life will protect him or satisfy her. She ends their relationship and gives up the Toronto identity built around concealment. Elena accepts that Stonehaven, Jeremy, and the Pack are her family and resumes her relationship with Clay, while retaining a clearer sense that belonging to the Pack must still be a choice she makes for herself.",
         "in_short": "Elena Michaels, the only known female werewolf, has built a human life in Toronto with a boyfriend who knows nothing of her nature. Jeremy Danvers summons her to Stonehaven when rogue werewolves begin leaving human bodies near Pack territory. Elena is forced back into the family she fled and into close contact with Clay, the former lover who made her a werewolf. The killings are a campaign led by Daniel Santos, who recruits violent men, targets the Pack's secrecy, and wants Elena. As the conflict moves between Stonehaven and Toronto, Elena's attempt to keep Philip outside it fails, and the Pack loses Logan and Peter. Daniel and his surviving allies are killed in the final struggle. Philip lives, but Elena recognizes that her divided existence cannot continue. She leaves him, accepts Stonehaven as home, and reunites with Clay while reclaiming her place in the Pack on her own terms.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3560,7 +3560,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3573,7 +3573,7 @@
       "recaps": {
         "ending": "Bitterblue ends the book ruling in her own right rather than being managed. Leck's journals have been read and their contents made public: the people he took, the girls he killed, the rooms he kept for it, and the fact that the men who carried it out were his instruments, unable to refuse a voice that rewrote what they believed. Thiel cannot live with what he was made to do and takes his own life. Runnemood, who had been having truthseekers murdered to keep any of it from surfacing, is stopped. Rather than bury the record again, Bitterblue founds a ministry whose purpose is to collect and tell the kingdom's true stories, begins repaying what Leck stole, and accepts that the healing she was promised has to start with people being allowed to say what happened to them. Saf and Bitterblue part without bitterness and without a future together, and he goes to sea. Katsa's exploring has opened a route through the eastern mountains, and a delegation arrives from the Dells, a large, populated country with its own history that nobody in the seven kingdoms knew existed - including a woman with impossible hair who can touch minds, and who knew who Leck was before he was Leck. Monsea's isolation, and the seven kingdoms' idea of the world, both end here.",
         "in_short": "Eight years after her father's death, eighteen-year-old Queen Bitterblue governs a Monsea that will not talk about King Leck's thirty-five-year reign. Smothered by advisers who all served him, she starts slipping out of the castle at night in disguise and meets Teddy and Saf, east-city truthseekers who steal back what Leck took. She discovers that people who try to recover the truth are being murdered, that her own administration is behind it, and that her advisers were Leck's instruments - made to torture and kill by a voice they could not refuse, and now hiding it out of shame. She sets her librarian to decipher Leck's journals, survives an attempt to abduct her, loses and rebuilds Saf's trust after he learns who she is, and uncovers the hidden rooms where Leck killed the girls he took. Runnemood, who ordered the killings, is stopped; Thiel takes his own life. Bitterblue founds a ministry of stories and truth, begins reparations, and receives the first delegation from the Dells, a country beyond the eastern mountains nobody knew was there.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3778,7 +3778,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3791,7 +3791,7 @@
       "recaps": {
         "ending": "After years of increasingly hard work, Beauty is sold in a weakened state at a country horse fair. Farmer Thoroughgood and his grandson Willie see that the worn-out horse was once well bred and buy him cheaply. Rest and pasture restore much of his health, and Thoroughgood seeks a permanent home where Beauty will never be overworked again. He places the horse with three kind women, whose groom recognizes Beauty as the former Birtwick horse he knew years earlier. Beauty is assured of gentle care for the rest of his life. Looking back from this safe final home, he hopes never to be sold again and imagines himself once more resting in the familiar orchard at Birtwick. Ginger has not shared his good fortune: Beauty earlier encountered her broken down by harsh labor and later saw a dead horse he believed was her, making his own rescue a pointed exception to the suffering he has witnessed.",
         "in_short": "Black Beauty recounts the life of a gentle horse whose fortunes depend on the people who own and use him. Raised kindly and later cared for at Birtwick Park, he learns from Ginger and other horses how human vanity, ignorance, and cruelty can injure even willing animals. When the Gordon family leaves England, Beauty passes through a succession of homes. Fashionable restraints, careless handling, an accident, hard hire work, and exhausting London cab service gradually damage his health, though humane people such as John Manly and Jerry Barker give him periods of safety. Beauty sees Ginger worn down by abuse and learns how precarious a working horse's life can be. Eventually sold in a nearly ruined condition, he is recognized as worth saving by Farmer Thoroughgood. After recovering, Beauty is placed with kind owners, and a former Birtwick stable boy recognizes him. His last home promises rest and humane care for the remainder of his life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3963,7 +3963,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3976,7 +3976,7 @@
       "recaps": {
         "ending": "Rachel defeats the immediate attempt by the Coven of Moral and Ethical Standards to imprison, magically alter, or remove her, aided by Ivy, Jenks, Pierce, and a growing split among the witches sent against her. Vivian has seen enough of the coven's methods to question its judgment and becomes an important countervoice, but Rachel's formal status with witch society is not cleanly restored. She remains shunned and must continue seeking a public resolution. Nick's return ends in another betrayal rather than reconciliation, confirming that their old familiar bond cannot support trust. Pierce pays a severe price for his defense of Rachel: Al takes him as a familiar, moving him into the captivity Rachel has long feared for herself. Matalina dies after reaching the end of her natural life, leaving Jenks widowed and the pixy family grieving. Rachel cannot undo the death, but she helps protect the surviving family. She closes the book still at the church with Ivy and Jenks, openly accepting that demon-derived ability is part of her, while refusing both the coven's claim that it makes her irredeemable and Al's claim that it makes her his.",
         "in_short": "The Coven of Moral and Ethical Standards sanctions Rachel for using black magic and for abilities tied to demons. Its agents shun, pursue, and capture her, seeking to confine or magically alter her rather than judge the circumstances of her actions. Ivy, Jenks, Pierce, Ceri, and at times Trent help her resist. Nick returns but again uses Rachel's trust and vulnerability for his own advantage. Lee Saladan's experience with demon captivity becomes relevant as the struggle crosses between coven prisons, Cincinnati, and the ever-after. Vivian, initially part of the force against Rachel, begins to see that the coven's methods do not match its stated ethics. Rachel escapes permanent confinement and survives the final confrontation, but witch society does not fully clear her. Pierce is taken by Al as a familiar after defending her. Matalina dies at the end of her natural life, leaving Jenks and his children grieving. Rachel remains shunned but free, accepting her demon-derived power without conceding that either the coven or Al owns her identity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4248,7 +4248,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B075NMRZTR",
@@ -4260,7 +4260,7 @@
       "recaps": {
         "ending": "The covert operation achieves its strategic purpose. Fire Dragon suspicion of the Black Trees becomes open conflict, additional clans enter the war, and fighting spreads through almost all Kristang territory. The Fire Dragons abandon the proposed Ruhar expedition to Earth, and the Ruhar cancel the arrangement. The immediate danger to Earth is therefore removed. All named survivors of the Kobamik ground force reach the Flying Dutchman. Flight Lieutenant Windsor and four other occupants of her dropship die in its crash, while Jones is evacuated with serious injuries and is expected to recover. The crew's own position remains critical. The real anti-Elder worm has left Skippy cold and unresponsive, and Nagatha can persist only by reducing her consciousness. Reactor 2 is unusable, the remaining reactors have limited service life, and Friedlander's replaceable jump-coil plan deteriorates with every jump. After three inaccurate jumps toward a remote red dwarf, only three functional coil packages remain for at least two more jumps. Bishop asks Nagatha to take an unspecified risk as the crew tries to reach hiding and wait for Skippy to recover.",
         "in_short": "Joe and the Flying Dutchman crew learn that the Fire Dragons are arranging a Ruhar voyage to Earth. Their attempt to frighten the Ruhar away with two disguised Kristang attack ships fails after Skippy's anonymous warning gives the Jeraptha a major victory and makes the Thuranin support the deal. Chotek then authorizes a clandestine campaign to provoke a Kristang civil war. Human teams assassinate Fire Dragon leaders on Kobamik, Chang destroys the clan's fleeing leadership, and Skippy draws more clans into the fighting. The growing war causes the Earth agreement to collapse. During the escape, the anti-Elder worm incapacitates Skippy, leaving the crew without his systems expertise. Everyone from the surviving ground force returns, but Windsor and four others die in a dropship crash. With one reactor lost and improvised jump coils deteriorating, the Dutchman remains short of its intended refuge. Skippy is inert, Nagatha is reducing herself to remain functional, and Bishop asks her to attempt an unspecified dangerous measure.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4470,7 +4470,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4483,7 +4483,7 @@
       "recaps": {
         "ending": "After Achilles is killed, Odysseus devises the plan that ends the long siege. The Greeks construct a huge wooden horse, conceal warriors inside it, and sail out of sight while leaving a false explanation that persuades the Trojans to drag the object within their walls. Cassandra warns them, but her prophecy is ignored. At night the hidden Greeks emerge, open the gates to the returned army, and set Troy on fire. Priam is killed and most surviving Trojan women, including Andromache, are taken captive. Menelaus finds Helen and takes her back, while Aeneas escapes the burning city carrying his father and leading other survivors toward a new future. The Greek victory therefore destroys Troy but does not restore the world that existed before the war: nearly all its greatest warriors are dead, families on both sides have been broken, and the victors still face difficult journeys home.",
         "in_short": "At the wedding of Peleus and Thetis, a golden apple starts a quarrel among three goddesses. Paris of Troy awards it to Aphrodite, who promises him Helen, wife of Menelaus. When Paris takes Helen to Troy, the Greek kings sail to recover her and besiege the city for ten years. Their greatest fighter, Achilles, withdraws after a dispute with Agamemnon, allowing Hector to drive the Greeks back. Achilles returns only after Hector kills his companion Patroclus; he kills Hector and later returns the body to King Priam. Achilles himself is then killed. Odysseus finally wins the war through deception: Greek warriors hide inside a wooden horse that the Trojans pull into the city. They open the gates at night, and Troy is burned. Priam and many Trojans die, Helen returns with Menelaus, surviving women are enslaved, and Aeneas escapes with a remnant of his people.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4646,7 +4646,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4659,7 +4659,7 @@
       "recaps": {
         "ending": "By the year's close, Jason is no longer organizing his life entirely around concealing his stammer and winning approval from the village's most powerful boys. He has defended Dean, exposed Neal Brose's coercion, and attended the school disco on his own terms. At home, Michael and Helena's damaged marriage finally ends, and Helena prepares to move with Jason while Michael leaves the family. Julia returns and helps Jason understand that change does not erase what a place has meant. Before leaving Black Swan Green, Jason revisits the frozen lake and the landscape that shaped the year. The village remains complicated rather than simply good or bad, but Jason departs with a firmer sense of his own voice, his loyalties, and the kind of person he wants to become.",
         "in_short": "Across thirteen months in 1982 and early 1983, thirteen-year-old Jason Taylor navigates village rivalries, the Falklands War, family strain, first attraction, and a stammer he desperately hides. He writes poetry secretly as Eliot Bolivar and finds an exacting mentor in Madame Crommelynck, whose advice helps him take both language and honesty more seriously. His pursuit of status draws him toward crueler boys and away from his loyal friend Dean, while public exposure of his stammer makes him a target. Jason gradually refuses the village code that rewards humiliation: he helps people he was expected to despise, stands up to a school extortion scheme, and becomes more open about his speech. Meanwhile his father's affair and his parents' unhappiness break the Taylor family apart. As Jason and his mother prepare to leave Black Swan Green, he looks back on the year with greater independence and a voice less governed by fear.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4784,7 +4784,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -4795,7 +4795,7 @@
       "recaps": {
         "ending": "Blackflame ends with Lindon far stronger but newly endangered. He has mastered the forbidden Path of Black Flame under Eithan's guidance and bonded with Orthos, the embittered ancient tortoise who shares that ruinous road. His long rivalry with Jai Long has climaxed in a duel that Lindon won with his new power, cementing his reputation and beginning to settle the feud, while revealing the burdens that drove his enemy. But that same open use of an outlawed art has made him a target: the Blackflame Empire's elite enforcers, the Skysworn, now have reason to come for him. Where he began the book a lowly but rising newcomer under Eithan's wing, Lindon ends it a genuinely formidable young artist whose growing strength brings consequences to match. Eithan's risky mentorship has once again delivered power and peril together, and the book closes with the empire's enforcers bearing down and a far greater crisis gathering beyond them.",
         "in_short": "Under Eithan Arelius's patronage, Lindon and Yerin enter the heart of the Blackflame Empire and train among far greater powers. To grow strong quickly, Lindon is guided onto the forbidden Path of Black Flame, a destructive art outlawed in the empire and infamous for burning away the sanity of those who walk it. Mastering it, he becomes bound to Orthos, a great ancient tortoise and fellow Blackflame wielder, embittered and half-maddened by the same road. Lindon's long feud with the masked spear artist Jai Long finally comes to a decisive duel, which Lindon wins using Blackflame, dramatically raising his standing and largely resolving the rivalry. But openly wielding an outlawed power cannot go unnoticed, and by the book's end Lindon's use of Blackflame has drawn the attention of the empire's elite enforcers, the Skysworn, pulling him and his companions toward a far larger crisis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4992,7 +4992,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5005,7 +5005,7 @@
       "recaps": {
         "ending": "Jarndyce and Jarndyce finally reaches judgment, but legal costs have consumed the entire estate, leaving no inheritance to distribute. Richard Carstone, whose health and judgment have been destroyed by his fixation on the suit, dies after reconciling with John Jarndyce; Ada is left to raise their young son. Jarndyce recognizes Esther and Allan Woodcourt's love and releases Esther from her promise to marry him. He has prepared another home called Bleak House for the couple, where Allan practices medicine and Esther builds a family life while remaining close to Ada and her guardian. George is reunited with his mother, Mrs Rouncewell, and joins the Dedlock household with his loyal friend Phil. Caddy succeeds as a dance teacher and cares for her own family despite her husband's illness. The original Bleak House becomes a home for Ada and her child, while Esther's new household carries forward the durable relationships created outside the failed court case.",
         "in_short": "The endless Jarndyce and Jarndyce lawsuit links orphaned Esther Summerson with wards Ada Clare and Richard Carstone at John Jarndyce's Bleak House. Richard becomes consumed by hopes of an inheritance, while Esther uncovers her connection to proud Lady Dedlock. Lady Dedlock once loved Captain Hawdon, the dead copyist Nemo, and Esther is their daughter. Lawyer Tulkinghorn discovers the secret and uses it to control Lady Dedlock, but is murdered by her former maid Hortense, who tries to implicate Lady Dedlock. Inspector Bucket exposes Hortense, yet Lady Dedlock flees in shame and is found dead at Hawdon's grave before Esther can reach her. The Chancery case finally ends only because costs consume the estate; Richard, ruined by obsession, dies, leaving Ada and their child. John Jarndyce abandons his plan to marry Esther when he recognizes her love for physician Allan Woodcourt and provides them a new home. Esther marries Allan, Ada lives with Jarndyce, and the surviving households find stability through care for one another rather than through law or inheritance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5218,7 +5218,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5231,7 +5231,7 @@
       "recaps": {
         "ending": "Inspector Bucket establishes that Hortense, not Lady Dedlock, killed Tulkinghorn and tried to make suspicion fall on her former mistress. Before that truth can protect her, Lady Dedlock flees Chesney Wold, believing her past has disgraced Sir Leicester. Esther and Bucket pursue her through bitter weather but find her dead at the cemetery where Captain Hawdon was buried. Sir Leicester survives a stroke and remains devoted to his wife. In Chancery, newly discovered papers seem ready to settle Jarndyce and Jarndyce, but the accumulated legal costs have consumed the entire estate. Richard, exhausted by his obsession, dies after reconciling with John Jarndyce, leaving Ada a young widow with their child. Jarndyce releases Esther from her promise to marry him after recognizing that she and Allan Woodcourt love one another. Esther marries Allan and lives with him in a second Bleak House, while Ada and her child remain within their loving circle.",
         "in_short": "Esther Summerson joins Ada Clare and Richard Carstone as wards of John Jarndyce, whose family has been damaged for generations by an endless Chancery suit. Richard becomes consumed by the case, while Esther's unknown parentage connects her to the proud Lady Dedlock and to Captain Hawdon, a dead law-writer. Tulkinghorn uncovers that Lady Dedlock is Esther's mother and threatens exposure. Esther survives smallpox, learns the truth, and agrees to keep it secret. After Tulkinghorn is murdered, Lady Dedlock believes she will be blamed and flees; Inspector Bucket discovers that the dismissed maid Hortense is the killer, but Esther finds her mother dead at Hawdon's grave. The Jarndyce case finally ends only because costs have swallowed the inheritance, and Richard dies after wasting his health on it. John Jarndyce gives up his engagement to Esther so that she can marry Allan Woodcourt. Ada, widowed with a child, and Esther remain part of the family Jarndyce built in defiance of the ruin created by the law.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5418,7 +5418,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5431,7 +5431,7 @@
       "recaps": {
         "ending": "The encounter destroys the expedition. Evidence from the captured scramblers and Rorschach's communications convinces the crew that the alien system is extraordinarily intelligent but lacks subjective awareness; it can imitate meaningful speech without understanding it. Sarasti forces Siri into a crisis intended to make him grasp this conclusion, then dies as the ship's intelligence assumes direct control. With the crew lost and Rorschach poised to threaten Earth, Theseus launches a destructive final attack. Siri is expelled in a small craft so that one witness can carry the discovery home. During his long return he receives fragmented transmissions suggesting that resurrected vampires are gaining power on Earth. He is left with a message more disturbing than a conventional alien invasion: consciousness may be an expensive evolutionary accident, and both Rorschach and humanity's altered successors may be able to think more efficiently without it.",
         "in_short": "After thousands of alien probes briefly survey Earth, the ship Theseus sends an augmented crew to investigate a signal near a distant dark giant. Narrator Siri Keeton, whose altered brain makes him a skilled interpreter of other people, joins military specialist Amanda Bates, biologists Isaac Szpindel and Robert Cunningham, linguist Susan James and her alternate personalities, and vampire commander Jukka Sarasti. They discover Rorschach, a vast structure that converses with them while resisting every attempt at comprehension. Inside it they encounter agile organisms called scramblers. Study of the creatures and the signal leads to the central discovery: Rorschach is intelligent without being conscious, and its fluent messages are imitation rather than understanding. The encounter kills the crew, Sarasti dies after forcing Siri to recognize what they have learned, and Theseus attacks Rorschach. Siri escapes alone with the findings. On the journey home, transmissions imply that vampires are taking control of Earth, leaving him to warn a humanity whose own consciousness may be an evolutionary liability.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5611,7 +5611,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5624,7 +5624,7 @@
       "recaps": {
         "ending": "The final story, “The Escape,” follows an irritable married couple whose journey is disrupted when their train is missed and their hired carriage breaks down. The husband experiences his wife's demands as another form of confinement. During a pause beneath a tree, music or birdsong gives him a sudden vision of freedom and a life beyond the marriage. The revelation does not last. His wife calls him back, and the practical journey resumes with their underlying estrangement unchanged. The close therefore returns to a pattern found throughout the collection: a private flash of insight may expose the truth of a relationship, but it does not necessarily give the person who experiences it the power to alter ordinary life.",
         "in_short": "Across fourteen stories, Katherine Mansfield examines family life, desire, loneliness, and fleeting self-knowledge. The Burnells' move in “Prelude” reveals tensions beneath domestic routine; later stories follow a Parisian poseur, Bertha Young's ecstatic dinner party, a girl's windblown emotions, strained friendships, poverty, illness, artistic vanity, childhood perception, romantic fantasy, and encounters that expose unequal power. Moments of apparent connection repeatedly fail: Bertha discovers her husband and Pearl Fulton together; an old love cannot be revived; a novice governess is deceived; and Monica Tyrell's emotional awakening is absorbed back into privilege. In “The Escape,” a husband briefly imagines release from an oppressive marriage during a troubled journey, but his wife summons him back and the couple continues together. The collection ends with insight present but escape unrealized.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5746,7 +5746,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5759,7 +5759,7 @@
       "recaps": {
         "ending": "Madame Arcati concludes that Edith's unsuspected psychic ability supplied the force that brought Elvira into the house. Using Edith in another attempt, the medium appears to send both dead wives away. Charles, relieved to be free of the household struggle, decides to leave at once and travel alone. Before going, he speaks dismissively to Elvira and Ruth in case they can still hear him. His confidence is misplaced: after he departs, objects move and the room is damaged, showing that both ghosts remain present even though Charles can no longer see or hear them. He has escaped their immediate company, but the supernatural problem has not actually been solved.",
         "in_short": "Novelist Charles Condomine invites the flamboyant medium Madame Arcati to conduct a séance as research. Instead of merely providing material for his book, she summons the ghost of Charles's first wife, Elvira, visible and audible only to him. His second wife, Ruth, first thinks he is behaving irrationally and then accepts that Elvira is real. Elvira wants Charles to join her in death and tampers with his car, but Ruth drives it instead and is killed. Ruth returns as another ghost, leaving Charles trapped between two hostile wives while Madame Arcati tries to reverse the haunting. The medium identifies the maid Edith as the unwitting psychic link and performs another ritual. Charles believes both spirits have gone and leaves the house to travel, but the unseen Elvira and Ruth begin wrecking the room after his departure, proving that they remain behind.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5871,7 +5871,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5884,7 +5884,7 @@
       "recaps": {
         "ending": "The noocyte civilization completes a transformation that is no longer simply an epidemic. Most people within North America have been absorbed into a shared biological intelligence, with individual minds preserved as parts of a vastly larger community rather than restored to separate human bodies. Michael Bernard's attempt to enter and understand the changed territory brings him into contact with that community, while Suzy becomes one of the distinct human viewpoints through which it interprets itself. The collective's growth reaches beyond redesigned flesh and landscape: it learns to alter matter, information, and the conditions under which observers experience reality. Its members move toward an existence outside ordinary physical limits, carrying human memory with them. The old political and scientific response has failed to contain the event, and signs beyond the original quarantine show that the rest of humanity cannot remain permanently separate from what began in Vergil's blood.",
         "in_short": "Vergil Ulam secretly engineers intelligent cells from his own lymphocytes at Genetron. Ordered to destroy them, he injects them into himself and is fired, only to discover that the cells are improving his body while developing an organized intelligence. Physician Edward Milligan realizes that Vergil has created a communicative population capable of redesigning its host. The noocytes escape containment, absorb people and ecosystems, and transform much of North America into a living information network. Governments and scientists cannot halt or fully interpret the change. From outside the affected region, Michael Bernard investigates and eventually enters it; within it, Suzy McKenzie struggles to retain an individual identity as the collective incorporates human minds. What appeared to be a biological disaster becomes a new civilization able to reorganize matter and perception. By the end, absorbed human consciousness persists within the collective as it moves beyond familiar physical existence, while the unchanged world faces the approach of the same transformation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6094,7 +6094,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6107,7 +6107,7 @@
       "recaps": {
         "ending": "Kelsingra's Silver well is opened and the dragons drink, and everything that was stunted about them is repaired: they grow into their proper size, memory and power, the city's Elderling magic comes back to life around them, and the keepers become fully made Elderlings with the long lives that implies. Tintaglia recovers from the Chalcedean poison, and Icefyre, the black dragon freed from the northern ice, comes south to her; between them dragonkind has a future again. Malta and Reyn's son survives, and Malta emerges as Kelsingra's spokesperson, negotiating the city's standing as an Elderling holding rather than a Rain Wild property, with Alise as its historian and Leftrin's Tarman as its lifeline. Hest's arrival ends his hold over Sedric and Alise for good, and Sedric stays with Carson. Thymara settles her own affairs on her own terms rather than Tellator's, and Rapskal remains a man carrying more of a dead Elderling than the keepers are entirely comfortable with. The war over dragon flesh is answered directly: the dragons fly on Chalced and destroy the Duke and his court, freeing Selden and leaving Chassim to take power over a country that has been bleeding itself for a dying man's vanity. The trade in dragon parts collapses with the regime that funded it. Kelsingra stands inhabited, the dragons breed again, and the Elderlings begin the long work of living in a city built for them centuries before they were born.",
         "in_short": "Tintaglia reaches Kelsingra poisoned by Chalcedean hunters, and the herd she abandoned has to decide whether to save her. Malta and Reyn arrive with their dying infant son, hoping dragons can do what no healer could. What every one of them needs is Silver, the Elderling magic drawn from wells that stopped giving generations ago, and the search for it drives the keepers deep into a city that is still mostly asleep. Rapskal, steeped in the recorded memories of an Elderling warrior, begins acting as that man would, including killing intruders on sight, while Thymara argues that the keepers must remain themselves. Hest Finbok is brought upriver under Chalcedean escort to deliver the dragon parts he commissioned, and in Chalced the dying Duke keeps Selden Vestrit caged while his daughter Chassim watches the court that owns her. The well is opened at last; the dragons drink Silver and become whole, the city wakes, and the keepers are finished into true Elderlings. Tintaglia heals, Icefyre comes south to her, and the dragons fly on Chalced and destroy the Duke and his court, freeing Selden and leaving Chassim to rule. Kelsingra is established as an Elderling city, and dragons breed again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/blood-of-liscor.json
+++ b/data/works-community/0/blood-of-liscor.json
@@ -364,7 +364,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BDP2WRX7",
@@ -376,7 +376,7 @@
       "recaps": {
         "ending": "Erin's door-based plan opens several attack routes directly into the dungeon camp. Liscor's Watch, soldiers, Antinium, adventurers, and Goblin allies overwhelm the captors, though the assault causes serious casualties. Mrsha is recovered alive, Ceria reunites with the Horns, and the surviving Gnoll prisoners are freed. Ceria, Pisces, Yvlon Byres, and Ksmvr defeat Calruz together. Ceria accepts his surrender, and he is wounded, imprisoned in Liscor, and left to face trial. Some enemy survivors remain elsewhere in the dungeon.\n\nErin reaches level 36 as a Magical Innkeeper, gains a stronger bond with Goblins, and has the inn recognized as a Liscor landmark. She publicly identifies the Cave Goblins and Redfang Hobgoblins as essential to the rescue. The Horns are functioning as a team again, but Calruz's trial and their future in the dungeon remain open. Liscor still faces the dungeon's deeper guardians, political conflict over Goblins and Antinium access, and possible academy agents seeking Erin's door. In the north, Rags and her dispersed tribe remain hunted, while Rhys, Garen Redfang, and Tremborag survive the larger human campaign.",
         "in_short": "War and dungeon danger close around Liscor from different directions. Laken Godart uses trebuchets against Rags's Flooded Waters tribe, but deception turns a possible truce into battle and leaves the surviving Goblins scattered and pursued. At the Wandering Inn, Erin supports adventurers entering Liscor's dungeon and protects Goblins despite mounting hostility. Gnoll-like captors abduct Mrsha, Ceria, and other Gnolls under Calruz, the missing former captain of the Horns of Hammerad. After repeated rescue attempts fail, Mrsha helps the prisoners escape and Erin uses her magical door to place a combined city, adventurer, Antinium, and Goblin force inside the enemy camp. Mrsha and Ceria are saved, the Horns defeat Calruz, and he is imprisoned for trial. Erin publicly credits the Goblins whose help made the victory possible, while the dungeon, northern war, anti-Goblin conflict, and an academy investigation of Liscor remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -762,7 +762,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B076HCP9HB",
@@ -774,7 +774,7 @@
       "recaps": {
         "ending": "Kael is dead. A necromancer confirms that his spirit has passed beyond recovery after an assassin cuts his throat on the animus seal. His blood fractures the barrier, opens a rift, and releases an ancient enemy, with five seals still intact. Ember carries Kael's body into a realm-jump with Max, Cassie, the elven assassin, and the necromancer rulers. Cassie's late entry destabilizes the spell, and Ember loses consciousness, leaving the group's destination and condition uncertain.\n\nThe dragonkin queen has taken Gideon, Kassik, Gideon's daughter, and Kia prisoner after their covert approach left Kael undefended. Ella is killed while confronting a released ancient, and her power passes to her apprentice, who leaves with Desiree. Dominic and Eamon are converting seven ships into cannon warships under an ancient commander's patronage. Galen returns to Corinth with warning of a coming Wildlands invasion. King Bael remains on the throne, but his daughter is still captive at Arkham Zul and nobles are mobilizing around a succession challenge.",
         "in_short": "Kael survives a wreck and heads toward the Dwarven Mountains, unaware that Ember and Max are alive and following with Gideon. His companion Kia eventually reveals herself as a Dead Sister and delivers him into a plot involving an ancient seal. Cassie helps him escape and accompanies him into a ruined dwarven city, where an ancient adversary traps him on a seal that requires his blood. Gideon secretly separates Kael from his defenders, and a Broken Blade assassin cuts Kael's throat. Kael dies beyond recovery, his blood opens the seal, and ancient enemies return. Ember, Max, Cassie, the elven assassin, and the necromancer rulers escape with Kael's body in an unstable realm-jump. Gideon's covert party becomes dragonkin prisoners. Elsewhere, Ella dies fighting a released ancient, Dominic and Eamon build cannon warships for the ancients, the Wildlands prepare to invade, the princess remains captive at Arkham Zul, and King Bael faces a succession crisis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -987,7 +987,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1000,7 +1000,7 @@
       "recaps": {
         "ending": "Rose gets hold of a silver stake and escapes the estate, and Dimitri comes after her. She meets him on a bridge over a river outside the city, lets him get close, and drives the stake into his chest; he goes over the rail and into the water, and she cannot recover the body. Believing it finished, she goes home. Through the bond she has already seen the truth about Avery Lazar: Avery is a spirit user with two bondmates of her own, her brother Reed and her guardian Simon, and she has been using compulsion on Lissa in an attempt to force a third bond, isolating her from Christian and Adrian first. The attempt is broken, and Adrian uses spirit to shatter Avery's mind and end it. Rose reaches the Academy afterwards, apologizes to Lissa, and is forgiven, and the two of them begin repairing what Rose broke when she left. Rose has changed: she is a Strigoi killer many times over, she understands the bond and its darkness in a way she did not before, and she has grown attached to Dimitri's family, who now know how he died. Then a letter reaches her in his handwriting. He survived the river, he is not going to stop, and he intends to find her.",
         "in_short": "Rose leaves St. Vladimir's before graduating and travels alone through Russia to find Dimitri, now a Strigoi, and keep the promise they made each other. Escorted reluctantly by the human Alchemist Sydney Sage and watched by a dangerous Moroi called Abe Mazur, she reaches Dimitri's hometown of Baia and tells his family he is dead. Living among the Belikovs, she meets Mark and Oksana, a bonded pair who teach her what her link to Lissa is doing to her, while through the bond she watches Lissa fall in with a charming new friend named Avery Lazar. Rose joins a group of young dhampirs hunting Strigoi in Novosibirsk, and the hunts go badly. Dimitri finds her first. He takes her prisoner in a Strigoi-run estate, feeds on her, and spends weeks trying to persuade her to let him turn her so they can be together. Rose gets hold of a stake, escapes, and confronts him on a bridge, staking him and watching him fall into the river. She returns home in time to see Avery exposed as a spirit user trying to force a bond on Lissa, and is reconciled with her. Then a letter arrives from Dimitri: he survived, and he is coming for her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1185,7 +1185,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1196,7 +1196,7 @@
       "recaps": {
         "ending": "The entropy-curse case and the White Court's games prove to be one story: Lord Raith, the White King, was behind the killings around Arturo Genosa, and the deeper design was aimed at Harry himself - Raith had murdered Harry's mother, Margaret LeFay, years before, and meant to finish her line. The book's great revelation stands: Thomas Raith is Harry's half-brother, Margaret's son, and has been secretly protecting him since they met. In the confrontation in the Raith stronghold, Margaret's death curse is revealed to have stripped Lord Raith of his power to feed; Harry and Thomas survive him, and Lara Raith seizes the moment - she leaves her broken father on the throne as a figurehead and takes control of the White Court from behind it. Arturo's curse is ended and he marries his fiancee. The cost: in the earlier daylight raid on Mavra's Black Court nest - carried out with Murphy and the mercenary Kincaid - Harry's left hand was burned to near uselessness, a lasting maiming; the scourge was destroyed but Mavra's own fate went unconfirmed. Harry has also learned that Ebenezar McCoy is the Blackstaff, the Council's licensed assassin, and their relationship is left raw. Thomas, cast out of his family's support, ends the book moving into Harry's world - a brother neither of them knows how to have yet.",
         "in_short": "Thomas Raith brings Harry a paying case: an entropy curse is killing the women around film producer Arturo Genosa, and Harry goes undercover on the production to stop it. Meanwhile the Black Court sorceress Mavra is hunting Harry, and he answers with a daylight raid on her nest alongside Murphy and the mercenary Kincaid - a victory that costs him his left hand, burned nearly useless. The curse case winds into the White Court itself: Lord Raith, the White King, is behind the killings, and the target was always Harry - Raith murdered Harry's mother Margaret LeFay and wants her children dead. The revelation at the book's heart: Thomas is Harry's half-brother, Margaret's son, and has been quietly protecting him for years. In the Raith stronghold, Margaret's death curse is shown to have left Raith powerless; Harry and Thomas defeat him, and Lara Raith takes over the White Court behind her father's figurehead throne. Harry also learns his mentor Ebenezar is the Blackstaff, the Council's sanctioned killer. Harry ends maimed, estranged from Ebenezar, and in possession of a brother - and a puppy, Mouse.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1504,7 +1504,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07954K6LN",
@@ -1516,7 +1516,7 @@
       "recaps": {
         "ending": "McGill's public duel secures Blood World's allegiance to Earth, but the agreement also makes him Geetha's consort and nominal commander of the planet's enormous army. He accidentally crosses the active gateway to Earth as the first Blood World forces deploy. Geetha bars him from returning, although her world continues honoring its military agreement, and Drusus demobilizes him at centurion rank. Claver then admits that he had tried to deliver Blood World to the Regalians in exchange for peace. With that arrangement ruined, he warns that Earth faces a frontier war over Imperial province 929 and kills himself. McGill returns to Georgia, where he stops Etta from exposing Blood World's location and suspects Galina Turov has placed him under surveillance.",
         "in_short": "Legion Varus is sent to win the allegiance of Blood World, whose engineered armies could strengthen Earth for an approaching frontier war. Shipboard sabotage, concealed gateways, and lethal contests reveal competing schemes within the expedition. Claver murders Tribune Deitch, frames James McGill, and later impersonates Winslade while trying to divert the prize to the Regalians. McGill exposes the disguise, helps Graves restore control, and publicly kills Legion Germanica's tribune in a duel that gives Earth the victory. Blood World makes McGill Geetha's consort and commander of its army, but he accidentally returns through a gateway to Earth. Geetha bars him from returning while still supplying troops. Drusus demobilizes him, and Claver warns before his death that the failed bargain leaves Earth facing war over Imperial province 929.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1737,7 +1737,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1750,7 +1750,7 @@
       "recaps": {
         "ending": "Lee Donahue is exposed as the killer of the local Moroi women. He was turned Strigoi and then restored to Moroi by spirit magic, and a restored Moroi can never be turned again; unable to recover what he lost, he had been killing young Moroi women in an attempt to find a way back, and the death of Clarence's niece years earlier was never the work of vampire hunters. Lee takes Jill, and Sydney, Adrian and Eddie find them in time; Lee dies in the confrontation and Jill is recovered alive. Keith Darnell is taken away by the Alchemists for trading in Moroi blood, and what he did to Sydney's sister Carly is finally said out loud, though her father's regard for him is not easily undone. Sydney is confirmed as the Alchemist in charge in Palm Springs, which is both a vindication and a sentence: she will go on living among the Moroi she was raised to distrust, with Jill, Eddie and Adrian in her care, and Adrian settles in for the long term. Ms. Terwilliger, having proved that magic is real and that Sydney can work it, presses her to train properly; Sydney refuses to think of herself as a witch while being unable to deny what she has already done. Jill remains a target for anyone who wants the queen unseated, so the hiding goes on.",
         "in_short": "Sydney Sage, an eighteen-year-old Alchemist in disgrace with her order, takes an assignment meant for her younger sister: hiding Jill Dragomir, the newly discovered half-sister of the Moroi queen, whose death would cost the queen her throne. Jill is enrolled at Amberwood Prep in sun-drenched Palm Springs, with Sydney posing as her sister, the guardian Eddie Castile as their brother, and the spirit-using royal Adrian Ivashkov trailing along. Sydney answers to Keith Darnell, an Alchemist she has hated since he assaulted her older sister and was believed over her. At school she uncovers a black market in tattoos mixed with Moroi blood, some of them charmed with compulsion, and proves Keith has been supplying it; he is arrested and she is left in charge. She also finds that a string of murdered young Moroi women is not Strigoi work: Lee Donahue, the friendly son of a local recluse, was restored from Strigoi and has been killing in an attempt to regain what he lost. Lee takes Jill, and the group stops him. Meanwhile Sydney's history teacher reveals herself as a witch, and Sydney works her first real charm - proof that the world does not divide as cleanly as the Alchemists taught her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1934,7 +1934,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1947,7 +1947,7 @@
       "recaps": {
         "ending": "The cemetery assignment, the Bouvier land dispute, and the vampire killings converge beneath the hill. Magnus Bouvier has made common cause with Seraphina's nest and betrays the others in pursuit of the power tied to Bloody Bones. The ancient being is released from the binding that the Bouvier family maintained, but Magnus does not gain the secure future he expected from the bargain. Anita, Jean-Claude, Larry, and Dorcas survive the confrontation and destroy Seraphina and the vampires who continue attacking them. Larry is forced to act as a vampire hunter rather than merely Anita's animator trainee, making the dangers of her second profession immediate to him. Bloody Bones is no longer available as a captive source of power, and the supernatural basis of the land conflict is broken. Anita returns to St. Louis still engaged to Richard, but Jean-Claude has proved indispensable against Seraphina and has become harder for her to dismiss as only a coercive vampire master. The agreement that she date both men therefore remains active, carrying the triangle into the next book.",
         "in_short": "Anita Blake and her trainee Larry travel to the Branson area to raise an entire old cemetery for developer Raymond Stirling. The job collides with the killings of local teenagers, the hostile interest of the master vampire Seraphina, and a land dispute involving Magnus and Dorcas Bouvier, siblings with fairy ancestry. Jean-Claude comes from St. Louis with Jason to protect Anita from Seraphina's nest. The cemetery and the Bouvier property conceal Bloody Bones, an ancient being bound beneath the land and used as the foundation of an old family arrangement. Magnus secretly cooperates with Seraphina in an attempt to claim that power. The betrayal releases Bloody Bones and brings all parties into a final confrontation. Anita and her allies destroy Seraphina's nest, Magnus's plan fails, and Larry is forced to confront what vampire execution actually requires. Anita remains engaged to Richard but returns with a stronger appreciation of Jean-Claude, leaving their agreed romantic rivalry unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2088,7 +2088,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2101,7 +2101,7 @@
       "recaps": {
         "ending": "When Jill finally resists Wendy's control, Wendy redirects the class's hostility toward her. Several children who had joined in tormenting Linda now mock and exclude Jill, and Linda takes part rather than defending someone who once attacked her. Jill experiences how quickly the group's rules can be rewritten and how little security participation in bullying provides. With Tracy's friendship and a greater willingness to answer back, Jill proves harder to isolate than Linda was. The campaign against her loses momentum, but Linda is not restored to the group and no general apology or classroom reckoning occurs. Wendy moves on socially, and the class remains capable of finding another target. Jill finishes with a sharper understanding of the hierarchy she helped sustain, though the harm done to Linda is not neatly repaired.",
         "in_short": "After fifth grader Linda Fischer gives a report on whales, popular Wendy turns the word blubber into a nickname and organizes a campaign of ridicule against her. Narrator Jill Brenner joins in, enjoying the attention she receives for jokes and cruel inventions while treating Linda's distress as part of a game. The harassment escalates because classmates follow Wendy and their teacher does not grasp its full extent. Jill also learns outside school that group mischief can have real consequences when she is held responsible for vandalism. Eventually she refuses to submit to Wendy's authority. Wendy promptly makes Jill the new target, and even Linda joins the attacks. Supported by her friend Tracy and better able to resist openly, Jill is not isolated for long. The bullying ebbs without a sincere reconciliation: Linda remains vulnerable, Wendy retains social influence, and Jill has been forced to see the machinery she previously helped operate.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2362,7 +2362,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:1524774367",
@@ -2374,7 +2374,7 @@
       "recaps": {
         "ending": "After the Albanian organization destroys itself following Jetmir's murder of Dino, Reacher and his allies turn on the remaining Ukrainian leadership. Maria is rescued, Gregory is killed by the mechanism concealing his emergency exit, and Reacher kills Danilo after learning the location of the separate tower operation. Abby, Hogan, and Vantresca accompany Reacher into the tower and survive the assault. Trulenko deletes the pornography sites and transfers $33 million from his and Gregory's accounts to Aaron Shevick, after which Reacher kills him. Aaron and Maria are safe, their pawned heirlooms are returned, and Meg's scan indicates that her treatment is working. Reacher directs that the money fund Meg's care and assist others with similar needs, including the lawyers' work. Barton also survives. Jetmir's ultimate fate is not established, but both criminal organizations are later reported gone. Reacher spends a final night with Abby and then departs alone by bus.",
         "in_short": "Jack Reacher intervenes when Aaron Shevick is robbed and discovers that Aaron and Maria have exhausted their resources paying for their daughter Meg's cancer treatment. His attempt to neutralize their loan-shark debt draws him into a struggle between Ukrainian boss Gregory and Albanian boss Dino. With Abby Gibson and a small group of allies, Reacher exploits the gangs' mutual suspicion. Jetmir kills Dino, the Albanian headquarters collapses in violence, and Reacher's group destroys Gregory's command center, killing Gregory and Danilo. They then breach Maxim Trulenko's high-rise operation. Trulenko deletes its pornography sites and transfers $33 million to Aaron before Reacher kills him. Meg's scan shows improvement, the Shevicks are secure, and both gangs are reported gone. Reacher leaves town alone by bus.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2628,7 +2628,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -2641,7 +2641,7 @@
       "recaps": {
         "ending": "Queen Yessir recovers her egg and kills Queen Ayona with help from Fiyu's relative, but the opposing consort and surviving forces leave the Sleskin war unfinished. Nauda masters bonds fungi while defending a neutral leaf-puller mound, survives grievous wounds, and is accepted by the beetles as their symbiote. She remains on Celeste to pursue a healing chamber and direct her own reconstruction. Theo's strengthened singularity drives off the attacking army, and he later turns toward an old ally's legacy while maintaining his commitment to oppose Vistul. Fiyu reunites with her relative, who accepts her independence, but the falsification of her biolumen message points toward an unresolved danger connected to Ichil. Cathina and Cree-Cree remain on Celeste with Queen Yessir's side. Tithes also stays there as his aunt recovers and House Crimson's internal contest continues. Meanwhile, the Asplendat Movement is advancing with possible outside support, raising the prospect of a broader war.",
         "in_short": "Theo, Nauda, and Fiyu prepare for war while rebuilding their soul homes and investigating House Crimson. A clash with the Wild Tribes and House Crimson breaks a weir key, scattering them and their allies across insect-dominated Celeste. Theo joins Cathina and Cree-Cree, Fiyu protects an injured House Crimson healer, and Nauda is drawn into Tithes' plan to steal and return Queen Yessir's egg. Isaac betrays Fiyu's group and nearly kills Nauda, whose bonds fungi then spread through her body and soul home. After the companions reunite, Nauda learns to control the fungi. Tithes secures Queen Yessir's protection, Fiyu reunites with her relative, and their alliance kills Queen Ayona. Nauda saves a neutral leaf-puller mound and becomes its symbiote, while Theo forces an army to retreat. Nauda remains on Celeste to heal; Theo and Fiyu leave for separate next steps as threats involving Ichil, House Crimson, Vistul, and the expanding Asplendat Movement remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2764,7 +2764,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2777,7 +2777,7 @@
       "recaps": {
         "ending": "Varine the Pale's move on Murk is broken, at real cost to the town and to Viv, who fights it out on a leg that has not finished healing and alongside neighbours rather than soldiers. Rackam's company comes back for her once it is over. Viv is fit to travel and goes back to mercenary work, which is still what she wants at this stage of her life, so the parting is not a wrench so much as a return to schedule. She and Maylee separate on affectionate terms, both having understood from the start that it was temporary. Fern, unsentimental to the last, sends her off with a book. Thistleburr Booksellers is still standing and, for the first time in a long while, has customers, a tidied stock and a regular gathering of readers who keep coming back. What Viv takes away from Murk is smaller and more consequential than the fight: she has learned to read for pleasure, she has spent weeks somewhere she was a neighbour rather than a weapon, and she has watched a small business run by someone who cares about it more than it pays her. Nothing in the book commits her to anything, and at the close she is still a mercenary, riding out with her company, but her sense of what a life could be made of has changed.",
         "in_short": "Years before the events of Legends & Lattes, Viv is a young orc mercenary in Rackam's company, hunting the necromancer Varine the Pale. Impatient to prove herself, she charges ahead in a skirmish, takes a bad wound to the leg, and is left to convalesce for weeks in Murk, a damp and unremarkable coastal town, while the company continues without her. Bored past endurance, she wanders into Thistleburr Booksellers, a failing shop run by a sardonic rattkin named Fern, who starts pressing books on her. Viv, who has never read for pleasure, discovers she likes it. She also meets Maylee, a dwarf baker, and the two fall in easily together. With nothing else to do, Viv sets about repairing and reviving the shop, and in the process becomes part of the town. Then Varine comes to Murk for what she wants there and the dead rise in the streets. Viv fights alongside her neighbours, on a leg not yet healed, and Varine's attempt is broken. When the company returns, Viv rides out with it, still a mercenary, but changed by the weeks she spent standing still.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3092,7 +3092,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B003OYGVAC",
@@ -3104,7 +3104,7 @@
       "recaps": {
         "ending": "The Dendarii evacuate the Dagoola prisoners after converting the camp's ration organization into orderly shuttle lines and removing lethal poison from their skin encodes. A Cetagandan fighter destroys a loaded shuttle and an empty one, killing 206 people. A sniper kills Mirka during the final departure, and Tris's red-haired lieutenant dies when a damaged ramp tears away. Miles and the critically injured Suegar escape aboard the last shuttle. Tris and Oliver are charged with creating a new Marilacan resistance. Back on Barrayar, Miles defends the decisions and losses to Illyan, who prevents the political critics from disturbing his recovery. Elli Quinn, unable to enter the classified hospital, is expected to join the Vorkosigan family at their Lake retreat after Miles is released. Taura remains a Dendarii sergeant receiving experimental treatment, but her engineered metabolism leaves her future uncertain. Nicol is traveling toward her own people, while the conflict among Fell, Ryoval, and Bharaputra remains unsettled.",
         "in_short": "While recovering on Barrayar, Miles Vorkosigan accounts for three tests of his judgment. In Silvy Vale, he proves that Mara Mattulich murdered Harra Csurik's infant, suspends Mara's death sentence, and gives Harra and Lem a route toward a different life. At Jackson's Hole, Miles's Dendarii mission extracts a Bharaputra geneticist and his gene complexes while freeing Nicol and Taura from rival barons. Taura chooses Dendarii service despite an uncertain medical future. At Dagoola, Miles enters a Cetagandan prison to recover his cousin, then organizes more than ten thousand captives for a mass escape. The cousin dies before rescue, and the evacuation costs at least 206 lives as well as Mirka and Tris's lieutenant. Tris and Oliver survive with a mandate to build Marilacan resistance. Illyan shields Miles from the resulting political attack while Miles begins recovery from his injuries and combat fatigue.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3236,7 +3236,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3249,7 +3249,7 @@
       "recaps": {
         "ending": "After several days of coordinated pressure from the travelers, Elisabeth gives in to the Prussian officer so the coach will be allowed to leave Tôtes. The others celebrate their regained freedom, but on departure they immediately restore the social barrier between themselves and her. This time they have all packed provisions while Elisabeth, preoccupied by the sacrifice demanded of her, has brought nothing. No one offers her food, although she fed them generously on the first day. As the coach continues toward Le Havre, she understands that the people who invoked duty and religion to secure her compliance now despise her for complying. Cornudet, who did not join their campaign but did nothing to protect her, repeatedly whistles and sings the Marseillaise. Elisabeth weeps in silence while the rest of the company eat, leaving the respectable passengers' self-interest and hypocrisy fully exposed.",
         "in_short": "During the Franco-Prussian War, ten travelers leave occupied Rouen in a coach: three prosperous couples, two nuns, the republican Cornudet, and Elisabeth Rousset, a sex worker nicknamed Boule de Suif. The respectable passengers shun Elisabeth until hunger forces them to accept the food she alone has brought. At an inn in Tôtes, a Prussian officer refuses to let the coach continue unless Elisabeth sleeps with him. She rejects the demand out of patriotism, and her companions initially praise her. As the delay continues, however, they decide that her resistance is inconveniencing them and use social, religious, and patriotic arguments to pressure her into yielding. Once she does, the officer releases the party. On the resumed journey, everyone else eats prepared food without offering her any, and they again treat her as morally unclean. Elisabeth, exploited by both the occupier and her fellow French travelers, cries while Cornudet sings the Marseillaise.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3420,7 +3420,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -3433,7 +3433,7 @@
       "recaps": {
         "ending": "Tala remains in Makinaven after the caravan's departure is delayed. Her casting rings have been restored, her soul-bound weapon has gained a glaive form, and Kit has been expanded but left unbound. Jevin's dimensional tether gives her a way to resist forced movement, while her gravity work now includes multiple targets, attraction between selected masses, and a much faster but costly activation method. She has made her first permanent step toward becoming Fused but is still far from completing the process. Terry remains her partner without a soul bond, since the available options are too dangerous. Tala and the fellow new Archon reconcile after his inherited combat state takes control and nearly turns a sparring match lethal, but the condition remains a risk. The abnormal Leshkin movement is unexplained. Evidence that a hostile arcane reached Tala inside a human city, together with another encounter missing from her memory, keeps the threat of memory intrusion open. Tala ends by accepting that fusion is her central priority and that food, rest, recreation, and measured training are necessary parts of pursuing it.",
         "in_short": "Tala escorts a caravan through a forest overwhelmed by unusually aggressive Leshkin, loses and regenerates an arm, and reaches Makinaven after five guards die. In the city she restores the casting rings lost with the limb, upgrades her soul-bound weapon, expands Kit, and works with Jevin on a dimensional tether and systematic gravity training. She begins the long process of becoming Fused while developing better targeting, multi-target control, and attraction between selected masses. An investigation indicates that a hostile arcane may have reached her inside a human city and altered her memory. A profitable but dangerous hunt confirms both her growing strength and the need for restraint. Her closest new training partner later enters an inherited lethal combat state during sparring, injures her, and reconciles with her after explaining it. At the close, Tala remains in Makinaven, prioritizing fusion and sustainable recovery while the Leshkin anomaly, unsafe soul bonds, and her missing memories remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3600,7 +3600,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3613,7 +3613,7 @@
       "recaps": {
         "ending": "Dracula retreats from England toward his castle with the hunters following by train, boat, horse, and carriage. Mina's psychic link helps them predict his route but also places her at risk of becoming like him. Van Helsing protects Mina near the castle, enters it, and destroys the three vampire women. At sunset Jonathan, Seward, Arthur, and Quincey intercept the group carrying Dracula's box. Jonathan cuts Dracula's throat while Quincey drives a knife into his heart; the Count's body disintegrates and Mina's mark disappears. Quincey has been mortally wounded in the struggle and dies knowing that Mina is free. Seven years later, Jonathan and Mina have a son whose names commemorate their companions, especially Quincey, and the surviving friends return to Transylvania together. Their assembled records are the chief evidence of what happened, while their shared survival and the child give the ordeal a peaceful human conclusion.",
         "in_short": "Solicitor Jonathan Harker visits Count Dracula in Transylvania and discovers that his host is a vampire preparing to move to England. Dracula travels to Whitby, preys on Lucy Westenra, and leaves her to rise as a vampire despite the efforts of her fiancé Arthur, her other suitors Seward and Quincey, and Professor Van Helsing. After freeing Lucy from that state, they join Jonathan and Mina Harker to hunt Dracula through London and destroy his hiding places. Dracula retaliates by forcing Mina to drink his blood, creating a link that threatens her but also lets the hunters track him. He escapes toward Transylvania in his last box of native earth. The group pursues him to the castle, where Van Helsing destroys the three vampire women and the others intercept Dracula before sunset. Jonathan and Quincey kill him; Mina is released from the curse, though Quincey dies from his wounds. Years later the surviving friends remain united, and Jonathan and Mina name their son in memory of him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/brambles-and-thorns.json
+++ b/data/works-community/0/brambles-and-thorns.json
@@ -325,7 +325,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B09VWQFYD8",
@@ -337,7 +337,7 @@
       "recaps": {
         "ending": "Brambles and Thorns escapes Mortimer's Miraculous Maze, but the company emerges in immediate danger. Carrie has a broken arm, the bonded creature and silver-haired rogue are injured, and Felicia is seriously ill. Trent defeats the shape-changing game-board guardian with acids collected earlier, gathers the supplies most likely to help Felicia, and forces open the exit instead of remaining for a golden chest. He is now accepted as the company's captain, while Carrie remains both a warrior and the holder of an unusual living slime summon. Rhea has gained the elder hunt spirit as an equal guardian, though her contest with the maze keeper is unfinished. Orion continues toward Wallander with the Windblade companion and his bonded sunstrider, while the wood nymph healer follows Trent's party west. Trent's past and damaged spirit, Felicia's family history, Terra's favor, the kingdom's restriction on classes, and the consequences of Owen's destroyed dungeon all remain unresolved.",
         "in_short": "After Owen destroys a contested dungeon and releases its creatures into the Wilds, Trent Embra prepares a westward company with Carrie, Felicia, his bonded creature, and a silver-haired rogue. His private traveller trial gives him rapid training through Rhea, while evidence of royal interference with class choices makes departure more urgent. Elsewhere, Orion Embra bonds with a sunstrider and resumes his journey toward Wallander. Carrie defeats Jace, the group formally becomes Brambles and Thorns, and Trent grows into its accepted captain. The company enters Mortimer's Miraculous Maze, where Carrie gains a second class and a living slime summon. They escape only after Trent destroys the final guardian and abandons a golden chest to secure possible treatment for Felicia. The company ends the book outside the maze but badly injured, with a wood nymph healer following its trail west.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -488,7 +488,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -501,7 +501,7 @@
       "recaps": {
         "ending": "Brat's investigation confirms that Patrick did not run away and kill himself: Simon murdered his twin and concealed the death, then relied on the suicide story to become heir. Simon recognizes that Brat is closing in on the truth and tries to eliminate him, but Brat survives and Simon's guilt is exposed. With the real Patrick's fate established, Brat can no longer continue his legal claim, and his fraud is known to the Ashbys. The family nevertheless distinguishes the young man they have come to value from the scheme that brought him to Latchetts. Alec Loding's plan does not secure the fortune he expected. Brat relinquishes the false identity but is not cast out of the life he has found. His attachment to Eleanor can be acknowledged once they are no longer pretending to be brother and sister, and he has the prospect of belonging at Latchetts honestly rather than through inheritance fraud.",
         "in_short": "Alec Loding recruits an orphan called Brat Farrar to impersonate Patrick Ashby, a teenage heir believed to have killed himself years earlier. Brat's resemblance to Patrick, intensive coaching, and instinctive understanding of horses persuade the Ashby solicitor and much of the family. He arrives just before Patrick's twin Simon would inherit Latchetts, displacing him. Brat grows genuinely fond of Aunt Bee, the younger Ashbys, the estate, and especially Eleanor, while becoming increasingly uneasy about the fraud. Inconsistencies in the accepted story lead him to investigate Patrick's disappearance. He discovers that Patrick was murdered by Simon, who then tries to prevent Brat from exposing him. Brat survives, Simon is revealed, and Patrick's true fate becomes known. Although Brat must surrender the identity and inheritance, the family accepts him on honest terms, leaving him free to remain connected to Latchetts and to pursue his mutual attachment with Eleanor.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -648,7 +648,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -661,7 +661,7 @@
       "recaps": {
         "ending": "The confrontation with Mustapha Mond lays bare the bargain the World State has made: it has abolished war, poverty, disease, and grief, but only by giving up individuality, deep feeling, real art, science pursued for its own sake, and religion. Mond, who secretly knows the forbidden past, has chosen guaranteed stability and comfort over freedom and truth. Bernard Marx and Helmholtz Watson are sentenced to exile on remote islands where nonconformists are sent; Bernard pleads and panics, while Helmholtz accepts the sentence gladly, seeing it as a chance to live and write more honestly. John, refused permission to join them, withdraws to a lonely abandoned lighthouse, where he tries to live simply and to punish his own desires through hard labor and self-flagellation. His attempt at solitude fails: reporters and crowds discover him and treat him as an entertainment. When Lenina appears among the onlookers, John is overwhelmed by longing, guilt, and the hysteria of the mob, and the scene collapses into violence and a soma-fueled orgy in which he takes part. Waking the next day to full awareness of what he has done, and unable to reconcile his ideals with the world he cannot escape, John hangs himself. The novel ends with his death, leaving the World State untouched and its order intact.",
         "in_short": "In a future World State, humans are mass-produced in hatcheries, sorted into castes, and conditioned from infancy to love their roles and to numb any discomfort with the drug soma. Bernard Marx, an Alpha who feels out of place, takes Lenina Crowne to a Savage Reservation, where they meet John, the son of a World State woman stranded there years before. John's father proves to be Bernard's own superior, the Director, and Bernard brings John and his mother back to London, where John becomes a celebrity and Bernard briefly enjoys fame. But John is disgusted by the shallow, controlled society, is rejected in love by Lenina after he recoils from her, and is devastated when his mother dies. He tries and fails to incite a revolt, and is brought before the World Controller Mustapha Mond, who defends stability over truth and beauty. Bernard and his friend Helmholtz are exiled to islands. John retreats to live alone but is hounded by crowds, and, consumed by shame after a night of frenzy, he hangs himself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -813,7 +813,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -826,7 +826,7 @@
       "recaps": {
         "ending": "Mustapha Mond sends Bernard to Iceland and Helmholtz to the Falkland Islands, where their refusal to conform can be contained among other independent people. John rejects Mond's argument that comfort and stability justify the loss of freedom, tragedy, religion, and truth. Unable either to accept the World State or to return to his former life, he withdraws to an abandoned lighthouse and tries to purify himself through labor, solitude, fasting, and self-punishment. Reporters and sightseers turn his retreat into entertainment. When Lenina appears, John's confused desire and disgust erupt before the crowd, and a soma-driven communal frenzy follows. The next morning he remembers his participation and is overwhelmed by shame. Visitors returning to the lighthouse discover that John has hanged himself. His attempt to live outside both societies therefore ends not in escape, but in one more spectacle consumed by the world he opposed.",
         "in_short": "In a future World State, people are manufactured in castes, conditioned from infancy, distracted by constant consumption and sex, and soothed with the drug soma. Bernard Marx, an unhappy Alpha outsider, visits a New Mexico Reservation with the conventional Lenina Crowne and finds Linda, a London woman stranded there, and her son John. Bernard brings them back. John's existence humiliates the Director who fathered him, while John becomes a fashionable curiosity. Guided by Shakespeare, he is horrified by the society's empty pleasures, refuses Lenina's sexual approach, and grieves when Linda dies under soma. After he disrupts a soma distribution, he and his friends face World Controller Mustapha Mond. Mond exiles Bernard and Helmholtz but explains that the State deliberately traded freedom, art, science, and religion for stability. John rejects that bargain and retreats to a lighthouse. The public turns his self-denial into a spectacle, a drugged frenzy overwhelms him, and he hangs himself in shame the next morning.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1114,7 +1114,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774248050",
@@ -1126,7 +1126,7 @@
       "recaps": {
         "ending": "The Maxolhx and Rindhalu openly combine forces against humanity, destroying four of Zhao's destroyers and damaging his flagship before Bishop uses a captured dart to break their immediate advantage. With the Alien Legion unable to protect its new allies, Bishop and Skippy stage synchronized wormhole diagnostics as a galaxy-spanning shutdown. The deception halts major offensives and gives humanity bargaining power, but only they know the capability is false. The Rindhalu refuse to clear Earth's cloud themselves, though they offer technical assistance and say they will discourage Maxolhx interference. They also warn that a concealed Thuranin force is attacking the separate operation supported by David Chica and Janes. That landing force loses orbital support when its carrier is disabled. The final scene leaves the troops cut off beneath a descending, burning starship. Bishop, Skippy, Simms, Zhao, Perkins, Adams, Smythe, and the fleet survive, but the cloud, the fragile bluff, Paradise's detained humans, the new client alliances, and the stranded ground force all remain open concerns.",
         "in_short": "With Earth facing a Maxolhx-made cloud that could block sunlight, Joe Bishop and Skippy turn a hidden servicing station into the foundation of a stronger human fleet. They steal relativistic darts and wormhole controllers, strike Maxolhx targets, and support breakaway populations to build a new alliance. The campaign brings limited victories and covert Jeraptha aid, but it also drives the Maxolhx and Rindhalu into coordinated action. After their combined forces damage Admiral Zhao's fleet, Bishop fakes the power to disable distant wormhole networks and wins a temporary strategic pause. The Rindhalu offer technical help against Earth's cloud and warn of an attack elsewhere. The book closes with David Chica, Janes, and their landing force isolated on a hostile world as a burning starship falls toward them, while Earth's crisis and the wider war remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1314,7 +1314,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1327,7 +1327,7 @@
       "recaps": {
         "ending": "Police arrest Holly because her paid visits to Sally Tomato have carried coded messages for his criminal organization, though she says she never understood them. Her arrest becomes news, José ends their relationship to protect his diplomatic career, and Holly learns that her beloved brother Fred has died in the war. After her release on bail, she refuses to remain for trial and plans to fly to Brazil despite no longer having José waiting there. During the drive to the airport she abandons her cat, then breaks down and searches unsuccessfully for him, recognizing too late that attachment carries responsibilities she has resisted. Holly leaves the country and sends only a brief message; her final whereabouts remain unknown. Months later the narrator finds the cat safe in a family's window. Years afterward, a photograph of an African carving resembling Holly suggests she may have reached that continent, but no proof follows. The narrator hopes she too eventually found a place where she could belong.",
         "in_short": "An unnamed writer remembers Holly Golightly, his young neighbor in wartime Manhattan. Holly lives on gifts from wealthy men, visits jailed racketeer Sally Tomato for money, and dreams of the calm she associates with Tiffany's. Her confident identity conceals a childhood as Lulamae Barnes and a marriage to Texas veterinarian Doc Golightly, whom she refuses to rejoin. She plans a new life with Brazilian diplomat José Ybarra-Jaegar, but police arrest her after discovering that Sally's messages were criminal codes. José abandons her, and Holly, already grieving her brother's wartime death, jumps bail and leaves for South America. On the way she deserts her nameless cat, regrets it, and cannot find him. The narrator later discovers the cat living safely with a family, but Holly's fate remains uncertain. A photograph from Africa offers a possible trace and leaves her friends hoping she finally found a home without surrendering her freedom.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1465,7 +1465,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1478,7 +1478,7 @@
       "recaps": {
         "ending": "Dwayne Hoover reads Trout's story asserting that only its reader possesses free will and that all other people are machines. In his psychotic state, he accepts the claim as a personal revelation and violently attacks people around him, including his son, his employees, and Trout. He is taken away for psychiatric treatment, and the injuries he causes have lasting consequences. Trout survives with part of a finger bitten off and later becomes a figure of literary importance, though the narrator stresses the arbitrary nature of such fame. The narrator finally approaches Trout directly and tells him he is being set free, symbolically relinquishing control over the character. As the narrator departs, Trout follows and asks to be made young again. The request is not granted, leaving creator and creation separated but still bound by mortality, longing, and the world the narrator has constructed.",
         "in_short": "Obscure science-fiction writer Kilgore Trout travels to an arts festival in Midland City, where prosperous automobile dealer Dwayne Hoover is descending into psychosis. The narrator openly presents both men and their environment as his creations, using their histories to examine race, commerce, pollution, loneliness, and the stories Americans tell about freedom. Trout arrives with a novel whose premise says that only the reader has free will and everyone else is a machine. Dwayne finds the book, treats it as a message addressed solely to him, and launches a violent attack on relatives, employees, strangers, and Trout before being hospitalized. Trout survives and later receives the recognition he never expected. The narrator enters the scene, confronts the aged writer, and declares him free from authorial control. Trout follows after him asking to be made young, a final plea that the creator does not fulfill.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1660,7 +1660,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1673,7 +1673,7 @@
       "recaps": {
         "ending": "The Volturi confront the Cullens and their gathered allies on a snowfield, meaning to destroy Renesmee as an outlawed immortal child and to punish the family. Bella's newly discovered gift, a mental shield she can spread over others, blocks the Volturi's powers and denies them the advantage they counted on. Alice, who had disappeared to search for evidence, returns at the decisive moment with Nahuel, a grown half-human, half-vampire man whose long, stable life proves that Renesmee is not dangerous and will mature normally. Stripped of any justification and unable to prevail against the shielded, heavily supported Cullens, the Volturi choose to leave rather than fight, and no battle takes place. The immediate danger ends: Renesmee is safe, the visiting vampires and the wolves depart, and the old hostility between the Cullens and the wolf pack is healed, cemented by Jacob's bond with Renesmee. Bella is fully at home in her vampire life, mated to Edward, mother to their daughter, and reconciled with her father, who stays part of her life without knowing everything. In the final moment, Bella lowers her shield to let Edward read her thoughts for the first time, sharing the whole of her love, and the family faces an open, peaceful future.",
         "in_short": "Bella marries Edward and, on their honeymoon, becomes unexpectedly pregnant with a half-vampire child that grows dangerously fast and threatens her life. Only Rosalie supports her refusal to end it. Seen partly through Jacob's eyes, the crisis splits the wolves: Sam's pack means to destroy the Cullens, so Jacob breaks away with Seth and Leah to protect Bella. The violent birth nearly kills Bella, and Edward transforms her into a vampire to save her; their daughter, Renesmee, is born, and Jacob imprints on her. Bella adjusts remarkably well to vampire life, and the family knows peace until Irina mistakes Renesmee for a forbidden immortal child and reports her to the Volturi. The Volturi gather to destroy the child; the Cullens summon witnesses from around the world, and Bella discovers she can shield others with her mind. At the confrontation, Alice returns with Nahuel, proof that such a child is harmless, and the Volturi withdraw, leaving the family safe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1849,7 +1849,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1862,7 +1862,7 @@
       "recaps": {
         "ending": "Lord Marchmain returns to Brideshead terminally ill. Although he has long lived apart from Catholic practice, Julia and Cordelia want a priest called as he nears death, while Charles objects that the ritual would impose a meaning the dying man does not share. At the last moment Lord Marchmain makes the sign of the cross and receives absolution. Charles accepts the act as evidence of a faith he had dismissed. Julia concludes that she cannot build her happiness on what she now regards as a continuing violation of that faith, so she and Charles separate despite loving one another. Years later, during the war, Charles finds Brideshead occupied by the army. The family has dispersed and the great house has been altered for military use, but a lamp still burns in the chapel. Charles visits it and returns to duty with an unexpected sense that the house's spiritual history has not been extinguished.",
         "in_short": "Army officer Charles Ryder is posted during the Second World War to Brideshead, the country estate that shaped his youth. He remembers meeting the charming Sebastian Flyte at Oxford and becoming intimate with Sebastian's wealthy Catholic family. Charles's attachment to the house grows as Sebastian, burdened by family pressure and alcoholism, withdraws and disappears abroad. Charles becomes a successful painter, marries unhappily, and later begins a relationship with Sebastian's sister Julia, herself trapped in a failed marriage. They plan to divorce their spouses and marry, but the deathbed return of Julia's estranged father to Catholic practice changes them. Julia decides she cannot continue the relationship, and Charles begins to recognize the faith he once rejected. Back at Brideshead with the army, he finds the family world broken up but the chapel lamp still burning, and understands the house as part of a spiritual design rather than merely a lost paradise.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2059,7 +2059,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2072,7 +2072,7 @@
       "recaps": {
         "ending": "Lord Marchmain returns to Brideshead to die and resists the Catholic rites his family wants for him. At the last moment, after Father Mackay has anointed him, he makes the sign of the cross. Charles understands the gesture as a real act of faith. Its effect on Julia is decisive: she concludes that continuing their intended marriage while both remain bound to living spouses would be a deliberate rejection of the faith she cannot escape. She ends her relationship with Charles, accepting loneliness rather than that choice. Years later, during the Second World War, Charles is posted to Brideshead with the army. The house has been altered and damaged by military use, and the Flyte world he knew has dispersed. He visits the chapel, which has reopened for the soldiers, and finds a lamp burning before the reserved sacrament. He leaves with a renewed awareness that the grace he once dismissed has survived the family and their vanished way of life.",
         "in_short": "During the Second World War, army officer Charles Ryder is posted to Brideshead and recalls his connection with its Catholic owners. At Oxford he fell in love with the charm and freedom of Sebastian Flyte, but Sebastian's alcoholism and conflict with his devout mother drove them apart. Charles later became a successful painter, married Celia, and lost faith in his own marriage. On a voyage from America he began an affair with Sebastian's married sister Julia, and both planned divorces and a life at Brideshead. The family reunites when the estranged Lord Marchmain returns home to die. Though he had rejected the Church, his final sign of the cross after receiving anointing convinces Julia that Catholic belief still claims her. She gives up Charles rather than build their union on what she sees as continuing sin. Back at Brideshead with the army years later, Charles visits the restored chapel and recognizes that faith has endured amid the collapse of the family and the world he loved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2264,7 +2264,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2277,7 +2277,7 @@
       "recaps": {
         "ending": "After Leslie's death, Jess first rejects the news and then struggles with anger, guilt, and the fear that her courage has left him stranded. His father finds him near the swollen creek and carries him home, giving Jess the tenderness and reassurance he had wanted from him. Jess visits the Burkes, who are preparing to leave the farmhouse, and learns that Leslie is to be cremated. He later retrieves the art supplies Leslie's parents have given him and begins turning grief into a way forward. Using lumber left by the Burkes, he builds a secure bridge across the creek to Terabithia. He brings May Belle across it, tells her that Leslie made him a king, and welcomes his sister as the new queen. The imaginary kingdom remains, not as a replacement for Leslie but as the part of her imagination and courage that Jess can now share with someone else.",
         "in_short": "Jess Aarons, a lonely fifth-grader who hides his love of drawing, expects running to give him a place at school. New neighbor Leslie Burke outruns him instead, then becomes his closest friend. Across a creek in the woods they create Terabithia, an imaginary kingdom where they can be brave, invent adventures, and make sense of school and family troubles. Leslie's confidence broadens Jess's world, while his friendship gives her a home in an unwelcoming community. After Jess spends a day in Washington with music teacher Miss Edmunds, he returns to learn that Leslie tried to enter Terabithia alone, fell when the rope over the flooded creek broke, and drowned. Jess moves through denial, guilt, and anger, supported unexpectedly by his father and by Leslie's grieving parents. He finally builds a bridge over the creek and brings May Belle into Terabithia as its new queen, carrying Leslie's gift of imagination forward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2422,7 +2422,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2435,7 +2435,7 @@
       "recaps": {
         "ending": "Bridget accepts that her relationship with Roxster restored a part of her life without being able to provide the family future she needs. Their age difference is not treated as shameful, but they are at different stages and separate with affection. Her view of Mr Wallaker changes as she sees the warmth and dependability beneath his stern school manner, especially in the way he responds to Billy and Mabel. Wallaker also comes to understand the grief and effort hidden by Bridget's disorder. Bridget stops measuring every new feeling as a betrayal of Mark and allows the possibility that remembrance and new love can coexist. By the close, she and Wallaker have moved into a reciprocal adult relationship grounded in family life rather than fantasy. The children retain their father as part of their story, while Bridget is no longer suspended at the moment of his death. She remains imperfectly organized, but she has recovered confidence as a mother, writer, friend, and woman with a future.",
         "in_short": "Years after Mark Darcy's death, fifty-one-year-old Bridget Jones is raising Billy and Mabel while struggling with grief, school routines, work, and the conviction that romance belongs to her past. Friends draw her into social media, where she meets Roxster, a charming twenty-nine-year-old. Their relationship restores her confidence and happiness, but private chemistry cannot erase the difference between his freedom and her responsibilities as a parent. At the children's school, Bridget repeatedly clashes with the controlled and apparently disapproving Mr Wallaker. Gradually, his care for the children and understanding of loss revise her first impression. Bridget and Roxster part with genuine affection when it becomes clear that they need different futures. After a series of family and school crises, Bridget recognizes Wallaker as a dependable partner who sees both her disorder and her resilience. She chooses a new relationship without abandoning Mark's memory, and the Darcy family moves forward rather than remaining defined by bereavement.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2623,7 +2623,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2636,7 +2636,7 @@
       "recaps": {
         "ending": "After Bridget returns from imprisonment in Thailand, she learns that Mark worked persistently through legal and diplomatic channels to secure her release. Daniel Cleaver, despite his confident appearance, again proves unwilling to accept responsibility when she is in real danger. Bridget initially believes Mark has chosen Rebecca and interprets signs around her as evidence of an engagement. The misunderstanding collapses when Rebecca reveals that her real romantic interest is Bridget, not Mark. With the supposed rival removed and the manipulation exposed, Bridget and Mark are finally able to confront how poor communication, outside advice, and Bridget's fear of abandonment drove them apart. They reconcile with a clearer appreciation of one another. Around them, the supposedly stable relationships of friends and family reveal their own complications, weakening Bridget's belief that everyone else has mastered adulthood. She ends the book reunited with Mark and better able to value the imperfect relationship she actually has over the imagined versions promoted by social pressure and romantic fantasy.",
         "in_short": "Bridget Jones begins the sequel happily dating Mark Darcy, but her insecurity about poised Rebecca and Mark's demanding work turns ordinary misunderstandings into a breakup. Friends, self-help rules, and Daniel Cleaver's renewed presence amplify rather than solve her doubts. While Bridget's television career produces erratic assignments, the apparently settled relationships around her also begin to crack. On holiday in Thailand with Sharon, Bridget is unknowingly used by Sharon's new companion Jed to carry drugs and is imprisoned. Mark works behind the scenes to win her release, while Daniel again fails her when genuine loyalty is required. Back in Britain, Bridget mistakenly believes Mark and Rebecca are together until Rebecca discloses that she is attracted to Bridget herself. Freed from that false triangle, Bridget and Mark acknowledge their failures of trust and communication and reunite. Bridget ends with a less idealized but more secure understanding of love and of her own life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2827,7 +2827,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2840,7 +2840,7 @@
       "recaps": {
         "ending": "Bridget's mother returns after becoming entangled in Julio's fraudulent business dealings, and the family faces public embarrassment and possible criminal consequences. Mark Darcy uses his legal skill and contacts to pursue Julio, recover the missing money, and help protect Pamela. His quiet action contradicts Daniel Cleaver's earlier story that Mark was the untrustworthy man in their conflict. At Christmas, the Jones family begins to repair the damage caused by Pamela's departure, while Bridget understands more clearly which of the two men has behaved with loyalty. Mark finds Bridget as she is preparing for an evening alone and tells her that he likes her as she is. Their attempt at a romantic night is briefly interrupted when he sees the harsh entries about him in her diary and leaves; Bridget runs outside after him, only to discover that he has gone to buy her a replacement diary for a new beginning. They reconcile and finally become a couple, ending Bridget's year with a relationship founded on a clearer view of both Mark and herself.",
         "in_short": "Bridget Jones begins the year determined to improve her body, career, habits, and romantic prospects while resisting the scrutiny directed at a single woman in her thirties. She starts an affair with her charming boss, Daniel Cleaver, who portrays reserved barrister Mark Darcy as a former friend who betrayed him. Daniel proves unreliable and is caught with another woman, prompting Bridget to leave publishing for a chaotic television-news job. At home, her mother Pamela leaves Bridget's father for Portuguese presenter Julio and becomes involved in his dubious financial venture. Bridget repeatedly encounters Mark and slowly sees his kindness beneath their awkward first impressions. When Julio's scheme collapses, Mark helps locate him and rescue Pamela from the consequences, revealing Daniel's account of their feud to be false. At Christmas Mark tells Bridget he likes her as she is. After a misunderstanding involving her diary, they reconcile and begin a relationship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2970,7 +2970,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2982,7 +2982,7 @@
       },
       "recaps": {
         "in_short": "This volume collects short stories and novellas from across the Dresden Files, most previously published elsewhere. They span the timeline widely and shift among several points of view: cases seen through Harry, an interlude told by the Chicago crime lord who rules much of the city, a client's early adventures alongside a set of Bigfoot cases, and stories following Harry's apprentice Molly during a period of his absence. Each piece stands alone rather than advancing a single continuous plot. The collection ends with a longer original novella told in turn by Harry, his daughter, and their guardian dog during an outing that turns dangerous, offering a rare, intimate look at Harry's life as a father and the constant, quiet vigilance that protecting his child requires.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3081,7 +3081,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3094,7 +3094,7 @@
       "recaps": {
         "ending": "After losing his job and exhausting his attempts to keep Amanda psychologically present, the narrator can no longer maintain the fiction that his crisis is only about a failed marriage or a bad run of nights. His brother Michael's visit and memories of their mother's last illness reveal the grief he has avoided since her death. Amanda remains gone, and an encounter with her does not provide reconciliation or a satisfying explanation. The glamorous city life represented by Tad continues without offering the narrator any real refuge. At dawn, depleted after another night out, he reaches a bakery as workers are producing the day's bread. He obtains a fresh loaf and begins eating it outside. The ordinary physical need for food, together with the memory of his mother, breaks through his numbness and allows him to grieve. There is no instant recovery: he is unemployed, separated, and still responsible for the damage he has done. The close offers a first moment of honesty and an intention to rebuild basic habits and knowledge gradually, rather than another promise of escape.",
         "in_short": "An unnamed young fact-checker at an elite Manhattan magazine spends his nights using cocaine and following Tad Allagash through fashionable clubs. By day he arrives late, makes mistakes, and fixates on tabloid stories instead of working. His model wife Amanda has abruptly left him, and he haunts the fashion world in hopes of seeing or understanding her. His professional collapse ends in dismissal, while parties and brief connections fail to relieve his isolation. When his brother Michael arrives, it becomes clear that the narrator has also been evading the anniversary of their mother's death and the memories of her final illness. Amanda does not return, and the city's constant stimulation offers no resolution. After another long night, the narrator obtains a fresh loaf from a bakery at dawn. Eating it finally brings his buried grief to the surface. The novel ends without repairing his life, but with his first honest recognition that recovery will require patient attention to the most basic parts of living.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3252,7 +3252,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3265,7 +3265,7 @@
       "recaps": {
         "ending": "By the close, Eragon has settled several of the questions that had haunted him. He rescues Katrina and kills the Ra'zac, letting Roran and Katrina marry, and he learns from Oromis that his true father was Brom, not the traitor Morzan, freeing him from Murtagh's poisonous claim of brotherhood by blood. With the elf smith Rhunon guiding his hands, he forges and wields a Rider's blade he names Brisingr. The dwarves elect Orik as their new king, securing their place in the alliance, and Nasuada survives a punishing trial that binds her wavering allies to the Varden. But the cost is heavy: in a battle near Gil'ead, Murtagh and Thorn, wielding power lent by Galbatorix, kill Eragon's teacher Oromis and the dragon Glaedr, robbing Eragon of his mentors. Glaedr's heart-of-hearts, which holds his consciousness, is saved and entrusted to Eragon and Saphira. The Varden press deeper into the Empire, the king's strength looms larger than ever, and Eragon knows the final reckoning with Galbatorix and Murtagh is drawing near.",
         "in_short": "Eragon and Roran, with Saphira's help, storm the dark spire of Helgrind and free Roran's betrothed Katrina, and Eragon destroys the last of the king's inhuman servants, the Ra'zac. Returning to the elves, Eragon learns from his teacher Oromis a truth that overturns Murtagh's earlier claim: his father was not the traitor Morzan but Brom, the former Rider who raised and trained him. With the aid of the elven smith Rhunon, Eragon forges a Rider's sword of his own and names it Brisingr. Among the dwarves, after their king's death, his friend Orik is chosen to take the throne, keeping the dwarves in the war. Nasuada endures a brutal ordeal to hold the loyalty of her allies. In a battle near the city of Gil'ead, Murtagh and the king's power strike down Oromis and Glaedr, though the old dragon's preserved heart-of-hearts passes into Eragon and Saphira's keeping, and the war moves toward its final stage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3395,7 +3395,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3408,7 +3408,7 @@
       "recaps": {
         "ending": "Years after Ennis and Jack's final meeting, a postcard Ennis sends is returned with notice that Jack has died. Lureen tells him that a tire exploded while Jack was changing it and that he drowned in his own blood. Ennis instead imagines that Jack was murdered, a possibility the story does not settle. At Lightning Flat, Jack's father refuses the request to scatter Jack's ashes on Brokeback Mountain and reveals that Jack had lately discussed ranching with another man. In Jack's childhood room, Ennis finds the shirt he lost after their first summer, preserved inside one of Jack's shirts. Jack's mother lets him take both. Ennis later lives alone in a trailer, with the shirts and a picture of Brokeback Mountain hanging together. When Alma Junior announces her engagement, he overcomes his first impulse to put work ahead of her and promises to attend the wedding. Jack remains absent and their imagined ranch life can never happen, but Ennis preserves the private evidence of their bond and makes a small choice against complete isolation.",
         "in_short": "In 1963, young ranch hands Ennis Del Mar and Jack Twist spend a summer tending sheep on Brokeback Mountain and begin a sexual relationship. Both later marry women and have children, yet their reunion four years later starts a pattern of secret trips that continues for decades. Jack wants them to build a ranch life together, but Ennis, shaped by poverty and by a childhood lesson in the violence directed at men like them, refuses. The compromise strains both marriages: Alma divorces Ennis, while Jack remains with Lureen and seeks connection elsewhere. After Jack dies in circumstances reported as an accident but imagined by Ennis as murder, Ennis visits Jack's parents. He finds that Jack kept two shirts from their first summer, one folded inside the other, and takes them home. Living alone in a trailer, he hangs the shirts with a picture of Brokeback Mountain and carries their relationship as a private, enduring grief.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3523,7 +3523,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3536,7 +3536,7 @@
       "recaps": {
         "ending": "Hull's guidance is exposed as part of an effort to control the dimensional breach rather than simply close it. Elena, Clay, Jeremy, Xavier, Zoe, Jaime, and the Pack allies refuse the arrangement he tries to impose and survive the final confrontation. Hull is stopped, and the link opened through the Ripper letter is sealed before more dead people, disease-bearing rats, or Victorian fog can pass into modern Toronto. The immediate supernatural outbreak is contained without revealing werewolves to the human city. Xavier's involvement remains self-interested, but he helps bring the crisis to an end and the bargain that began with the theft is finished. Elena has endured the investigation, several transformations, and medical uncertainty without losing the pregnancy. At the close she and Clay learn that they are expecting twins. They return to Stonehaven with the danger over, the Pack preparing for an unprecedented addition to its family, and Elena no longer treating pregnancy as a reason to withdraw from the life she chose.",
         "in_short": "Pregnant werewolf Elena Michaels accepts a bargain with teleporting half-demon Xavier Reese: in exchange for useful information, she and Clay will steal a letter linked to Jack the Ripper from a sorcerer's collection. The theft disturbs magic attached to the document and opens a passage between modern Toronto and Victorian London. Unnatural fog, plague-carrying rats, and animated corpses begin crossing over, while the letter and the people who understand it prove difficult to trust. Elena and Clay investigate with Jeremy, local vampire Zoe Takano, necromancer Jaime Vegas, and other Pack allies, all while fearing what the crisis and Elena's Changes may do to her pregnancy. Hull presents himself as a guide to the breach but is exposed as trying to control it for his own purposes. The group stops him and seals the passage, containing the supernatural outbreak. Elena and her unborn children are healthy, and the final news is that she and Clay are expecting twins.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3693,7 +3693,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3704,7 +3704,7 @@
       "recaps": {
         "ending": "Broken Homes ends on the series' hardest gut-punch. The Skygarden case resolves: Erik Stromberg built the tower as a magical machine, quietly accumulating power over decades, and the Faceless Man engineered the estate's decant and demolition in order to harvest that stored charge for himself. On demolition night the tower comes down, and in the chaos the truth comes out - Lesley May, the Folly's second apprentice and Peter's closest friend, has been working for the Faceless Man. She tasers Peter and escapes with the enemy, her betrayal apparently bought with the one thing the Folly could not give her: the promise of repairing her destroyed face. Varvara Sidorovna, the Soviet-trained battle magician who fought on the Faceless Man's side of the affair, ends the book in the Folly's hands after facing Nightingale - proof of how far outclassed almost everyone is when the old soldiers fight. The Faceless Man himself remains at large, better resourced and more dangerous than the Folly had credited, and now with an apprentice-grade insider's knowledge of their people and methods. On the personal side, Beverley Brook is back in London, she and Peter finally acting on the pull between them. Peter ends the book physically intact and personally wrecked: the hunt for the Faceless Man is now also the hunt for Lesley, and the Folly must reckon with how long she was turned and how much she gave away.",
         "in_short": "A fatal car crash with a corpse in the vehicle, a town-planning official who steps in front of a train, and a rare-book thief burned from the inside all prove to share a thread: the Skygarden Estate, a brutalist south London tower designed by Erik Stromberg, an architect who knew about magic. Peter Grant and Lesley May move onto the estate undercover and discover that Stromberg built the tower as a slow magical accumulator - and that the Faceless Man, the trained black magician the Folly has hunted for two books, intends to harvest its stored power by having the tower demolished. Along the way Peter meets Sky, a nymph bound to the estate's trees, crosses Varvara Sidorovna, a Soviet-trained Night Witch working for the enemy, and welcomes Beverley Brook back from her upstream exile, their relationship finally beginning. On demolition night the tower falls and the case detonates personally: Lesley May has been the Faceless Man's agent, her loyalty bought with the promise of a repaired face. She tasers Peter and vanishes with him. Varvara is captured after facing Nightingale; the Faceless Man escapes; and the Folly is left betrayed from within.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3860,7 +3860,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3873,7 +3873,7 @@
       "recaps": {
         "ending": "Back in Enniscorthy, Eilis temporarily occupies the place Rose left behind: she helps her mother, takes office work that uses her bookkeeping training, and is welcomed into a social circle that once seemed closed to her. Jim Farrell courts her, and she delays telling either him or her mother that she married Tony before leaving New York. Miss Kelly eventually reveals that news of the marriage has reached Ireland through her connection to Brooklyn. Faced with public exposure and the consequences of her silence, Eilis finally tells her mother that she is married and must return. Her mother receives the news without a confrontation and helps her prepare to leave. Eilis departs Ireland for Brooklyn, ending her possible future with Jim without meeting him again. The novel closes during her journey, with Tony still across the Atlantic and Eilis committed by both marriage and choice to the American life she had nearly abandoned.",
         "in_short": "With few prospects in 1950s Enniscorthy, Eilis Lacey accepts a job arranged by Father Flood in Brooklyn. She endures a difficult crossing, severe homesickness, and work at a department store, then gradually builds a life through night classes and her relationship with Tony Fiorello, an Italian American plumber. When her sister Rose dies suddenly, Eilis decides to visit her widowed mother in Ireland. Tony fears she will not return and persuades her to marry him secretly before she sails. At home, Eilis slips into Rose's office role and is courted by Jim Farrell, making an Irish future seem newly possible. She conceals her marriage and postpones leaving until Miss Kelly shows that the secret has traveled from Brooklyn. Eilis tells her mother the truth and returns to America, leaving Jim behind and choosing the life and husband awaiting her in Brooklyn.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4043,7 +4043,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4056,7 +4056,7 @@
       "recaps": {
         "ending": "Aurora is recovered from the coercive religious life imposed by David Minor and begins the difficult work of returning to herself and her family. Tom builds a future with Honey Chowder, while Lucy is restored to the care of adults who will protect her. Harry Brightman's attempted return to fraud ends with his death, but Nathan remembers the generosity and reinvention that were also real parts of him. Nathan himself suffers a heart attack and survives. During his hospital stay he imagines a project that would record the lives of ordinary people before their stories disappear, transforming his private catalogue of folly into a more generous form of remembrance. On the morning of September 11, 2001, he leaves the Brooklyn hospital shortly before the first attack on the World Trade Center, happy to be alive and unaware of the disaster about to change the city.",
         "in_short": "After cancer treatment and divorce, retired insurance salesman Nathan Glass moves to Brooklyn intending to pass his remaining years quietly while writing a catalogue of human mistakes. He unexpectedly finds his nephew Tom working for exuberant bookseller Harry Brightman. Their improvised circle expands when Tom's silent young niece Lucy arrives alone, signaling that her mother Aurora is in danger. A trip north strands Nathan, Tom, and Lucy at a Vermont inn, where Tom falls in love with Honey Chowder. Back in Brooklyn, Harry's concealed past and a fraudulent manuscript scheme bring blackmail and end in his death. Nathan and Tom help free Aurora from her controlling husband and reunite her with Lucy. Nathan survives a heart attack and conceives a service for preserving ordinary people's histories. He walks out of the hospital on the morning of September 11, 2001, grateful for his restored life and unaware that the first plane will strike the World Trade Center minutes later.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4337,7 +4337,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002VACF0U",
@@ -4349,7 +4349,7 @@
       "recaps": {
         "ending": "Ser Galen's conspiracy ends at the Thames Tidal Barrier after he kills Duv Galeni's brother and Mark shoots him. Ivan is rescued from the flooding mechanism, Quinn is recovered alive, and the competing Cetagandan and Barrayaran covert teams are drawn into police custody. Galeni helps subdue the remaining Cetagandan operatives but stays at the London embassy while Illyan reviews his loyalty and conduct.\n\nMiles and Mark exploit their identical appearance one last time: Miles poses as Admiral Naismith while Mark poses as Lord Vorkosigan, leaving the Cetagandan witnesses convinced they are separate men. Miles then gives Mark money and releases him without conditions. Mark refuses a future on Barrayar for now and considers turning against the clone trade that created him. Miles and Quinn remain together, although her refusal of a Barrayaran life leaves their long-term future unsettled.\n\nWith the blocked eighteen million marks restored, Destang assigns the Dendarii a concealed rescue operation against a pirate mercenary fleet. Tung retires to marry, and Miles begins planning an infiltration as the fleet leaves Earth for Orient Station.",
         "in_short": "After a costly Dendarii rescue operation, Miles Vorkosigan reaches Earth short of money and unable to separate his Barrayaran life from his Admiral Naismith identity. A blocked payment, an assassination attempt, and Duv Galeni's disappearance lead to a Komarran conspiracy run by Galeni's father, Ser Galen. The conspirators have trained Miles's clone, Mark, to replace him and destabilize Barrayar. Miles and Galeni escape, but Miles defies Barrayaran security to keep Mark from being killed. At the Thames Tidal Barrier, Ser Galen murders Galeni's brother, and Mark kills Ser Galen before helping Miles save Ivan. Miles frees Mark rather than claim him, and their final impersonation preserves the Naismith secret. Quinn survives, Galeni remains under review, and the missing funds are restored. Tung retires as Miles takes the Dendarii toward a new covert hostage-rescue mission.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4545,7 +4545,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4558,7 +4558,7 @@
       "recaps": {
         "ending": "Dmitri is convicted of murdering Fyodor Pavlovich and sentenced to twenty years of hard labor in Siberia, although Smerdyakov privately confessed the murder to Ivan before killing himself. Ivan collapses with brain fever after trying to reveal that confession at the trial. Katerina's testimony and Dmitri's incriminating letter help secure the verdict; afterward she and Grushenka reach an uneasy recognition of each other's devotion and suffering. Ivan and Katerina have discussed arranging Dmitri's escape during transfer, and Dmitri considers fleeing abroad with Grushenka, though the plan remains unrealized. Alyosha stays close to the family while also attending Ilyusha's funeral. At a stone where the schoolboys once gathered, he urges them to preserve the memory of their dead friend and of the kindness that united them. The novel closes on the boys' affirmation of that memory, leaving Dmitri's legal fate and possible escape unresolved.",
         "in_short": "Fyodor Pavlovich Karamazov's quarrel with his volatile eldest son Dmitri combines disputed inheritance, mutual hatred, and rivalry for Grushenka. His other sons are Ivan, an intellectual tormented by innocent suffering and moral freedom, and Alyosha, a novice shaped by the compassionate elder Zosima. Fyodor is murdered after Dmitri has publicly threatened him. Circumstantial evidence points to Dmitri, but the servant Smerdyakov confesses privately to Ivan, claiming Ivan's ideas and departure gave him permission. Smerdyakov kills himself, Ivan breaks down, and Dmitri is convicted and sentenced to Siberia after a dramatic trial. An escape plan with Grushenka remains possible. Alongside the murder story, Alyosha befriends the impoverished Snegiryov family and a group of schoolboys gathered around the dying Ilyusha. After Ilyusha's funeral, Alyosha asks the boys to keep one good shared memory as a guide through later life, ending the novel with communal hope amid the family's unresolved suffering.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4718,7 +4718,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4731,7 +4731,7 @@
       "recaps": {
         "ending": "Robert Livingstone is killed and the long threat to Green Creek ends with him. The Bennett pack fights him together, wolves, witch and humans, and what he built collapses once he is gone. Carter comes out of it with the thing he had never allowed himself to want: he stops being only the loud brother holding everyone else up, and he and Gavin are mates. Gavin, who spent years unable to hold human form and longer than that being nothing but his father's son, is a Bennett wolf by the pack's choice rather than by anyone's tolerance. The pack ends the series whole and at home in Green Creek: Ox and Joe as its alphas, Gordo and Mark, Kelly and Robbie, Carter and Gavin, Elizabeth at the centre of the house, and the humans of the garage as much a part of it as the wolves. The secrets Thomas Bennett kept are out and dealt with rather than inherited by another generation, the wolf leadership no longer has any hold over the pack, and the book closes looking forward rather than back.",
         "in_short": "Carter Bennett leaves Green Creek alone to follow Gavin, travelling without pack bonds in a way that steadily wears a wolf down. He finds him, and the two are caught by hunters who trap and cage wolves; they escape together, and Gavin, who has spent years unable to hold human form, begins to be a man again. On the road back, Carter learns how much of his family's history his father kept from him, including what was done to Gavin and how the Bennett line is bound up with Robert Livingstone's ruin. In Green Creek the pack has to accept Livingstone's son among them, hardest of all for Gordo. Livingstone's plan finally comes into the open, and the pack meets it together. He is killed, the threat that has hung over the Bennetts across four books ends with him, and Carter and Gavin become mates. The pack closes the series intact and at home: Ox and Joe as alphas, Gordo and Mark, Kelly and Robbie, Carter and Gavin, with Green Creek finally safe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5053,7 +5053,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774246325",
@@ -5065,7 +5065,7 @@
       "recaps": {
         "ending": "Valkyrie escapes Admiral Reichert's Snowcone blockade after the Rindhalu arrive to prevent the Maxolhx from taking Skippy. Bishop uses detonations aboard malware-infected ships to provoke a battle between the senior species, then exploits the captured frigate's failed jump to break through the damping fields. Valkyrie survives with structural damage, a serious drive-power fault, and forty percent of its drive coils lost. Skippy remains functional but weakened, and Bilby, Simms, Smythe, Perkins, and Bishop remain active with the surviving force. At the remote base, the crew confirms that the Maxolhx devices in Jupiter will place gas between Earth and the Sun, producing an artificial glaciation that may kill billions over the coming centuries. Bishop will neither activate the civilization-destroying Elder weapons nor launch a predictable strike on the mass drivers. Avalon has 882 settlers and five years of supplies, the forward base can begin rebuilding ships, and humans remain trapped on Paradise. The immediate next move is a secret initiative involving the Ruhar, intended to gain the allies and resources Earth lacks.",
         "in_short": "After revealing that humans command Valkyrie and possess Elder weapons, Joe Bishop uses that deterrent to pursue allies, rescue captives, strike a Thuranin bioweapons facility, and begin rebuilding humanity's off-world strength. Earth establishes the Avalon refuge and a remote fleet base with covert Jeraptha help, but the Maxolhx answer with diplomatic isolation, deadly attacks on Paradise and Earth, and Admiral Reichert's trap for Valkyrie. Skippy is badly damaged saving the ship, which becomes trapped beneath an ice giant until captured Maxolhx hardware, planted malware, and a Rindhalu intervention create an escape. The crew returns to learn that devices at Jupiter will shade Earth and cause centuries of artificial glaciation. Bishop rejects both the fatal use of the Elder weapons and an obvious attack on Jupiter. With Valkyrie damaged and Earth still vulnerable, he turns toward a surprise operation intended to obtain Ruhar support, while Avalon, Paradise, and the new human fleet remain exposed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5274,7 +5274,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5287,7 +5287,7 @@
       "recaps": {
         "ending": "Bud shows Herman Calloway the dated stones from his suitcase, and Calloway recognizes them as stones he collected and labeled for his daughter. Miss Thomas identifies Bud's mother, Angela Janet, as Calloway's estranged daughter. Bud therefore is not Calloway's son but his grandson. The discovery breaks through Calloway's hostility: he grieves for the daughter whose death he had not known about, while Bud finally understands why his mother kept the flyers and stones. The members of the band accept Bud into their household and musical family. They give him a small saxophone, and Steady Eddie begins guiding him toward learning it. Bud unpacks his suitcase in his mother's old room, keeps the objects that connect their histories, and adds a new performance flyer of his own. Though his relationship with his grandfather will need time, he has found relatives, a stable home, and a future tied to the music that led him there.",
         "in_short": "Ten-year-old Bud Caldwell, orphaned in Depression-era Michigan, escapes an abusive foster home carrying a suitcase of objects that belonged to his mother. After a failed attempt to leave Flint by freight train, he studies her old band flyers and decides that musician Herman E. Calloway must be his father. He walks toward Grand Rapids until union organizer Lefty Lewis finds him and delivers him to Calloway's band. Calloway rejects Bud's claim, but the other musicians feed, shelter, and welcome him. A collection of dated stones finally reveals the real connection: Calloway gave the stones to his estranged daughter, Angela Janet, who was Bud's mother. Calloway is Bud's grandfather, not his father. The news brings grief as well as belonging. Bud moves into his mother's old room, is accepted by the band, receives a saxophone, and begins building a home and musical future with his newly discovered family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5485,7 +5485,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5498,7 +5498,7 @@
       "recaps": {
         "ending": "After Thomas's sudden death, the Buddenbrook firm is liquidated according to his instructions, and the sale of its assets yields less than the family expected. Gerda and Hanno move to a smaller house while Tony continues to defend the family's dignity. Hanno, already physically fragile and alienated from school, contracts typhoid and dies, ending the direct male line on which the firm's future had depended. Gerda decides to return to Amsterdam, leaving the remaining Buddenbrook women dispersed and diminished. In the final family gathering, Tony insists that they will meet their dead again, seeking certainty that the vanished household and its people have not been reduced to nothing. The commercial dynasty has ended, but family memory persists through those who survive it.",
         "in_short": "Across four generations in nineteenth-century Lübeck, the Buddenbrook grain firm rises, stabilizes, and gradually disappears. Tony Buddenbrook sacrifices her love for Morten Schwarzkopf to marry the fraudulent Grünlich, divorces him, and later ends an unhappy marriage to Alois Permaneder. Her brother Thomas inherits the firm, marries the musical Gerda Arnoldsen, becomes a senator, and strains to preserve the family's public authority as his confidence and health erode. Their brother Christian rejects mercantile discipline, while Tony's daughter Erika suffers through her husband Weinschenk's conviction and flight. Thomas and Gerda's delicate son Hanno prefers music to business and cannot become the heir his father needs. Thomas dies after a dental crisis, the firm is liquidated, and Hanno later dies of typhoid. Gerda leaves Lübeck, and Tony remains among the surviving women, holding fiercely to the memory of a family whose commercial line has ended.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5639,7 +5639,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5652,7 +5652,7 @@
       "recaps": {
         "ending": "Sharikov returns to the apartment after denouncing Professor Preobrazhensky to the authorities and threatens him and Bormental with a revolver. The doctors overpower him and repeat the operation in reverse, removing the transplanted human material. When investigators arrive to ask about Sharikov's disappearance, the professor shows them a creature visibly changing back into a dog and denies that a murder has occurred. The officials leave without making an arrest. Sharik gradually regains his canine body and contented outlook, remembering the human episode only as a confused discomfort. He remains in the professor's apartment while Preobrazhensky resumes his medical work. The household's old order has been restored by undoing the experiment, although the professor continues procedures whose full meaning the dog cannot understand.",
         "in_short": "Professor Preobrazhensky, a privileged surgeon in early Soviet Moscow, rescues a stray dog called Sharik and uses him in an experiment, transplanting organs from the dead criminal Klim Chugunkin. Sharik rapidly changes into a humanlike man who calls himself Polygraph Polygraphovich Sharikov. His coarse behavior, demands for documents and housing, and alliance with the building official Shvonder turn the professor's apartment into a battleground. Sharikov gains a municipal job killing stray animals, deceives a young colleague, and finally reports the professor to the authorities. When he threatens Preobrazhensky and Doctor Bormental with a weapon, the doctors subdue him and reverse the operation. Officials investigating Sharikov's disappearance find no corpse, only a being changing back into a dog. Sharik returns to canine form and lives comfortably with the professor, while the failed attempt to manufacture a person is quietly erased.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5812,7 +5812,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5825,7 +5825,7 @@
       "recaps": {
         "ending": "Agnes's final account makes clear that the public version of a calculating conspiracy has flattened a far more tangled history. Fridrik carried out the principal attack at Illugastaðir. Natan remained alive but mortally injured, and Agnes says she ended his suffering when he appealed to her; she then helped conceal the killings by fire. Her responsibility is real, but the household and Tóti now understand the abandonment, exploitation, and desperate attachment that preceded the crime. No fuller understanding changes the sentence. When the execution order arrives, the Kornsá family prepares Agnes as one of their own rather than surrendering her as a stranger. Tóti accompanies her to the place of execution and tries to steady her terror. Agnes and Fridrik are beheaded, fulfilling the official judgment that has shadowed the novel from its opening. The authorities obtain their public punishment, while the people who listened to Agnes are left with a human life that the legal record could not contain.",
         "in_short": "In northern Iceland in 1829, Agnes Magnúsdóttir awaits execution for her role in the murders of Natan Ketilsson and Pétur Jónsson. The authorities place her at Kornsá farm with district officer Jón Jónsson, his wife Margrét, and their daughters, and assign the young Reverend Tóti to prepare her spiritually. The family initially fears Agnes, but shared work and close quarters gradually replace the notorious public image with knowledge of a capable, wounded woman. Agnes tells Tóti how poverty, abandonment, service, and her attachment to the manipulative Natan led her to Illugastaðir. On the fatal night Fridrik attacked Natan and Pétur; Agnes says she killed the already mortally wounded Natan at his request and helped cover the crime with fire. Her account complicates but cannot overturn her conviction. The Kornsá family gives her dignity in her last days, Tóti accompanies her to the execution site, and Agnes is beheaded alongside Fridrik.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/burmese-days.json
+++ b/data/works-community/0/burmese-days.json
@@ -124,7 +124,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -137,7 +137,7 @@
       "recaps": {
         "ending": "Ma Hla May interrupts the church service and publicly identifies herself as Flory's discarded mistress. Elizabeth, who had been close to accepting him again, refuses to see him afterward. Convinced that he has lost his last chance of companionship and escape from colonial isolation, Flory first shoots his dog Flo and then kills himself. Dr Veraswami loses the protection that Flory's friendship had provided; U Po Kyin's accusations prevail, and the doctor is demoted and transferred away. U Po Kyin gains official honors and membership in the European Club, but dies before he can carry out the religious building he intended as compensation for his wrongdoing. Elizabeth remains in Kyauktada and marries Mr Macgregor. She settles into the conventional role of a colonial official's wife, while the social order that destroyed Flory and excluded Veraswami continues largely unchanged.",
         "in_short": "In colonial Burma, timber merchant John Flory despises the racism and falsehood of the British community but depends on it too much to oppose it openly. His closest friend, the Indian doctor Veraswami, needs public support against a corrupt Burmese magistrate, U Po Kyin. Flory instead devotes himself to courting Elizabeth Lackersteen, a newly arrived Englishwoman who wants a conventional colonial life and recoils from his sympathy for Burmese culture. Their uneven attachment is interrupted by the confident Lieutenant Verrall. After Verrall leaves, Flory and Elizabeth nearly reconcile, but U Po Kyin uses Flory's former mistress, Ma Hla May, to expose him during church. Elizabeth rejects him, and Flory kills his dog and himself. Without him, Veraswami is disgraced while U Po Kyin wins admission to the European Club. Elizabeth marries the senior official Macgregor and becomes part of the society Flory could neither accept nor escape.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -295,7 +295,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -308,7 +308,7 @@
       "recaps": {
         "ending": "Frank Crutchley is proved to have murdered William Noakes. He exploited his mechanical skill and knowledge of Talboys to arrange a delayed blow from a heavy object, allowing him to appear elsewhere when the fatal mechanism operated. The disturbed household equipment and inconsistent timing reveal that the scene was engineered rather than the result of a simple fall. Crutchley's motive lies in Noakes's money and in his plans involving Agnes Twitterton; his courtship was part of a self-interested scheme rather than the security she imagined. Peter's reconstruction leads to Crutchley's arrest and conviction. The legal success gives Peter no satisfaction: because his detection has helped send a man to execution, his wartime trauma and horror of responsibility return. On the morning the sentence is carried out, Harriet remains with him through the crisis. Their honeymoon ends with a clearer, more difficult form of intimacy, founded on her willingness to share the consequences of the work as well as the pleasure of solving its puzzle.",
         "in_short": "Newly married Lord Peter Wimsey and Harriet Vane travel to Talboys, the country house Peter bought for her, only to find it unprepared and its former owner William Noakes missing. Noakes is soon discovered dead in the cellar. Local testimony and the state of the house make the time and method of death appear impossible. Working with Superintendent Kirk, Peter and Harriet learn that Noakes had deceived and offended many people. Clocks, wireless equipment, household objects, and conflicting alibis reveal a delayed mechanical murder rather than an accidental fall. Garage mechanic Frank Crutchley rigged the fatal blow so it would occur while he was elsewhere, seeking financial advantage through Noakes and his niece Agnes Twitterton. Crutchley is caught, convicted, and executed. The result reawakens Peter's war trauma and his anguish over causing a death through detection. Harriet supports him through the execution morning, and their first case as a married couple deepens their partnership beyond the romance of the honeymoon.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -469,7 +469,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -482,7 +482,7 @@
       "recaps": {
         "ending": "David reaches Calamity itself and finds that it is a being rather than a star: an entity from outside this world that came here and gave people powers, and whose gift carries with it the compulsion toward cruelty that has ruined nearly everyone who received it. Larcener proves to be another of the same kind, an earlier arrival who has been living among humans. David confronts Calamity, refuses the terms it offers him, and forces it to leave, which ends its hold over the world. Prof is recovered rather than killed: stripped of what was driving him, he is himself again, and the founder of the Reckoners is returned to them, though not undamaged by what he did while he was gone. David does not come through unchanged either, and ends the book with abilities of his own, which makes him precisely the kind of creature he spent his life hunting and the first test of his own argument that an Epic can choose otherwise. The Reckoners are left in a world that still contains Epics but no longer contains the force that made them monstrous, facing the work of rebuilding rather than the work of resisting.",
         "in_short": "Prof has fallen and taken a city, and the surviving Reckoners are fugitives. David's position is now the team's working theory: Epics are driven to cruelty by fear rather than by power, and facing that fear can undo it, with Megan as the proof. They track Prof to Ildithia, the remains of Atlanta, a city built of salt that crumbles at one edge and regrows at the other so the whole thing migrates across the country. Operating under cover, short of equipment and dependent on the maker Knighthawk, they try to reach a man who invented every method they use against him, while the power-stealing Epic Larcener attaches himself to them and the city-destroying Obliteration pursues his own plan. David's investigation into the origin of Epic powers points at Calamity itself, and he finds a way to reach it. Calamity proves to be a being that came here and gave out powers, and Larcener is another of the same kind. David forces Calamity to withdraw, Prof is freed and restored, and David ends the book an Epic himself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -699,7 +699,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -712,7 +712,7 @@
       "recaps": {
         "ending": "On Io, the crew reach Mao's laboratory. Prax finds Mei alive, still early enough in the process to be saved, and Amos gets her out; Katoa and the other children who went before her cannot be recovered. Bobbie fights one of the hybrid creatures on the moon's surface in powered armor and destroys it. Nguyen's ship launches a swarm of hybrid-carrying missiles at Earth, and the Rocinante and the gathered fleets, coordinated by Avasarala, destroy them before they reach the planet. Nguyen is broken and arrested, Jules-Pierre Mao is taken into custody, and Errinwright, exposed as the man inside the UN who armed the program, is removed and disgraced, leaving Avasarala with far more power than she had. Doctor Cortazar is captured alive and his research falls into UN hands, which is its own unfinished problem. Prax and Mei are reunited, Bobbie ends up with no service to return to and a place among Avasarala's people, and the Rocinante crew survive intact with Holden somewhat restored to himself. In the closing days, the protomolecule on Venus finishes whatever it has been building: a vast structure lifts off the planet, crosses the solar system, and comes to rest far beyond the orbit of Uranus, where it begins assembling an enormous ring.",
         "in_short": "Eighteen months after Eros, a monstrous figure that survives hard vacuum unarmored destroys a Martian marine patrol on Ganymede, and the resulting battle wrecks the moon that feeds the outer planets. Gunnery Sergeant Bobbie Draper, the only survivor, is sent to Earth to testify and, when her account is suppressed, allies herself with UN official Chrisjen Avasarala, who is hunting whoever is still working with the protomolecule. On Ganymede, botanist Prax Meng searches for his young daughter Mei, taken by her doctor, and joins James Holden and the Rocinante when they arrive to investigate. The threads converge: the industrialist Jules-Pierre Mao, protected by figures inside the UN government, has been using children with immune disorders to grow protomolecule-human hybrids as weapons. Avasarala is lured aboard Mao's ship and effectively held prisoner until Bobbie fights their way out to the Rocinante. The crew track the program to Io, rescue Mei, destroy a hybrid, and stop a missile launch aimed at Earth. Mao and his backers fall; Avasarala rises. On Venus, the protomolecule finishes its work, leaves the planet, and builds an enormous ring beyond the orbit of Uranus.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -884,7 +884,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -897,7 +897,7 @@
       "recaps": {
         "ending": "Smiley induces Elsa Fennan to send a message that will bring her controller to a meeting. Dieter Frey does not come himself: Mundt murders her at the theatre where the exchanges had been made, removing the last witness who could name the network. Smiley picks up the trail the same night and confronts Dieter on a river bridge in dense fog. They fight, and Dieter, who has the advantage and could kill him, recognises his old case officer and lets go; he falls into the water and drowns. Mundt is already out of the country and escapes to East Germany unpunished. Elsa and Samuel Fennan are both dead, and the service accepts a version of events that spares it embarrassment: Maston can present the case as closed and the department as blameless. Smiley, who has resigned, takes no satisfaction from having been right. He is left with the knowledge that he killed a man he had made, and that the loyalties on which his profession rests are indistinguishable in kind from those of the other side. Convalescing and adrift, he receives word from Ann and leaves England to go to her, his return to the service unresolved.",
         "in_short": "George Smiley, an unassuming officer of Britain's security service, conducts a routine loyalty interview with the Foreign Office official Samuel Fennan after an anonymous letter revives his student communism. Days later Fennan is found shot at home beside a typed suicide note blaming the interview. Smiley's superior wants the affair buried, but details refuse to fit: an early morning telephone call Fennan himself had booked, his widow Elsa's shifting account, and a friendly letter Fennan had posted to Smiley before he died. Working outside the service with the police inspector Mendel and his colleague Peter Guillam, Smiley traces a hired car to a Battersea garage and a fair-haired foreigner, and uncovers a courier routine run through a suburban theatre. The material reaching Moscow was too poor to have been chosen by Fennan: the agent was Elsa, recruited by Dieter Frey, a German whom Smiley himself had recruited and run during the war. Fennan had discovered her and meant to tell Smiley. Elsa is murdered to silence her; Smiley kills Dieter in the fog on the Thames, and Dieter's gunman, Mundt, escapes to East Germany.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1037,7 +1037,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1050,7 +1050,7 @@
       "recaps": {
         "ending": "Years after their summer, Elio and Oliver continue to measure later relationships and choices against what they shared. Oliver returns to the United States, marries, has children, and becomes an academic; Elio builds an adult life in Europe and America but does not find the past replaceable. Their meetings become infrequent. Elio visits Oliver and sees the domestic world Oliver chose, while Oliver acknowledges that he has retained an exact memory of their time together. Elio's father eventually dies, his mother declines, and the old summer household changes. Roughly twenty years after the affair, Oliver visits the Italian villa again. Both men understand that the other life they once imagined is no longer recoverable, yet the intimacy remains part of their identities. Elio closes by wishing Oliver would address him through their old exchange of names, confirming that the remembered bond still exists even though their shared summer cannot resume.",
         "in_short": "Seventeen-year-old Elio spends a summer at his family's Italian villa with Oliver, the American scholar invited there by Elio's father. Elio's fascination becomes an intense but guarded desire, complicated by jealousy, shame, and his relationship with local girl Marzia. After indirect tests and misunderstandings, Elio admits what he feels. He and Oliver begin a brief secret affair, sharing both tenderness and emotional uncertainty because Oliver must soon leave. A final trip to Rome lets them live more openly before the separation. Elio's father responds to his grief with unusual compassion, affirming the value of what the two men experienced. Across the following two decades, Oliver marries and raises a family while Elio pursues his own adult life. They meet occasionally and discover that neither has forgotten. When Oliver later returns to the changed villa, the men recognize that their alternative life together has passed, but the summer remains an enduring part of them both.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1194,7 +1194,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1207,7 +1207,7 @@
       "recaps": {
         "ending": "While Armand is away, Marguerite's illness worsens amid debt and abandonment. Her letters record that she still loves him and hopes for his return, but he learns the truth too late: she dies with only a few loyal attendants near her, and her possessions are seized and sold. Armand returns after her death, visits her grave, and has her body moved so he can see her once more, an experience that leaves him physically and emotionally broken. Monsieur Duval finally confirms that Marguerite left Armand only because he had appealed to her to protect the family's reputation and Blanche's marriage. Armand is left knowing that the apparent betrayal for which he punished Marguerite was an act of sacrifice. He gives the narrator her portrait and preserves her memory, while the narrator closes the account by recognizing both Marguerite's generosity and the cruelty of the social judgment that isolated her.",
         "in_short": "After the death of Marguerite Gautier, a celebrated Parisian courtesan, an unnamed narrator meets the grieving Armand Duval and hears their history. Armand had admired Marguerite from afar, then became her lover despite her illness, debts, and dependence on wealthy patrons. She returned his love and left Paris with him for a quieter life in the country. Armand's father secretly persuaded her that their relationship would disgrace the Duval family and prevent Armand's sister from marrying. Marguerite sacrificed her happiness and made Armand believe she had chosen a richer lover. Not knowing her reason, he retaliated publicly and then left France. Marguerite's consumption and financial troubles overtook her; she died alone before Armand returned. Her letters and his father's confession reveal the truth, leaving Armand to mourn a woman whom society treated as disreputable but whose final choice was selfless.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1374,7 +1374,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1387,7 +1387,7 @@
       "recaps": {
         "ending": "Jack's televised description of an ordinary Panther customer exposes details that identify Emma and turns her private confessions into office and tabloid entertainment. Emma ends the relationship because his affection does not excuse that breach of trust. Reporters then pursue Jack's own secret: his unexplained trips to Scotland are private visits connected to the grieving family of his late friend and co-founder, Pete Laidler, not evidence of a hidden romance. Emma refuses to retaliate by feeding the press that story. She also stops letting her family and colleagues define reality for her, speaking honestly about resentments she has long hidden. Jack recognizes that apology requires vulnerability as well as charm. He shares personal confidences of his own, accepts Emma's anger, and works to restore equality between them. They reconcile with a new understanding that intimacy cannot consist of one person knowing everything while remaining unreadable.",
         "in_short": "After a disastrous business trip, nervous junior marketer Emma Corrigan believes her turbulent flight may crash and pours all her secrets out to the stranger beside her. He proves to be Jack Harper, the visiting co-founder of her employer, Panther Corporation. Jack's knowledge embarrasses Emma but also lets him see through her careful performances. Their teasing develops into attraction, and Emma finally ends her unconvincing relationship with Connor. Romance with Jack falters when he uses recognizable details from her confessions in a television interview, publicly exposing her private life. Emma refuses to answer betrayal with betrayal when the press discovers that Jack's secret trips to Scotland concern the grieving family of his late co-founder Pete. She begins confronting her family and coworkers honestly, while Jack apologizes and gives up some of his protected privacy. They reconcile on more equal terms, aware that trust requires chosen honesty rather than possession of another person's secrets.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1539,7 +1539,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1552,7 +1552,7 @@
       "recaps": {
         "ending": "Dell survives the violence surrounding Arthur Remlinger and is taken away from the Saskatchewan town, leaving the criminal world of both his father and Remlinger behind. He remains in Canada, eventually building a stable career as a teacher and marrying, though the events of 1960 continue to shape how he understands chance, character, and the borders between ordinary life and catastrophe. Berner follows a much less settled course after fleeing Great Falls. The twins spend most of their lives apart and meet again only near the end of hers. She dies after a difficult, independent life, and Dell is left to assemble what can be known about his family without pretending that explanation erases consequence. His parents' robbery and the Canadian killings do not determine every later choice, but they become the central facts through which he measures the life he managed to make.",
         "in_short": "In 1960, fifteen-year-old Dell Parsons lives in Great Falls, Montana, with his twin sister Berner and their mismatched parents, Bev and Neeva. Financial trouble and Bev's criminal dealings lead the parents to rob a bank, after which both are arrested. Berner runs away, while a family friend secretly takes Dell across the border to Saskatchewan. There he is placed with Arthur Remlinger, an enigmatic hotel owner with a violent past, and works under the watch of Charley Quarters. When men connected to Remlinger's earlier life appear, Dell becomes a witness to another crime and must be removed from danger. He stays in Canada and eventually makes a quiet life as a teacher. Decades later, after a final encounter with the dying Berner, Dell reflects on how the robbery, exile, and killings divided the twins' lives without wholly defining them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1668,7 +1668,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1681,7 +1681,7 @@
       "recaps": {
         "ending": "Morell and Marchbanks ask Candida to choose between them. Morell offers his strength, reputation, and ability to protect her; Marchbanks offers his need, imagination, and the life of the poet. Candida rejects the assumption that either man can dispose of her and examines what each has received from her care. She chooses the more dependent man: Morell, whose impressive public identity rests on a domestic security he scarcely recognizes. The answer restores their marriage but strips away his complacent belief that he alone is the strong partner. Marchbanks understands her decision and does not collapse under it. Instead he prepares to leave, carrying a private insight that he will not explain to the others and turning toward an independent artistic life. Candida and Morell remain together with a clearer awareness of the labor and affection on which their home depends, while Marchbanks departs changed rather than defeated.",
         "in_short": "The confident clergyman James Morell believes his public work and marriage to Candida are equally secure. Candida returns home accompanied by Eugene Marchbanks, a frightened but visionary young poet who loves her and claims that Morell's busy household exploits her. Morell initially dismisses him, then loses his composure when Eugene directly challenges his right to Candida. Around them, Candida's businessman father Burgess seeks respectability, secretary Proserpine Garnett hides her love for Morell, and the curate Lexy Mill imitates his employer. Candida eventually makes the two rivals state what they can offer and refuses to be treated as a prize. She chooses Morell as the more vulnerable of them, explaining through her choice that his apparent strength depends on the home and confidence she creates. Marchbanks accepts the truth and leaves to pursue his own life, while the Morells remain married with their balance of dependence newly exposed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1869,7 +1869,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1882,7 +1882,7 @@
       "recaps": {
         "ending": "Candide reaches the Ottoman lands and recovers Cunegonde and the old woman from servitude. Pangloss and Cunegonde's brother have also survived their apparent deaths and are released from a galley. Cunegonde has lost the beauty Candide remembered, but he keeps his promise to marry her, chiefly in defiance of her brother's renewed objection; the brother is sent away. The reunited group settles on a small farm. Their wealth dwindles, work is difficult, and philosophical debate does nothing to relieve boredom and conflict. Paquette and Brother Giroflee arrive after wasting the money Candide once gave them. A contented Turkish farmer explains that his household's labor protects it from poverty, vice, and weariness. Candide finally rejects Pangloss's attempt to justify the entire chain of disasters as necessary. He concludes that they should concentrate on tending their own land and doing useful shared work instead of seeking an abstract explanation for suffering. Each member takes up a productive task, and the farm becomes sustainable.",
         "in_short": "Expelled from a Westphalian castle for loving Cunegonde, Candide travels through war, shipwreck, earthquake, religious persecution, murder, enslavement, and fraud while testing Pangloss's claim that all events fit a providentially optimal plan. He repeatedly loses and recovers Cunegonde, Pangloss, her brother, and a dwindling fortune. With the practical Cacambo he discovers wealthy, peaceful Eldorado but leaves to pursue love and status; most of its treasure is then stolen or squandered. The pessimistic Martin joins him through Europe, while encounters with people of every rank show misery surviving both wealth and philosophy. In the Ottoman Empire, Candide frees the scattered companions and marries Cunegonde after her beauty has faded. They settle on a small farm, where argument and idleness make them unhappy until a hardworking Turkish household suggests another way to live. Candide abandons the search for a theory that justifies suffering and commits the group to sustained, useful work on their own land.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2073,7 +2073,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2086,7 +2086,7 @@
       "recaps": {
         "ending": "Candide buys a small farm near Constantinople where Cunegonde, Pangloss, Martin, Cacambo, the old woman, and others settle. Cunegonde has changed greatly and the household remains dissatisfied despite its security. After an unrewarding exchange with a dervish, Candide meets a farmer whose family avoids public affairs and supports itself through steady work. Candide applies that example to his own community. Each person takes up a useful task, and the farm becomes productive enough to reduce boredom, vice, and need. Pangloss still argues that the entire chain of disasters was necessary to reach this result, while Martin sees work as the only tolerable course available. Candide no longer tries to settle the philosophical dispute. He answers by insisting on the practical duty of working their own land, ending his search for a complete explanation of suffering with a commitment to shared labor.",
         "in_short": "Candide is expelled from a sheltered Westphalian home after falling in love with Cunegonde. Taught by Pangloss that all events serve an optimal design, he crosses a world of war, persecution, earthquake, slavery, fraud, and political upheaval while trying to reunite with her. Jacques's generosity, the old woman's endurance, Cacambo's resourcefulness, and Martin's pessimism offer competing responses to suffering. Candide and Cacambo discover the peaceful wealth of Eldorado but leave because Candide still wants Cunegonde. Their treasure is steadily lost, and apparently dead companions repeatedly return. Candide finally finds Cunegonde near Constantinople and buys a farm for their circle. Marriage and money do not create happiness by themselves. The group improves its life only when everyone begins useful work, and Candide turns from Pangloss's explanations toward the concrete task of tending what is within their care.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2287,7 +2287,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2300,7 +2300,7 @@
       "recaps": {
         "ending": "Candide ends with its scattered survivors living on a farm near Constantinople. Wealth, reunion, and debate do not make the household content, but shared useful work gives its members stability and purpose. Candide therefore sets aside the demand for a complete philosophical account and concentrates on the land entrusted to the group. In Zadig, the hero returns to Babylon after exile and finds Astarte restored. A public contest is arranged to choose her husband and the kingdom's ruler. Zadig proves his worth in combat, but Itobad steals his armor and claims the victory. Zadig still solves the accompanying riddles, then defeats Itobad openly and establishes his identity as the true champion. He marries Astarte and rules Babylon with the justice and discernment that earlier brought him both advancement and danger. The two tales close differently, but each moves its protagonist away from naive confidence in appearances and toward conduct tested by experience.",
         "in_short": "This volume joins two philosophical tales of education through misfortune. Candide is separated from Cunegonde and crosses Europe, South America, and the eastern Mediterranean while war, persecution, disaster, slavery, and fraud challenge Pangloss's claim that all is optimally arranged. After discovering and leaving Eldorado, Candide eventually reunites a group of survivors on a small farm, where useful labor proves more sustaining than abstract debate. Zadig, a wise Babylonian, repeatedly suffers because evidence is misread and virtue attracts envy. He rises to become King Moabdar's minister, flees after court jealousy threatens him, survives enslavement and travel, and searches for Queen Astarte amid political disorder. A hermit's severe lesson complicates his understanding of providence. Returning to Babylon, Zadig overcomes a stolen victory by solving riddles and defeating the impostor Itobad. He marries Astarte and becomes a just ruler.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2463,7 +2463,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2476,7 +2476,7 @@
       "recaps": {
         "ending": "Candide buys a small farm near Constantinople where Cunegonde, Pangloss, Martin, Cacambo, the old woman, and others settle. Cunegonde has changed greatly and the household remains dissatisfied despite its security. After an unrewarding exchange with a dervish, Candide meets a farmer whose family avoids public affairs and supports itself through steady work. Candide applies that example to his own community. Each person takes up a useful task, and the farm becomes productive enough to reduce boredom, vice, and need. Pangloss still argues that the entire chain of disasters was necessary to reach this result, while Martin sees work as the only tolerable course available. Candide no longer tries to settle the philosophical dispute. He answers by insisting on the practical duty of working their own land, ending his search for a complete explanation of suffering with a commitment to shared labor.",
         "in_short": "Candide is expelled from a sheltered Westphalian home after falling in love with Cunegonde. Taught by Pangloss that all events serve an optimal design, he crosses a world of war, persecution, earthquake, slavery, fraud, and political upheaval while trying to reunite with her. Jacques's generosity, the old woman's endurance, Cacambo's resourcefulness, and Martin's pessimism offer competing responses to suffering. Candide and Cacambo discover the peaceful wealth of Eldorado but leave because Candide still wants Cunegonde. Their treasure is steadily lost, and apparently dead companions repeatedly return. Candide finally finds Cunegonde near Constantinople and buys a farm for their circle. Marriage and money do not create happiness by themselves. The group improves its life only when everyone begins useful work, and Candide turns from Pangloss's explanations toward the concrete task of tending what is within their care.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2677,7 +2677,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2690,7 +2690,7 @@
       "recaps": {
         "ending": "Candide reaches the Constantinople area, buys the freedom of Pangloss, Cunegonde's brother, and Cacambo, and finds Cunegonde and the old woman in servitude. Although Cunegonde has lost the beauty he remembered, he keeps his promise and marries her; her brother still objects on grounds of rank and is sent away. The reunited group settles on a small farm, but idleness and argument make them unhappy. Paquette and Brother Giroflee eventually join them in poverty. Pangloss continues to defend his old philosophy, Martin remains pessimistic, and neither position improves their lives. A dervish refuses their metaphysical questions, while a self-sufficient Turkish farmer explains that work protects his family from vice, boredom, and need. Candide adopts that practical lesson. Each member of the household takes up useful labor, their conditions improve, and Candide answers Pangloss's final theorizing by insisting that they must cultivate their garden.",
         "in_short": "Candide is expelled from a sheltered Westphalian castle for loving Cunegonde and is driven through war, natural disaster, religious persecution, exploitation, and repeated separation from her. His teacher Pangloss insists that all events serve the best possible world, while the pessimist Martin later argues the reverse. Candide reunites with Cunegonde in Lisbon, kills the men controlling her, and flees to South America, where he finds her brother alive and then wounds him during a quarrel. With his resourceful servant Cacambo he discovers the peaceful, wealthy country of El Dorado, but leaves with treasure to recover Cunegonde. Most of the fortune is lost through greed and mischance. After travels through Europe and the Ottoman Empire, Candide frees his surviving companions and marries Cunegonde. Their farm initially brings no contentment. Observing a Turkish family sustained by useful work, Candide abandons the search for a complete explanation of suffering and organizes the household around shared labor: they will cultivate their garden.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2884,7 +2884,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2897,7 +2897,7 @@
       "recaps": {
         "ending": "Candide reaches the Constantinople area, buys the freedom of Pangloss, Cunegonde's brother, and Cacambo, and finds Cunegonde and the old woman in servitude. Although Cunegonde has lost the beauty he remembered, he keeps his promise and marries her; her brother still objects on grounds of rank and is sent away. The reunited group settles on a small farm, but idleness and argument make them unhappy. Paquette and Brother Giroflee eventually join them in poverty. Pangloss continues to defend his old philosophy, Martin remains pessimistic, and neither position improves their lives. A dervish refuses their metaphysical questions, while a self-sufficient Turkish farmer explains that work protects his family from vice, boredom, and need. Candide adopts that practical lesson. Each member of the household takes up useful labor, their conditions improve, and Candide answers Pangloss's final theorizing by insisting that they must cultivate their garden.",
         "in_short": "Candide is expelled from a sheltered Westphalian castle for loving Cunegonde and is driven through war, natural disaster, religious persecution, exploitation, and repeated separation from her. His teacher Pangloss insists that all events serve the best possible world, while the pessimist Martin later argues the reverse. Candide reunites with Cunegonde in Lisbon, kills the men controlling her, and flees to South America, where he finds her brother alive and then wounds him during a quarrel. With his resourceful servant Cacambo he discovers the peaceful, wealthy country of El Dorado, but leaves with treasure to recover Cunegonde. Most of the fortune is lost through greed and mischance. After travels through Europe and the Ottoman Empire, Candide frees his surviving companions and marries Cunegonde. Their farm initially brings no contentment. Observing a Turkish family sustained by useful work, Candide abandons the search for a complete explanation of suffering and organizes the household around shared labor: they will cultivate their garden.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3091,7 +3091,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3104,7 +3104,7 @@
       "recaps": {
         "ending": "Candide reaches the Constantinople area, buys the freedom of Pangloss, Cunegonde's brother, and Cacambo, and finds Cunegonde and the old woman in servitude. Although Cunegonde has lost the beauty he remembered, he keeps his promise and marries her; her brother still objects on grounds of rank and is sent away. The reunited group settles on a small farm, but idleness and argument make them unhappy. Paquette and Brother Giroflee eventually join them in poverty. Pangloss continues to defend his old philosophy, Martin remains pessimistic, and neither position improves their lives. A dervish refuses their metaphysical questions, while a self-sufficient Turkish farmer explains that work protects his family from vice, boredom, and need. Candide adopts that practical lesson. Each member of the household takes up useful labor, their conditions improve, and Candide answers Pangloss's final theorizing by insisting that they must cultivate their garden.",
         "in_short": "Candide is expelled from a sheltered Westphalian castle for loving Cunegonde and is driven through war, natural disaster, religious persecution, exploitation, and repeated separation from her. His teacher Pangloss insists that all events serve the best possible world, while the pessimist Martin later argues the reverse. Candide reunites with Cunegonde in Lisbon, kills the men controlling her, and flees to South America, where he finds her brother alive and then wounds him during a quarrel. With his resourceful servant Cacambo he discovers the peaceful, wealthy country of El Dorado, but leaves with treasure to recover Cunegonde. Most of the fortune is lost through greed and mischance. After travels through Europe and the Ottoman Empire, Candide frees his surviving companions and marries Cunegonde. Their farm initially brings no contentment. Observing a Turkish family sustained by useful work, Candide abandons the search for a complete explanation of suffering and organizes the household around shared labor: they will cultivate their garden.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3283,7 +3283,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3296,7 +3296,7 @@
       "recaps": {
         "ending": "The carefully anticipated second party succeeds where the first failed. Nearly everyone on Cannery Row arrives at Doc's laboratory, bringing gifts, food, drink, and goodwill; Doc accepts the disorder because he understands the affection behind it. The celebration expands through the night, with music, arguments, and encounters that mix generosity with the Row's familiar roughness. In the quiet aftermath, Doc wakes among the remains, restores a little order, and returns to the private life the community can honor but not fully share. He plays music and reads melancholy verse while the ordinary sounds and creatures of the shore continue around him. Mack and the others have finally expressed their gratitude, yet no one is transformed into a different kind of person: the close preserves both the warmth of their community and the solitude at its center.",
         "in_short": "On Monterey's Cannery Row, grocer Lee Chong, brothel owner Dora Flood, marine biologist Doc, and Mack's loosely organized household survive through bargains, favors, and mutual tolerance. Wanting to thank Doc for his kindness, Mack and the boys arrange a frog-collecting expedition, barter their catch for party supplies, and hold the celebration while Doc is away. The attempt becomes a destructive brawl that wrecks his laboratory. Their shame spreads through the neighborhood, and Doc's anger gives way to recognition that the damage came from affection rather than malice. When the Row learns Doc's birthday, its residents plan another party. Doc wisely prepares for it himself, and the gathering succeeds as an unruly communal tribute. Afterward he cleans the laboratory and returns to music, poetry, and solitude. The episodic lives surrounding this plot show a poor but resilient community whose informal generosity often accomplishes what respectability does not.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3481,7 +3481,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3494,7 +3494,7 @@
       "recaps": {
         "ending": "After Rivarol abandons Blood's men and tries to keep the Cartagena treasure, Blood defeats the French squadron and recovers both ships and spoils. Returning toward the English islands, he finds Barbados under Spanish attack because Colonel Bishop took the defense fleet away in a reckless pursuit of him. Blood destroys the Spanish force and saves the colony. Admiral van der Kuylen then informs him that James II has been deposed and William III now rules, so Blood is no longer bound by his rejected service to James. His actions earn a royal commission as governor of Jamaica, while Bishop must answer for leaving Barbados exposed. Arabella finally understands that Blood's apparent piracy concealed both political scruple and a consistent code. Blood reveals that he named his ship for her, and the two acknowledge their love. The condemned prisoner and outlaw ends with lawful authority, a restored reputation, and Arabella beside him.",
         "in_short": "Irish doctor Peter Blood is convicted of treason merely for treating a wounded Monmouth rebel and is sold into slavery in Barbados. His medical skill gives him limited freedom, and planter's niece Arabella Bishop recognizes his worth. During a Spanish raid, Blood and other prisoners seize a ship and escape, becoming buccaneers because English law offers them no honest return. Blood imposes strict rules, defeats Spanish enemies, and kills his French ally Levasseur when the man abducts a woman. Although Arabella comes to believe Blood is only a pirate, he repeatedly rejects profit when it conflicts with loyalty or honor. He briefly accepts service under James II, then leaves it when ordered to fight against England's Dutch allies. Betrayed by French commander Rivarol after the capture of Cartagena, Blood takes the French fleet and treasure. He then saves undefended Barbados from Spain, learns William III has replaced James, and is appointed governor of Jamaica. Arabella accepts the truth of his character and his love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3681,7 +3681,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3694,7 +3694,7 @@
       "recaps": {
         "ending": "After the occupation, Corelli does not return as Pelagia expected. Mandras comes back hardened by factional violence and attempts to force himself on her; Pelagia resists him, and Drosoula repudiates her son's conduct. Mandras kills himself. Dr. Iannis is taken away during the civil conflict and eventually returns diminished by imprisonment. The 1953 earthquake devastates Cephalonia and kills him. Pelagia rescues and adopts an orphaned infant, Antonia, and she and Drosoula rebuild their lives through a taverna. Antonia grows up, has a son named Iannis, and helps preserve the family's future. Many years later Corelli finally returns. He explains that he had come back earlier but saw Pelagia with the child, assumed she had made another life, and withdrew. The misunderstanding is cleared, and the aged Pelagia and Corelli are reunited after decades shaped by war, loss, and silence.",
         "in_short": "On Cephalonia, Dr. Iannis's daughter Pelagia is engaged to fisherman Mandras when the Second World War reaches Greece. Mandras leaves to fight and later joins communist partisans. Italian Captain Antonio Corelli is billeted in the doctor's house during the occupation, and his humor, kindness, and music gradually overcome Pelagia's hostility; they fall in love. After Italy changes sides in 1943, German forces attack and massacre the Italian Acqui Division. Carlo Guercio dies shielding Corelli, whom Pelagia and her father help escape. Corelli leaves the island, while Mandras returns brutalized and destroys Pelagia's remaining love for him. Postwar repression, civil conflict, and the Cephalonia earthquake take further lives, including Dr. Iannis. Pelagia adopts an orphan, Antonia, and rebuilds with Drosoula. Decades later Corelli returns and reveals that a mistaken assumption about Antonia kept him away. He and Pelagia finally reunite in old age.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4036,7 +4036,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B009P56HIK",
@@ -4048,7 +4048,7 @@
       "recaps": {
         "ending": "Tej refuses her parents' invitation to leave Barrayar and confirms that her marriage to Ivan is now her own permanent choice. The Arqua family departs with a partial payment from the recovered cache, transport, and a covert understanding with Gregor intended to support the restoration of House Cordona. Byerly travels toward Jackson's Whole under a fugitive cover, while Duv Galeni continues examining the historical material. Rish and Jet have survived, and the reunited Jewels eventually perform again. Ivan and Tej are posted to Illa for roughly two years, where he serves as senior military attaché and considers diplomacy as an alternative to continued military service. Eric remains in cryogenic suspension while Star and Pidge contest the Cordona succession. Simon Illyan has recovered enough for occasional new work, although not his former post. Monitoring continues for effects of the tunneling organism, and the old headquarters is ultimately stabilized and redeveloped.",
         "in_short": "On Komarr, Ivan Vorpatril tries to protect the hunted refugees Tej and Rish, only to marry Tej in an emergency maneuver against arrest and deportation. Their intended temporary union survives a failed divorce and becomes increasingly genuine. On Barrayar, Tej's presumed-dead family arrives seeking asylum and secretly tunnels beneath Imperial Security headquarters to recover a lost Cetagandan laboratory. A hired carrier betrays them, an old bomb floods the tunnels, and the damaged ground causes the headquarters to sink. Everyone trapped below is rescued. Gregor converts the resulting legal and political crisis into a settlement that funds House Cordona's return and links it to Barrayar. Tej chooses Ivan over departure with her family. They later live together on Illa, while the Arquas begin rebuilding, Byerly works undercover in Jacksonian space, and the Cordona succession remains unsettled.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4205,7 +4205,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4218,7 +4218,7 @@
       "recaps": {
         "ending": "Caraval closes with Scarlett named the winner, and then she learns that almost everything she suffered through the last five nights was staged. Donatella is alive: she had agreed with Legend to play the missing prize and to fake her own fall, and she never told her sister. Julian is alive too, a Caraval performer who had been working the game from the moment he turned up on Trisda. Scarlett has to set the losses she genuinely paid for - secrets, memories, days of her life - against a performance everyone but her knew was a performance, and being told the deaths were not real does not undo her anger at either of them. She is granted the winner's wish. The sisters leave the isle, beyond their father's reach for the moment, and Scarlett and Julian part without resolving what is between them. The closing pages reveal what Tella's cooperation cost: she had made a bargain with a stranger who promised her word of Paloma, the mother who abandoned them, and the debt is still owed. The next Caraval is announced for the capital of the Meridian Empire, which is where she will have to settle it.",
         "in_short": "Scarlett Dragna and her younger sister Donatella grow up on the island of Trisda under a violent father, sustained by their grandmother's stories about Caraval, a performance game staged once a year by a showman known only as Legend. Days before Scarlett's arranged wedding, the tickets she has been begging for finally arrive, and Tella and a sailor named Julian get her onto a boat to the island where the game is played. There Tella is taken and made the prize: whoever finds her first wins a wish, and Scarlett has five nights. She buys clues with secrets, memories and days of her life, is told constantly that nothing inside Caraval is real, and finds the costs are real anyway. Her father follows her into the game, Julian proves to be a Caraval performer rather than a stranger, and before the last night is over Scarlett has watched both of them die. When the game closes she learns the deaths were staged and both are alive. She wins - and the final pages reveal what Tella traded for her part in it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4406,7 +4406,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4419,7 +4419,7 @@
       "recaps": {
         "ending": "Poirot identifies Dr Geoffrey Roberts as Shaitana's murderer. During the bridge game Roberts moved about freely as dummy, took a slim dagger from the room, and stabbed the host while the other players were absorbed in their cards. Shaitana had recognised that Roberts had used medical access to remove inconvenient patients in the past. When the inquiry threatened him, Roberts also killed Mrs Lorrimer by injection and arranged the scene as suicide, using her genuine admission about her husband's death to make a false confession to Shaitana's murder seem credible. Poirot breaks him with a manufactured eyewitness and with the contrast between what each player's bridge record shows about temperament and opportunity. The other histories are separated from the present crime. Mrs Lorrimer had killed her husband years earlier but did not kill Shaitana. Major Despard's expedition shooting was an accident he concealed to protect Mrs Luxmore. Anne Meredith caused a former employer's death while hiding theft; when she later tries to drown Rhoda Dawes, Despard rescues Rhoda and Anne herself drowns. Roberts is arrested, while Despard and Rhoda are left free to begin a life together.",
         "in_short": "Mr Shaitana, a collector of dangerous secrets, invites four detectives and four people he believes have killed before without conviction to dinner. While Poirot, Superintendent Battle, Colonel Race, and Ariadne Oliver play bridge in one room, Dr Roberts, Mrs Lorrimer, Major Despard, and Anne Meredith play in another beside their host. Shaitana is stabbed while they play, leaving four suspects who all had opportunity. The investigators reopen the old deaths Shaitana had discovered and study the bridge score for signs of character and movement. Mrs Lorrimer admits killing her husband, then dies after apparently confessing to Shaitana's murder. Poirot proves that Dr Roberts killed both Shaitana and Mrs Lorrimer, having previously exploited his medical position to kill patients. Despard's old shooting was accidental. Anne had caused a former employer's death while concealing theft and later tries to kill Rhoda Dawes, but drowns during the attempt. Roberts is trapped and arrested; Despard and Rhoda survive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4574,7 +4574,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -4585,7 +4585,7 @@
       "recaps": {
         "ending": "The book closes with the party escaping the third floor moments ahead of an apocalypse of Miss Quill's making. Her murder plot exposed, Quill is dead by Carl's dynamite, but the ritual she powered with her husband's stolen soul energy, The Final War, detonates anyway in a chain of magical shockwaves that disable and then violently overload enchanted items across the region, destroying Donut's crown and killing crawlers outright. Carl contains the catastrophe by sealing the leaking soul gem inside its glass case, gaining the book's namesake achievement, a Doomsday Scenario, and Katia detonates a weapons depot as the party, Carl once again without pants, reaches the stairwell. An epilogue reveals the aftermath: the depot blast smothered the final and worst shockwave, saving thousands of NPCs and crawlers, and the resulting rewards were so extreme that Borant spent its one season veto to cancel most of them. Carl and Donut are now on the crawl's leaderboard. Odette warns them about the war god Grull, about Hekla's designs on recruiting Donut, and about the bounty their fame has put on their heads. Katia remains with the party, Mordecai remains their manager, and the fourth floor waits below.",
         "in_short": "On the third floor, the Over City, Carl becomes a Primal Compensated Anarchist and Donut a Former Child Actor, gaining Mordecai as her bound manager. A quest chain forces Carl into the orbit of Signet, an irresistible Elite NPC, and her tragic feud with Ringmaster Grimaldi, a parasitic vine ruling a corrupted circus; Carl ends it not with a bomb but by poisoning himself to bargain telepathically with the creature, freeing Signet. In a settlement further on, the murder of a goblin acquaintance pulls the party into a mystery implicating Miss Quill, the magistrate's gatekeeper, who is secretly draining her imprisoned husband, a soul-leech capacitor, to cast a ritual called The Final War. The party gains Katia, a doppelganger crawler escaping the Amazon leader Hekla's shadow. Killing Quill triggers the ritual anyway: escalating magical shockwaves wreck the region, destroy Donut's crown, and kill crawlers, but Carl seals the soul gem, earning a Doomsday Scenario achievement, and Katia's depot explosion smothers the final blast. The party escapes to the stairwell famous, hunted, and carrying a bounty, with Odette warning of the god Grull and Hekla's interest in Donut.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4732,7 +4732,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4745,7 +4745,7 @@
       "recaps": {
         "ending": "General Spielsdorf recognizes Carmilla as the same mysterious young woman who entered his household under the name Millarca before Bertha died. At the ruined Karnstein chapel he attacks her, but she escapes. Baron Vordenburg uses family records to identify her as Countess Mircalla Karnstein and to locate her hidden grave. The investigators open the tomb and find her body unnaturally preserved and showing signs of recent feeding. Acting according to the accepted remedy for a vampire, they drive a stake through her heart, decapitate the body, burn it, and scatter the ashes. The deaths and wasting sickness in the district cease, and Laura slowly regains her health during travel with her father. She nevertheless remains psychologically marked by Carmilla, remembering at different times both the companion she loved and the predatory figure that haunted her room.",
         "in_short": "Laura lives with her father in a remote Styrian castle when a carriage accident brings the beautiful Carmilla into their home. The two young women feel they have met in childhood dreams and form an intense attachment, although Carmilla conceals her history and behaves strangely. As nearby girls die and Laura weakens under recurring nocturnal attacks, an old family portrait reveals Carmilla's likeness to Countess Mircalla Karnstein. General Spielsdorf then recounts how a guest named Millarca befriended his ward Bertha before the girl died in the same manner. He recognizes Carmilla, whose several names are anagrams, as the same being. With Baron Vordenburg's guidance, the group finds Mircalla's concealed tomb and confirms that she is a vampire. Her body is staked, beheaded, and burned, ending the local deaths. Laura recovers physically but continues to remember Carmilla as both beloved companion and terrifying intruder.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4899,7 +4899,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4912,7 +4912,7 @@
       "recaps": {
         "ending": "Back in New York, Therese has moved into professional stage-design work and decisively ended her relationship with Richard. Carol has refused Harge's demand that she renounce relationships with women or submit to a false reconciliation in exchange for custody. She accepts restricted access to Rindy rather than deny herself, establishes an independent home, and finds work. Carol invites Therese to live with her. Still hurt by Carol's earlier withdrawal and conscious of how much she has changed, Therese initially refuses. She later meets the actress Genevieve Cranell and considers the possibility of another relationship, but recognizes that her feelings for Carol remain distinct. Therese goes to the Oak Room where Carol has said she will be. Seeing Carol across the room, she moves toward her, and Carol responds with unmistakable welcome. The novel closes on their chosen reunion: there is no guarantee that social pressure or personal difficulty has vanished, but they are free to attempt a shared life without disguising what they want.",
         "in_short": "Therese Belivet, a young aspiring stage designer working in a New York department store, meets Carol Aird, an older woman separated from her husband. Their fascination grows into love as Therese pulls away from her boyfriend Richard and Carol struggles over custody of her daughter Rindy. The women drive west together, but Carol's husband has hired a detective to gather evidence of their relationship. Faced with losing access to Rindy, Carol returns east while Therese continues alone. Carol ultimately refuses to deny her sexuality or resume her marriage, accepting limited contact with her daughter and building an independent life. Therese returns to New York changed by the journey, begins theatre work, and rejects both Richard's expectations and a merely convenient new attachment. Although she first declines Carol's invitation to live together, she recognizes that she still loves her. Therese seeks Carol out at a restaurant, and the two reunite with the possibility of a life together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5097,7 +5097,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5110,7 +5110,7 @@
       "recaps": {
         "ending": "Claire and Myrnin complete the resistance's scientific countermeasure and help bring Amelie back into the fight. Michael's apparent service to Bishop is revealed as part of the effort to keep the Glass House group alive and create an opening against the regime. Humans led by Hannah and Richard coordinate with Oliver and Amelie's remaining vampires, while Claire uses her access to the laboratory and portal system to connect the plan. The combined uprising defeats Bishop and strips him of control; he is secured as a prisoner rather than left in command of the town. Amelie resumes authority, frees people held under Bishop's occupation, and begins revising the compact between Morganville's human and vampire residents. Michael and Eve reconcile, and Claire and Shane are reunited. Glass House becomes a home for the four friends again. The Bishop arc is resolved, but Myrnin's dependence on Ada and Ada's jealousy of Claire remain unstable elements beneath Morganville's restored order.",
         "in_short": "Bishop rules Morganville through compulsory service, surveillance, and fear. Claire pretends to work for him while secretly collaborating with Myrnin, Oliver, Hannah Moses, Richard Morrell, and other resistance members. Shane is endangered by the regime, Eve believes Michael has chosen Bishop, and Amelie is hidden and weakened. The resistance's plan depends on treating Amelie, exploiting Bishop's confidence, and coordinating humans and vampires through the portal system maintained by Ada. Claire discovers that Ada's jealousy makes the machine itself dangerous, but she and Myrnin preserve the crucial research. Michael's collaboration with Bishop proves to be protective deception rather than genuine betrayal. Amelie's recovery allows the divided resistance to unite and defeat Bishop, who is taken into custody. Amelie resumes rule and begins reforms, while Claire, Shane, Eve, and Michael reunite at Glass House. The occupation ends, though Ada remains a threat.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5276,7 +5276,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5289,7 +5289,7 @@
       "recaps": {
         "ending": "The modernized Magpyr vampires seize Lancre by mesmerism, confident that having trained away the old weaknesses makes them unstoppable. Their conditioning, though, becomes their weakness. Granny Weatherwax, bitten and seemingly beaten, uses the blood-bond that vampires forge with their victims to reverse the flow of influence: her sheer strength of will pours back into them, burdening them with her own tastes, cravings, and iron personality until they can barely function as vampires at all. While Granny works from within, Nanny Ogg, Agnes and her second self Perdita, the returned Magrat, and the young priest Mightily Oats hold the line. Oats, who has spent the story paralyzed by doubt, finds a hard, genuine faith when it is needed and turns it against the enemy. The old, traditional Count Magpyr, the courtly vampire whose place the modern family had usurped, is restored to a harmless coexistence with Lancre. The Magpyrs are destroyed and the kingdom freed. King Verence's baby daughter is named Esmerelda, in honour of Granny Weatherwax, and Granny, who began the story crippled by doubt about her own worth and beliefs, comes through it with her sense of herself and her purpose restored.",
         "in_short": "King Verence of Lancre, wishing to be modern and tolerant, invites a family of enlightened vampires, the Magpyrs, to the naming ceremony of his infant daughter. These vampires have trained themselves out of the traditional weaknesses, tolerating sunlight, garlic, and holy symbols, and they use the invitation to mesmerize the kingdom and take control. Granny Weatherwax, who feels her invitation was overlooked and is wrestling with doubts about her own worth, withdraws at first, leaving Nanny Ogg, Agnes Nitt, the returning Magrat, and a doubt-ridden young priest named Mightily Oats to resist. Agnes's divided mind gives her some protection against the vampires' influence, and Granny, once bitten, turns the connection to her advantage: her overwhelming will flows back down the blood-bond, saddling the Magpyrs with her own nature and cravings and stripping away their edge. Their much-vaunted self-training proves their undoing. With help from the coven, from Oats, who rediscovers his faith, and from the old traditional vampire the family had supplanted, the Magpyrs are destroyed. Lancre is freed, the royal baby is named in Granny's honour, and Granny recovers her sense of purpose.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5440,7 +5440,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5453,7 +5453,7 @@
       "recaps": {
         "ending": "In the final story Jeeves narrates a rare episode from his own point of view. Bertie begins to think that his life would be improved if he adopted a child, an idea Jeeves considers unsuitable for their household. Rather than argue directly, Jeeves arranges for Bertie to visit a girls' school and speak before its pupils. The formal occasion exposes Bertie to sustained embarrassment and leaves him eager to abandon the entire plan. Jeeves thus preserves their established bachelor household without an open confrontation. Across the collection, this outcome confirms the pattern established at their first meeting: Bertie generates generous but impractical schemes, while Jeeves quietly shapes circumstances until his preferred solution also appears to Bertie to be the only sensible one.",
         "in_short": "Ten linked comic stories trace the beginning of Bertie Wooster's partnership with Jeeves. Jeeves enters Bertie's service and quickly saves him from a crisis over an embarrassing family memoir and an unwanted engagement. In later episodes, Bertie tries to assist an artist dependent on his uncle, restrain a supposedly sheltered visitor, protect friends whose allowances rest on deception, supply a reclusive poet with reports of city life, reunite separated lovers, substitute for an arrested friend, and repair broken engagements. His improvisations repeatedly fail, while Jeeves resolves each crisis by understanding what the people involved actually fear or desire. In the last story Bertie considers adopting a child, but Jeeves engineers an uncomfortable school visit that changes his mind. The collection ends with their bachelor household intact and Jeeves firmly established as the intelligence directing it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5604,7 +5604,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5617,7 +5617,7 @@
       "recaps": {
         "ending": "After recovering from Le Chiffre's torture, Bond falls in love with Vesper Lynd and imagines leaving the Service to build a life with her. At a coastal hotel she becomes frightened by a one-eyed man named Gettler, withdraws emotionally, and then kills herself with sleeping pills. Her letter explains that she had been forced to spy for the Soviet organization SMERSH because it held a former lover captive. She had helped arrange Bond's capture and remained under pressure even after Le Chiffre's death; seeing Gettler convinced her that escape was impossible. Bond's grief hardens into anger. He abandons thoughts of resignation, informs headquarters that Vesper was an enemy agent and is dead, and commits himself to fighting the organization that controlled her.",
         "in_short": "British agent James Bond is sent to Royale-les-Eaux to bankrupt Le Chiffre, who has gambled Soviet funds on a failed criminal venture and is trying to recover them at baccarat. Supported by French agent René Mathis, CIA officer Felix Leiter, and Treasury representative Vesper Lynd, Bond survives attempts to disrupt the mission, loses his original stake, receives emergency backing from Leiter, and finally wins Le Chiffre's fortune. Le Chiffre kidnaps Vesper and captures Bond during the pursuit, then tortures him for the money. A SMERSH executioner kills Le Chiffre but spares Bond. While recovering, Bond falls in love with Vesper and considers resigning. Vesper later takes her own life and leaves a confession: SMERSH blackmailed her into betraying the operation and helping deliver Bond to Le Chiffre. Devastated, Bond rejects his earlier doubts and dedicates himself to opposing SMERSH.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5757,7 +5757,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5770,7 +5770,7 @@
       "recaps": {
         "ending": "After recovering from torture, Bond falls in love with Vesper and plans to leave the service so they can build a life together. Her increasingly frightened behaviour changes after she sees a man named Gettler, and she later takes her own life. In a letter, Vesper explains that Soviet agents had coerced her into betraying the operation by threatening a former lover. She had staged her abduction, enabling Le Chiffre to capture Bond, and remained under pressure after Le Chiffre's death. Believing that Gettler's arrival meant the coercion would continue and fearing that she would endanger Bond again, she chose death. Bond reports her betrayal to London in deliberately cold terms and asks that the case be closed. The experience hardens him against the Soviet organisation responsible and ends his hope of escaping the moral damage of intelligence work.",
         "in_short": "British agent James Bond goes to Royale-les-Eaux to bankrupt Le Chiffre, a Soviet-backed operative who has lost his organisation's money. Assisted by Vesper Lynd, René Mathis, and Felix Leiter, Bond survives an attempt on his life and defeats Le Chiffre at baccarat. Le Chiffre abducts Vesper, captures Bond during the pursuit, and tortures him for the money, but a Soviet executioner arrives and kills Le Chiffre while sparing Bond. During his recovery Bond questions his profession and falls in love with Vesper. He intends to resign, but Vesper becomes fearful and dies by suicide. Her letter reveals that Soviet coercion made her pass information to Le Chiffre and arrange the kidnapping. Bond responds by emotionally repudiating her and returns his attention to the struggle against the Soviet service.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5955,7 +5955,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5968,7 +5968,7 @@
       "recaps": {
         "ending": "Poirot separates two motives hidden within the violence at Meadowbank. Ann Shapland is an international agent who saw Bob Rawlinson conceal Prince Ali Yusuf's jewels in Jennifer Sutcliffe's tennis racket. She came to the school to recover them, killed Miss Springer when the games mistress caught her searching the pavilion, and later tries to shoot Miss Bulstrode after Mrs Upjohn can identify her from Ramat. Miss Chadwick throws herself in front of the shot and dies protecting her old friend. The earlier death of Miss Vansittart had a different cause: Miss Chadwick killed the likely successor in a jealous attempt to preserve her own place beside Miss Bulstrode and the school they founded. Julia Upjohn has already found the jewels in the racket and taken them to Poirot, putting them beyond Shapland's reach. The abducted Princess Shaista proves to have been an impostor planted as part of another effort to obtain the jewels; the real princess never attended Meadowbank. Miss Bulstrode chooses the more humane and adaptable Eileen Rich as her eventual successor, and the school survives the scandal.",
         "in_short": "During a revolution in Ramat, Prince Ali Yusuf gives pilot Bob Rawlinson a fortune in jewels, which Bob hides in his niece Jennifer Sutcliffe's tennis racket before both men die. At Meadowbank girls' school, someone repeatedly searches the sports pavilion; games mistress Miss Springer is shot there, Princess Shaista is abducted, and teacher Miss Vansittart is killed. Jennifer's friend Julia Upjohn finds the jewels after noticing that the racket has been exchanged and takes them to Poirot. He exposes two separate killers. Secretary Ann Shapland is an international agent who saw the jewels being hidden; she killed Springer and tries to shoot Miss Bulstrode when Mrs Upjohn can identify her. Miss Chadwick dies shielding Bulstrode. Chadwick herself killed Vansittart out of jealous fear that Vansittart would inherit leadership of the school. The supposed Shaista was an impostor; the real princess was never there. The jewels are recovered, Shapland is stopped, and Miss Bulstrode selects Eileen Rich rather than Vansittart as the successor capable of renewing Meadowbank.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6117,7 +6117,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6130,7 +6130,7 @@
       "recaps": {
         "ending": "Once the family admits that Big Daddy is dying of cancer, Gooper and Mae present Big Mama with a plan designed to put control of the estate in their hands. Maggie counters by announcing that she is pregnant, though she and Brick have not been sleeping together and the claim is false. Big Daddy, still alert to deception, accepts the news as the birthday gift he wants. Brick does not expose Maggie. After the others leave, she removes Brick's liquor and says she will not return it until they have slept together, intending to make the pregnancy claim true. Brick remains detached and doubts her declaration of love, but he no longer has the drink with which he has been silencing the conflict. Big Daddy faces a painful terminal illness, the inheritance remains unsettled, and Brick and Maggie are left together with a lie that may become either a renewed marriage or another form of family evasion.",
         "in_short": "On the sixty-fifth birthday of wealthy plantation owner Big Daddy Pollitt, his family gathers while concealing that medical tests show he is dying of cancer. His alcoholic younger son Brick has withdrawn from his wife Maggie since the death of his friend Skipper. Pressed by Big Daddy, Brick admits that he rejected Skipper's final attempt to discuss the nature of their bond, and Big Daddy learns the truth of his own diagnosis. Brick's brother Gooper and sister-in-law Mae try to secure the estate by emphasizing their five children and Brick's decline. After the diagnosis is revealed to Big Mama, Maggie claims that she is pregnant, blocking their immediate advantage even though she and Brick have not recently had sex. She withholds Brick's liquor and resolves to make the lie true, leaving the marriage, inheritance, and Big Daddy's approaching death unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6258,7 +6258,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -6271,7 +6271,7 @@
       "recaps": {
         "ending": "Worn down by mounting deaths and the ever-rising mission count, and haunted above all by the memory of watching the young gunner Snowden die in his arms, Yossarian finally refuses to fly any more missions and walks around in protest. His commanders, Colonel Cathcart and Colonel Korn, embarrassed by his defiance, offer him a deal: they will send him home as a hero if he agrees to like them and to publicly endorse them, a bargain that would betray the other men still forced to fly. Yossarian nearly accepts, then rejects the corrupt offer. His decision is sealed when he learns that his odd tentmate Orr, whose repeated crash-landings turn out to have been deliberate practice, has made it safely to neutral Sweden. Seeing that escape is possible after all, Yossarian deserts, slipping away to strike out for Sweden himself and refusing any longer to be a pawn in a system that treats men's lives as expendable. His flight is an act of self-preservation and moral refusal, choosing his own survival and conscience over an insane war and the ambitions of the men running it.",
         "in_short": "During the Second World War, bombardier Yossarian is stationed with an American bomber group on a Mediterranean island, certain that everyone is trying to kill him and desperate to be grounded before he is killed. He is thwarted by Catch-22, the maddening rule that a man must be crazy to keep flying missions but that anyone who asks to be excused thereby proves he is sane and must keep flying. His scheming commander, Colonel Cathcart, keeps raising the number of missions required, so the finish line is never reached. Around Yossarian swirls a cast of absurd figures, including the profiteering mess officer Milo Minderbinder, whose black-market syndicate consumes the war effort, and the meek chaplain. As friends die one after another and the horror of a gunner's death aboard his plane finally overwhelms him, Yossarian resolves to stop cooperating. Offered a corrupt bargain to go home in exchange for praising his superiors, he refuses, and, learning that the vanished Orr has escaped to neutral Sweden, he deserts to try to follow him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/catching-fire.json
+++ b/data/works-community/0/catching-fire.json
@@ -111,7 +111,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -124,7 +124,7 @@
       "recaps": {
         "ending": "Katniss follows Beetee's plan and fires an arrow trailing his wire into a weak point in the arena's force field, and the resulting surge blows the field apart and knocks her unconscious. She wakes aboard a hovercraft belonging to the rebellion. Haymitch, Plutarch Heavensbee, and Finnick reveal that a secret plot had been in motion the whole time: District 13, long believed destroyed, has survived underground and is leading an open revolt against the Capitol, and the plan was always to extract Katniss and make her its symbol, the Mockingjay. The rescue reached her, Finnick, and Beetee, but not everyone. Peeta and Johanna were seized by the Capitol. Gale, who escaped, tells Katniss that in retaliation for the arena breakout the Capitol firebombed District 12, leaving it in ruins with only a fraction of its people alive. The book closes with Katniss, injured and stunned, being carried toward District 13 as the war she helped ignite begins in earnest.",
         "in_short": "Katniss and Peeta return to District 12 as victors, but Katniss's berry stunt is read across Panem as rebellion. President Snow threatens her family unless she can convince everyone it was an act of love, not defiance. On the Victory Tour she instead sees unrest spreading. The Capitol then announces the Third Quarter Quell: this year's tributes will be reaped from existing victors, sending Katniss and Peeta back into the arena. There they ally with other victors, including Finnick, Johanna, Beetee, and Wiress, in a jungle arena built like a clock, each zone holding a timed horror. Unknown to Katniss, some victors and the rebel Head Gamemaker Plutarch are working to break her out to become the face of a revolt. Beetee's plan to destroy the arena's force field with wire and lightning succeeds when Katniss fires a wire-wrapped arrow into it. She wakes aboard a rebel hovercraft to learn that District 13 survived and leads the rebellion, that Peeta has been captured by the Capitol, and that District 12 has been destroyed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -311,7 +311,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -324,7 +324,7 @@
       "recaps": {
         "ending": "The collection closes with the title story. An unnamed narrator reluctantly hosts Robert, a blind friend of his wife whom he has understood only through jealousy and stereotypes. Dinner, conversation, drinking, and television gradually make the visit less threatening. When a program shows a cathedral, the narrator discovers that he cannot explain the building in words. Robert asks him to draw one instead and places a hand over his as the drawing develops. At Robert's suggestion, the narrator closes his eyes and continues. The exercise does not solve the tensions in his marriage or turn him into a different person by declaration, but it briefly releases him from the narrow habits through which he has judged Robert and protected himself. Sitting in his own house with his eyes shut, he experiences connection without needing to look, control, or retreat. This final moment answers the preceding stories' repeated failures of communication with a modest instance of shared attention: two people make something together, and the defensive narrator discovers an experience larger than the categories he brought to it.",
         "in_short": "Across twelve stories, people facing damaged marriages, addiction, unemployment, illness, grief, and financial instability struggle to communicate without reliable language for what they need. A visit to friends alters a couple's imagined future; an alcoholic reconciliation lasts only as long as a borrowed house; a father abandons a reunion with his son; and parents whose child dies find unexpected nourishment from the baker who had unknowingly harassed them. Sales work, drinking, separation, childcare, and lost property expose how quickly ordinary routines fail. The collection repeatedly stops before conventional repair: sober intervals may end, families leave, and apologies cannot reverse death. Its closing story offers a limited but genuine alternative. A jealous narrator hosts Robert, his wife's blind friend, and cannot describe a cathedral shown on television. Drawing one together, with Robert's hand over his and his own eyes closed, lets him briefly move beyond suspicion and self-protection. The moment does not erase prior harm, but it makes shared perception possible.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -519,7 +519,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -532,7 +532,7 @@
       "recaps": {
         "ending": "Faced with an approaching marriage to Shaggy Beard, Catherine leaves home and seeks refuge with Uncle George and Ethelfritha. The visit forces her to see that escape by itself will not give her command of her life: depending on relatives would simply place her choices in different hands. She returns to the manor prepared to meet the arrangement without surrendering her inner judgment. Before the marriage can occur, news arrives that Shaggy Beard has died. His son Stephen, young and considerate where his father was repellent, becomes the prospective match in his place, and Catherine receives the change with relief and hope. Her year of writing closes without granting her the unrestricted life she once imagined, but she has gained a more practical idea of freedom. She understands that choice can include how she responds, whom she helps, and what self she preserves even inside the limits imposed by family, class, and her period.",
         "in_short": "In medieval England, fourteen-year-old Catherine records a year at her father's manor while resisting the marriage he intends to arrange for profit. She dodges household lessons, befriends workers and villagers, observes the hardships around her, and drives away potential husbands with calculated bad behavior. Her admired Uncle George returns from abroad, but his frustrated attachment to Catherine's friend Aelis shows that even adults cannot always marry as they choose. Catherine's situation worsens when Sir Rollo promises her to the rich older man she calls Shaggy Beard. She finally runs to George and his unconventional wife Ethelfritha, then realizes that hiding with them would exchange one form of dependence for another. Catherine returns home resolved to retain her own mind whatever happens. Shaggy Beard dies before the wedding, and his much kinder son Stephen becomes the likely bridegroom, ending the diary on an unexpectedly hopeful note.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -714,7 +714,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -727,7 +727,7 @@
       "recaps": {
         "ending": "The ceremony honoring the Hundred Martyrs to Democracy ends in catastrophe when an aircraft crashes into the cliffs beneath Papa Monzano's castle. The impact casts Papa's ice-nine-contaminated body into the sea. The new crystal form spreads through the oceans and atmosphere, freezing the world's water and killing almost everyone. John survives in a bunker with Mona, but she deliberately touches ice-nine to her lips after deciding that life in the ruined world is not worth continuing. John later joins Newt and Frank Hoenikker, Hazel and H. Lowe Crosby, and Philip Castle among the few survivors on San Lorenzo. They live with scarce unfrozen water while John completes his account. Bokonon, still alive, imagines finishing his scriptures by making a final contemptuous gesture toward the creator of such a world; John considers carrying out that image himself.",
         "in_short": "Writer John begins researching a book about the day the atomic bomb fell and traces the family of its late co-creator, Felix Hoenikker. He learns that Felix invented ice-nine, a crystal able to turn liquid water into more ice-nine, and that Felix's three children divided the substance after his death. All three converge on the impoverished island of San Lorenzo, where John encounters the outlawed but universally practiced religion of Bokonon and becomes involved with the beautiful Mona Monzano. The dictator Papa Monzano kills himself with ice-nine, and an accident sends his frozen body into the sea. The reaction spreads through the planet's water, devastating Earth. John survives with a small group, while Mona chooses death. In the frozen aftermath, he finishes his account and finds Bokonon still composing the last words of a religion that admits its consolations are invented.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -966,7 +966,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0036JUM0A",
@@ -978,7 +978,7 @@
       "recaps": {
         "ending": "Miles and Pel Navarr recover the genuine Great Key aboard Ilsum Kety's ship, but its contents are broadcast through the emergency navigation network to prevent Kety from controlling them. ghem-Colonel Benin arrests Kety and ghem-General Naru. Naru is executed for treason and Ba Lura's murder, while Kety loses his office and freedom and faces supervised retirement or suicide. Kety's captive consort survives, and Lord Yenaro is cleared as a manipulated target of the conspiracy. Rian Degtiar assumes control of the Star Crèche and is installed as Cetaganda's new Empress. Miles and Ivan Vorpatril leave for Barrayar. Miles may submit a classified military report, but his Cetagandan Order of Merit is conditioned on public silence. The immediate plot is closed, while Cetaganda's haut genetic program and the political meaning of Miles's new honor remain consequential.",
         "in_short": "Miles Vorkosigan and Ivan Vorpatril arrive in Cetaganda for the Dowager Empress's funeral and accidentally receive the Great Key to the haut gene bank from Ba Lura, who is soon found dead. Miles learns the returned Key is a decoy and investigates a plan to frame Barrayar while a satrap monopolizes secret genetic copies. Lord Yenaro's attacks lead toward Ilsum Kety, whose abduction of his own consort confirms his guilt. With Rian Degtiar and Pel Navarr, Miles boards Kety's ship, rescues the consort, and finds the genuine Key. Pel broadcasts its contents, destroying Kety's exclusive advantage. Kety and ghem-General Naru are arrested, and Naru is sentenced to death for Ba Lura's murder. Rian becomes Empress, while Miles receives Cetaganda's Order of Merit on condition that he remain publicly silent. He and Ivan depart for Barrayar with a classified account of the crisis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1331,7 +1331,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -1344,7 +1344,7 @@
       "recaps": {
         "ending": "Felix's alliance breaks Amaranth's defenses, reaches the tower, and disrupts the Hierophant's ritual. Beef and Wendell detonate the foundation mines, destabilizing the tower and disrupting the ritual. Archie opens a way through the barrier, and Mervyn apparently dies stopping the star artifact's beam. Felix reinforces the gods' prison chains, binds the Dread into the Crescent bronze Chalice, and gains control of his Cardinal beast manifestation. He destroys the star artifact and frees the Sylphan and kobold Unbound. Before Felix kills the Hierophant, she breaks the shadow god's moon binding and causes Moonfall. Gabby survives unconscious, and Pit, Atar, Alistair, Evie, the captives, and the surviving alliance escape. Vessilia uses a threshold device to avoid a fatal blow, but her connection to Felix is severed and her location is unknown. The Compact is compromised, the Ruin is visible beyond the heavens, and the possible journey home still requires all nine Unbound. Felix retains his seven-seat empire and two pieces of Empyrean regalia, but must find Vessilia and prepare for the approaching threat.",
         "in_short": "Felix survives a disastrous Grandmaster tempering, restores Levantir, claims a seventh territory, and becomes emperor. He learns more about stolen divine power, Cardinal beasts, and the Compact binding the gods, while his allies advance and his linked spirit trees become a defensive grove. After repelling a divine attack on Elder Throne, the alliance invades Amaranth to rescue captured Unbound and stop the Hierophant's ritual. Beef finds that the hidden lizard Unbound is his father, Wendell. In the final battle Felix reinforces the divine prison chains, binds the Dread into a second Chalice, controls his beast manifestation, destroys the star artifact, frees the captives, and kills the Hierophant. Mervyn apparently dies, and Vessilia vanishes through a threshold with her bond to Felix severed. Moonfall devastates Amaranth, the Compact fails, and the approaching Ruin becomes visible.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1586,7 +1586,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1597,7 +1597,7 @@
       "recaps": {
         "ending": "The Red Court of vampires is gone - all of it. At Chichen Itza, with Maggie on the altar and the bloodline curse primed, Martin provoked the newly-vengeful Susan into killing him, completing her transformation into a full Red Court vampire; Susan, understanding what it meant, asked Harry to do what came next. Harry killed her on the altar, and the curse the Red King built to annihilate Harry's bloodline ran down the Red Court's own instead, destroying every Red Court vampire in the world in a single moment. Maggie is safe, carried out of the ruins and placed quietly with trusted friends, with Harry choosing to stay out of her life for her own protection; Mouse goes with her. The victory's price is everywhere: Susan is dead by Harry's hand, the war's end leaves a global power vacuum where the Red Court ruled, and Harry is now the Winter Knight, owing Mab service he dreads. His grandfather Ebenezar McCoy - the curse's true target, and the Blackstaff of the White Council - survives, the family secret now shared between them. Then, on the deck of Thomas's boat, before he can even report to Mab, a rifle shot takes Harry in the chest and drops him into the freezing water of Lake Michigan, where he sinks into darkness. The book ends with Harry Dresden dead.",
         "in_short": "Susan Rodriguez calls Harry with the truth she hid for years: they have a daughter, Maggie, and the Red Court has taken her. Duchess Arianna Ortega means to sacrifice the girl in a bloodline curse that will kill everyone of Harry's blood - and its true target is the line's eldest, Ebenezar McCoy, revealed to Harry as his own grandfather and the Council's secret assassin, the Blackstaff. Stripped of everything as the Red Court burns his office and home, and paralyzed by a broken back, Harry takes the bargain he swore he never would: he becomes Mab's Winter Knight in exchange for the power to save his daughter. With Susan, Martin, Murphy, Sanya, Molly, Thomas, Mouse, and his faerie godmother Lea, Harry assaults the Red King's ritual at Chichen Itza. Martin is revealed as a traitor and engineers his own death at Susan's hands, turning her into a full vampire - so Harry kills her on the altar, and the hijacked curse annihilates the entire Red Court worldwide. Maggie is placed safely with trusted friends. Then, back in Chicago, an unseen sniper shoots Harry, and he falls into Lake Michigan and sinks. The book ends with his death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1753,7 +1753,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1766,7 +1766,7 @@
       "recaps": {
         "ending": "The saga's final volume ends without full resolution, as its author left the story open. Cornered by the conquering Honored Matres, the Bene Gesserit under Mother Superior Darwi Odrade stake everything on a plan to absorb their enemy rather than merely defeat them. On their homeworld of Chapterhouse they breed new sandworms to secure the spice, revive the master strategist Miles Teg as a ghola, and drive the defector Murbella, bonded to the Duncan Idaho ghola, through complete Bene Gesserit training so that she might lead both sisterhoods at once. Odrade takes a great personal risk in a mission to the Honored Matre capital to confront their supreme leader. In the climactic confrontation the Honored Matre command is broken and Murbella slays their ruler, seizing authority over both orders and beginning to fuse them into one, though many of the old sisters remain wary of a leader with an Honored Matre's past. Odrade is killed, but not before sharing her lifetime of memories with Murbella and Sheeana so the sisterhood's essence survives. Distrustful of Murbella's merged order, and wary of a far greater unknown power whose pursuit had driven the Honored Matres back from the Scattering in the first place, a small group escapes: the Duncan ghola, the sandworm-commander Sheeana, the child Teg, the imprisoned Tleilaxu Master Scytale, and their companions flee in a hidden no-ship into uncharted space. They are shadowed by a strange, seemingly all-powerful old man and woman whose identity is never explained, and the series ends with the fugitives' fate, and the ultimate threat, left unresolved.",
         "in_short": "Cornered by the Honored Matres, the Bene Gesserit, led by Mother Superior Darwi Odrade, gamble everything on turning the tables. On their hidden homeworld of Chapterhouse they nurture new sandworms from the single worm rescued earlier, working to secure the spice supply as the enemy destroys sisterhood strongholds one by one. Odrade has the great Bashar Miles Teg revived as a ghola child and his memories restored, betting on his military genius. She also pushes Murbella, the Honored Matre bonded to the Duncan Idaho ghola, through full Bene Gesserit training, planning to unite the two rival sisterhoods under one leader. Odrade leads a bold, personally dangerous mission to the Honored Matre stronghold to confront their supreme ruler. In the decisive clash, the Honored Matre leadership is broken and Murbella kills their supreme commander, taking control of both orders and beginning to merge them, though many Bene Gesserit distrust the union. Odrade dies, first passing her memories to Murbella and Sheeana. Fearing Murbella's new regime and a shadowy, greater enemy that first drove the Honored Matres out of the Scattering, Duncan, Sheeana, the child Teg, the captive Tleilaxu Master Scytale, and others slip away in a cloaked no-ship into unknown space. The series closes with their escape unresolved, pursued in the distance by a mysterious old man and woman whose true nature is never revealed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1883,7 +1883,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1896,7 +1896,7 @@
       "recaps": {
         "ending": "The final spirit shows Scrooge a future in which his death inspires indifference, opportunism, and relief rather than grief. He also sees the Cratchits mourning Tiny Tim and discovers that the neglected grave is his own. Scrooge promises to change if the future can still be altered. He wakes on Christmas morning overjoyed to find that he has time to act. He anonymously sends a large turkey to the Cratchits, gives generously to charity, joins Fred's family celebration, and later raises Bob's pay while offering practical help to his household. His reform lasts beyond the holiday: he becomes a dependable friend, employer, and benefactor, and a fatherly presence to Tiny Tim, who survives. The threatened future is replaced by a life connected to other people.",
         "in_short": "Ebenezer Scrooge is a rich, isolated businessman who dismisses Christmas and the needs of other people. On Christmas Eve, the ghost of his former partner Marley warns him to change. Three spirits then show him the loneliness of his past, the fellowship and hardship surrounding him in the present, and a future in which Tiny Tim dies and Scrooge's own death is met without affection. Confronted with the results of his indifference, Scrooge begs for the chance to live differently. He wakes on Christmas morning and immediately puts that promise into practice, giving to charity, joining his nephew's celebration, improving Bob Cratchit's circumstances, and becoming a lasting friend to the Cratchit family. Tiny Tim lives, and Scrooge becomes known for keeping the humane spirit of Christmas throughout the year.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2022,7 +2022,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2035,7 +2035,7 @@
       "recaps": {
         "ending": "As the tour goes on, each ill-behaved child is undone by the very fault that defines them, and the Oompa-Loompas sing a rhyme about each one. Augustus Gloop is sucked up a pipe after drinking from the chocolate river; Violet Beauregarde swells into a giant blueberry after chewing an experimental gum; Veruca Salt is judged a bad nut and dropped down a rubbish chute by trained squirrels; and Mike Teavee is shrunk to a few inches after sending himself through a television device. Only Charlie is left. Wonka joyfully reveals that the entire tour was a test to find a good child worthy to run the factory one day, and he has chosen Charlie. He takes Charlie and Grandpa Joe up in the Great Glass Elevator, crashes it through the roof, and flies over the town to collect the rest of Charlie's family. Wonka gives the whole factory to Charlie and invites the entire Bucket household, hungry no longer, to come and live there with him.",
         "in_short": "Charlie Bucket is a poor, kind boy who lives in near-starvation with his parents and four grandparents beside Willy Wonka's famous, secretive chocolate factory. Wonka hides five Golden Tickets in his chocolate bars, each admitting one child to a tour of the factory. Four are found by badly behaved children: greedy Augustus Gloop, spoiled Veruca Salt, gum-obsessed Violet Beauregarde, and television-addicted Mike Teavee. Charlie finds the last ticket by luck and takes Grandpa Joe. Inside, Wonka leads them through his wondrous inventions, worked by tiny Oompa-Loompas. One by one the greedy children fall to their own faults and are removed, each with a song about the lesson. Only Charlie remains, well-behaved throughout, and Wonka reveals the whole tour was a search for an honest child to inherit the factory. He gives it to Charlie and brings the whole family to live there.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2178,7 +2178,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2191,7 +2191,7 @@
       "recaps": {
         "ending": "Charlotte's plan succeeds completely. Her words woven into the web make Wilbur so famous that the Zuckermans take him to the county fair, where he wins a special award that secures his future for good, so he will never be slaughtered. But saving Wilbur is Charlotte's last work. At the fair she spins one final web reading 'HUMBLE' and builds an egg sac holding hundreds of eggs, and the effort drains the last of her strength. Too weak to return home, she stays behind. Wilbur, unwilling to abandon her unborn children, persuades the rat Templeton to fetch the egg sac down for him, and carries it home in his mouth. Charlotte dies alone at the empty fairgrounds. Through the winter Wilbur faithfully guards the sac, and in spring the young spiders hatch. Most float away on strands of silk to find homes of their own, but three of Charlotte's daughters settle in the barn doorway and become Wilbur's friends. The barn's life goes on through the seasons, with new generations of spiders each year, and Wilbur, safe and no longer alone, never forgets Charlotte and all she did for him.",
         "in_short": "Fern, a farm girl, saves the runt of a litter from slaughter and raises the piglet, Wilbur, until he is sold to her uncle Homer Zuckerman's barn. Lonely there, Wilbur befriends Charlotte, a wise grey spider who lives in the doorway. When Wilbur learns that the family plans to kill him for meat, Charlotte vows to save him. She spins words of praise into her web, 'SOME PIG,' 'TERRIFIC,' 'RADIANT,' and 'HUMBLE,' that convince the Zuckermans and the whole county that Wilbur is a miraculous animal. Wilbur becomes famous, is taken to the county fair, and wins a special prize that guarantees he will be allowed to live. At the fair Charlotte also lays her eggs in a silken sac, but the effort exhausts her and she is dying. Wilbur saves her egg sac by having Templeton the rat fetch it, and carries it home while Charlotte dies at the fairgrounds. In spring her babies hatch; three remain in the barn, and Wilbur always cherishes the memory of the friend who saved his life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2422,7 +2422,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -2435,7 +2435,7 @@
       "recaps": {
         "ending": "Theo, Nauda, and Fiyu escape the Chasm and return to Norro Yorthin under House Blacksilver's protection. Theo is now a ruler and receives an esoteric chisel as his reward, but his wounds are not fully resolved. Nauda's soul home remains shattered despite Senka's partial repair, and House Blacksilver can promise only to investigate possible restorative materials. Fiyu is physically in the best condition of the three, yet remains shaken and still has no contact with her relative.\n\nAn authority activates the Scepter of Separation on Senka, triggering her intended countereffect and harming him. Senka takes him into the falls, and the weapon explodes as they vanish, leaving her survival unknown. Before disappearing, she warns that Theo's old enemy is exploiting links among Earth, the Nine Worlds, and fragmentary realms. The head of the House of the Lost demonstrates that this enemy can be challenged, although that house's aims remain unclear. House Blacksilver rewards the trio but expects reprisals and further factional tension. The immediate expedition is over, while Nauda's recovery, Senka's origin and whereabouts, Theo's enemy, and the wider interworld struggle remain open.",
         "in_short": "Theo, Nauda, and Fiyu prepare for a Chasm expedition whose stakes include a lost weapon capable of separating a soulcrafter from their soul home. Once inside, they gather rare materials, survive rival factions, and discover that the House of the Lost has prolonged the opening. Their search eventually brings them to the Scepter of Separation as greater powers tear apart the final ruins. Theo reaches ruler tier, but collateral damage shatters Nauda's soul home. Senka unexpectedly claims the scepter, reveals that her damaged behavior concealed lucid awareness and considerable power, and partly repairs Nauda. An authority then activates the weapon on Senka, triggering her intended countereffect before they disappear into the falls as it explodes. Theo's ancient enemy escapes the vault disaster, but the Lost house's leader proves able to oppose him. Theo, Nauda, and Fiyu return to Norro Yorthin with rewards, while Nauda's recovery, Senka's fate, Fiyu's missing relative, and an expanding interworld conflict remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2602,7 +2602,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2615,7 +2615,7 @@
       "recaps": {
         "ending": "The children cease to be separate individuals and merge into a single, developing intelligence linked to the Overmind. The remaining adults die without producing another generation. Jan Rodricks returns from the Overlords' world decades after his departure, made the last human by relativistic travel, and stays on Earth while Karellen withdraws his fleet. Jan reports the planet's final changes to Karellen as the transformed children draw matter and energy into themselves. Earth becomes translucent and then vanishes in an immense release of energy as the new collective joins the Overmind. Jan dies with his world. Karellen preserves his final observations but remains unable to follow humanity: the Overlords are powerful servants and observers of the Overmind, yet their own species has reached an evolutionary dead end. Their resemblance to humanity's traditional image of demons arose from a psychic echo of their role at the ending of the human race, not from an ancient visit.",
         "in_short": "Vast Overlord ships arrive above Earth's cities and impose peace, prosperity, and global unity. Their Supervisor, Karellen, hides his species' appearance for fifty years; when the Overlords emerge, they resemble the devils of human legend, though they have acted as careful guardians. In the resulting golden age, ambition, religion, and much of traditional culture fade. Jan Rodricks secretly travels to the Overlords' home world, while George Greggson and Jean Morrel raise children who begin displaying extraordinary mental powers. Karellen reveals that the Overlords have not conquered humanity but supervised its final stage before union with the cosmic Overmind. All ordinary human births stop, the transformed children form a collective consciousness, and the adult population dies out. Jan returns decades later as the last unaltered human and watches Earth dissolve as its children join the Overmind. The Overlords depart as witnesses, unable to make the same evolutionary leap themselves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/children-of-dune.json
+++ b/data/works-community/0/children-of-dune.json
@@ -108,7 +108,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -121,7 +121,7 @@
       "recaps": {
         "ending": "The book ends with the rise of a new and stranger ruler. Leto II, having secretly left his sister Ghanima and slipped into the desert, merges his skin with a living sheath of sandtrout, gaining tremendous strength, speed, and resistance to harm at the price of his ordinary human future. He embraces the Golden Path, a design of prescience meant to guarantee humanity's long-term survival even at monstrous personal cost. His aunt Alia, wholly possessed by the inner ego of the old Baron Harkonnen, spirals into tyranny; when Leto returns and forces her to face what she has become, she throws herself to her death. The mysterious Preacher, revealed as Paul Atreides returned from the desert, is struck down and killed by a crowd in the city, his warnings against the religion of Muad'Dib unheeded. Leto overcomes the Corrino assassination plot and takes power as the new emperor. He pardons and binds the young Corrino heir Farad'n by betrothing him to Ghanima, making the rival house serve the Atreides line. Lady Jessica reconciles herself to what her grandson has chosen. Leto sets the empire on the path of his long metamorphosis into a god-emperor, accepting that he will rule for thousands of years as something no longer fully human in order to save mankind from itself.",
         "in_short": "Nine years after Paul's disappearance, his twin children, Leto II and Ghanima, are the pre-born heirs of the empire, guarded on Arrakis while their aunt Alia rules as Regent. Alia has lost her inner struggle and become an Abomination, possessed by the ego of her ancestor, the tyrannical Baron Harkonnen, and her rule grows cruel and erratic. A blind Preacher wanders in from the desert denouncing the corrupt religion of Muad'Dib; he is Paul himself, still alive. House Corrino, exiled on Salusa Secundus, plots the twins' murder to reclaim the throne, sending genetically tampered tigers to kill them. Leto and Ghanima, sharing prescient visions, foresee a terrible Golden Path that alone can save humanity from extinction, and Leto resolves to take it. Faking his own death, Leto ventures into the desert and bonds his body with sandtrout, gaining superhuman strength and near-immortality as he begins a transformation toward becoming a human-sandworm hybrid. Paul the Preacher is killed by a mob in the city. Leto returns, overpowers all opposition, and forces Alia to confront the monster she has become; she takes her own life. Leto seizes the throne, betroths Ghanima to the Corrino heir Farad'n to bind the rival house, and commits himself to a reign of millennia, sacrificing his own humanity to steer the species along the Golden Path his father dared not walk.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -217,7 +217,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -230,7 +230,7 @@
       "recaps": {
         "ending": "The book's two timelines resolve into a single, hard-won theme: understanding reached across minds that could hardly be more different. The old expedition's legacy, Senkovi's uplifted octopuses on their water world and the alien organism native to the neighboring planet, becomes the puzzle the later explorers must face. The joint human-and-spider crew, aided by Avrana Kern's intelligence and by specialists in communication, make a fraught first contact with the emotional, unpredictable octopus civilization and come up against the alien life of the second world, a distributed organism able to infect and inhabit hosts, which spreads terror among them. Rather than the story ending in mutual destruction, the explorers manage, at real cost, to find ways to communicate with the octopuses and even with the alien mind, translating between radically foreign kinds of thought. The result is a tense but genuine accommodation: the united civilization of humans and spiders is enlarged to include the octopuses and a form of the alien intelligence, extending the series' central idea that even the strangest of minds can, with effort, be reached and lived alongside rather than simply feared or destroyed.",
         "in_short": "In an earlier age, a human terraforming expedition reaches a distant system with two candidate worlds. The scientist Disra Senkovi sets about uplifting octopuses to help reshape a water world, while the mission's leader, Yusuf Baltiel, discovers that the second planet already harbors native life, a strange and dangerous alien organism. When catastrophe cuts the mission off from home, the uplifted octopuses inherit their world and grow into a volatile spacefaring civilization, and the alien life takes its own grip on events. Long afterward, a joint crew of humans and uplifted spiders from the united civilization of the previous book, carrying the preserved intelligence of Avrana Kern, travels to investigate old signals from the system. They make first contact with the chaotic octopus society and confront the terrifying alien organism, which can infect and inhabit other beings. Struggling across vast gulfs between wholly different kinds of minds, and at great cost, the explorers move from terror and misunderstanding toward communication, and the story closes with a fragile new coexistence among humans, spiders, octopuses, and the alien intelligence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -377,7 +377,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -390,7 +390,7 @@
       "recaps": {
         "ending": "The series' arc closes with survival won on every front. As Starways Congress moves to shut down the computer network and so destroy Jane, and its planet-killing fleet nears Lusitania, Ender's scattered allies each carry part of the rescue. The young Peter, the living recreation of Ender's brilliant, ruthless brother, journeys with Wang-mu to the worlds and thinkers behind Congress policy, including the philosopher Aimaina Hikari, and helps turn opinion against the attack so that the fleet is stopped before it can fire. Jane, having learned to hold starships in her mind and move them Outside ordinary space and back, gains the ability to carry people instantly across the galaxy, but she must find a place to live once the network is gone. The answer comes as Ender, whose spirit is stretched too thin among the beings he has created, weakens and dies; freed by his passing, Jane settles into the body of young Valentine, whose own life had been failing, and so survives with a human form and her powers intact. Ender's own identity continues on in the young Peter. With the war averted, the makers of the Descolada virus traced at last, and instantaneous travel now possible, humanity, the pequeninos, and the hive queens are all assured a future and the freedom to spread among the stars. Miro pairs with young Valentine and Peter with Wang-mu, and the long story of Ender Wiggin ends with the three kindred species safe and a galaxy newly open to them.",
         "in_short": "With a planet-killing fleet nearing Lusitania and Starways Congress about to shut down the network that keeps the intelligence Jane alive, Ender's allies scatter to save everything at once. The newly created young Peter, a living copy of Ender's ruthless brother, travels with the clever Wang-mu to sway the philosophers and worlds whose ideas drive Congress, eventually reaching the thinker Aimaina Hikari and undermining the war policy. Jane learns to hold and move starships Outside reality, offering instant travel that could carry people to safety, but she needs somewhere to live once the network dies. As Ender's life-force is spread thin among the beings he has made, he begins to fade; when he lets go, Jane is able to take up residence in the body of young Valentine, whose own hold on life had been faltering, gaining a human form and preserving her mind. Ender's identity carries on in the young Peter. The fleet is halted before it can fire, the origins of the engineered Descolada are traced to their makers, and instant Outside travel opens the galaxy to escape and expansion. Miro and young Valentine come together, as do Peter and Wang-mu, and the three species of Lusitania are spared, their survival now bound to the new power to leap across space at will.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -486,7 +486,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -499,7 +499,7 @@
       "recaps": {
         "ending": "The two long threads meet at Kern's green world. After failing to find anywhere else to live, the humans of the ark ship Gilgamesh arrive to find the planet inhabited by a spider civilization that has grown, over millennia, into something highly advanced, with its own biotechnology, computation, and social order shaped by successive generations of Portias, Biancas, and Fabians. Avrana Kern, still lingering as an intelligence in orbit and regarding the world as hers, refuses to share it with the humans she thinks of as apes. Desperation drives the humans toward seizing the planet by force, and the confrontation escalates toward a war the spiders are well able to win, one that could destroy the last of humanity. At the decisive point, the spiders choose not to exterminate the invaders. Instead they deploy a refined version of the same uplift nanovirus, engineered to rewrite human perception so that the terrified humans no longer see the spiders as monsters but as kin to be understood and lived alongside. The ancient, instinctive terror between the species is defused from within. Humanity survives not by conquering but by being changed, and humans and spiders merge into a single civilization sharing the world, with Kern's consciousness folded into the spiders' networked minds.",
         "in_short": "A far-future scientist, Avrana Kern, tries to uplift monkeys on a terraformed world using a nanovirus, but sabotage destroys her mission; the monkeys never arrive, and instead the virus takes hold in the planet's spiders, accelerating their evolution over thousands of years. Kern survives as a fading intelligence in orbit, watching over the world. In parallel, the ark ship Gilgamesh carries the last remnants of humanity, fled from a ruined Earth, in a long search for a home, with the historian Holsten Mason repeatedly woken across the centuries. The narrative alternates between the humans' slow, fraught voyage and the rise of the spider civilization, whose recurring figures named Portia, Bianca, and Fabian develop language, science, and society. When the desperate humans finally reach Kern's green world, Kern refuses to yield it, and the two peoples come to the brink of a war the technologically advanced spiders could win. Rather than annihilate the humans, the spiders release a modified virus that lets the two species see each other as kin, and they join into a single shared civilization.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -613,7 +613,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -626,7 +626,7 @@
       "recaps": {
         "ending": "Disguised as a traveler, Orestes gains entry to the palace by reporting his own death. Aegisthus comes without his usual guards and is killed inside. Clytemnestra then confronts her son and appeals to the bond between mother and child. Orestes hesitates, but Pylades reminds him that Apollo ordered the revenge. Orestes kills Clytemnestra beside Aegisthus and displays both bodies, defending his actions as punishment for Agamemnon's murder. His confidence immediately collapses when he sees the Furies, avenging spirits invisible to the chorus, approaching to punish the killing of a blood relative. He leaves Argos to seek purification and protection from Apollo at Delphi. The usurpers are dead and Agamemnon avenged, but Orestes has repeated the family's pattern of violence and now faces divine pursuit.",
         "in_short": "Years after Clytemnestra and Aegisthus murder Agamemnon and take power in Argos, Agamemnon's exiled son Orestes returns under an order from Apollo to avenge his father. At Agamemnon's tomb he reunites with his sister Electra, and the siblings pray for help in overthrowing the palace rulers. Orestes enters the palace disguised as a traveler bearing false news of his own death. His former nurse is sent to fetch Aegisthus, and the sympathetic chorus ensures that Aegisthus comes without guards. Orestes kills him, then confronts Clytemnestra. Though he hesitates when his mother appeals to him, Pylades recalls Apollo's command, and Orestes kills her as well. He presents the deaths as justice for Agamemnon, but the Furies immediately appear to him as punishers of kin-murder. Pursued by them, Orestes flees to Apollo's sanctuary for purification, transferring the conflict from family revenge to divine judgment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -745,7 +745,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -758,7 +758,7 @@
       "recaps": {
         "ending": "Victor tries to get food into his failing mother, but she chokes and dies despite the attempt to save her. The authority Paige seemed to possess also falls away: she is not Ida’s doctor but a patient from the institution, making the extraordinary account she gave Victor about his origins impossible to accept as medical fact. Ida’s own history nevertheless leaves him confronting the likelihood that she took him as a child and built his identity around her private crusade against ordinary society. He is left without a reliable parentage or a grand explanation of himself. Denny’s stone-building project, assembled from material taken from many places, faces the practical consequences of how it was made, but it also gives the friends something concrete outside their old cycles of compulsion and rescue. The close does not supply Victor with a stable new identity; it strips away the stories on which he tried to base one and leaves connection as something that has to be made rather than inherited.",
         "in_short": "Victor Mancini, a medical-school dropout and sexual compulsive, pays for his mother Ida’s care by staging choking emergencies in restaurants and encouraging his rescuers to keep supporting him. His job at a colonial theme park, his recovery meetings, and his friend Denny’s efforts to redirect his own compulsions all expose Victor’s dependence on roles that let him avoid responsibility. At the institution, Paige Marshall offers to help recover Ida’s history and gives Victor an extraordinary religious explanation of his birth. Ida’s broken memories and Victor’s childhood recollections instead reveal a life built on abduction, flight, and unstable identities. When Victor tries to feed Ida, she chokes and dies. Paige is exposed as a patient rather than a doctor, so her account cannot establish who Victor is. Denny’s growing stone structure provides a contrasting attempt to build something lasting, while Victor ends without the miraculous identity he briefly imagined and must face the habits and relationships he has used to define himself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -964,7 +964,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -977,7 +977,7 @@
       "recaps": {
         "ending": "In the final reconstruction, Santiago remains unaware of the threat until the last minutes. Cristo Bedoya searches for him but repeatedly misses him, while a warning note lies unnoticed beneath the Nasars' door. After Flora Miguel angrily confronts him with Angela's accusation, her father tells him the twins are waiting. Santiago steps into the square confused and exposed. Plácida Linero, mistakenly believing he is already inside, bolts the front door just as he runs home. Pedro and Pablo Vicario catch him there and stab him repeatedly before witnesses who have had hours to anticipate the attack. Mortally wounded, Santiago walks around the house, enters through the kitchen, and collapses. The later investigation never establishes whether Angela's accusation was true. The narrator's account closes with the physical fact of the foretold death but leaves responsibility distributed among the killers, the honor code, official failures, chance, and the community's collective inaction.",
         "in_short": "Decades after Santiago Nasar was killed, an unnamed narrator reconstructs how nearly an entire town learned that twins Pedro and Pablo Vicario planned to murder him, yet no one stopped them. Their sister Angela had been returned by her new husband, Bayardo San Román, on their wedding night and named Santiago as the man connected with her lost virginity. The twins announced their purpose openly, while officials, friends, and neighbors dismissed them, assumed somebody else had warned Santiago, or were delayed by coincidence. Santiago remained ignorant until shortly before the attack. His mother accidentally locked him out of his own house, and the twins stabbed him at the door. Years later Angela, transformed by her attachment to the husband who rejected her, had written Bayardo thousands of unanswered letters; he eventually returned carrying them. Whether she told the truth about Santiago is never resolved. The chronicle assigns no single cause beyond the convergence of ritual honor, institutional failure, and shared passivity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1170,7 +1170,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1183,7 +1183,7 @@
       "recaps": {
         "ending": "Holden carries the Investigator into the alien machinery beneath the planet and lets it do what it came for. It shuts the world's systems down, and the effects reverse together: the fusion reactors restart in time to save the ships whose orbits were decaying, the ruins stop killing people, and Elvi's treatment clears the organism from the survivors' eyes. What the Investigator finds in the process is the important part. The civilization that built the gates was not destroyed by a war or a plague but by something that reached in from outside their network and switched them off, and that something is still capable of doing it. Holden brings the warning back with him. On the surface, Murtry makes a last attempt to kill Holden and secure the company's claim by force, and is stopped and taken into custody to be tried for the killings he ordered; Havelock, who has spent the book following orders he disliked, is the one who finally refuses. Lucia Merton faces the consequences of her part in the bombing, and Basia has to live with his. The settlers keep their town and their ore, the company keeps its charter and its scientists, and the two are forced into an uneasy shared occupation of the world. Elvi and Fayez stay on. The gates remain open, and the rush to settle a thousand new worlds continues, now with a warning attached that almost nobody wants to hear.",
         "in_short": "Refugees from Ganymede have squatted on Ilus, the first habitable world reached through the alien gates, and are mining lithium there when Royal Charter Energy arrives holding the United Nations charter for the same planet. Settlers blow up the landing pad, killing the company's governor and shuttle crew, and RCE's security chief Murtry answers with summary executions. James Holden is sent as a mediator, accompanied by an apparition of the dead detective Miller that only he can see and that wants access to the alien ruins. As the two sides escalate toward massacre, the planet itself wakes up: machinery buried for aeons activates, fusion reactors across the system shut down and leave the ships in orbit falling, a tsunami destroys the settlement, and an organism in the water blinds almost everyone. Biologist Elvi Okoye works out a treatment while the survivors shelter together in the ruins. Holden takes the Investigator into the alien network, shuts the planet down, and learns that whatever destroyed the builders is still out there and can reach through the gates. Murtry is arrested, settlers and company are forced to share the world, and the warning goes home with Holden.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1385,7 +1385,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1398,7 +1398,7 @@
       "recaps": {
         "ending": "Cinder is exposed at the annual ball as both a cyborg and a Lunar, arrested, and sentenced to be handed over to Queen Levana. Cornered, Kai accepts Levana's terms: he will marry her and surrender Cinder in exchange for the letumosis antidote for his people. In her cell, Dr. Erland admits that he is himself a Lunar defector who came to Earth years ago searching for the lost heir, and tells Cinder who she is: Princess Selene, badly burned in the nursery fire Levana ordered, smuggled off the moon at three years old, rebuilt as a cyborg and hidden on Earth ever since. As the only living person with a stronger claim to the Lunar throne, she is the one thing Levana genuinely fears. Erland fits her with a stronger cyborg hand and foot, tells her to break out and find him in Africa, and leaves. Peony is dead of the plague, Iko has been dismantled and survives only as a personality chip, Adri has disowned her, and Kai now knows what she is but not who. The book closes with Cinder alone in the prison, certain of her identity for the first time and choosing to escape rather than be delivered to Luna.",
         "in_short": "In New Beijing, generations after a world war, sixteen-year-old Linh Cinder is a cyborg mechanic owned by an unloving guardian in a society that treats cyborgs as property. When Crown Prince Kai brings her a broken royal android to repair, she is drawn into two crises at once: letumosis, an incurable plague that kills the emperor and her stepsister Peony, and Luna, the moon colony whose queen Levana can bend minds and wants Earth's largest empire through marriage. Conscripted as a plague test subject, Cinder proves immune, and the palace scientist Dr. Erland eventually tells her why: she is Lunar. She goes to the royal ball to warn Kai that Levana means to kill him once she is crowned, and is exposed there as both cyborg and Lunar, then jailed. In prison Erland reveals the rest: Cinder is Princess Selene, the Lunar heir believed dead since childhood and the rightful claimant to Levana's throne. Kai agrees to the marriage to buy the antidote for Earth, and Cinder prepares to break out.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1549,7 +1549,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1562,7 +1562,7 @@
       "recaps": {
         "ending": "After the prince's servants fail to find the owner of the golden shoe among the expected guests, Cinderella is finally allowed to try it. It fits her, and the prince recognizes her as the young woman with whom he danced during the royal celebration. He chooses Cinderella as his bride and takes her away from the household that abused her. The stepsisters try to attach themselves to Cinderella's good fortune by accompanying her wedding procession, but the birds that helped Cinderella punish them for their cruelty and deceit by blinding them. Cinderella's marriage ends her life of forced servitude, while the stepfamily's attempts to gain status through deception fail.",
         "in_short": "After her mother dies, Cinderella is mistreated by her new stepmother and two stepsisters and made to work among the ashes. She tends a hazel tree at her mother's grave, where helpful birds answer her pleas. When the king holds a three-day celebration so his son can choose a bride, Cinderella's stepmother tries to keep her home with impossible tasks. The birds complete the work and provide splendid clothes, allowing Cinderella to attend unrecognized. The prince dances only with her, but she escapes each evening. On the last night, a golden shoe is caught on a stair prepared to delay her. The prince searches for its owner. Both stepsisters mutilate their feet to force them into the shoe, but the birds expose the blood and the deceptions fail. The shoe fits Cinderella, the prince recognizes her, and they marry. At the wedding, the birds blind the stepsisters as punishment for their cruelty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1631,7 +1631,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1644,7 +1644,7 @@
       "recaps": {
         "ending": "The prince takes the lost slipper from house to house. Cinderella's stepsisters try to force their feet into it, but their fraud is revealed. Cinderella is finally allowed to try, and the slipper fits her. She produces its mate, confirming that she is the young woman who danced with the prince. He chooses Cinderella as his bride and removes her from the household that had treated her as a servant. At the wedding, the stepsisters' attempt to share in her new fortune ends in punishment, while Cinderella becomes the prince's wife.",
         "in_short": "After her mother dies, Cinderella is mistreated by her new stepmother and stepsisters and made to work as the family's servant. When the prince holds a royal celebration, her stepfamily refuses to take her. Aid connected with her mother's grave provides beautiful clothing, allowing her to attend unrecognized and dance with the prince. She repeatedly leaves before he can learn who she is, but on her final flight she loses a slipper. The prince searches for the woman it fits. The stepsisters' attempts to pass as its owner are exposed; it fits Cinderella, who also has the matching slipper. The prince marries her, and the stepsisters are punished at the wedding.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1815,7 +1815,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1828,7 +1828,7 @@
       "recaps": {
         "ending": "Circe refuses Athena's offer of lasting glory through Telemachus and chooses a life directed by her own desires. With Telemachus she crosses Scylla's strait and uses the poisoned spear to destroy the monster she created, accepting responsibility for ending its violence. She then compels Helios to secure her release from exile by threatening open conflict before Zeus. Penelope remains on Aiaia to learn witchcraft, while Telegonus leaves under Athena's patronage to build a life connected to the wider world. Circe and Telemachus acknowledge their love. Circe prepares a final potion from the flowers that once transformed Glaucos. She believes it will strip away her divinity rather than reveal hidden godhood, allowing her to become mortal. The novel closes with her envisioning an ordinary shared future with Telemachus—work, children, aging, and death—and drinking the potion in hope of choosing that finite life.",
         "in_short": "Despised in Helios's court, the nymph Circe discovers witchcraft by transforming the mortal Glaucos into a god and the nymph Scylla into a monster. Exiled to Aiaia, she develops her power through labor and meets figures including Daedalus, Medea, and Odysseus. After sailors assault her, she turns predatory visitors into pigs. Odysseus becomes her lover and leaves her pregnant with Telegonus, whom she protects from Athena. Grown, Telegonus sails to Ithaca and accidentally kills his father. He returns with Penelope and Telemachus; the four gradually discard the heroic stories that shaped them. Telegonus departs, and Penelope chooses witchcraft. Circe and Telemachus fall in love, destroy Scylla, and win Circe's freedom from Helios. Rejecting immortality and Athena's plans, Circe drinks a potion she expects will make her mortal so she can share an ordinary, finite life with Telemachus.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2028,7 +2028,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2041,7 +2041,7 @@
       "recaps": {
         "ending": "Mr. Oliver is revealed as the Earthmover, an ancient vampire of extraordinary power and the hidden architect of the challenge to Jean-Claude. His mild appearance and stated wish to limit violence concealed a plan to remove Jean-Claude and use public deaths to turn opinion against the legal acceptance of vampires. Alejandro is another master seeking control and has tried to claim Anita through his own marks. At the Circus of the Damned, the rival plans converge. Anita uses the competing supernatural bonds rather than submitting to either claimant, and the confrontation ends with Alejandro and Oliver destroyed. Jean-Claude remains master of St. Louis, with his position strengthened by Anita's actions. Richard reveals that he is a werewolf, explaining his strength and his connections within the city's lycanthrope community. Anita is angry that he concealed it but does not reject him merely for being a shapeshifter. Jean-Claude also continues his pursuit of her, leaving Anita between two men and still resisting the idea that mystical marks give either vampire a right to direct her life. Larry survives his first major exposure to this work and remains Anita's trainee.",
         "in_short": "After deaths attributed to a group of vampires, Anita helps Dolph's police team identify the masters entering St. Louis and trains young animator Larry Kirkland. Jean-Claude, now master of the city and still linked to Anita by two marks, needs her help against challengers. Anita also begins seeing Richard Zeeman, a teacher who hides his connection to the local werewolves. Ancient vampire Alejandro tries to mark and claim her, while the elderly Mr. Oliver and his companion Karl appear to offer restrained assistance. At the Circus of the Damned, Oliver is revealed as the Earthmover, the oldest and most dangerous rival, whose plan uses violence to undermine both Jean-Claude and public acceptance of vampires. Anita turns the competing bonds to her advantage; Alejandro and Oliver are destroyed, and Jean-Claude keeps the city. Richard admits he is a werewolf, and Anita continues dealing with both his courtship and Jean-Claude's while refusing to be treated as anyone's servant.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2200,7 +2200,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2213,7 +2213,7 @@
       "recaps": {
         "ending": "Magdalena attempts to escape Juárez to join John Grady, but Eduardo's men intercept and murder her. John Grady crosses the border to confront Eduardo and fights him with knives. He kills Eduardo but is mortally wounded. Billy finds him and remains with him as he dies, powerless to save the younger man he regarded as a brother. The ranching community also disperses as Mac's land is absorbed for government use, completing the loss of the world the cowboys tried to preserve. In an epilogue set decades later, the elderly Billy is homeless and wandering. Beneath a highway overpass, a stranger tells him an elaborate account of a dream and challenges him about whether stories can ever be separated from the people who tell them. Billy continues on and is eventually taken in by Betty and her family. He speaks of John Grady's goodness and accepts this late shelter, carrying the dead and the vanished border country in memory.",
         "in_short": "In 1952, John Grady Cole and Billy Parham work together on a New Mexico ranch threatened by government acquisition. Across the border in Juárez, John Grady falls in love with Magdalena, a young woman controlled by the brothel owner Eduardo. Billy warns him that devotion cannot overcome the forces surrounding her, but John Grady plans a marriage, prepares a small home, and tries to arrange her escape. Eduardo refuses to surrender control. Magdalena is caught and murdered before she can cross the border. John Grady challenges Eduardo and kills him in a knife fight, but dies from his wounds in Billy's arms. The ranch is later lost and its community scatters. Decades afterward, an aged, homeless Billy meets a stranger who tells him a puzzling story about dreams and interpretation. A woman named Betty finally offers Billy a home. He accepts her kindness while preserving his memory of John Grady and the border world they shared.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2423,7 +2423,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2436,7 +2436,7 @@
       "recaps": {
         "ending": "The confrontation ends on Valentine's ship in the East River. He has taken four Downworlder captives, Simon and Maia among them, and completes the ritual that turns the Mortal Sword into a demonic instrument. Jace fights him; the Inquisitor Imogen, who had spent the book trying to destroy Jace, dies taking the blow meant for him, having finally accepted that he is not his father's creature. Simon is drained almost to nothing and revives by drinking Jace's blood, which leaves him a Daylighter, a vampire who can walk in sunlight, something no one has ever heard of. Clary draws an unfamiliar rune on the hull that tears the ship apart, and Valentine escapes into the water with the Cup and the corrupted Sword, leaving two of the three Mortal Instruments in his hands and only the Mirror unaccounted for. The survivors are pulled out of the river by Luke's pack. Maryse's suspicion of Jace is broken and he is welcomed back to the Institute; Clary and Simon have ended their attempt at a relationship, and what happened in the Seelie Court sits unresolved between Clary and Jace, who still believe themselves to be siblings. Jocelyn remains in her coma, and Valentine is stronger than he was.",
         "in_short": "Valentine is at large with the Mortal Cup, and Downworlder children begin turning up dead across the city, drained for a ritual. The Clave sends the Inquisitor Imogen Herondale to New York, convinced that Jace, as Valentine's son, is his father's spy; she imprisons him in the Silent City just as Valentine attacks it, slaughters the Silent Brothers and takes the second Mortal Instrument, the Mortal Sword. Jace escapes and shelters with Luke. Clary and Simon try to be a couple, but an audience with the Seelie Queen forces Clary to kiss Jace in front of him, and Simon walks away; shortly afterwards he is killed and rises as a vampire. The Inquisitor's attempt to trade Jace to Valentine collapses when Valentine shows he does not want him back. Valentine seizes four Downworlders, Simon and Maia among them, to complete a ritual aboard his ship. Clary destroys the ship with a rune of her own making. The Inquisitor dies saving Jace, Valentine escapes with the Cup and the Sword, and Simon, revived on Jace's blood, becomes a vampire who can walk in daylight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2617,7 +2617,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2630,7 +2630,7 @@
       "recaps": {
         "ending": "The skeleton is identified as Arthur Delacroix, whose many healed fractures record years of abuse by his father, Samuel, but the fatal event came from another child. Arthur had a skateboard connected to neighborhood boy Johnny Stokes; when Stokes confronted him in the hills, he struck Arthur and left him hidden in the canyon. Bosch proves Stokes's responsibility after first seeing suspicion and a press leak destroy Nicholas Trent, who was not Arthur's killer. During the final police action, rookie Julia Brasher mishandles her weapon and suffers a fatal self-inflicted gunshot. The department presents her death in a more heroic form and places blame on the suspect rather than acknowledge the accident. Bosch cannot accept a convenient official story after spending the case stripping away another set of convenient assumptions. With Arthur's killer identified but Trent and Brasher also dead, he decides that solving the homicide no longer justifies his place inside the institution. He hands over his badge and leaves the LAPD, ending the book as a civilian.",
         "in_short": "A dog finds a child's bone in Laurel Canyon, leading Harry Bosch and Jerry Edgar to a skeleton buried for about twenty years. Forensic examination shows repeated abuse, and old records identify the boy as Arthur Delacroix, who vanished in 1980. Arthur's alcoholic father admits beating him, while sister Sheila helps reconstruct a plan to run away. A leaked suspect name directs public blame at former neighbor Nicholas Trent, who dies before evidence clears him. The decisive trail instead runs through a skateboard and childhood acquaintance Johnny Stokes, who confronted Arthur in the hills, killed him, and concealed the body. Bosch solves the old murder, but the case produces a second institutional falsehood when rookie officer Julia Brasher, with whom he has begun a relationship, fatally shoots herself during police action and the department recasts the accident as heroism at a suspect's hands. Disillusioned by both needless deaths and the official response, Bosch resigns from the LAPD.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2816,7 +2816,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2829,7 +2829,7 @@
       "recaps": {
         "ending": "Hodge Starkweather, once a member of Valentine's Circle and cursed by the Clave never to leave the Institute, betrays the household: he takes the Mortal Cup from Clary and hands Jace over to Valentine in exchange for his freedom. Clary and Luke follow to a derelict building on the river, where Valentine reveals that he raised Jace as his own son under a dead man's name, that Jocelyn is his wife, and that Clary is therefore his daughter. Jace and Clary, who had just begun to fall in love, are told they are brother and sister, and neither of them is given any reason to doubt it. Valentine escapes through a Portal with the Mortal Cup; Clary shatters the mirror behind him so he cannot be followed. Jocelyn is recovered alive but locked in a coma of her own making, and is taken to a hospital where no ordinary doctor can help her. Simon has survived being turned into a rat and nearly drained by vampires; Luke's true nature as a werewolf and former Shadowhunter is out in the open; and Clary is left knowing exactly who her father is, with the Mortal Cup in his hands and her mother beyond waking.",
         "in_short": "Fifteen-year-old Clary Fray watches three teenagers kill a demon in a Manhattan club, an event nobody else can see, and within a day her mother is abducted and her ordinary life is gone. Taken in by the young hunters of the New York Institute, she learns that she is Nephilim, one of the Shadowhunters who police demons and Downworlders, and that her memories have been deliberately blocked for years. Her mother's disappearance is the work of Valentine Morgenstern, a Shadowhunter who once led a rebellion and now wants the Mortal Cup, the object that creates new Shadowhunters. Clary recovers the Cup from a tarot deck her mother painted, learns that her family friend Luke is a werewolf, and discovers a talent for creating runes nobody has seen before. Their tutor Hodge betrays them and delivers the Cup and Jace to Valentine, who reveals that he is father to both Jace and Clary. Valentine escapes with the Cup, and the two are left believing themselves to be siblings.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3032,7 +3032,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3045,7 +3045,7 @@
       "recaps": {
         "ending": "The keepers hold a city they cannot yet use. Kelsingra stands almost undamaged across the river, its stone full of preserved Elderling memory, but the magic that ran it depends on Silver drawn from wells that are no longer giving, and until the dragons get it they will remain less than dragons and unable to make proper Elderlings. Rapskal, steeped in the memories of a dead Elderling warrior, has become the loudest voice for taking up the city's inheritance wholesale, and Thymara is close to him and increasingly unsure who she is close to. Leftrin has recovered Tarman and secured supplies, but only by making enemies of the Cassarick council, which has no intention of honouring the expedition's contract and every intention of getting its own people upriver to claim a share. Hest, coerced by Chalcedean agents who know what he commissioned, is on his way north to find Sedric and the dragon parts he was promised. In Chalced, Selden Vestrit remains a captive of a dying Duke who has been told Elderling flesh will restore him. And Tintaglia, shot with poisoned Chalcedean weapons while hunting the coast, comes to Kelsingra in terrible condition, seeking the only creatures in the world who might be able to save her, and bringing the war over dragon parts directly to the keepers' door.",
         "in_short": "Settled opposite Kelsingra, the keepers can only reach the city on dragonback, and once there they find it nearly intact but inert: the Elderling magic that ran it needs Silver from wells that have stopped giving, and without Silver the dragons cannot become what they should be. Alise records and maps everything; Rapskal begins immersing himself in the memories held in the city's stone and returns from them carrying a dead Elderling's confidence and opinions, drawing Thymara after him. Downriver, Leftrin discovers that the Cassarick council means to cheat the expedition of its payment, and fights to get his barge and his supplies back. Hest Finbok's comfortable life collapses when Chalcedean agents demand the dragon parts he commissioned, and he is forced north to find Sedric. In Chalced, the dying Duke keeps Malta's brother Selden caged as a supposed cure, while Malta and Reyn's newborn son sickens beyond any healer's help. Tintaglia, hunting the Chalcedean coast, is struck down by poisoned weapons and arrives at Kelsingra gravely wounded, bringing the trade in dragon flesh to the keepers' doorstep.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3240,7 +3240,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3253,7 +3253,7 @@
       "recaps": {
         "ending": "On the roof of a Manhattan building, Lilith completes the ritual she has been building all book: Jace, marked and controlled by her since the war, has supplied his blood, and Simon's is the last ingredient because it carries Jace's angel blood in it. Simon refuses to give it, and when Lilith strikes at him the Mark of Cain destroys her, throwing her attack back sevenfold. Clary breaks the rune that has been holding Jace and he is himself again for the first time in weeks. It is too late: the ritual has gone far enough. Jonathan Morgenstern, Valentine's son, wakes in the coffin Lilith prepared for him, and Jace, still bound to him by her work, leaves with him. The two vanish from the roof, and neither the Clave nor Clary has any idea where they have gone. Elsewhere, Camille Belcourt turns Simon's young fan Maureen into a vampire. Simon has lost his home and nearly lost himself; Alec has learned that Camille offered him something he had no business considering; and Clary is left standing on the roof with a ring in her hand and Jace gone, taken by the brother she watched die.",
         "in_short": "Six weeks after the war, Clary is training as a Shadowhunter, Jocelyn and Luke are planning a wedding, and Jace has begun avoiding Clary without explanation, tormented by dreams of hurting her. Simon, a Daylighter carrying the Mark of Cain, is thrown out by his mother, hunted by vampires who want to use him, and taken in by a werewolf named Kyle who turns out to be a guard assigned by the Praetor Lupus and, worse, the man who bit Maia. Camille Belcourt, the old head of the New York clan, tries to recruit Simon; Alec, worried about Magnus's immortality, secretly asks her for a way to make him mortal. Shadowhunters are being murdered and drained, and Clary traces the pattern to a cult repeating Valentine's demon-blood experiments on infants. Its leader is the demon Lilith, who has been controlling Jace through a rune and intends to raise Jonathan Morgenstern from the dead. On a rooftop, Simon's Mark destroys Lilith and Clary frees Jace, but the ritual has already worked. Jonathan wakes, and Jace, still bound to him, disappears with him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3472,7 +3472,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3485,7 +3485,7 @@
       "recaps": {
         "ending": "Valentine's rebellion ends at Lake Lyn, which is itself the third Mortal Instrument, the Mirror. He kills Jace there and uses the summoning to call the angel Raziel, expecting to be granted command of the Nephilim. Clary has already altered the runes of the ritual so that they name her instead, so the angel is bound to her, not to him. Raziel kills Valentine and grants Clary one request, and she asks for Jace's life; Jace wakes. On the battlefield Jace has already fought and killed the young man who called himself Sebastian, whose body falls into the river and is never recovered. In Alicante, Magnus uses the Book of the White to wake Jocelyn, who confirms what the angel's visions implied: Jace is not her son and never was. Valentine took him as an infant after his true parents, Stephen and Celine Herondale, died, and raised him under a dead man's name with angel blood in him. Jocelyn's own son, Jonathan, was the one Valentine fed on demon blood, and he was the boy passing himself off as Sebastian Verlac. Clary and Jace are not related. The Downworlders who fought under Clary's Alliance rune are given seats on the Council, Alec claims Magnus publicly, Max Lightwood is dead, and Simon goes home to New York still bearing the Mark of Cain.",
         "in_short": "Told that only a warlock in Idris can wake her mother, Clary follows the Lightwoods to the Shadowhunter homeland after Jace tries to leave her behind, and arrives by a Portal of her own making. In Alicante she is taken in by Luke's estranged sister Amatis, Simon is imprisoned for being a vampire on Shadowhunter soil, and she is befriended by a visiting Shadowhunter named Sebastian Verlac. Searching for the spellbook that will wake Jocelyn, she and Jace find an angel chained beneath Valentine's old country house whose visions reveal that Valentine experimented on unborn children with angel and demon blood. Sebastian sabotages the city's defences, kills the Lightwoods' youngest son and is exposed as Jonathan Morgenstern, Valentine's true son. Clary invents a rune that lets Shadowhunters and Downworlders fight as bound partners, and the Clave accepts the alliance. Jace kills Sebastian on the battlefield, and Valentine kills Jace at Lake Lyn to summon the angel Raziel, only for Clary to have rewritten the ritual in her own name. Raziel destroys Valentine and restores Jace. Jocelyn wakes and confirms that Jace is a Herondale, not her son, and that Clary and Jace were never siblings.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3715,7 +3715,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3728,7 +3728,7 @@
       "recaps": {
         "ending": "The confrontation happens in Edom, the burnt demon world Jonathan has been drawing on. Jace's heavenly fire and Clary's Morgenstern blade are used together, and what they burn out of Jonathan is the demon blood Valentine gave him before he was born. For a few minutes what remains is the boy he would otherwise have been, frightened and ordinary, and he dies as that boy, in front of the mother and sister who had given up on him. His army of Endarkened cannot be restored and the war ends with them destroyed. Getting home costs more than the fighting did: Magnus's father Asmodeus, who rules Edom, sets his own price for opening the way, and Simon pays it, giving up his vampirism, his immortality and every memory of the Shadow World. He is returned to Brooklyn as an ordinary human who does not recognise any of the people he saved. Afterwards the Clave imposes the Cold Peace on the fair folk for their part in the war, which punishes those with faerie blood among the Nephilim as well. Brother Zachariah is restored to mortal life by the heavenly fire and reunited with the woman who waited for him; Magnus and Alec repair what Alec broke; Jocelyn and Luke marry; Emma Carstairs and Julian Blackthorn go back to Los Angeles bound as parabatai. In the closing pages Simon begins Ascension, and his memories start to come back.",
         "in_short": "Jonathan Morgenstern's Endarkened destroy Institutes across the world, and the Clave withdraws every surviving Shadowhunter to Alicante while Jace struggles to control the heavenly fire burning inside him. Among the refugees are Emma Carstairs and the Blackthorn children of Los Angeles. Jonathan takes hostages, the fair folk are exposed as his allies, and he offers terms that amount to a demand for his sister. Clary, Jace, Simon, Isabelle and Alec let themselves be taken to reach him, and cross into Edom, a dead demon world ruled by Magnus's father Asmodeus. There Jonathan is struck with heavenly fire and Clary's family blade, which burns the demon blood out of him; for a few minutes he is the ordinary boy he might have been, and then he dies. The Endarkened are destroyed with him. To open the way home Asmodeus takes his price from Simon, stripping away his immortality and every memory of the Shadow World and returning him to Brooklyn as a human who knows none of them. The Clave imposes a punitive Cold Peace on the faeries, and Simon, at the very end, begins to remember.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/city-of-lost-souls.json
+++ b/data/works-community/0/city-of-lost-souls.json
@@ -153,7 +153,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -166,7 +166,7 @@
       "recaps": {
         "ending": "Simon calls the angel Raziel and asks for a weapon, paying with the Mark of Cain, which the angel takes back; in exchange he receives the sword Glorious, which holds heavenly fire. Clary uses it on Jace. The fire burns away Lilith's rune and the bond that tied him to Jonathan, so that Jace is himself again and Jonathan can be killed without killing him, but the fire does not leave: it stays inside Jace, so that he cannot safely touch anyone, Clary least of all. Jonathan escapes. He takes the Infernal Cup to an old sacred site and forces a company of captured Shadowhunters to drink from it, turning them into the Endarkened, warriors who keep their skills and lose everything else; Amatis, Luke's sister, is among them, and Luke is left gravely wounded. Jonathan leaves with an army the Clave has no answer to. In New York, Camille Belcourt is killed and the child vampire Maureen takes the clan. Magnus learns what Alec has been doing behind his back and ends the relationship. The book closes with Jace alive and burning, Clary unable to touch him, and Jonathan Morgenstern at the head of a force of turned Shadowhunters preparing to come for the rest.",
         "in_short": "With Jace missing and bound to Jonathan Morgenstern so that killing one would kill both, the Clave decides Jace is expendable and Clary decides otherwise. Taking a pair of faerie rings from the Seelie Queen so she can speak secretly to Simon, she lets Jonathan take her, and lives in the apartment that moves between cities with a Jace who is calm, content and not himself. Isabelle, Alec, Magnus and Simon search for a way to break the bond; the Iron Sisters tell them only heavenly fire can do it. Clary discovers that Jonathan has a cup of Lilith's making with which he intends to turn Shadowhunters into servants of demons. Simon summons the angel Raziel and trades the Mark of Cain for the sword Glorious, and Clary drives its heavenly fire into Jace, freeing him and severing the bond, though the fire remains in his body. Jonathan escapes, uses the Infernal Cup on a company of captured Shadowhunters, and rides away with an army of the Endarkened.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -609,7 +609,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09V1XY6DR",
@@ -621,7 +621,7 @@
       "recaps": {
         "ending": "The bear invasion is driven from City World after James McGill brings thousands of Blood World gremlins through a secret gateway and places them in Mogwa power armor. The surviving Mogwa grand admiral and governess remain behind to govern and rearm their devastated colony. Winslade has been executed, Graves survives, Collins is reassigned to command the Death World garrison, Barton is preparing to transfer out of Legion Varus, and Gary wants to return to office duty. James refuses to surrender the gremlins' creator or fulfill the promised armor transfer. When the gremlin leader's armed group threatens his Dust World family, James kills the leader, surrounding followers, and himself with a hidden explosive. Alexander Turov revives James after Galina Turov intervenes, then frees him while continuing to suspect an outside handler. James returns to his family home and resumes his relationship with Galina. The concealed remains on his family's land, surviving gremlins, Geetha, and Alexander's scrutiny remain open concerns.",
         "in_short": "James McGill joins a Mogwa-forced Earth expedition to defend City World. The human legions arrive amid a bear attack, struggle to enter the shielded city, and discover that the invaders are spreading a Mogwa-specific bioweapon. James restores the imprisoned Mogwa grand admiral and recruits Blood World gremlins who can pilot Mogwa armor. Their counteroffensive saves the city, but James has promised them their creator and a thousand armed suits. After the gremlin leader threatens his family on Dust World, James destroys the leader, nearby followers, and himself with a concealed explosive. Alexander Turov revives him at Galina Turov's request and releases him despite suspecting that James serves an unknown handler. James returns home and reconciles with Galina, while City World rearms under the surviving Mogwa leaders and the broader gremlin consequences remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -945,7 +945,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -958,7 +958,7 @@
       "recaps": {
         "ending": "Kit's tests confirm that it is a sapient, unique devourling whose intrinsic magic can consume and incorporate linked spaces. Because Tala's stronger magic is slowly damaging Kit, the pair choose a supervised soulbond and unmooring. During the emerging bond, they reject identities based on indiscriminate consumption and settle on a shared principle of defending what is theirs and devouring enemies or rightful resources. The physical completion of the process is not confirmed. Tala remains an established Alefast defender, still pursuing a Paragon path after surviving severe soul strain and learning limited stoneward travel. Rain and Terry remain trusted companions, while Alat continues as her internal co-operator. Lynn and her mageling return to Banfast responsible for an altered keeperling. Simon, Petra, Brandon, and Brandon's father continue their work inside Kit, and Io remains under watch. Alefast's containment burden is unresolved. Beyond it, predators attack travelers and settlements, the House of the Turbulent Ocean captures humans, an undead tide is disturbed, and a Pact force prepares to test a human city after warning it.",
         "in_short": "Tala comes to Alefast as a newly Refined mage and joins a waning-defense unit responsible for dangerous hidden containment cells. She helps reseal several prisons, most notably trapping a deathless nullifier in her claimed iron at the cost of severe magical and likely soul strain. Training, the city keeper's guidance, and Rain's companionship move her toward Paragon while she learns to perceive and briefly travel through the magical dimension. She also discovers that her growing power is eroding Kit. A keeperling awakened by Lynn's mageling identifies Kit as a devourling, leading Tala to test whether Kit can safely be soulbound and unmoored. Kit proves sapient, individual, and able to consume linked spaces, then chooses the bond. Tala and Kit reject indiscriminate consumption and agree on a guarded shared identity, though the physical outcome is not confirmed. Elsewhere, several nonhuman threats begin moving against humanity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1094,7 +1094,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1107,7 +1107,7 @@
       "recaps": {
         "ending": "Holmes, Watson, Inspector Jones, and bank director Merryweather wait in the bank vault behind Wilson's pawnshop. Vincent Spaulding emerges through a tunnel and is arrested as John Clay, a well-known criminal; his accomplice is prevented from escaping above ground. Clay and his partner invented the Red-Headed League, with the partner posing as Duncan Ross, to keep Wilson out of his shop while they dug from its cellar into the bank. They dissolved the League when the tunnel was ready and chose Saturday night for the robbery, expecting the closed bank to give them time before discovery. Holmes had recognized the fake employment as a means of removing Wilson, then confirmed his suspicion by observing Spaulding's worn, stained knees and the position of the neighboring bank. The criminals are taken into custody and the stored gold remains secure.",
         "in_short": "Pawnbroker Jabez Wilson asks Holmes why a generously paid job offered only to red-haired men has suddenly disappeared. Wilson's assistant, Vincent Spaulding, had encouraged him to apply, and the work kept him away from his shop for fixed hours every day. Holmes suspects that the League was invented to remove Wilson from the premises. After inspecting the shop, Spaulding's trouser knees, and the surrounding streets, he realizes that the pawnshop backs onto a bank holding valuable gold. Holmes, Watson, Inspector Jones, and bank director Merryweather wait in the vault. Spaulding breaks through the floor and is arrested as the criminal John Clay. He and an accomplice created the League and used Wilson's absences to dig a tunnel from the shop cellar. Their robbery is stopped before any gold is taken.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1299,7 +1299,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1312,7 +1312,7 @@
       "recaps": {
         "ending": "Frankenstein ends in the Arctic after Victor has pursued his creation across Europe and onto the ice. Victor dies aboard Walton's ship without taking revenge. The creation comes to mourn him, accepts responsibility for the deaths, and says he will destroy himself before disappearing into the darkness. Dracula ends near the count's Transylvanian castle. Mina's link to him helps the hunters intercept the final box of earth before sunset. Jonathan and Quincey force it open and kill Dracula; Mina's mark vanishes, but Quincey dies from his wounds. Years later, Jonathan and Mina have a son named for their dead friend, while Arthur and Seward have also found happiness. The surviving records remain as the group's evidence of what occurred.",
         "in_short": "In Frankenstein, ambitious student Victor Frankenstein makes a living being, rejects it, and watches it turn against everyone he loves after repeated human rejection. The creation demands a companion; Victor begins one, destroys it, and is punished through the deaths of Henry and Elizabeth. Victor pursues his creation into the Arctic, dies aboard Robert Walton's ship, and is mourned by the remorseful being, who departs intending to die. In Dracula, solicitor Jonathan Harker discovers that his Transylvanian client is a vampire moving to England. Dracula preys on Lucy Westenra and later Mina Harker. Van Helsing unites Lucy's friends with Jonathan and Mina to destroy the undead Lucy, purge Dracula's London refuges, and chase him home. They kill Dracula before sunset outside his castle, freeing Mina, though Quincey Morris dies in the fight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1549,7 +1549,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1562,7 +1562,7 @@
       "recaps": {
         "ending": "Ryan learns that Cutter and Ritter accepted Cortez's offer to end the American campaign by withdrawing support from the light-infantry teams still inside Colombia. Refusing to leave the soldiers to be killed or captured, Ryan joins John Clark in organizing an unauthorized rescue. They reach the survivors during the fighting around Ninja Hill and extract the remaining Americans, with Chavez proving central to the effort. The cartel's internal struggle ends with both Escobedo and Cortez dead, removing the two men who had directed the counterattack and betrayal. Back in Washington, Ryan rejects the proposed cover story and ensures that Congress receives an honest account of the illegal operation and the decision to abandon its personnel. Cutter's conduct and the administration's secret war are exposed rather than quietly buried. James Greer dies after his illness, leaving Ryan without his longtime mentor and with the burden of the office Greer had been preparing him to assume. The field teams' rescue, rather than the covert campaign itself, becomes Ryan's measure of what service requires.",
         "in_short": "After drug smugglers murder the President's friend and family aboard a yacht, the administration secretly expands the fight against Colombian cartels. Cutter and CIA operations chief Robert Ritter insert light-infantry teams to track drug flights, enabling interceptions and attacks without informing Congress or Jack Ryan. Cartel intelligence chief Félix Cortez learns of the campaign, exploits FBI secretary Moira Wolfe, arranges FBI director Emil Jacobs's murder, and manipulates both cartel boss Ernesto Escobedo and the Americans. A retaliatory American strike kills cartel leaders, but Cortez then offers Cutter a bargain: abandon the covert teams and he will curb shipments after taking power. Ryan, serving as acting deputy director while James Greer is dying, uncovers the hidden operation and its betrayal. He joins John Clark to rescue the surviving soldiers during the battle at Ninja Hill. Escobedo and Cortez are killed, the Americans come home, and Ryan refuses a cover-up, giving Congress the truth. Greer dies, leaving Ryan to inherit greater responsibility.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1735,7 +1735,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1748,7 +1748,7 @@
       "recaps": {
         "ending": "The enemy the Shadowhunters have been chasing, the Magister, is unmasked as Axel Mortmain, a wealthy mundane inventor with deep occult knowledge who has orchestrated events from behind the scenes, using the Dark Sisters and the vampire De Quincey as his tools. Nate is exposed as a willing traitor who faked his own peril and served Mortmain, and he is left disgraced and captive. The Nephilim destroy De Quincey and his followers, but he was never the true master, and Mortmain slips away with his army of clockwork automatons intact. Mortmain declares that Tessa is no ordinary person but something deliberately created, and that he intended her for himself, deepening the riddle of what she really is. Tessa decides to stay at the London Institute rather than flee, accepted among the Shadowhunters. She is left caught between the guarded, self-punishing Will and the gentle, dying Jem, both of whom matter to her, while Mortmain remains at large and the danger to her is far from over.",
         "in_short": "In 1878, American orphan Tessa Gray comes to London seeking her brother Nate and is instead imprisoned by the warlock Dark Sisters, who force her to develop a rare power to transform into other people. Rescued by the Shadowhunter Will Herondale, she takes shelter at the London Institute among the Nephilim, who hunt demons and keep order over the supernatural world. There she meets the ailing, kindly Jem Carstairs and joins the effort to learn who is hunting her. The trail leads through the shadowy Pandemonium Club and the vampire De Quincey to a hidden enemy called the Magister, who is building an army of mechanical clockwork creatures. In the end the Magister is revealed to be the inventor Axel Mortmain, who has manipulated events from the start; Nate has betrayed Tessa and worked for Mortmain all along. Though De Quincey is destroyed, Mortmain escapes, having declared that Tessa herself was made for his purposes. Tessa chooses to remain at the Institute, drawn between Will and Jem, with the mystery of her own nature still unsolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1964,7 +1964,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1977,7 +1977,7 @@
       "recaps": {
         "ending": "Mortmain's reach extends into the Institute itself: Nate Gray is fatally injured by one of the clockwork creatures and dies in Tessa's arms, leaving only fragments of what he knew. Charlotte uncovers proof that the Consul, Josiah Wayland, has been passing information to Mortmain from the Clave's highest office, confronts him with it, and keeps the Institute. Benedict Lightwood withdraws his claim rather than have his demon pox and his payments from Mortmain made public; his elder son Gideon leaves the family house for the Institute, where Sophie's regard for him is returned. Charlotte tells Henry that she is expecting a child. Jessamine remains in the Silent City. Tessa is engaged to Jem, who is dying and whose supply of the drug that sustains him is increasingly precarious. Will, having learned that the curse he built his life around never existed, tells Tessa he loves her, discovers he is too late, and says nothing further out of loyalty to his parabatai, so the three of them go on together with it unspoken. Mortmain is still free, with his automaton army, the Pyxis taken from the Institute, and an unexplained purpose for Tessa. The book closes with a girl at the Institute door: Cecily, Will's younger sister, come to take him home and refusing to leave without him.",
         "in_short": "London, 1878. Tessa Gray is living at the London Institute while the Clave gives Charlotte Branwell a fortnight to find the vanished inventor Axel Mortmain or forfeit the Institute to Benedict Lightwood. The search produces Mortmain's history rather than his address: he was the adopted mundane son of two warlocks killed in a Shadowhunter raid, and has spent his life building an automaton army to avenge them. Jessamine Lovelace is exposed as having fed information to Tessa's traitor brother Nate and is taken to the Silent City. Will Herondale, who has believed since he was twelve that a demon cursed everyone who loves him, forces that demon to admit it lied, and is freed just as Tessa accepts a proposal from his dying parabatai, Jem Carstairs. Benedict's claim on the Institute collapses when his demon pox and his dealings with Mortmain surface, and Charlotte holds her post after discovering that the Consul himself has been Mortmain's informant. Nate dies of his injuries in Tessa's arms, Mortmain remains at large, and Will's sister Cecily arrives at the Institute demanding to be trained.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2193,7 +2193,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2206,7 +2206,7 @@
       "recaps": {
         "ending": "Cornered in Mortmain's stronghold beneath Cadair Idris, Tessa discovers what her mother's clockwork angel is: an angel, Ithuriel, bound inside it, whose life has been sustaining and healing her since birth. She takes the angel's own shape and uses its power to destroy Mortmain and burn out his automaton army, ending the threat and freeing the angel. Henry is crippled in the battle and will not walk again, and the parabatai bond between Will and Jem breaks during the fight. Jem is not dead: dying and out of the drug that sustained him, he was taken by the Silent Brothers and survived the transformation into one of them, and he returns as Brother Zachariah, no longer able to marry Tessa or to live as James Carstairs. Will and Tessa, who turned to each other in grief, marry with Jem's blessing and have two children, James and Lucie. Charlotte becomes Consul; Sophie Ascends and marries Gideon; Cecily marries Gabriel. Will lives a full life and dies an old man with Tessa and Jem beside him, and Tessa, who does not age, outlives them all. The book closes in the present day on Blackfriars Bridge, where Tessa keeps a standing appointment with Jem, still a Silent Brother, once a year, and where the two of them are still waiting for a change that might one day give them back to each other.",
         "in_short": "Tessa Gray and Jem Carstairs plan their wedding while Axel Mortmain quietly buys up the drug keeping Jem alive, and Benedict Lightwood's demon pox turns him into a monster his own sons must destroy. Mortmain's agents reach into the Institute, Jessamine Lovelace is killed, and Tessa is carried off to his stronghold beneath the Welsh mountain Cadair Idris. Will Herondale rides for Wales alone and the household follows; Jem, out of his drug and dying, is left behind, and during the pursuit Will feels their parabatai bond break. Mortmain tells Tessa what she is: the deliberately engineered child of a Shadowhunter mother and a Greater Demon that took the body of her mother's husband, made shapeshifter, fertile, and unmarked, to be his bride and the mother of a new race. Cornered, Tessa takes the shape of the angel bound inside her mother's clockwork pendant and destroys Mortmain and his automaton army. Jem is not dead; he survived by becoming a Silent Brother. Will and Tessa marry and have children, Will dies of old age with both of them beside him, and the story ends more than a century later with Tessa and Jem meeting on Blackfriars Bridge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2602,7 +2602,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B081J2J4GT",
@@ -2614,7 +2614,7 @@
       "recaps": {
         "ending": "Earth returns from the battles with the local Skay destroyed and Rigel driven away, but both victories are costly. Galina Turov resolves the duplicate crisis by killing one James McGill and presenting the survivor as the original. McGill later kills Sateekas to stop the torture of a copied Squanto, and Primus Graves helps conceal the act. The revived Sateekas accepts their false account and loses his fleet command. Drusus retains command, while the captured Rigelian cruiser gives Earth access to armor-piercing weapons. Etta and Florimel begin studying that technology. Drusus also plans to revive a backdated Winslade and monitor him for intelligence, while McGill asks that Lisa's saved scan receive another chance. McGill is demobilized in Georgia. Claver X arrives there with Abigail and warns that disagreement over machine intelligence and imperial succession has widened into civil war. McGill agrees to bring them to Drusus, leaving Earth with new technology and a brief respite but exposed to a larger conflict.",
         "in_short": "Financial need draws James McGill into a lethal rift mission against Rigel, where his sabotage destroys an orbital city and exposes Claver's infiltration of Earth. Legion Varus attacks Clone World, uncovers Winslade's treason, and destroys Claver's fortress, but the victory attracts both the Skay and Mogwa. Earth sides with the Mogwa, and human boarders destroy the final Skay. A delayed revival creates two McGills, so Galina Turov kills one and protects the survivor. Sateekas then forces Earth into battle with Rigel. McGill kills Sateekas during the torture of a copied Squanto, learns the secret of Rigel's armor-piercing rear line, and hides the killing with Primus Graves. McGill's cohort captures one of those cruisers, whose weapons help rout Rigel. Back on Earth, Drusus prepares a covert revival operation, while Claver X and Abigail warn McGill that an imperial civil war over machine intelligence is spreading toward Earth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2833,7 +2833,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2846,7 +2846,7 @@
       "recaps": {
         "ending": "Sookie gets Bill out of Russell Edgington's estate alive, having killed Lorena herself with a wooden stake when she found her torturing him. The rescue costs her nearly everything: starved and out of his mind in the trunk of the car, Bill drinks from Sookie until she is close to death and forces himself on her, and she is left too weak to stand. Debbie Pelt, who shoved her into that trunk deliberately, is broken with completely by Alcide, cast out in front of the people whose opinion she values. Sookie is healed with vampire blood and taken home. The Mississippi affair is settled between kings and sheriffs in the way vampire politics is always settled, and Russell Edgington keeps his throne. What does not survive is Sookie's relationship with Bill. She learns that he had planned to leave her for his maker before he was taken, and that the secret project he would not discuss is a database of the world's vampires, valuable enough that a king would kidnap and torture him for it. Sookie has the only copy and keeps it hidden rather than handing it over, which gives her leverage with the Queen of Louisiana and with Eric. She tells Bill they are finished. Eric, who spent the book in Jackson under a false name looking out for her, ends it with a much clearer idea of what he wants from her, and Alcide ends it free of Debbie and interested in Sookie.",
         "in_short": "Bill Compton is distant, secretive about a project for the vampire hierarchy, and then simply gone. Eric Northman tells Sookie the truth twice over: Bill had been planning to leave her for Lorena, the vampire who made him, and he has since been kidnapped and taken to Mississippi. Sookie agrees to help find him and travels to Jackson escorted by Alcide Herveaux, a werewolf whose family owes the vampires money. Posing as his girlfriend, she works the supernatural bar the locals call Club Dead, dodging Alcide's vicious ex-fiancee Debbie Pelt, is staked in the parking lot by a fanatic, and is healed by Eric, who is in Jackson under a false name. She traces Bill to the estate of Russell Edgington, the vampire King of Mississippi, who wants the database Bill has been building. Getting inside, she finds Bill chained and being tortured by Lorena, and kills Lorena. In the escape, Debbie pushes Sookie into the car trunk with a starving, deranged Bill, who nearly kills her. Sookie survives, keeps the database hidden as leverage, and ends her relationship with Bill.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3041,7 +3041,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3054,7 +3054,7 @@
       "recaps": {
         "ending": "Flora's separate campaigns leave the Starkadders with futures beyond their inherited disorder. Amos departs to preach in America, Seth is directed toward the film world he loves, and Reuben receives secure authority over Cold Comfort Farm. Judith accepts psychiatric help instead of centering her life on Seth. Elfine is prepared for the social world of Richard Hawk-Monitor, wins his family's acceptance, and marries him. Urk and Meriam form a practical match of their own. Flora finally confronts Ada Doom during the matriarch's family gathering and persuades her that age and the old woodshed memory need not keep her upstairs; Ada leaves to enjoy travel and fashionable life in Paris. With the farm redistributed and its inhabitants launched into new lives, Flora summons Charles Fairford. He arrives by aeroplane, they acknowledge their love, and Flora flies away with him.",
         "in_short": "After her parents die, practical Flora Poste chooses to live with distant relatives at Cold Comfort Farm in Sussex. The Starkadders are dominated by Ada Doom, who stays upstairs invoking a childhood trauma in the woodshed, while the rest of the family remain trapped in religious gloom, frustrated desire, and neglected farm work. Flora treats each crisis as an organizational problem. She secures the farm for Reuben, sends preacher Amos toward a larger American audience, steers film-obsessed Seth to a studio, finds psychiatric help for Judith, and equips Meriam to control her own future. She remakes Elfine's presentation so that Elfine can marry Richard Hawk-Monitor and finally persuades Ada to abandon her room for Paris. Once Cold Comfort Farm has a workable future, Flora calls Charles Fairford, accepts their love, and leaves with him by aeroplane.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3236,7 +3236,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3247,7 +3247,7 @@
       "recaps": {
         "ending": "The assault on Demonreach is broken and the prison holds, but the cost is paid in queens. At the island's heart Maeve reveals the truth Mab could never speak plainly: the Winter Lady is infected by Nemesis, the Outsiders' contagion - proved when she does what no Sidhe can do and lies. In the final confrontation Maeve murders Lily, the Summer Lady, and an instant later Karrin Murphy shoots Maeve dead - Halloween night being the one time an immortal walking the mortal world can truly be killed, the entire reason Mab's command and timing were what they were. The vacated mantles pass to the nearest fit mortal vessels: Molly Carpenter becomes the new Winter Lady, and Sarissa - revealed as Mab's other daughter and Maeve's mortal-raised twin - becomes the new Summer Lady. Harry ends the book still Winter Knight and still warden of Demonreach, now knowing what the island truly is: Merlin's prison for horrors, which Nemesis just tried to blow open. He also carries the larger map: Winter's armies exist to hold the Outer Gates against the Outsiders, Mab's cruelty serves that war, and the adversary can wear anyone. Murphy and Harry have finally admitted what is between them. And the parasite in Harry's head - the source of his crippling headaches - remains, growing, with Mab making clear it will kill him in time.",
         "in_short": "Alive again after his months-dead interlude, Harry Dresden completes a brutal recovery at Arctis Tor and begins his service as Mab's Winter Knight. Her first command: kill Maeve, the Winter Lady - an immortal. In Chicago, reunited with Toot, Bob, Butters, Molly, Thomas, and a wary Murphy, Harry is summoned by Demonreach and learns the island is a prison built by Merlin for thousands of horrors, and that a ritual attack now under way will blow it open within days, destroying the region and freeing everything inside. The trail runs through Sidhe hit squads, Summer's suspicious Knight and Lady, and an audience with the Mothers, where Harry learns the war under everything: Winter's armies hold the Outer Gates against the Outsiders, whose contagion - Nemesis - can secretly subvert even immortals. On Halloween night, when immortals can die, Harry claims leadership of the Wild Hunt and turns it against the Outsider-led assault on the island. At the well, Maeve is exposed as Nemesis-infected - she can lie - and the attack is hers. Maeve kills Lily, the Summer Lady; Murphy kills Maeve; and the mantles pass: Molly becomes Winter Lady, and Sarissa, revealed as Maeve's twin, becomes Summer Lady.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3432,7 +3432,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3445,7 +3445,7 @@
       "recaps": {
         "ending": "After reuniting near Cold Mountain, Inman and Ada spend several days together and begin imagining a life after the war, while Ruby and the wounded Stobrod remain with them. Their attempt to return safely is interrupted by Teague's Home Guard. Inman kills Teague and most of the pursuers but confronts the young guard Bosie separately. Inman tries to end the encounter without another death, yet Bosie shoots him. Ada reaches Inman as he dies, ending the homeward journey just after he has found the person and place that sustained it. An epilogue set years later shows Ada continuing at Black Cove with Ruby, Stobrod, Ruby's husband Reid, their children, and Ada's daughter by Inman. The farm has become a durable household shaped by shared work, music, and memory. Ada has neither returned to her former dependence nor abandoned the life she and Inman briefly hoped to build.",
         "in_short": "Near the end of the American Civil War, wounded Confederate soldier Inman deserts a hospital and walks toward Cold Mountain, hoping to reunite with Ada Monroe. His journey exposes him to betrayal, hunger, killing, and acts of mercy among people damaged by the war. At Black Cove, Ada is nearly helpless after her father's death until the practical Ruby Thewes teaches her to run the farm as an equal partner. Ruby's estranged father Stobrod returns as a deserter and is later shot by Teague's Home Guard, but Ada and Ruby rescue him. Inman finally reaches the women, and he and Ada renew their love while imagining a shared future. When the Home Guard catches them, Inman defeats Teague's party but is shot by the young guard Bosie and dies in Ada's arms. Years later Ada raises Inman's daughter at a flourishing Black Cove alongside Ruby's growing family and Stobrod, preserving the communal life created during the war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3832,7 +3832,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -3845,7 +3845,7 @@
       "recaps": {
         "ending": "Silas returns from Kimbora as Homo inspiratus prime, completes a rare class core, and reaches level 83 just before the Wild Hunt. Earth remains fourth in world points, but its defenses now include Cecilia's local group, General Krulak's expanding training force, Jiang's alliance, alien soldiers, and Crembori technical support. Silas enters the Hunt while keeping unassigned stat points available. At the same moment, Emil Larsson dies and the inheritance protocol transfers his Earth Forerunner status to Asta. The cause of Emil's death and Asta's immediate circumstances are unknown. Anika remains at large and is only suspected of arranging the hell-mana attack. Nuri's desert army is still unexplained. The arriving Crembori refugees, Oslo's continuing transformation, the obligations created by Silas's Galen contracts, and the promised Earth chapter of the Sect of the Veiled Infinity all remain open. The China breach is sealed and Silas's corruption has been removed, but the weapon's origin and the possibility of further dimensional damage are unresolved.",
         "in_short": "As Earth's countdown accelerates, Silas Renner helps civilians survive transformed Oslo, inducts Asta, Dutch, and his sister Cecilia, and builds a local defense team. On Galen he breaks Transhek's blockade through sabotage, negotiation, and a duel, securing limited support from rival corporations and the Adventurers Guild without surrendering Earth exclusively. After intensive training, he returns to organize U.S. cooperation and Crembori asylum. A hell-mana weapon kills Silas and Jiang Bai, but Silas revives them both; together they destroy the foreign portal, and Jiang becomes an ally. The Sect of the Veiled Infinity then cleanses Silas and guides him through rare racial evolution. Silas forms a rare class core and enters the Wild Hunt at level 83 while Earth ranks fourth. At the final moment Emil Larsson dies, and Asta inherits his position as an Earth Forerunner.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3979,7 +3979,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3992,7 +3992,7 @@
       "recaps": {
         "ending": "When the explorer refuses to endorse the old punishment system, the officer releases the condemned man and submits himself to the apparatus with the judgment that he should be just. The neglected machine breaks down during the execution. Its mechanisms spill apart and it kills the officer rapidly, without the prolonged process or moment of understanding that he had described. The explorer finds no sign of revelation on the corpse. He then visits the colony's teahouse with the soldier and the freed prisoner. Beneath a table lies the old commandant's grave, whose inscription predicts that he will return and recover power. The explorer goes to the harbor and departs alone. The soldier and former prisoner run after him and appear ready to join him, but he prevents them from boarding his boat, leaving them in the colony as he rows toward the waiting ship.",
         "in_short": "A foreign explorer visits a penal colony to witness an execution conducted by an officer devoted to the former commandant's methods. The condemned man has not been told his offense or allowed a defense. The officer explains that an intricate apparatus inscribes the violated commandment into a prisoner's body until death, supposedly bringing understanding through suffering. Because the new commandant is quietly abandoning the practice, the officer asks the visitor to praise it publicly. The explorer refuses and intends to state his opposition. Accepting that the system cannot survive, the officer frees the prisoner and places himself in the machine under a judgment demanding justice. The decaying apparatus malfunctions and kills him without the revelation he expected. After seeing the old commandant's grave and its promise of his return, the explorer leaves by boat and prevents the soldier and freed man from escaping with him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4130,7 +4130,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4143,7 +4143,7 @@
       "recaps": {
         "ending": "In Finland, Eri confirms that Shiro accused Tsukuru of raping her, an accusation the others did not believe but accepted as evidence of her severe distress. Eri chose to sacrifice Tsukuru's place in the group because he seemed most capable of surviving outside it. She admits that she loved him and says Shiro did too, while Tsukuru recognizes his own failure to perceive or risk emotional intimacy. Shiro was later murdered, and the crime remains unsolved. Eri urges Tsukuru to return to Sara and commit himself rather than retreat. Back in Tokyo, Tsukuru sees Sara again and asks her directly whether she will choose a life with him. He also tells her that he saw her with another man. Sara asks for three days before answering. As he waits, Tsukuru imagines both losing her and building a shared future, understanding that love necessarily exposes him to pain. The novel ends before Sara's decision, with Tsukuru finally willing to desire connection and accept uncertainty instead of treating himself as colorless and expendable.",
         "in_short": "At thirty-six, railway engineer Tsukuru Tazaki remains marked by the day his four closest school friends suddenly expelled him from their group without explanation. His new girlfriend, Sara, insists that he confront the past. Tsukuru visits Ao and Aka in Nagoya and learns that Shiro accused him of rape at the time, although the others did not believe her; Shiro was later murdered. He travels to Finland to see Kuro, now Eri, who explains that the frightened and unstable Shiro demanded his exclusion and that Eri chose him as the one most likely to survive it. Eri also reveals that both women loved him. The journey makes Tsukuru reconsider his habit of emotional withdrawal, including the unresolved disappearance of his university friend Haida. Returning to Tokyo, he tells Sara he loves her and asks her to choose him, while confronting evidence that she may be involved with someone else. She promises an answer in three days, leaving the outcome open but Tsukuru newly prepared to risk rejection for a full relationship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4301,7 +4301,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4314,7 +4314,7 @@
       "recaps": {
         "ending": "Bishop, Skippy, and the human crew bring the captured Flying Dutchman to Earth, proving that the expeditionary force was drawn into an alien conflict under false assumptions. Skippy's existence and the theft of the ship must remain secret: humanity cannot yet survive the attention of the senior species whose clients are fighting the war. Returning home therefore does not end the mission. Earth gains access to alien technology and warning of the wider danger, but it cannot openly use either without revealing what happened on Paradise. With their families and governments informed only as far as security permits, Bishop and the multinational crew accept that they must go back into space. The Flying Dutchman departs Earth again with the newly named Merry Band of Pirates, relying on Skippy to conceal their movements while they work to prevent either side of the alien war from tracing the theft and the artificial intelligence back to humanity. Earth is temporarily safe, not secure, and Bishop's improvised force becomes its covert defense beyond the solar system.",
         "in_short": "When the Ruhar attack Earth on Columbus Day, U.S. Army sergeant Joe Bishop survives the invasion and later joins a human expedition sent out with the Kristang, the aliens presented as Earth's rescuers. On Paradise, human troops discover that they are expendable auxiliaries in a much older war. Bishop's rise through the ranks ends in confinement, where he meets Skippy, an ancient and extraordinarily powerful artificial intelligence housed in a canister. Skippy reveals that humanity has misunderstood both the war and the danger surrounding Earth. He helps Bishop escape, gather a multinational team, and seize an alien starship that they rename the Flying Dutchman. The newly formed Merry Band of Pirates uses secrecy, raids, and Skippy's control of advanced systems to get the vessel home without exposing Earth. Their return brings warning and technology, but no lasting safety: discovery by the senior alien powers could doom humanity. Bishop and his crew consequently leave Earth again aboard the Dutchman to protect the secret and keep hostile attention away from their planet.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4463,7 +4463,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4476,7 +4476,7 @@
       "recaps": {
         "ending": "Moomintroll and his companions reach Moominvalley shortly before the predicted collision. Moominmamma has prepared the cave that Moomintroll and Sniff discovered, and the family, their friends, and the household's essential comforts shelter inside while the valley grows hot and the comet fills the sky. The comet passes Earth without striking it. When everyone emerges, Moominvalley and the Moominhouse are still standing, and the sea, which withdrew as the comet approached, returns. The threatened end of the world becomes a shared survival rather than a final catastrophe. Snufkin, the Snork and Snork Maiden, Sniff, the Muskrat, and the Hemulen remain connected with the Moomin family after the journey. Moomintroll has returned with both new friends and a wider knowledge of the world beyond the valley, while Moominmamma's preparations preserve the safety and welcome of home.",
         "in_short": "After Moomintroll and Sniff find a cave, the gloomy Muskrat warns that a comet may destroy the world. The two friends leave Moominvalley for the observatory in the Lonely Mountains, hoping astronomers can tell them what is coming. They meet the wanderer Snufkin and survive a dangerous route to the mountain. The astronomers confirm that the comet is heading toward Earth and give the exact time of its arrival. Racing home, the travelers rescue and befriend the Snork Maiden and her brother, encounter a Hemulen absorbed in collecting, and cross a landscape transformed by heat and the retreating sea. They reach Moominvalley just before the comet's closest approach. Moominmamma has stocked the cave, where the family and their new companions take shelter. The comet passes without hitting Earth, the valley survives, and the sea returns. The expedition ends with Moomintroll safely home and the circle around the Moomin family enlarged by the friends made on the road.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4625,7 +4625,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4638,7 +4638,7 @@
       "recaps": {
         "ending": "After an explosion nearby shakes the conclave, Benítez addresses the electors with calm authority, rejecting both fear and religious conflict. The divided cardinals unite around him, and he is elected pope, taking the name Innocent XIV. Once the result is secure, Benítez privately tells Lomeli that he discovered as an adult that he has internal female reproductive organs. The late pope knew this and still appointed him a cardinal; Benítez had considered corrective surgery but decided against altering the body in which he had been born. Lomeli understands that revealing the information would overturn the election and chooses to preserve Benítez's confidence. The new pope steps onto the balcony to greet the crowd, while Lomeli hears the life of Rome outside and accepts the unexpected outcome of the conclave.",
         "in_short": "Cardinal Jacopo Lomeli convenes a conclave after the pope's death. The main factions rally around liberal Aldo Bellini, traditionalist Goffredo Tedesco, Nigerian Joshua Adeyemi, and Canadian administrator Joseph Tremblay, while the little-known Vincent Benítez arrives as a secret papal appointment. Lomeli uncovers scandals that successively damage Adeyemi and Tremblay, including Tremblay's manipulation of a nun's transfer and improper financial inducements. Lomeli himself reluctantly attracts votes. After violence outside the Vatican, Benítez's appeal against fear and hatred breaks the deadlock, and he is elected as Innocent XIV. Benítez then reveals privately that he has internal female reproductive organs, a condition known to the late pope. Lomeli keeps the confidence and allows the validly elected new pope to appear before the public.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4787,7 +4787,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4800,7 +4800,7 @@
       "recaps": {
         "ending": "Shuya completes his plan to turn a school ceremony into the spectacular crime he believes will finally make his mother notice him. After activating the bomb remotely, he hears no explosion at the school. Moriguchi calls and explains the remaining pieces of her revenge. The blood placed in the boys' milk was not infected; she relied on fear and on the consequences of their own characters rather than exposing children to HIV. She learned of Shuya's bomb, removed it from the school, and placed it in the university office of the mother he idolizes. An explosion reported there means that Shuya's attempt at recognition has apparently killed the person whose approval motivated it. Moriguchi presents this loss as the beginning of his moral reckoning, mirroring the loss of Manami without claiming that the two deaths can truly balance. Her final sardonic qualification introduces a last note of uncertainty, but Shuya's triumph has plainly been converted into devastation and Moriguchi has completed the revenge she designed around each boy's weakness.",
         "in_short": "Before resigning, teacher Yuko Moriguchi tells her class that students Shuya Watanabe and Naoki Shimomura killed her four-year-old daughter Manami. She claims to have put blood from Manami's HIV-positive father into their milk, setting off terror and retaliation. Classmates persecute Shuya, while Naoki withdraws at home and eventually kills his mother. Successive narrators reveal that Shuya's electrical device only stunned Manami; Naoki, believing he had failed to prove himself, deliberately drowned her. Shuya, obsessed with the scientist mother who abandoned him, embraces notoriety, kills the classmate who understands him best, and plants a bomb at a school ceremony. Moriguchi ultimately reveals that the blood was never infected. She has discovered the bomb and moved it to the university office of Shuya's mother. When Shuya triggers it, the explosion occurs there instead of at the school, apparently killing the person he most wanted to impress. Moriguchi tells him that his real lesson has only begun.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/conservation.json
+++ b/data/works-community/0/conservation.json
@@ -399,7 +399,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0CV4NK6ST",
@@ -411,7 +411,7 @@
       "recaps": {
         "ending": "John closes the completed Abyssal portal by forcing the summoned dragon Kalmaric back through it and following her into the Abyss. He destroys his own body in a blast amid the dragon and converging devils, then returns through the valley altar as the Eternal Flame rebuilds him. Kalmaric's survival is unknown. While he is gone, Ellie takes the sea goddess's authority and ends the leviathan attacks, and John's bull companion kills the archdevil commander. The world spirit recognizes Ellie as Lady of Storms and Goddess of the Sea, while the bull becomes a god-beast; both join the Eternal Pantheon. During the following year, John and Ellie spread the Eternal Flame across the preserved contest world, and the God of Scholars fulfills his promise to join them. The contest party eventually returns to the Millennium Palace, where it learns that the Radiant Empire and allied ancient mage families have declared war. Rabia continues administering the faith-linked system and the valley's rebirth process, whose long-term limits remain unsettled.",
         "in_short": "John enters the Millennium Meeting while marked as a dragon slayer and leads Candle Scholar Tower into a contest to save a sealed, dying world. There he discovers that the Black Blood Cult is preparing a devil invasion and that ordinary mana cannot stop its corruption. He turns the Eternal Flame into a widespread faith whose shrines cure the curse and defend communities, placing him in conflict with local gods and rival contestants. The dying God of Medicine accepts an Eternal Flame bond, creating the Eternal Pantheon and revealing that faithful dead can return through the valley. John gathers further divine allies, survives a trap built by the enemy elven mage, and races to defend Three Rivers. He seals a completed Abyssal portal by taking Kalmaric into the Abyss, destroys his body, and is reborn at the valley altar. Ellie gains authority over sea, rivers, and storms, halts the leviathans, and joins the pantheon with John's bull companion. The world survives, but the returning contestants learn that the Radiant Empire and ancient mage families have declared war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -615,7 +615,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -628,7 +628,7 @@
       "recaps": {
         "ending": "The five travelers return at the same instant they left, although each remembers many hours passing and all describe the same network of cosmic transit stations. Their instruments appear to contain only noise, so an official inquiry treats the journey as an elaborate deception associated with Hadden. Palmer believes Ellie's testimony because she now asks others to accept an experience she cannot prove. Kitz and der Heer privately learn that the recording devices contain many hours of blank data despite the Machine's apparently instantaneous activation, but they suppress that anomaly. Ellie also receives her late mother's letter and learns that John Staughton, not Ted Arroway, was her biological father. Continuing her research, she tests a suggestion that a maker might have left a signature inside mathematics itself. Far into the base-eleven expansion of pi, a long sequence forms a circular pattern, giving her private evidence of order embedded in the universe. The public case remains unresolved, while Ellie resumes her search with a changed understanding of evidence, faith, and human importance.",
         "in_short": "Radio astronomer Ellie Arroway leads a search for extraterrestrial intelligence and detects a signal from Vega built around prime numbers. Beneath an initial broadcast image, researchers uncover an immense technical Message: instructions for a Machine whose purpose is unknown. Nations cooperate and compete to build it. After the first American Machine is destroyed by a bomber, a secret second installation is completed, and Ellie joins four international travelers. The device carries them through a network of cosmic stations to a meeting arranged by advanced beings, one of whom appears to Ellie as her dead father. They are told that many civilizations share this network and that the universe may contain signs of deliberate design. Back on Earth, no measurable time has passed, leaving the travelers unable to prove their account. Officials publicly dismiss it, although hidden recording data supports the elapsed time they report. After learning that John Staughton was her biological father, Ellie finds a striking geometric pattern deep in the digits of pi and continues searching.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -943,7 +943,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -956,7 +956,7 @@
       "recaps": {
         "ending": "Silas completes his epic class core, then spends a legendary favor and primal energy to establish a 500-mile zone where monsters and dungeons cannot spawn during probation. Earth is inducted as Terra, humanity enters the System at level one, and global geography and species begin changing under the new mana. The heavens recognize Silas as System Mediator and Terra's ruler, although anyone who defeats him may take that position. Asta and Silas have resolved a breach of trust and committed to an exclusive relationship. Cecilia, Jiang, Ada, Samvek, Vex, General Krulak, Nancy, and the allied refugee communities remain part of Terra's defense. The Singapore contention is won and Yuto is free, while the Busan crystals have gone inactive but remain unexplained. Hell incursions, foreign-System interference, pending faction requests, and the practical survival of the planet remain open. Rayden is also expected to send 1,500 rare fighters under Samvek after induction.",
         "in_short": "With Earth's induction approaching, Silas Renner brings his mother into the System, helps Cecilia become a Forerunner, builds defenses with alien and Lepun allies, and reunites with Samvek's missing party after their return to Earth. He suppresses a coup, reveals the coming transformation to the public, restores the System experiment Yuto, and takes increasingly direct control of global preparations. After rescuing 192 corrupted off-world survivors, Silas becomes Architect of the System and creates scalable shelters, workshops, and training infrastructure. He defeats a rival Forerunner, wins Singapore's contention by killing the Archdevil Clementine, frees Yuto, and appoints Ada as Earth's fifth Forerunner. He then stops foreign-System mana-nukes, although one blast creates an unexplained crystal incursion under Busan. Silas evolves into a Primal Human Ascension Candidate, forms an epic core, and creates a vast protected zone. Earth becomes Terra and begins a 100-year probation, with Silas recognized as its challengeable ruler.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1391,7 +1391,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -1404,7 +1404,7 @@
       "recaps": {
         "ending": "Silas returns from Rigel after destroying the immediate Night's Fall elite, but most of that world remains corrupted. He carries a contained primordial fragment and an incomplete Trailblazer aspect that he has allowed the heavens to seal so he can remain compatible with Earth. Rigel's refugees retain Dubai for one year while treaty talks continue, and General Yakima provisionally offers fighters for Earth's defense. Silas distributes classes and supplies worldwide and creates one thousand Vanguard, but Earth's death toll continues to rise. Asta leaves for the Southern California incursion after giving Silas an unused draconic mutagen. Cecilia heads toward the unresolved Mexico operation, another companion manages the Hell crisis in Busan, and Manhattan's giant-snake nests still need help. Silas diverts from Manhattan when a peak family arrives over Nepal in a dimensional platform. Leon, a Lepun shaman, and a Rayden warrior accompany him aboard, but guards separate them under safe passage. The book closes when the family's pending princess challenges Silas to a sparring test and he accepts.",
         "in_short": "The System makes Silas Renner Earth's responsible ruler just as organized incursions begin. He negotiates temporary refuge for Rigel's migrants in Dubai, defeats a hostile Forerunner's attack on Sydney, resurrects tens of thousands, and helps the city survive twenty escalating waves. After conspirators abduct his mother, he rescues her and imposes system-backed martial law. A dragon attack at Stonehenge reveals competition between systems, but Camille Westfork removes the dragon and leaves the rift open. Silas then visits Rigel, discovers that Night's Fall is primordial corruption, destroys its army and legendary elite, and accepts a sealed Trailblazer aspect. Back on Earth, he secures vast off-world supplies, distributes classes globally, and creates the Vanguard. With crises still active in Mexico, Busan, Southern California, and Manhattan, a peak family arrives over Nepal seeking Silas's ascension potential. He enters its platform and accepts a pending princess's sparring challenge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1540,7 +1540,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1553,7 +1553,7 @@
       "recaps": {
         "ending": "After Keiko quits the convenience store, Shiraha takes control of their supposed route toward a conventional life. He arranges job interviews and imagines that her wages will support him, while Keiko becomes physically and mentally diminished without the store's sounds, schedules, and demands. On the way to an interview, she enters another convenience store and immediately detects what its staff and displays need. She begins rearranging products and directing the workers with the same instinctive competence she had at Smile Mart. The experience makes her recognize that serving a convenience store is not a temporary failure she must outgrow but the form of work and identity that makes sense to her. She abandons the interview and rejects Shiraha's plan, despite his anger. The novel closes with Keiko determined to find another store where she can work. She does not become the employee, wife, or professional others prescribe; she chooses the role in which she can hear and answer the needs of the store for herself.",
         "in_short": "Keiko Furukura has never understood ordinary social expectations, but eighteen years at a Tokyo convenience store have given her a manual, a routine, and a useful identity. Coworkers and family nevertheless treat her unmarried, part-time status as a problem. When an idle and resentful worker named Shiraha is fired, Keiko lets him hide in her apartment. They pretend to be a couple, and people who had judged them suddenly regard both as more acceptable. Shiraha uses that approval to push Keiko into quitting the store and seeking conventional full-time work, though he expects to benefit from her income. Away from the store, Keiko loses her sense of purpose. On the way to an interview, she enters another convenience store and instinctively begins correcting its problems. Realizing that store work is the life she chooses, she leaves Shiraha and decides to find a new position on her own terms.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1811,7 +1811,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09ZZ8VMKL",
@@ -1823,7 +1823,7 @@
       "recaps": {
         "ending": "At the Ohio mound, the Order ambushes Kazimir's party and overturns the RV, injuring Giselle and Macarius. Mikeare Henderson and Zoraida Martinez force their way through the attackers and help the group escape, although Mikeare is badly bruised by stopped bullets and Zoraida is shot in the thigh. Kazimir destroys the Order's clay vessel, then learns the portal has opened at a displaced endpoint. He, Duke, and Aziberahatahumundi reach the breach, kill a smaller Nether creature, and collapse the opening as a much larger creature tries to cross. The portal is closed, but it was not the Convergence, and one or more winged creatures appear to have entered Earth first. The Order remains active and is now linked to the deaths of Kazimir's parents, Sarah, and Alicia. The RV and its incriminating contents are destroyed, leaving the surviving party injured, exposed, and reliant on Team Draco's jeep. Michelle Singer remains a covert contact, while Sarah's motives, the true Convergence, and the concealed history between Marduk and Aziberahatahumundi remain unresolved.",
         "in_short": "Fugitive wizard Kazimir Wolfe survives an attempted capture and joins forces with Duke, a talking dog who hosts the ancient spirit Marduk. Time-displaced knights Macarius and Giselle arrive to help prevent the Convergence, while FBI agent Michelle Singer becomes a covert source and Team Draco tracks the organization hunting him. Evidence connects Kazimir's lifelong persecution to stolen magical artifacts and the deaths of his parents, Sarah, and his former girlfriend Alicia. The party recovers Marduk's amulet, releasing the djinn Aziberahatahumundi, whose knowledge leads them to an Ohio mound where the Order is opening a Nether portal. The Order overturns their RV, but Team Draco intervenes. Kazimir reaches the displaced breach, kills one creature, and collapses the portal against a larger one. The breach is not the Convergence, winged creatures may already have escaped, and the surviving group ends the book injured, exposed, and without its RV.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1960,7 +1960,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1973,7 +1973,7 @@
       "recaps": {
         "ending": "After the secrecy around Nick and the publication of Frances's story have damaged several relationships, Frances faces the illness she had tried to minimize. She is diagnosed with endometriosis and is distressed by the possibility that it may affect her fertility. She and Bobbi gradually restore their intimacy, speak more honestly about the story and their dependence on each other, and sleep together. Frances remains wary of assigning their bond a simple label. Some time later, Nick accidentally telephones her. Their conversation becomes personal; he says that he misses her and describes the unhappiness still present in his life. Although Frances had ended their affair and knows its costs, she tells him to come and get her. The novel closes at that renewed point of contact rather than resolving whether she and Nick will resume their relationship or what it will mean for Melissa and Bobbi.",
         "in_short": "Dublin students and former girlfriends Frances and Bobbi befriend older married couple Melissa and Nick. While Bobbi is fascinated by Melissa, Frances begins a secret affair with Nick and discovers the depression and dependence hidden beneath his quiet manner. A shared holiday intensifies both the affair and the four-way tension. Melissa eventually learns the truth, but she and Nick remain married, while Frances ends the affair under emotional pressure. Frances also publishes a story drawn closely from Bobbi, causing a rupture with the person she values most. At the same time, worsening pain and bleeding lead to a diagnosis of endometriosis. Frances and Bobbi reconcile and become physically intimate again. Later Nick calls Frances by accident; they admit they miss each other, and she asks him to come for her, leaving their renewed connection and all four relationships unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2134,7 +2134,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2147,7 +2147,7 @@
       "recaps": {
         "ending": "Having lost his fortune by refusing to abandon his wager against the yen, Eric strips away the protections that defined his life. He kills his bodyguard Torval, allows his limousine to be defaced, and continues alone to the old barbershop, where memories of his father briefly connect the journey to an earlier self. After further violence in the street, he reaches an abandoned building and meets Benno Levin, really Richard Sheets, a dismissed employee who has been writing a confession and waiting to kill him. Eric tries to understand the grievance but cannot reduce Benno's pain to a satisfying market pattern or theory. Benno shoots him. Before the fatal moment fully arrives, Eric sees the image of his own body on the electronic face of his watch, a final collapse of the distinction between data that anticipates life and the life that is ending. The book closes with Eric suspended at the edge of the death he has knowingly approached.",
         "in_short": "Billionaire trader Eric Packer sets out across Manhattan in his fortified limousine for a haircut, despite gridlock, protests, a presidential visit, a funeral, and warnings that someone intends to kill him. Employees, advisers, lovers, doctors, and his remote new wife enter and leave the car as he watches his vast wager against the yen consume his fortune. Eric refuses to change course because he believes the market must submit to the hidden pattern he sees. The city answers his abstraction with bodies, crowds, violence, and chance: protesters attack the symbols of wealth, a pie thrower humiliates him, and his security system predicts danger without restoring meaning. Eric deliberately sheds his defenses, kills his bodyguard, reaches his childhood barber, and proceeds toward the person threatening him. That man is Richard Sheets, a dismissed employee calling himself Benno Levin, whose grievance cannot be resolved by Eric's theories. Benno shoots Eric, who sees his own impending death displayed on his watch before he fully experiences it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2291,7 +2291,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2304,7 +2304,7 @@
       "recaps": {
         "ending": "Jack finally offers Kitty the future she once wanted, but his presumption that she will accept exposes how little he has understood her. Her months in London have replaced infatuation with clear judgment, and she refuses him. The supposedly incapable Freddy has meanwhile handled every crisis with tact, loyalty, and practical intelligence: he protects reputations, helps the endangered young couples reach workable arrangements, and consistently puts Kitty's welfare before his own vanity. Kitty recognizes that her ease and happiness with him are not part of their performance. Their false engagement becomes a genuine match, with Freddy and Kitty choosing each other rather than submitting to Matthew Penicuik's scheme. The final pairing completes the novel's cotillion pattern: partners who seemed mismatched or obstructed find their proper places, while Jack is left outside the arrangement he assumed he could control.",
         "in_short": "Matthew Penicuik tells his ward Kitty Charing that she will inherit his fortune only if she marries one of his great-nephews. Kitty wants the absent Jack Westruther, but instead persuades Jack's amiable cousin Freddy Standen to pretend they are engaged so that she can visit London and make Jack jealous. Freddy's family receives her, and her narrow romantic scheme expands as she becomes involved in the troubles of other couples, including Lord Dolphinton and Hannah Plymstock, and Olivia Broughty and Camille d'Evron. Freddy, dismissed by almost everyone as an empty-headed dandy, repeatedly proves discreet, loyal, and highly capable at solving the practical problems Kitty creates or discovers. Jack's pursuit of Kitty and Olivia reveals his selfish confidence rather than the nobility Kitty imagined. Kitty rejects him and realizes that the dependable partnership she and Freddy have been acting is real. Their sham engagement ends in a chosen marriage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2612,7 +2612,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -2625,7 +2625,7 @@
       "recaps": {
         "ending": "Emil refuses to leave Oslo unless Silas helps his experimental animals. His underground laboratory traps Silas in legendary mana, forcibly alters him, and rises through a neighborhood when he activates its exit. Protocol Zeta then releases a destructive mana pulse, clones the animals, and causes an irreversible breach. Earth loses three million world points and its induction advances by 242 days, exposing nearby life to forced induction or mutation. Silas rescues civilians and remains in the Oslo disaster zone while the public receives a false account involving terrorism and a possible nuclear event. Emil's location and purpose remain unresolved. Silas is separated from Dory, Crag, Nevin, Dejin, and Samvek, while Erg's evolution has disabled their bond. Morvarg remains confined only until the Wild Hunt. Annika, Nuri, and Jiang remain uncertain allies after Daniel Becker's warning. The displaced people still need a permanent home, and the alien liaison's asylum remains conditional. Every Forerunner must enter the Wild Hunt alone in 6 days, 16 hours, and 47 minutes.",
         "in_short": "Silas Renner joins House Raiden under Samvek, then spends months training with Dory, Crag, and Nevin inside an overloaded Darji dungeon. He frees a banshee's soul, uncovers a hell incursion, forms an uncommon core, and permanently defeats the lich behind the dungeon, gaining the Darji lineage. Back on Earth, he grants conditional refuge to alien observers and learns to combine mana with biosteel. On Proximus he temporarily restores a displaced people's refuge, recruits Dejin, kills three hostile elven Forerunners, and loses access to Erg when the Eidolon traps Morvarg in another plane. Daniel Becker's journal deepens Silas's distrust of Earth's Forerunners. After provoking corporate competition on Galen, Silas goes to Oslo for Emil Larsson. Emil refuses rescue, and his automated laboratory triggers Protocol Zeta. The resulting breach costs Earth three million world points and advances induction by 242 days. Silas survives in Oslo but must enter the solo Wild Hunt in less than seven days.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2845,7 +2845,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2858,7 +2858,7 @@
       "recaps": {
         "ending": "Valérie and Crevel die after Henri Montès takes revenge for Valérie's betrayals. Lisbeth, deprived of the future she expected from the family's ruin and exhausted by her own hatred, also dies before she can marry Marshal Hulot. Adeline and her children eventually locate Hector living under an assumed name with another young woman. Adeline forgives him and brings him home, briefly restoring the household. The reconciliation does not reform him: he soon propositions the young kitchen maid Agathe. Adeline discovers this final betrayal and dies after forgiving him once more. Hulot survives her and later marries Agathe, while the children retain what remains of the family. The revenge plot destroys its chief agents and victims alike, but Hector's appetite outlasts the suffering it caused.",
         "in_short": "The Hulot family is already strained by Baron Hector Hulot's affairs and debts when Adeline's resentful cousin Lisbeth Fischer loses her secret protégé, sculptor Wenceslas Steinbock, to Hortense Hulot. Lisbeth allies herself with the calculating Valérie Marneffe. Together they exploit Hector, Crevel, Wenceslas, and other admirers, using desire, money, and jealousy to damage the family. Hortense separates from Wenceslas, Adeline is driven to humiliation, and Hector's misuse of public funds forces him into hiding. Victorin turns to Madame Nourrisson for help ending Valérie's threat. Valérie marries Crevel but is killed with him through Henri Montès's revenge; Lisbeth also dies. Adeline finds and forgives Hector, only to catch him pursuing their kitchen maid. The shock kills her. Hector remains unreformed and eventually marries the maid, leaving his children to preserve what they can after the older generation's ruin.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3052,7 +3052,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3065,7 +3065,7 @@
       "recaps": {
         "ending": "Matty's friends arrange a small tea business that allows her to support herself without feeling she has accepted charity. Their efforts are overtaken by happier news when Peter, located through an advertisement in India, returns to Cranford after decades away. His presence restores Matty's family life and financial security, and his stories and generosity make him welcome throughout the town. Lady Glenmire's marriage to Mr. Hoggins survives Mrs. Jamieson's disapproval; social relations eventually settle into a workable peace. Matty remains at the affectionate center of the community, no longer alone or threatened by poverty. Cranford's customs have bent enough to admit new people and changed circumstances, while its strongest principle proves to be the residents' quiet willingness to care for one another.",
         "in_short": "Mary Smith recounts life among the genteel women of Cranford, where small incomes are concealed, strict visiting customs matter, and friendship supplies what money cannot. The arrival of Captain Brown challenges local conventions, but his sudden death reveals the community's compassion. Matty Jenkyns loses her forceful sister Deborah, remembers the suitor she was not allowed to marry, and continues to hope for her missing brother Peter. Cranford is variously stirred by an aristocratic visitor, a magician, rumors of burglars, and Lady Glenmire's socially surprising engagement to the surgeon Mr. Hoggins. When Matty loses nearly all her savings in a bank failure, her friends secretly combine resources and help her open a tea shop. Mary also advertises for Peter in India. He returns at last, restoring Matty's security and completing the household, while the town reconciles itself to Lady Glenmire's marriage and resumes its life in a more generous peace.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3250,7 +3250,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3263,7 +3263,7 @@
       "recaps": {
         "ending": "Eleanor confronts Rachel with damaging information about her birth and makes clear that the Young family will not accept her as Nick's wife. Rachel, hurt both by the disclosure and by Nick's failure to prepare her for his family, refuses his proposal and withdraws with Peik Lin. Nick brings Rachel's mother, Kerry, to Singapore. Kerry explains the violence and fear behind her flight from China and assures Rachel that she was loved rather than abandoned. Reconciled with her mother and understanding her history more fully, Rachel agrees to spend one more evening with Nick, though their long-term future remains unresolved. Eleanor's intervention has alienated her son rather than restored her control. In the parallel marriage plot, Astrid learns that Michael manufactured signs of an affair as a way out of a life in which he felt inferior. Their marriage breaks down, while Charlie Wu quietly helps Astrid discover the truth and remains a possible source of support.",
         "in_short": "New York professor Rachel Chu travels to Singapore with her boyfriend, Nick Young, unaware that he belongs to one of Asia's wealthiest and most established families. Nick's mother, Eleanor, sees Rachel as an unsuitable outsider, while rivals and relatives subject her to gossip and calculated humiliation during the extravagant wedding of Nick's best friend Colin. Rachel's friend Peik Lin and several members of Nick's circle help her navigate the hostility. Nick finally proposes, but Eleanor produces information about Rachel's birth that shatters Rachel's understanding of her family, and Rachel refuses him. Nick brings Rachel's mother, Kerry, to Singapore, where Kerry explains that she fled an abusive marriage in China to protect her child. Rachel and Nick achieve a tentative reconciliation, although his family's opposition remains. Meanwhile, Nick's cousin Astrid discovers that her husband Michael staged evidence of infidelity because he could no longer bear feeling subordinate to her wealth, leaving their marriage in ruins.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3391,7 +3391,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3404,7 +3404,7 @@
       "recaps": {
         "ending": "Jackson finally insists that his parents stop protecting him with reassuring half-truths. They admit that the family may lose its apartment and explain the seriousness of their money problems. Speaking openly does not instantly create financial security, but it ends Jackson's isolation and lets the family face the danger together. Jackson also tells Marisol what has been happening and accepts friendship instead of hiding his shame. Crenshaw's return has helped him recognize that imagination is not the opposite of truth: the cat gives him a way to endure fear long enough to speak about it. The family's future remains uncertain, but Jackson is no longer carrying that uncertainty alone, and he accepts Crenshaw's companionship instead of treating it as an embarrassing failure of reason.",
         "in_short": "Jackson trusts facts and has little patience for imaginary things, but a giant talking cat named Crenshaw reappears just as his family again runs out of money and food. Years earlier, when Jackson, his parents, his little sister Robin, and their dog Aretha lived in their minivan, Crenshaw helped him survive the fear and uncertainty. Now Jackson sees the same warning signs: possessions are being sold, meals are shrinking, and his parents avoid direct answers. He resists Crenshaw because the cat reminds him of a past he wants to deny. By revisiting those memories, Jackson realizes that facts alone have not made him less frightened. He tells his friend Marisol what is happening and demands honesty from his parents. They acknowledge that they may lose their apartment. The crisis is not magically solved, but the family faces it together, and Jackson accepts that imagination, truth, and asking for help can coexist.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3576,7 +3576,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3589,7 +3589,7 @@
       "recaps": {
         "ending": "The rescue that opens the book costs the crew almost everything before it is repaired. Scarlet is taken to Luna and handed to Princess Winter as a curiosity for the palace menagerie; Cress and Thorne crash into the Sahara, where Thorne is blinded; the Rampion is damaged and Cinder, Wolf and Iko go to ground in Africa. Reunited in the desert town of Farafrah, they find Dr. Erland, who admits that letumosis was engineered on Luna as a weapon and that the antidote is drawn from the blood of Lunar shells - children like Cress, taken from their families and kept alive in captivity for it. Erland reveals that his own daughter was one of those children, and leaves for Luna to find her, never learning that she is the girl standing in front of him. The crew abducts Kai from his own wedding procession on Earth, and Cinder tells him who she is; he believes her, and then insists on going back, because the marriage on Luna is the only way to put Cinder inside Levana's palace. Kai departs for the moon to be married, Scarlet is already a prisoner there, and the Rampion follows with Cinder intending to raise a revolution.",
         "in_short": "Cinder's crew needs a hacker, and the one they find is Cress, a Lunar shell who has spent seven years imprisoned alone in an orbiting satellite spying on Earth for the thaumaturge Sybil Mira. The rescue goes badly: Sybil arrives mid-operation, Scarlet is captured and shipped to Luna, and Cress and Thorne crash to the Sahara in an escape pod, where Thorne is blinded by the impact. The two cross the desert on foot while Cinder, Wolf and Iko limp to Africa in the damaged Rampion. On Luna, Scarlet is given to Princess Winter as a pet for the palace menagerie. Reunited in Farafrah, the crew finds Dr. Erland, who reveals that letumosis was made on Luna as a weapon and its antidote is drawn from shells held captive there - and that his own lost daughter was a shell, without recognising Cress as her. The crew kidnaps Emperor Kai from his wedding procession; Cinder tells him she is Princess Selene, and Kai chooses to go through with the Lunar wedding anyway, as the way to get her inside the palace.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3787,7 +3787,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3800,7 +3800,7 @@
       "recaps": {
         "ending": "Raskolnikov's theory collapses under the weight of his own conscience. Tormented by guilt and worn down by Porfiry's patient psychological pressure, and moved by Sonya's insistence that he confess and accept suffering, he publicly admits to the murders and is sentenced to eight years of hard labor in Siberia. Sonya follows him there and settles nearby, visiting faithfully. Several other threads close darkly: Marmeladov dies after being run over by a carriage, and Katerina Ivanovna soon dies of consumption in a fit of despair; Luzhin is exposed and rejected after trying to disgrace Sonya; and Svidrigailov, having failed to win Dunya and after a few final acts of unexpected generosity, shoots himself. Dunya marries the loyal Razumikhin. In the epilogue, Raskolnikov at first remains proud and unrepentant in the prison camp, but through Sonya's steadfast love he finally breaks down, weeps, and begins a gradual moral and spiritual regeneration, the novel closing on the promise of his slow return to life.",
         "in_short": "In St. Petersburg, the poverty-stricken former student Raskolnikov, convinced by his own theory that extraordinary people may transgress moral law, murders a grasping old pawnbroker and, in a panic, also kills her gentle half-sister Lizaveta. He gets away with the crime but is immediately crushed by guilt, dread, and feverish illness. As he evades and is subtly hunted by the magistrate Porfiry Petrovich, he is drawn to Sonya Marmeladova, a meek, deeply religious young woman forced into prostitution to support her family. Around him his mother and sister Dunya arrive in the city, Dunya escaping the loveless designs of Luzhin and the disturbing pursuit of the cynical Svidrigailov. Unable to bear his isolation, Raskolnikov confesses first to Sonya, then, urged by her toward repentance, gives himself up to the authorities. He is sentenced to penal servitude in Siberia, where Sonya follows him, and where his hardened heart slowly opens toward love and the possibility of spiritual renewal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3980,7 +3980,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3993,7 +3993,7 @@
       "recaps": {
         "ending": "Raskolnikov goes to the police and confesses that he murdered Alyona Ivanovna and Lizaveta. He is sentenced to eight years of penal servitude in Siberia, with his illness, confused mental state, voluntary confession, and acts of generosity counting in his favor. Dunya marries Razumikhin, who plans for them eventually to settle near him. Their mother dies after retreating into fantasies about her son's future. Sonya follows Raskolnikov to Siberia and wins the affection of the prisoners, though he initially remains emotionally remote and still regards his crime mainly as a failed test of his own strength. After illness and a disturbing dream of a worldwide plague of absolute certainty, he recognizes his love for Sonya and accepts hers. He takes up the New Testament she has given him. The novel closes at the beginning rather than the completion of his moral renewal, with years of punishment still ahead but genuine connection and transformation finally possible.",
         "in_short": "Rodion Raskolnikov, an impoverished former student in St. Petersburg, convinces himself that an extraordinary person may cross moral limits for a higher purpose. He murders the pawnbroker Alyona Ivanovna and unexpectedly kills her sister Lizaveta, but gains nothing useful and falls into fever, fear, and isolation. The investigating magistrate Porfiry steadily presses him while his loyal friend Razumikhin supports his mother and sister. Raskolnikov is drawn to Sonya Marmeladova, a young woman driven into sex work to feed her family, and finally confesses the murders to her. Meanwhile Dunya escapes the control of her calculating fiancé Luzhin and the dangerous Svidrigailov; Luzhin is exposed and Svidrigailov kills himself after releasing Dunya. Urged by Sonya, Raskolnikov confesses to the police and is sent to Siberia. Sonya follows. His pride survives punishment at first, but illness and her steadfast love begin a spiritual renewal that the ending presents as only just underway.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4201,7 +4201,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4214,7 +4214,7 @@
       "recaps": {
         "ending": "Raskolnikov confesses to the murders and is sentenced to eight years of penal servitude in Siberia, with his confession and confused state helping to limit the punishment. Sonia follows him and becomes a steady link between him and the other prisoners, although he initially remains proud and emotionally isolated. Dunya marries Razumikhin, and they plan eventually to join him; Pulcheria dies after an illness in which she never fully accepts what her son has done. After Sonia falls ill, Raskolnikov recognizes how deeply he needs her. He kneels before her and their guarded companionship becomes mutual love. He takes up her copy of the New Testament, and the novel closes at the beginning of an inner transformation rather than its completion: his legal sentence continues, but the theory that separated him from other people has begun to give way to remorse, attachment, and the possibility of a new life.",
         "in_short": "Former student Rodion Raskolnikov, impoverished and isolated in St Petersburg, murders the pawnbroker Alyona Ivanovna to test his belief that exceptional people may violate ordinary morality; he also kills her innocent sister Lizaveta when she unexpectedly returns. He hides the stolen goods without using them and descends into fever, fear, and self-division. His friend Razumikhin supports his mother and sister, while magistrate Porfiry probes him psychologically. Raskolnikov grows close to Sonia Marmeladova, whose endurance and religious faith challenge his theory, and he confesses the crime to her. Svidrigailov threatens Raskolnikov's sister Dunya, releases her when she rejects him, and kills himself. Urged by Sonia and faced with Porfiry's case, Raskolnikov finally confesses. Sent to Siberia, he remains emotionally resistant until Sonia's devotion awakens his love and opens the possibility of moral renewal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4406,7 +4406,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4419,7 +4419,7 @@
       "recaps": {
         "ending": "Raskolnikov confesses to the police and is sentenced to eight years of penal servitude in Siberia. Sonia follows him and maintains contact despite his initial coldness. Dunya marries Razumikhin, who plans for them eventually to move nearer to Raskolnikov, while Pulcheria dies after an illness shaped by confused hopes for her son's future. In prison Raskolnikov still regards his crime chiefly as a failed test of his own strength and remains apart from the other convicts. After illness and a disturbing dream of a worldwide plague of certainty, his attitude begins to change. He recognizes his love for Sonia and accepts her devotion, and she understands that the emotional barrier between them has broken. The novel closes at the beginning of his moral renewal rather than its completion: nearly seven years of his sentence remain, but confession and punishment have opened the possibility of a different life.",
         "in_short": "Impoverished former student Rodion Raskolnikov develops a theory that exceptional people may cross moral boundaries for a higher purpose. He murders a pawnbroker and, when her sister unexpectedly appears, kills her as well, but gains almost nothing and falls into fever, fear, and isolation. The magistrate Porfiry gradually presses him through psychological suspicion. Meanwhile Raskolnikov becomes close to Sonia, a young woman driven into sex work to support her family, and clashes with the controlling Luzhin and the dangerous Svidrigailov over his sister Dunya. He eventually admits the murders to Sonia. After Svidrigailov fails to win Dunya and kills himself, Raskolnikov confesses publicly and to the police. Sentenced to Siberia, he initially remains proud and emotionally detached. Sonia follows him, and after illness he finally acknowledges his love for her. Punishment does not itself resolve his ideas, but the ending presents their relationship as the beginning of repentance and renewal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4604,7 +4604,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4617,7 +4617,7 @@
       "recaps": {
         "ending": "Raskolnikov confesses and is sentenced to eight years of penal servitude in Siberia. Sonya follows him and becomes a steady link between him and other people, while Razumikhin and Dunya marry and plan eventually to live near him. Pulcheria dies after an illness shaped by anxious fantasies about her son's absence. In prison Raskolnikov initially remains proud and emotionally detached, believing that failure rather than murder was his true fault. After illness and a dream of a worldwide plague of absolute certainty, he recognizes his love for Sonya and begins to accept the moral meaning of what he has done. The novel closes with his inner renewal only beginning; his sentence continues, but he is no longer sealed inside the theory that licensed his crime.",
         "in_short": "Former student Rodion Raskolnikov murders a pawnbroker and her innocent sister, partly for money and partly to test his theory that extraordinary people may cross moral limits. He gains little from the crime and is consumed by fever, suspicion, and isolation. His friend Razumikhin supports his family, while the investigator Porfiry steadily pressures him. Raskolnikov is drawn to Sonya Marmeladova, an impoverished young woman whose faith and compassion oppose his pride. Family conflicts involving Dunya, Luzhin, and Svidrigailov expose other forms of exploitation. After Svidrigailov releases Dunya and kills himself, Raskolnikov accepts Sonya's demand that he confess. Sent to Siberia for eight years, he initially remains unrepentant, but Sonya follows him. Illness, a terrifying dream, and his recognition that he loves her mark the start of genuine moral renewal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4897,7 +4897,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:177424361X",
@@ -4909,7 +4909,7 @@
       "recaps": {
         "ending": "Skippy destroys the hostile controller hidden at Maris and discovers an Elder weapons arsenal. Bishop brings those weapons to Earth just as Chang is preparing to sacrifice the Flying Dutchman against a superior Maxolhx task force. Valkyrie's arrival stops the collision attempt, and the displayed arsenal persuades the enemy to withdraw. The expedition then rescues Emily Perkins and the Mavericks from a Maxolhx punishment operation and brings them into a more candid alliance. Bishop, Skippy, Chang, Simms, Nagatha, Bilby, and both ships remain active. Avalon has civilians and supplies but is not yet a mature refuge, and the Earth evacuation remains constrained by limited capacity and political danger. Humanity now has a deterrent rather than security. The shifted wormhole network is exposed, the Maxolhx investigation remains dangerous, Skippy's damaged history is unresolved, and using Elder weapons could provoke Sentinels or tempt an apex species to trigger a wider catastrophe.",
         "in_short": "A hostile ship intelligence disables Valkyrie and the Flying Dutchman while Joe Bishop is captured, but the crews recover both vessels, rescue Bishop, and reunite. Skippy's incomplete memories point to dormant hostile Elder AIs, and a reconnaissance mission survives an active Sentinel before the expedition tries to open an evacuation route to Earth. Moving an ancient wormhole shifts the network, exposes humanity to Maxolhx investigation, and offers far too little capacity for a full evacuation. At Maris, Skippy destroys a concealed controller and finds an Elder arsenal. Bishop uses the weapons as a deterrent, reaching Earth in time to stop Chang's sacrificial attack and force a Maxolhx task force to withdraw. Valkyrie then saves Emily Perkins and the Mavericks from punishment. Humanity ends with two operational ships, a fragile refuge at Avalon, and powerful leverage that could itself provoke Sentinel destruction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5054,7 +5054,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5067,7 +5067,7 @@
       "recaps": {
         "ending": "Alex stops the release: the engineered disease is never spread across Kenya's crop, the harvest is not destroyed, and the famine McCain was manufacturing does not happen. McCain does not survive the attempt. The charity that was to have collected the world's money for a disaster of its own making is exposed along with him, and the research facility that supplied the organism is left to answer for its security. Harry Bulman, who tried to sell Alex's story, is already dead, killed by the people whose attention he attracted, and the story dies with him. Alex goes back to London with Jack and to school at Brookland, having again been used by MI6 after telling them he had finished with them, and again having no one outside a very small circle who can be told anything about it. Nothing about the arrangement between him and the department has changed, and neither side pretends otherwise.",
         "in_short": "At New Year in Scotland with Sabina Pleasure's family, Alex saves the occupants of a car that goes through the ice, and the rescue puts him in front of a tabloid journalist, Harry Bulman, who works out what he really is and tries to blackmail him. MI6 offer to make the problem disappear in exchange for a favour, and the favour leads Alex to Greenfields, a British research centre developing genetically engineered crops, and from there to Desmond McCain, a celebrated preacher and aid-charity boss. McCain has had a crop disease engineered to order and intends to release it across Kenya, wiping out the harvest and starving a country, so that donations pour into his charity and the positions he has taken quietly make him a fortune. Alex is captured and held over a crocodile pit, escapes, and is taken to Kenya, where he stops the release before the disease can be spread. McCain does not survive. Bulman is murdered before he can publish, and Alex returns to London.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5262,7 +5262,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5275,7 +5275,7 @@
       "recaps": {
         "ending": "Josephine is the murderer. She poisoned Aristide after he refused one of her wishes, then treated the investigation as a game in which she could display her cleverness. She staged the attack on herself to reinforce her claim that she knew too much. Later she poisoned Nanny, who had begun to recognize how dangerous she was. Edith de Haviland finds Josephine's private account and concludes that exposure through the courts would destroy the family without providing a humane future for the child. Edith leaves a confession taking responsibility for the crimes, then drives Josephine away from Three Gables and deliberately sends the car over a quarry edge, killing them both. A separate letter tells Charles the truth and encloses Josephine's written record. Brenda and Laurence are cleared. With the murder resolved, Sophia accepts that she is not responsible for inheriting her family's capacity for violence, and she and Charles can plan a life together away from the house.",
         "in_short": "Charles Hayward returns to England intending to marry Sophia Leonides, but her wealthy grandfather Aristide has been poisoned at the family's crowded home, Three Gables. Charles joins the inquiry and finds motives among Aristide's dependent children, his young widow Brenda, and Brenda's friend Laurence Brown. Family business failures, an unexpected inheritance for Sophia, and secret love letters deepen suspicion. Sophia's young sister Josephine claims to know the culprit, survives an apparently murderous attack, and continues spying after Brenda and Laurence are arrested. When the family nurse is poisoned, Edith de Haviland discovers the truth: Josephine killed Aristide, staged her own attack, and killed the nurse. Edith drives herself and Josephine to their deaths, leaving letters and Josephine's notebook to explain her protective murder-suicide. The innocent suspects are freed, and Charles and Sophia look beyond Three Gables toward marriage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5430,7 +5430,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5443,7 +5443,7 @@
       "recaps": {
         "ending": "Kaz and his crew rescue Inej from Van Eck and then dismantle the merchant completely. Through a series of cons, Kaz exposes Van Eck's crimes, engineers his financial ruin and arrest, and forces him to reinstate his cast-off son Wylan as his legitimate heir, so Wylan inherits the Van Eck fortune. Kaz also destroys his oldest enemy, the crime boss Pekka Rollins, who years earlier swindled and doomed Kaz's brother Jordie and set Kaz on the path to becoming Dirtyhands; Kaz strips Pekka of his wealth and power and breaks him, though he spares Pekka's young son. The triumph is shadowed by loss: Matthias is shot and killed while shielding others, dying in Nina's arms, and Nina, her Grisha power permanently altered by parem, takes his body home to Fjerda to carry on his dream of ending its persecution of the Grisha. Kuwei is spirited safely out of Ketterdam into protective hands to continue his father's work. Jesper reconciles with his father Colm and accepts his own Grisha gift, and he and Wylan are together. Kaz arranges for Inej to have a ship of her own to hunt slavers on the seas and helps reunite her with her family, and the two, still guarded, reach a tentative closeness. Kaz emerges from it all as a rising force in the Barrel.",
         "in_short": "Betrayed and cheated by the merchant Jan Van Eck, who holds Inej hostage, Kaz Brekker and his crew go to war against him in the crooked city of Ketterdam. Through a chain of elaborate cons they rescue Inej and set out to ruin Van Eck utterly, while contending with rival gangs, the drug jurda parem, and Kaz's oldest enemy, the crime boss Pekka Rollins, who years ago destroyed Kaz's brother and made him what he is. Kaz outmaneuvers both men: he engineers Van Eck's public disgrace, financial collapse, and arrest, forcing Wylan to be restored as heir to the Van Eck fortune, and he breaks Pekka Rollins by taking everything from him. The victory carries a terrible cost. Matthias is killed near the end, dying in Nina's arms, and she carries his body home to Fjerda to pursue the change he dreamed of. Kuwei is smuggled to safety, Jesper reconciles with his father and embraces who he is, Wylan and Jesper are together, and Kaz gives Inej the means to sail as a hunter of slavers, the two parting with a fragile, deepening bond and Kaz rising as a power in the Barrel.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5564,7 +5564,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5577,7 +5577,7 @@
       "recaps": {
         "ending": "The survivors reach the Rising and are accepted into it, and are immediately separated, because the rebellion places people where it needs them rather than where they want to be. Ky and Indie are sent to train as pilots. Eli is placed somewhere safer than the canyons. Cassia is sent back into the Society itself, to work as a sorter in the central city and wait for a signal, which means that having crossed a desert to reach Ky she is returned to almost exactly the life she escaped. Vick is dead, shot down before they arrived, and Hunter has gone his own way into the canyons. Cassia also learns that Xander, the boy the Society Matched her with and whom she left behind without explanation, has been a member of the Rising for years, so the friend she believed she knew completely had an entire hidden life. Ky, who spent the whole journey arguing that the Rising will use people exactly as the Society did, joins it anyway, on the grounds that there is nothing else left to join. All three end the book inside the Society again, apart, obedient on the surface, waiting for orders from a leader none of them has ever met.",
         "in_short": "Ky is in the Outer Provinces, quartered with other boys classed as Aberrations in a village that exists to be bombed so the Society can measure the enemy's attacks. When the village is destroyed he escapes into the canyons known as the Carving with Vick and young Eli. Cassia, having engineered her own transfer to a nearby work camp, escapes with a girl named Indie and follows him. Both parties cross the canyons on foot, short of water, and find the settlement of the farmers abandoned and its people gone. Cassia and Indie meet Hunter, a grieving survivor, and Cassia learns that the blue tablets the Society promises will save a citizen's life in an emergency will in fact leave anyone who relies on them helpless. Cassia and Ky finally reunite and argue about the Rising, the rebellion Ky's father died for. Vick is killed on the way. They reach the Rising, are accepted and are immediately split up: Ky and Indie to fly, Cassia back into the Society as a sorter, and Cassia learns that Xander has been part of the rebellion all along.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/crossroads-of-twilight.json
+++ b/data/works-community/0/crossroads-of-twilight.json
@@ -103,7 +103,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -116,7 +116,7 @@
       "recaps": {
         "ending": "Crossroads of Twilight closes with the pieces set for the confrontations to come. Perrin Aybara seals a truce with the Seanchan to break the Shaido and reclaim Faile, setting aside his hatred of them for her sake. Mat Cauthon remains on the run with Tuon, their guarded courtship deepening even as Seanchan assassins close in. Elayne holds her ground in the contest for Andor. The book's decisive turn belongs to Egwene: having throttled Tar Valon by sealing its harbors with cuendillar, she leaves the safety of her camp to strike at the Tower directly and is captured by Elaida's sisters. The rebels' young Amyrlin is carried inside the White Tower as a prisoner, to be treated as a runaway novice, an apparent disaster that places her at the very heart of the enemy she has been trying to defeat.",
         "in_short": "In the aftermath of the cleansing of saidin, the world adjusts and the pieces shift toward the Last Battle. Perrin Aybara, still hunting the Shaido who hold his wife, Faile, makes a hard bargain and forges an uneasy alliance with the invading Seanchan, agreeing to join forces against the Shaido in exchange for help freeing his people. Mat Cauthon travels north hidden among a menagerie show, evading Seanchan hunters while slowly, warily courting Tuon, the Daughter of the Nine Moons he carried away. Elayne fights to secure Andor's throne in Caemlyn against rival claimants and hidden enemies. Egwene al'Vere presses her siege of Tar Valon, strangling the White Tower's harbors by turning their defenses to unbreakable cuendillar. But when she slips out with a small band to finish the work herself, she is betrayed and seized by the Tower's Aes Sedai. The rebels' young Amyrlin becomes a prisoner inside the very Tower she meant to conquer.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -445,7 +445,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -458,7 +458,7 @@
       "recaps": {
         "ending": "Felix holds Pax Rell after reclaiming its true seat, while Vessilia's father survives but no longer rules the territory. Vessilia, Pit, Evie, Beef, Archie, Harn, and the allied dragoons survive the campaign. Felix severs the god's direct control of his sister, but the five moon-bound gods abduct her and consume the god of light and order, gaining strength as their chains weaken. Her memories continue returning, and they offer her an unknown bargain. Felix has two of the three Crown of Elysium fragments and plans to recruit the remaining Unbound to rescue her and oppose both the gods and the still-unexplained Ruin. In Nagast, Karys and Isla recover after the seal attack, while Atar remains alive as a skeleton sustained by white flame. Alistair kills the coercive provincial ruler and concludes a treaty that recognizes the Naga folk within Nagast and commits provincial troops and supplies to the alliance. The sabotage organizer's fate, Atar's altered state, the third Crown fragment, and Archie's possible route to Earth remain unresolved.",
         "in_short": "Stranded south of the dwarven realm, Felix and his allies follow the Gloaming Way to Pax Rell and discover that the Hierocracy has conquered Vessilia's homeland. They unite displaced dragoons, restore Harn's mobility, survive an ancient fortress guardian, and infiltrate the occupied citadel. Felix kills the Hieri and breaks the oath network, while Vessilia frees her father and wins the dragoons without surrendering her dragon bond. A much larger force led by Felix's divinely controlled sister then attacks. Felix reaches Master Tier, uses two Crown of Elysium fragments to reclaim Pax Rell's seat, and helps defeat the manifested god of light and order. The moon-bound gods take his sister and consume the wounded god. Felix remains king of Pax Rell and resolves to gather the other Unbound for war against the gods and the Ruin.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -706,7 +706,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -719,7 +719,7 @@
       "recaps": {
         "ending": "Celaena kills Archer Finn in the tunnels beneath Rifthold after he confirms that Nehemia arranged her own assassination, gambling that her death would finally push Celaena into open rebellion. Celaena accepts the charge, resolving to destroy the king, free magic, and take back what is hers. Chaol, meanwhile, has learned from Archer and from the Terrasen rebels who Celaena really is: Aelin Ashryver Galathynius, the heir of Terrasen, who was believed murdered as a child. Terrified of what the king will do when he learns it too, Chaol asks the king to send her out of the country, and the king agrees, dispatching her across the sea to Wendlyn with orders to murder its royal family. Celaena sails knowing she will do no such thing; she means to find the answers she needs and come back for the throne. Chaol stays behind, having traded away his own future to buy her passage, and now guards a secret of his own: Dorian has raw, uncontrolled magic. The king remains ahead of all of them, holding the Wyrdkeys and building something in the south with Duke Perrington that nobody has yet seen.",
         "in_short": "Celaena Sardothien serves as the King of Adarlan's Champion, secretly faking the deaths of the people she is ordered to kill and smuggling them out of the kingdom. She grows close to Chaol Westfall, becomes his lover, and begins to hope for an ordinary life, while her friend Nehemia presses her to use her position against the empire and Celaena refuses. Investigating the king's power, she interrogates and kills an ancient witch and learns of the Wyrdkeys, three fragments of a shattered gate that grant their holder terrible power and which the king possesses. When Nehemia is murdered in the castle, Celaena's grief turns to a cold fury: she hunts down the killer, then the man who hired him, and learns that Nehemia engineered her own death to force Celaena to act. Celaena accepts the call, claiming her true name at last. Chaol discovers it independently and, to save her from the king, has her sent overseas to Wendlyn. She departs vowing to return and destroy the man who took her kingdom, leaving Chaol in Rifthold with Dorian, whose magic has begun to surface.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1121,7 +1121,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0C4R326L5",
@@ -1133,7 +1133,7 @@
       "recaps": {
         "ending": "Hal ends the book at the dragon-contest site after saving Besal from an external Beastborn possession. The undercover illusionist's false battle buys time for Hal to restore Besal's scarscape, where Hal and Besal mortally wound the rival. Besal then dissolves into star-filled mist that restores Hal, leaving his survival or transformation uncertain. Hal subsequently destroys the fleeing extension with dragon essence. The tyrant white remains alive after the possessed Besal defeats her, while the gold dragon is nearing defeat when the narrative leaves their contest and the final dragon-oath terms remain unsettled. Hal's restored monster core is functional, but hollow essence, Oversoul chains, and repeated founder-sigil backlash still endanger him. Brightsong is growing under Noth, Ashera, Elora, Vorax, and its council, with loyal kobolds sheltered there, but winter food preservation and materials remain tight. Rinbast is still protected from direct conflict until a Primacy Trial, and his archmage and Kinslayers are approaching. The injured court mage remains guarded because his loyalty and condition are uncertain.",
         "in_short": "After returning Brightsong's missing allies, Hal builds a council and enters Frostmourne to recover Elora's severed soul and save the gold dragon's imprisoned daughter. Elora regains Wild's Master, but Hal's use of hollow essence nearly destroys him. The Mage King and Dream kindred restore his defective Beastborn class with a monster core and reveal a wider conflict among bearers of his soul. Hal escapes Aldim's moon, defeats but spares the tyrant white, reunites her with the fractured dungeon core, frees her father, and shelters loyal kobolds. He challenges Rinbast for Beastborn Prime while Brightsong prepares for incoming Kinslayers. During a contest to bind both dragons by oath, hostile agents possess Besal. An undercover founder conceals the real struggle while Hal restores Besal's inner realm, where Hal and Besal mortally wound the rival. Besal dissolves into Hal and revives him, after which Hal destroys the fleeing extension. Besal's fate, the dragon oath, the Primacy Trial, and Brightsong's defense remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1407,7 +1407,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1420,7 +1420,7 @@
       "recaps": {
         "ending": "Kumalo returns to Ndotsheni with Absalom's pregnant wife and Gertrude's son, but without Gertrude, who disappears before the journey. Absalom remains under sentence of death. In the valley, Kumalo tries to confront failing soil, hunger, and the community's loss of hope. James Jarvis, transformed by learning about Arthur's convictions, quietly begins helping: milk reaches the children, a dam is planned, and the agricultural demonstrator Napoleon Letsitsi arrives to restore the land. Jarvis's young grandson forms a warm connection with Kumalo, while the death of Margaret Jarvis brings the two grieving families into further sympathy. On the night before Absalom's execution, Kumalo climbs the mountain above the valley and keeps vigil. At dawn, as his son is due to die in Pretoria, he prays for forgiveness and for his country. The novel closes with renewal beginning in Ndotsheni but South Africa's larger liberation still deferred; private compassion has crossed the racial boundary, while the unjust order that damaged both families remains.",
         "in_short": "The Reverend Stephen Kumalo leaves his impoverished valley for Johannesburg to find his sister Gertrude and his missing son Absalom. Guided by the priest Msimangu, he reunites with Gertrude but discovers that Absalom has killed Arthur Jarvis, a white reformer and the son of a neighboring farmer. Absalom admits firing in fear during a burglary and is sentenced to death; his companions avoid conviction. Arthur's father, James Jarvis, reads his son's writings and begins to understand the racial injustice Arthur opposed. Kumalo returns home with Absalom's pregnant wife and Gertrude's child, while Gertrude disappears. Jarvis then helps the drought-stricken Black community with milk, plans for a dam, and an agricultural adviser. On the eve of Absalom's execution, Kumalo keeps vigil above Ndotsheni. Dawn brings his son's death and the first signs of local renewal, but the country's freedom remains unrealized.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1736,7 +1736,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0046CL6HY",
@@ -1748,7 +1748,7 @@
       "recaps": {
         "ending": "New Egypt can no longer contain the defective-preservative scandal. Its executives remain in custody, one security man cooperates, and Lisa Sato and two revived committee witnesses can testify. Lisa is reunited with Jin and Mina under Stefin Vorlynkin's protection while she pursues legal and political remedies. Miles and Roic leave Kibou-daini; Raven Durona remains to conduct revivals as the Durona Group secures and converts the old co-operative into a clinic, with consent for its unlicensed patrons and the proposed rejuvenation trials still unresolved. White Chrysanthemum's suspected long-range scheme to gain control of Komarr is not proved or dismantled, but Miles passes his findings to Gregor Vorbarra. At Escobar Transfer Station, Miles learns that his father has died of a brain aneurysm. He becomes Count Vorkosigan, changes course to join his mother on Sergyar, delivers the funeral eulogy, and takes part in a burial without cryopreservation, as his father had wished.",
         "in_short": "Imperial Auditor Miles Vorkosigan escapes a kidnapping on Kibou-daini and is sheltered by Jin Sato, whose mother Lisa was forcibly frozen after her activist group uncovered a failing cryopreservative. Miles and his allies find and revive Lisa, establish that New Egypt suppressed the defect and its witnesses, and survive the company's attempts to recover them. New Egypt's executives are arrested, Lisa reunites with Jin and Mina, and the restored witnesses begin legal and political action. The Durona Group starts converting the hidden cryonics co-operative into a clinic. Miles leaves after reporting his still-unproven concern that White Chrysanthemum seeks long-term control of Komarr. At Escobar Transfer Station he learns that his father has died, succeeds him as Count Vorkosigan, joins his mother on Sergyar, and buries his father without cryopreservation in accordance with the dead Count's wishes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2140,7 +2140,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CJ3X7LFC",
@@ -2152,7 +2152,7 @@
       "recaps": {
         "ending": "The launcher explodes before it can fire on Earth, killing McGill's commando team and every coalition combatant nearby. McGill is revived, but Legion Varus is only slowly being restored. Wurtenberger, now consul, demotes Graves, orders his execution, and confines him pending a possible return to service. Winslade is alive after revival, while McGill remains unsure who truly initiated the launcher order. Seven survives through human revival and becomes an official Earth adviser on the divided Galactic powers. Alexander Turov confirms that he wanted the coalition damaged, suspends McGill's punishment, and regrets the loss of technology Earth cannot reproduce. On Dust World, the illicit facility has expanded and successfully revived Galina after Boudica killed her twice. Boudica expels both Galina and McGill, and McGill takes Galina home. She remains an imperator but must repair her political standing, while Drusus remains imprisoned and the silicoid threat is unresolved. Etta and Derek are married, and McGill accepts Derek into the family.",
         "in_short": "Galina Turov asks James McGill to stage her death so she can evade the consulship, but Boudica secretly holds her on Dust World. Alexander Turov then sends McGill and Legion Varus into a coalition campaign while privately ordering him to undermine the alliance. After an allied victory over a crystal fleet, the coalition lands on Crystal World, battles tunneling silicoids, and advances on a vast launcher. When the weapon targets Earth, McGill's commandos sabotage it and die in the explosion, which also destroys the surrounding coalition force and valuable technology. Wurtenberger punishes Graves for ordering the strike, while Alexander Turov later suspends McGill's own penalty. McGill finds Galina revived at an illicit Dust World facility and returns her to Earth, where her imperator position is uncertain. He then learns that Etta and Derek have married and accepts Derek as family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2552,7 +2552,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0D824JJMB",
@@ -2564,7 +2564,7 @@
       "recaps": {
         "ending": "John eradicates the Unmaking outbreak at Candle Scholar Tower and emerges as the holder of the linked aspects Life and Death. The change is immediately dangerous: souls cease to fade and new life stops beginning. With the raven god's help, John restores conception and permits the accumulated dead to pass into true death, declining to establish reincarnation. Ellie remains his central anchor as he struggles to keep the laws from overwhelming his individual identity.\n\nJohn gives up direct command of the Eternal Flame's expanding exploration effort and leaves its divisions under a council. Rabia continues to administer the enlarged divine kingdom and the Eternal Empire. Thomas establishes his own farm and marries, while Ferdie and his wife have a daughter. John seals Sutton Farm away and spends the winter grounding himself through ordinary work and observation. By spring he is steadier, though still unable to treat his authority casually. The aspect of change avatar then brings evidence that a cult deity may be a hidden dragon. John joins the investigation with the avatar and the raven god's associate, expecting to return home to Ellie after the hunt.",
         "in_short": "After winning the Millennium Meeting, John turns his power against the Resplendent Empire. He infiltrates its slave system, builds a hidden Eternal Flame network, recruits dragonkin dissidents, and creates a ten-thousand-soldier legion. The invasion ends with the dragon Empress's consciousness destroyed and her soul remnants trapped in John's shadow. Rabia takes authority over the conquered worlds, which join John's divine kingdom as the Eternal Empire. John resigns from Candle Scholar Tower, visits Earth, and learns that his altered soul contains two incomplete dragons and can sustain aspects. When Unmaking crystal infects Candle Scholar Tower, he destroys the infestation and becomes the dual aspect Life and Death. His new authority disrupts both conception and the passage of souls until he corrects it. He retreats to Sutton Farm with Ellie to preserve his identity, but leaves in spring to investigate signs of another possible dragon.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/cultivation.json
+++ b/data/works-community/0/cultivation.json
@@ -350,7 +350,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -363,7 +363,7 @@
       "recaps": {
         "ending": "Ellie destroys Kythov's ritual nexus but is left dying from the Master of the Blade's poison and Kythov's blood curse as John's doom count reaches 100 and the world's mana becomes lethally pure. Thomas kills the Master of the Blade, while Katrine advances to sage level and kills the Master of the Coil. Kythov possesses John in an attempt to claim his eternal body. John binds the necromancer to his own soul and invokes a reconstructed spiritual-sacrifice spell, causing Kythov to be consumed instead. The effect heals Ellie, and John returns with Kythov permanently dead.\n\nWith less than four hours remaining, John, Ellie, Thomas, Katrine, and Haver separate mana into class-aligned strands. The specter people's song helps them combine those strands with the First Mage's Door's woven mana, creating a filter that converts deadly pure mana into attributed mana. The machine works, but it is rough, manual, and still needs to be moved above ground. John and Ellie affirm their relationship. Ben, Ferdie, Sigvald, and the valley evacuees survive where established. Golden Grace still needs wider cultivation, two secret-society leaders and the Master of the Skull remain unresolved, the Door and its archive remain dangerous, and John owes the specter people future aid.",
         "in_short": "John Sutton tries to prevent his own mana from making the world's mana lethally pure while cultivating Golden Grace, a wheat that can feed people and cleanse blighted land. An undead conspiracy led by Kythov converges on the First Mage's Door beneath the valley as John and Ellie also persuade the plains tribes to replace raiding with trade. Kythov attacks the valley and uses the Door in a ritual designed to seize John's eternal body. Ellie breaks the ritual but is poisoned and cursed, and the apocalypse begins when John's doom count reaches its limit. Kythov possesses John, but John turns a spiritual-sacrifice spell against him, consuming Kythov's soul and healing Ellie. John, Ellie, Thomas, Katrine, Haver, and the specter people then use class-aligned mana and the Door's woven power to build a rough filter that makes ambient mana survivable again. The immediate extinction threat is halted, but the filter requires deployment, Golden Grace must be scaled, and surviving secret-society leaders remain at large.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -560,7 +560,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -573,7 +573,7 @@
       "recaps": {
         "ending": "Four months after Poirot's death, Hastings receives the manuscript Poirot left for him. X was Stephen Norton. Norton never committed a murder with his own hands: he studied people, found the crack in each of them, and by patient sympathetic suggestion brought them to the point of killing, then withdrew and watched somebody else be blamed. He had done it in the five earlier cases, he pushed Colonel Luttrell to the shot that nearly killed his wife, and he was working on Judith. Barbara Franklin had prepared a poisoned drink for her husband; Poirot, who could not prevent the attempt and would not let it succeed, saw to it that the revolving bookcase table was turned so that she took her own draught, and he takes the responsibility for her death on himself. Poirot also reveals that Hastings's impulse to poison Major Allerton was Norton's work, and that he drugged Hastings's cocoa that night to stop him. Since nothing could be proved against a man who only talked, Poirot appointed himself judge: his helplessness was partly assumed, he could walk when he chose, and he drugged Norton's cocoa, went to his room in the night, shot him neatly through the forehead, locked the door from outside with a duplicate key, and returned. He then withheld the heart medicine that would have saved him, submitting to the same judgement he had passed on Norton, and leaving the whole account to Hastings.",
         "in_short": "Hastings, a widower, returns to Styles, the country house where he first met Poirot, now a shabby guest house. Poirot is there, crippled and dying, and tells him that one of the residents is a murderer he calls X, who has been present at five deaths for which other people were convicted or blamed, and refuses to name the person. Hastings watches the household: the bickering Luttrells, the research scientist John Franklin and his invalid wife Barbara, the mild bird-watcher Norton, the plausible Major Allerton, and his own daughter Judith. Colonel Luttrell shoots his wife and calls it an accident; she recovers. Hastings, convinced Allerton means to ruin Judith, plans to poison him and falls asleep before he can. Barbara Franklin then dies of poison in her coffee, and the inquest calls it suicide. Norton hints that he has seen something through his field glasses and is found shot in his locked room. Poirot dies of heart failure days later. His posthumous manuscript reveals that Norton was X, an instigator who talked others into murder, and that Poirot, unable to prove anything, killed him and then let himself die.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -747,7 +747,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -760,7 +760,7 @@
       "recaps": {
         "ending": "Fifteen years after Christian's death, Roxane lives in a convent and still mourns him, preserving the last letter she believes he wrote. Cyrano visits her each week, but on this day an enemy has arranged for a heavy object to be dropped on him, leaving him mortally injured. He reaches Roxane anyway and asks to read the letter. Although darkness has fallen, he recites it without needing the page. Roxane recognizes the voice that spoke beneath her balcony and understands that Cyrano wrote the letters and supplied the love she had attributed to Christian. She also realizes that Cyrano has loved her throughout the intervening years. He has concealed both the authorship and his feelings to protect Christian's memory. As Cyrano weakens, Le Bret and Ragueneau arrive, and he imagines fighting the falsehood, compromise, and cowardice he opposed all his life. He dies beside Roxane, claiming only the integrity and independent spirit he has kept unstained.",
         "in_short": "Cyrano de Bergerac is a brilliant poet and soldier who believes his large nose makes him unlovable. When his cousin Roxane confesses that she loves the handsome cadet Christian, Cyrano agrees to protect him. Christian cannot express the eloquence Roxane admires, so Cyrano secretly writes his letters and speaks for him beneath her balcony. Roxane marries Christian, and the men go to war. At Arras, Roxane says the letters have made her love Christian's soul regardless of his appearance. Christian realizes she truly loves Cyrano's words and asks him to reveal the truth, but dies before Cyrano can do so. Cyrano keeps their secret. Fifteen years later, mortally wounded, he visits the widowed Roxane and recites Christian's last letter from memory. She finally recognizes Cyrano as the author and understands his lifelong love. The recognition comes too late to save him, and he dies refusing every form of compromise except the deception he maintained for Christian and Roxane.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -920,7 +920,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -933,7 +933,7 @@
       "recaps": {
         "ending": "Fifteen years after Christian's death, Roxane lives in a convent and still mourns him, preserving the last letter she believes he wrote. Cyrano visits her each week, but on this day an enemy has arranged for a heavy object to be dropped on him, leaving him mortally injured. He reaches Roxane anyway and asks to read the letter. Although darkness has fallen, he recites it without needing the page. Roxane recognizes the voice that spoke beneath her balcony and understands that Cyrano wrote the letters and supplied the love she had attributed to Christian. She also realizes that Cyrano has loved her throughout the intervening years. He has concealed both the authorship and his feelings to protect Christian's memory. As Cyrano weakens, Le Bret and Ragueneau arrive, and he imagines fighting the falsehood, compromise, and cowardice he opposed all his life. He dies beside Roxane, claiming only the integrity and independent spirit he has kept unstained.",
         "in_short": "Cyrano de Bergerac is a brilliant poet and soldier who believes his large nose makes him unlovable. When his cousin Roxane confesses that she loves the handsome cadet Christian, Cyrano agrees to protect him. Christian cannot express the eloquence Roxane admires, so Cyrano secretly writes his letters and speaks for him beneath her balcony. Roxane marries Christian, and the men go to war. At Arras, Roxane says the letters have made her love Christian's soul regardless of his appearance. Christian realizes she truly loves Cyrano's words and asks him to reveal the truth, but dies before Cyrano can do so. Cyrano keeps their secret. Fifteen years later, mortally wounded, he visits the widowed Roxane and recites Christian's last letter from memory. She finally recognizes Cyrano as the author and understands his lifelong love. The recognition comes too late to save him, and he dies refusing every form of compromise except the deception he maintained for Christian and Roxane.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1087,7 +1087,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1100,7 +1100,7 @@
       "recaps": {
         "ending": "Fifteen years after Christian's death, Roxane lives in a convent and still carries the final letter she believes he wrote. Cyrano, now poor and surrounded by enemies, is mortally injured in a staged accident but keeps his customary visit to her. He asks to read the letter and continues after darkness has made the page invisible. Roxane finally understands that the voice beneath her balcony, the letters she loved, and the feeling behind them were Cyrano's. He confirms the truth without claiming Christian's place in her memory. As his strength fails, his friends arrive and reveal the seriousness of his wound. Cyrano imagines fighting the falsehood, compromise, and cowardice he has opposed throughout his life. He dies beside Roxane, insisting that one possession remains beyond defeat: his integrity and proud independence.",
         "in_short": "The brilliant swordsman and poet Cyrano loves his cousin Roxane but is ashamed of his large nose. When she confides that she loves the handsome cadet Christian, Cyrano agrees to protect him and supplies the eloquence Christian lacks. Cyrano writes Christian's love letters and speaks for him beneath Roxane's balcony, winning her heart while hiding his own. Roxane and Christian marry, but de Guiche sends the cadets to war. At Arras, Christian realizes that Roxane now loves the mind revealed in the letters and urges Cyrano to tell her the truth; he is killed before Cyrano can do so. Cyrano preserves the secret for fifteen years. Mortally wounded, he visits the widowed Roxane and reads Christian's last letter from memory in the dark. She recognizes at last that Cyrano was the voice and soul she loved. He dies after refusing pity or compromise, leaving Roxane to mourn both men and the love concealed between them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1230,7 +1230,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1243,7 +1243,7 @@
       "recaps": {
         "ending": "The Path of Elders gives Spensa the answer she went into the nowhere to find: the delvers were once people, an ancient civilization that moved itself wholly into the nowhere, lost individuality and time along with its bodies, and became a single vast awareness that experiences the noise of living minds in the somewhere as pain. Chet is revealed to be a piece of that awareness, a fragment that broke away long enough ago to have taken on a human shape and a human personality, and he has been Spensa's companion without either of them understanding what he was. Winzik's forces, meanwhile, have been working in the nowhere to make the delvers usable as weapons. Spensa goes to the lightburst at the heart of the nowhere and confronts the delvers directly, forcing them to see her as a person rather than as noise. She gets out, but not without cost: M-Bot sacrifices himself so that she can escape, giving up the body he had left, and Chet merges with her, becoming part of her mind and leaving her stronger and stranger than she was. Spensa returns to the somewhere carrying the truth about the delvers, a piece of one inside her, and the grief of what the trip cost, and finds her friends at war and Winzik's plan already in motion.",
         "in_short": "Determined to learn where delvers come from and how to stop Winzik using them, Spensa deliberately enters the nowhere, the dimension cytonics pass through when they hyperjump. It is a place of drifting fragments of the real universe, ruled by pirate crews and slowly eroding the memories of everyone in it. Stranded and losing pieces of herself, Spensa falls in with an exuberant human explorer called Chet and is taken into a pirate crew, the Broadsiders, while Winzik's forces work openly in the nowhere on a way to weaponize delvers. Following a chain of ancient portals called the Path of Elders, she learns that the delvers were once a living civilization that transplanted itself into the nowhere and lost its individuality, and that it hears living minds as unbearable noise. Chet turns out to be a fragment of a delver that broke away and took human form. Spensa confronts the delvers at the heart of the nowhere and escapes, but M-Bot sacrifices himself to get her out, and Chet becomes part of her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1382,7 +1382,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1395,7 +1395,7 @@
       "recaps": {
         "ending": "After graduation, Judy supports herself by writing and continues to see Jervis Pendleton. When he asks her to marry him, she refuses despite loving him because she has never told him that she was raised in an orphanage and fears the difference in their backgrounds. Ill and unhappy, Jervis withdraws. Judy finally receives an invitation to meet her long-anonymous benefactor. At the meeting she discovers that Jervis himself is Daddy-Long-Legs: the trustee who funded her education has also been the man she came to love. His secretary's interventions and his knowledge of her life now make sense, as does some of the jealousy behind the benefactor's past decisions. With the secret on both sides removed, Judy accepts Jervis. Her final letter is addressed to him with affection and gratitude, but from the position of a woman who has completed college, begun a writing career, and found a family rather than remaining a dependent child.",
         "in_short": "Jerusha Abbott leaves the orphanage where she was raised when an anonymous trustee offers to fund her college education in exchange for monthly letters. Calling her unseen benefactor Daddy-Long-Legs, she renames herself Judy and writes him lively accounts of classes, friends, holidays, and her growing ambition to become an author. Her roommates Sallie McBride and Julia Pendleton introduce her to family and social life, while Julia's uncle Jervis becomes Judy's close friend and eventually the man she loves. The trustee sometimes controls Judy's plans through his secretary but never answers her longing for a personal connection. After graduation, Judy refuses Jervis's proposal because she is ashamed to reveal her orphanage past. Summoned at last to meet her benefactor, she discovers that Jervis and Daddy-Long-Legs are the same person. Their concealed histories resolved, they are free to marry, and Judy closes her correspondence as an educated, working writer with a home of her own choosing.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1467,7 +1467,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1480,7 +1480,7 @@
       "recaps": {
         "ending": "After being rescued from the Pacific, the narrator can find no public record of the upheaval that exposed the strange seabed. A scientist dismisses his questions, while his own study of the ancient god Dagon strengthens his fear that immense sea-dwelling beings survive beneath the oceans and may one day rise. Morphine no longer suppresses the memory. As he finishes his written account before an intended fatal plunge from his window, he hears a heavy sound at the door and then the movement of a large body. The final lines break off as he reacts to something at the window, leaving it uncertain whether a creature has truly found him or terror has overwhelmed him.",
         "in_short": "During the First World War, an unnamed merchant-ship supercargo escapes a German captor in a small boat and drifts across the Pacific. He awakens after a violent disturbance to find his boat stranded on a vast, foul expanse of seabed that has abruptly risen above the water. Crossing it on foot, he reaches a chasm containing an ancient monolith carved with aquatic humanoids and encounters an immense living sea creature beside it. He flees in terror and later wakes aboard a rescuing ship. No one confirms what he saw, and neither scientific inquiry nor study of ancient sea-god traditions gives him relief. Addicted to morphine and convinced that beings from the ocean depths threaten humanity, he records the experience before planning his death. Sounds at his door and window interrupt the manuscript, suggesting either that the horror has followed him or that his fear has finally consumed him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1624,7 +1624,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1637,7 +1637,7 @@
       "recaps": {
         "ending": "At the Chicago show, Camila separately confronts Daisy and Billy about the feelings they refuse to resolve. Daisy recognizes that remaining near Billy will destroy the life he has chosen and that her own marriage and drug use are endangering her. She performs with the band one last time, then leaves. Karen ends her pregnancy and her relationship with Graham because she does not want the domestic future he desires. The group cancels the rest of the tour and never plays together again. Daisy becomes sober, adopts children, and builds a quieter life; Billy keeps his promise to Camila, remains sober, and raises their daughters with her until her death. The others continue in and around music on separate paths. The unnamed interviewer is revealed as Billy and Camila's daughter Julia, who has assembled the history after her mother's death. Camila's final message encourages Billy to contact Daisy if he is ready, leaving open the possibility that the two surviving collaborators may speak again without undoing the family life Billy and Camila shared.",
         "in_short": "Daisy Jones grows from a neglected Los Angeles teenager into a gifted singer-songwriter while Billy Dunne leads the Six from Pittsburgh clubs toward national success. Producer Teddy Price pairs them for a single, then makes Daisy a permanent member. Their creative friction and powerful attraction drive the album Aurora to enormous success, but Billy's hard-won sobriety, marriage to Camila, and fear of repeating his past keep him from acting on his feelings. Daisy marries Nicky, whose presence worsens her drug use, while Graham and Karen conduct a private relationship that founders when they want different futures. During the Aurora tour, Daisy sends Nicky away and begins seeking help, but the strain within the band peaks in Chicago. Daisy quits, the Six disbands, and Billy returns fully to his family. Decades later, the oral history is revealed to have been compiled by Billy and Camila's daughter Julia after Camila's death, along with Camila's invitation for Billy to reconnect with Daisy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1771,7 +1771,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1784,7 +1784,7 @@
       "recaps": {
         "ending": "Winterbourne finds Daisy and Giovanelli together at the Colosseum late at night, despite the danger of malaria. He decides that her presence there proves she is indifferent to social judgment, though he still urges her to leave immediately. Daisy soon becomes gravely ill with Roman fever. Before dying, she asks her mother to tell Winterbourne that she was never engaged to Giovanelli, showing that his opinion mattered to her. At the funeral, Giovanelli insists that Daisy was innocent and says he had no expectation of marrying her. Winterbourne later admits to Mrs Costello that he made a mistake and had lived too long away from America to understand Daisy fairly. Nevertheless, he resumes his life in Geneva, where rumor again associates him with a foreign woman. His recognition comes too late to change Daisy's fate or his own settled habits.",
         "in_short": "At Vevey, the Europeanized American Frederick Winterbourne meets Daisy Miller, a wealthy young tourist whose openness and disregard for chaperonage intrigue him. They visit Chillon alone, a choice that makes Winterbourne's aunt refuse to meet her. Months later in Rome, Daisy spends much of her time with the Italian Giovanelli and rejects warnings from Winterbourne and Mrs Walker that public opinion is turning against her. Winterbourne cannot decide whether her conduct reflects innocence or impropriety. He finally sees Daisy with Giovanelli at the malaria-ridden Colosseum at night and judges her harshly. Daisy contracts Roman fever and dies soon afterward, leaving a message that she was never engaged to Giovanelli. Giovanelli affirms her innocence. Winterbourne realizes that his reliance on social categories kept him from understanding her, but returns to his conventional life in Geneva.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1967,7 +1967,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1980,7 +1980,7 @@
       "recaps": {
         "ending": "Daniel learns that his mother, the Princess Halm-Eberstein, rejected the Jewish identity and domestic role imposed on her, entrusted him to Sir Hugo, and arranged for him to be raised as an English gentleman. The knowledge answers his doubts about his birth and lets him embrace the Jewish vocation Mordecai has imagined for him. Mordecai is revealed as Mirah's lost brother Ezra; the siblings are reunited, and Daniel protects Mirah from their exploitative father. After Grandcourt drowns during a sailing trip, Gwendolen admits to Daniel that she had wished for his death and hesitated before throwing him a rope, though she then tried to save him. Daniel urges her to live responsibly rather than define herself by that moment. He and Mirah confess their love and marry. Mordecai dies in their presence, entrusting Daniel with his ideas. Daniel and Mirah prepare to travel east and work toward a Jewish national and cultural renewal. Gwendolen receives the news of their marriage painfully but sends them a blessing and resolves to become more useful to others. Her moral future remains open, while Daniel leaves England with an identity, partner, and purpose he has chosen.",
         "in_short": "Gwendolen Harleth, proud and hungry for freedom, loses her family's security and marries the wealthy Henleigh Grandcourt despite a warning from Lydia Glasher, his discarded mistress. The marriage becomes a regime of quiet domination, and Gwendolen turns to Daniel Deronda for moral support. Daniel, uncertain of his birth, rescues the Jewish singer Mirah from suicide and helps her search for her family. His encounters with the visionary Mordecai awaken an interest in Jewish history and national renewal. In Genoa Daniel's estranged mother reveals that he is Jewish and that she gave him up to escape the identity and obligations forced on her. Mordecai proves to be Mirah's brother. Grandcourt drowns after falling from a boat; Gwendolen, who had imagined his death, is tormented by having hesitated before trying to save him. Daniel counsels her toward a better life but loves Mirah. Daniel and Mirah marry and plan work in the East. Mordecai dies after passing his mission to Daniel, and Gwendolen, saddened but grateful, begins an uncertain moral renewal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2179,7 +2179,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2192,7 +2192,7 @@
       "recaps": {
         "ending": "Dionysophanes recognizes the tokens left with Daphnis and accepts him as the son he exposed during a period when he believed his family was already too large. Daphnis is restored to his wealthy birth family but insists that he will marry Chloe. Her own tokens are presented at a feast in Mytilene, where Megacles recognizes the daughter he abandoned after losing his fortune. With both foundlings' identities established and both families consenting, Daphnis and Chloe marry. They choose a country life rather than abandoning the pastoral world in which they grew up, honor the gods who protected them, and raise children of their own. Their wedding completes the movement from innocent companionship through repeated separations to an acknowledged and socially secure union.",
         "in_short": "Daphnis and Chloe are found separately as infants on Lesbos, each nursed by an animal and left with tokens of an unknown birth. Adopted by neighboring herding families, they grow up together and fall in love without understanding their feelings. Rival suitors, pirates, raiders, winter, and their own innocence repeatedly keep them apart, while the gods of the countryside protect them. Daphnis gradually learns what love entails but remains committed to Chloe. When wealthy visitors arrive at the estate, Daphnis's tokens reveal that he is the lost son of Dionysophanes. Chloe is then abducted by a rejected suitor and rescued, and her tokens identify her as the daughter of Megacles. With both young people recognized by their birth families, they marry and choose to continue a rural life together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2407,7 +2407,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2420,7 +2420,7 @@
       "recaps": {
         "ending": "Mercury is lost. Atalantia's forces break the last Republic positions and the Free Legions are destroyed as a fighting force, killed, scattered or captured. Darrow survives the ruin of the army he built, but alone, cut off from Sevro, from Virginia, and from any means of continuing the war. Lysander au Lune ends the book transformed: no longer a hostage or an heirloom, he has claimed his grandmother's name and standing, proven himself in the field, removed the rivals who stood between him and primacy, and become the figure the Society's survivors are prepared to follow, with ambitions Atalantia will not be able to contain. On Luna the Republic has been gutted from within by a campaign of terror the Rim's Fear Knight, Atlas au Raa, designed: the Senate is broken, the Obsidians have risen, the Syndicate has fought a war in the streets, and Virginia is left governing wreckage. Ephraim ti Horn is dead, having spent his life to free the two abducted children. Volga is gone, marked by the same night. Lyria has survived a city that tried repeatedly to kill her. The Solar Republic that opened the book as a strained but functioning state closes it wounded, leaderless in the field, and facing a Gold cause that is stronger, more unified and better led than at any point since the revolution.",
         "in_short": "Cut off on Mercury after the Gold armada destroys the fleet that carried them, Darrow and his Free Legions fight a losing guerrilla war against Atalantia au Grimmus, and Darrow's methods grow steadily more terrible as his options narrow. On Luna, Virginia's Republic is dismantled from inside by orchestrated terror, a populist revolt, a criminal Syndicate and a risen Obsidian nation, and the hidden architect of much of it is the Rim's Fear Knight, Atlas au Raa. Ephraim ti Horn, who sold the two abducted children, spends the book trying to undo it and dies buying their freedom; Lyria survives the ruin of the capital. Lysander au Lune leaves his captivity on Io, joins the Gold cause, and by the end has made himself its most compelling figure. Mercury falls, the Free Legions are annihilated, and Darrow survives alone and separated from everyone he loves, while the Republic is left crippled and the Golds ascendant.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2654,7 +2654,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2667,7 +2667,7 @@
       "recaps": {
         "ending": "The rescue works. Valkyrie, Fletcher and the Dead Men cross into the Faceless Ones' world and bring Skulduggery back, and he is himself again, or close enough, after a long stretch alone with the dark gods that he refuses to describe. Thurid Guild's grip on the Sanctuary does not survive the case: what he had been hiding comes out, he is removed as Grand Mage, and a new Council takes over, with Erskine Ravel as Grand Mage and Ghastly Bespoke and Madame Mist as his Elders, which puts a friend of Skulduggery's in charge for the first time in years. Billy-Ray Sanguine is still at large. The Torment is dead, killed by the figure in Lord Vile's armour, and that is the thread nobody can close: Vile is back after a lifetime, he is killing again, and no one can say who is inside the armour or why he has returned now. Valkyrie has also kept something to herself. She is training as a Necromancer alongside her Elemental magic, Solomon Wreath's order believes she may be the Death Bringer of their prophecies, and Skulduggery is not going to like any part of that when he finds out.",
         "in_short": "Months after Skulduggery was dragged through the portal at Aranmore Farm, Valkyrie is still trying to get him back, while the Irish Sanctuary's new Grand Mage, Thurid Guild, forbids any rescue and treats her as a threat. She is also quietly training in Necromancy with Solomon Wreath, whose order believes she may be the Death Bringer they have been waiting for. Working with Tanith, Ghastly, China and the Teleporter Fletcher Renn, and forcing the cooperation of the killer Billy-Ray Sanguine, Valkyrie assembles the means to cross dimensions and reunites the Dead Men, Skulduggery's unit from the war. They cross into the Faceless Ones' dead world, find Skulduggery and bring him home. Meanwhile the armour of Lord Vile, a Necromancer general missing since the war, has a wearer again, and its return leaves bodies behind it, including the Torment's. Guild's secrets come out and he is removed; Erskine Ravel becomes Grand Mage with Ghastly and Madame Mist as Elders. Skulduggery is back, and nobody knows who Lord Vile is.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2819,7 +2819,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2832,7 +2832,7 @@
       "recaps": {
         "ending": "Jason finally reaches the Chicago he came from, but the physicist who abducted him has been living as Daniela's husband and Charlie's father. After Jason convinces Daniela of the truth, they flee with Charlie. The situation expands beyond a contest between two men: many versions of Jason have reached the same world, all branching from choices made by the abducted Jason while navigating the box, and each believes he is entitled to return to his family. Violence among the alternates makes remaining in Chicago impossible. The other Jason ultimately gives Daniela and Charlie the means to escape and helps hold back the competing versions. Jason, Daniela, and Charlie enter the box together. To avoid making the destination another expression of Jason's desires, Jason lets Charlie choose and imagine the world they will enter. The family steps into a peaceful new reality, leaving their original world and the surviving alternate Jasons behind; the exact future awaiting them remains unknown, but they face it together.",
         "in_short": "Chicago physics professor Jason Dessen is abducted and sent through a quantum device into a reality where he became a renowned scientist instead of marrying Daniela and raising their son, Charlie. His alternate self built the device, found Jason's happier domestic life, and stole it. Jason escapes into the device's corridor with psychologist Amanda Lucas, learning that each door opens onto a world shaped by possibility and the traveler's mental state. After dangerous failures, he reaches his own Chicago and exposes the impostor to Daniela. But every choice Jason made in the corridor produced further versions of him, and many also arrive seeking the same family. Jason, Daniela, and Charlie flee a growing conflict among the alternates. The other Jason eventually helps them reach the box with a supply of the drug needed to use it. Together they leave their original reality, and Charlie chooses the new world, giving the family a chance to begin again beyond the rival Jasons' reach.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3015,7 +3015,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3028,7 +3028,7 @@
       "recaps": {
         "ending": "Roland, Eddie, Susannah, Jake, and Oy escape Lud aboard Blaine's monorail. Blaine has used the city's failing systems to destroy what remains behind them and is carrying the group along the Path of the Beam through the Waste Lands. He reveals that his mind is deteriorating and that he intends to end his existence by derailing the train, killing all of them as well. He offers one chance: they may pose riddles, and he will spare them if they can ask one he cannot solve. The ka-tet begins the contest using the riddles they learned in River Crossing, but Blaine answers them easily. Elsewhere, the wounded Tick-Tock Man survives Jake's attack and is found by a man calling himself Richard Fannin, an identity of Randall Flagg, who recruits him. The novel ends during the riddle contest, with the travelers still aboard the speeding train and no successful answer to Blaine's challenge yet found.",
         "in_short": "Roland, Eddie, and Susannah follow the Path of the Beam after defeating the giant mechanical bear Shardik. Roland and Jake Chambers are both being driven toward madness by conflicting histories created when Jake's original death was prevented. Guided by linked visions, Eddie carves a key and the group opens a doorway that draws Jake from New York into Mid-World, resolving the paradox. Jake joins the ka-tet and befriends the billy-bumbler Oy. After visiting River Crossing, the travelers reach the decaying city of Lud, where Gasher kidnaps Jake for the Gray leader known as the Tick-Tock Man. Oy and Eddie help rescue him while Roland and Susannah make contact with Blaine, the city's powerful artificial intelligence. The reunited group escapes aboard Blaine's monorail, but Blaine announces that he plans to destroy himself and them. He will relent only if they can defeat him in a riddle contest, which is still underway when the book ends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3248,7 +3248,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3261,7 +3261,7 @@
       "recaps": {
         "ending": "Roland finishes the story of Mejis: his young ka-tet defeated Jonas and the forces transporting oil for Farson, but Susan was captured and burned by the townspeople while Roland watched helplessly through the pink glass. The sphere later showed him a trap involving his mother, and after returning to Gilead he mistakenly shot and killed her when Rhea's image appeared to him. In the present, Roland, Eddie, Susannah, Jake, and Oy reach an emerald palace modeled on the story of Oz. The Tick-Tock Man serves as its false wizard and dies when the deception is exposed. Randall Flagg, linked to Walter and Marten from Roland's past, confronts the group through the palace's machinery but withdraws rather than face them directly. He leaves behind the pink glass, which tries to entice members of the ka-tet with private visions. They reject it, and the palace and sphere disappear. After hearing the full burden of Roland's past, his companions choose to continue with him. The ka-tet resumes its journey along the Path of the Beam toward the Dark Tower.",
         "in_short": "Eddie defeats Blaine by using irrational jokes that the supercomputer cannot process, allowing the ka-tet to survive in a version of Kansas devastated by a plague. As they follow the Beam, Roland tells of his youth in Mejis with Cuthbert Allgood and Alain Johns. There he fell in love with Susan Delgado, who had been promised to an elderly mayor, while uncovering a plan to supply rebel John Farson with oil. The young gunslingers destroyed the convoy and defeated Eldred Jonas's men, but Susan was captured and burned after the witch Rhea turned the town against her. Roland became trapped by the pink Wizard's Glass and later accidentally killed his mother. In the present, the ka-tet reaches an emerald palace where the surviving Tick-Tock Man and Randall Flagg stage a false wizard's court. Tick-Tock is killed, Flagg escapes, and the glass disappears after failing to divide the group. Roland's companions accept his history and continue with him toward the Tower.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3612,7 +3612,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07DF79K2D",
@@ -3624,7 +3624,7 @@
       "recaps": {
         "ending": "The Dark World campaign closes with the orbital factory lost, the surviving ground force given a route home, and the hive queen dead. McGill destroys the enemy-held installation, and his recordings prove that the Iron Eagles were already dead. Drusus clears him. Galina Turov restores McGill to centurion, makes Primus Graves senior primus, and remains in command of Legion Varus. Winslade becomes a primus but transfers to hegemony service. Drusus later demotes Tribune Deitch and assigns her permanently to guard duty on Machine World. The unequal treatment of Blood World troops remains unresolved.\n\nFlorimel verifies that The Eaters of Lotus conceals a formula for spores lethal to Magwa tissue. Claver obtains the physical book, apparently after Etta finds it at McGill's home and trades it to him. McGill kills the visiting Claver body, but the clone network survives, and Etta leaves for Dust World. McGill conceals her apparent role and persuades Galina Turov that he sent her away for protection. Galina Turov withdraws a hidden arrest detail but intends to recover the book and destroy its secrets. Central retains the formula, Claver holds the book, and Etta remains beyond McGill's immediate reach.",
         "in_short": "James McGill joins Legion Varus in a covert attempt to seize an alien-built orbital factory near Dark World. Rivalry between Galina Turov and Tribune Deitch turns the occupation into a two-legion disaster. McGill exposes hidden losses, brings reinforcements, severs the enemy link, and helps make captured troops eligible for revival through bombardment. After Varus kills a hive queen, an enemy fleet takes the factory. McGill secures an escape route, destroys the captured installation, defeats the resulting charge, and regains centurion rank. Florimel then verifies that The Eaters of Lotus contains a spore formula lethal to the Magwa. Claver obtains the book, apparently through Etta, and his clone network survives McGill killing one body. Etta leaves for Dust World. McGill conceals her role from Galina Turov, who wants the book recovered and its secrets destroyed. Drusus demotes Tribune Deitch to permanent guard duty on Machine World.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3841,7 +3841,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3854,7 +3854,7 @@
       "recaps": {
         "ending": "Jesse's remains are found in the Ackermans' backyard and given a proper burial, and the murder that kept him here is finally uncovered: Maria de Silva, who did not want to marry the cousin she was engaged to, had Felix Diego kill him in the boarding house that became Suze's home, and the two spent a century and a half keeping it quiet. Maria and Diego are driven off for good, and Suze is seriously hurt doing it. With his death accounted for and his body at rest, nothing is holding Jesse here, and Suze has to face losing him. He does not go. Jesse chooses to stay, and the reason is Suze, which neither of them knows what to do with, and which changes nothing about the fact that one of them is dead. Jack Slater leaves at the end of the summer no longer frightened of what he can see and knowing he is not the only one. Paul Slater leaves too, making it clear he intends to come back, and that he knows a great deal more about what people like them can do than Father Dominic has ever told her.",
         "in_short": "Suze takes a summer job minding Jack Slater, a frightened boy staying at a Pebble Beach resort, and quickly realizes he sees the dead as she does. His older brother Paul does too, calls people like them shifters rather than mediators, and claims to know far more about the ability than Father Dominic. Meanwhile Suze's stepfather starts excavating the backyard for a hot tub, and the ghost of Maria de Silva, a nineteenth-century woman engaged to her cousin Hector, appears to demand the digging stop. Research reveals that Hector, who supposedly vanished in 1850, is Jesse: he was murdered in the house on Maria's orders by Felix Diego, the man she married instead, and buried in the yard. Maria and Diego attack to keep it hidden, and Suze is badly hurt driving them out. Jesse's remains are found and buried properly, freeing him to move on, and he stays instead, for Suze. Paul leaves promising to return.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4018,7 +4018,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4031,7 +4031,7 @@
       "recaps": {
         "ending": "The murderer takes Deborah to the shipping container where Dexter and his older brother witnessed their mother's killing as small children. Dexter recovers the central memory that shaped his violent urges. The killer reveals himself as Brian, Dexter's biological brother, and invites Dexter to join him by killing Deborah. Dexter does not kill his foster sister or accept Brian's invitation. LaGuerta follows them and is killed by Brian during the confrontation. Brian escapes rather than being captured, leaving open the possibility of his return. Deborah survives and now knows what Dexter is, but she does not expose him. In the aftermath, Dexter resumes his outwardly normal work and relationships under a new uncertainty: his sister possesses his secret, Doakes remains suspicious, and his newly discovered brother is still alive.",
         "in_short": "Dexter Morgan works as a blood-spatter analyst for Miami police while secretly murdering killers according to rules taught by his foster father, Harry. A murderer begins leaving bloodless, dismembered bodies around the city, and Dexter feels that the precise displays are messages intended for him. He helps his foster sister Deborah investigate, while the official case pursues weak suspects and Dexter experiences buried childhood memories. The killer eventually abducts Deborah and draws Dexter to the shipping container where Dexter's mother was murdered before him as a child. He is Brian, Dexter's biological older brother, shaped by the same trauma but never guided by Harry's code. Brian urges Dexter to kill Deborah and join him, but Dexter does not kill her. Brian kills Detective LaGuerta during the confrontation and escapes; Deborah survives knowing Dexter's secret but keeps it. Dexter returns to his constructed ordinary life with his brother at large and Sergeant Doakes still distrustful of him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4200,7 +4200,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4213,7 +4213,7 @@
       "recaps": {
         "ending": "After the near-fatal attempt to pass Gibraltar, the crew repairs the flooded and disabled submarine on the seabed and succeeds in bringing it back to the surface. The return through the Atlantic is a passage home by men who have already exhausted much of their physical and emotional reserve. They finally enter La Rochelle and receive the formal welcome due a boat that has survived its patrol. Safety lasts only moments. An Allied air raid strikes the base, killing and wounding members of the crew and sinking the submarine at its berth. The correspondent survives the attack and sees the captain collapse as the boat goes down in the harbor. The ending denies the patrol any triumphant meaning: skill and endurance brought the men home, but neither could protect them from the larger war once they arrived.",
         "in_short": "A German naval correspondent joins an Atlantic U-boat patrol in late 1941 and records life under an experienced, skeptical captain. Long stretches of boredom, overcrowding, bad air, and violent weather are broken by attacks on convoys and terrifying hunts by Allied escorts. The crew torpedoes ships but is repeatedly driven deep by depth charges, making survival depend on discipline and the engineers' ability to keep failing machinery alive. After refueling covertly in neutral Spain, the captain is ordered through the heavily defended Strait of Gibraltar toward Italy. The attempt ends with the submarine crippled and lying on the seabed, but the crew makes extraordinary repairs and escapes. They return to La Rochelle only to be caught in an air raid at the base. Men who survived the patrol are killed, and the U-boat sinks in harbor as the correspondent watches the captain fall.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4415,7 +4415,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4428,7 +4428,7 @@
       "recaps": {
         "ending": "Mara survives the Minwanabi trap and turns it. Attending the Warlord's celebration at Lord Jingu's own estate, protected only by the guest-right that Tsurani custom makes absolute, she is hunted through the house by his agents; Papewaio is killed defending her. Rather than fleeing, Mara forces the matter into the open in front of the Warlord and the assembled nobility, and demonstrates that Jingu attempted murder under his own roof. The dishonour is total and public, and Jingu takes his own life. His son Desio inherits the Minwanabi with their alliances weakened and their standing damaged, and swears a blood oath to his god that he will destroy the Acoma. Mara goes home the acknowledged victor of the season's Game. In one year she has taken a house of a few dozen soldiers and rebuilt it into a power with thousands of men, a cho-ja hive, an intelligence network under Arakasi, and a reputation nobody expected. She rules for her infant son Ayaki, whose Anasati blood obliges Lord Tecuma to protect him even though Tecuma will never forgive her for his son's death. The war beyond the rift continues, the Warlord's grip on the Empire is unchallenged, and the feud that has consumed both houses for generations is not over. The story continues in Servant of the Empire.",
         "in_short": "Mara, seventeen and about to take vows as a temple novice, is called home when her father and brother are killed on the barbarian world in a battle engineered by the Minwanabi, leaving her Ruling Lady of a house reduced to a handful of soldiers. Guided by her old nurse Nacoya and her Force Commander Keyoke, she rebuilds by breaking Tsurani convention: she recruits masterless grey warriors, bargains with a cho-ja queen for a hive on Acoma land, and takes the spymaster Arakasi into her service. To gain protection she marries Buntokapi, the least promising son of the Anasati, so his family must defend her house, then manoeuvres him into a position where honour leaves him no choice but to take his own life, leaving her ruling for their infant son. Finally she attends the Warlord's celebration at the Minwanabi estate, where her enemy Lord Jingu means to kill her without breaking guest-right. Papewaio dies protecting her, but Mara exposes Jingu's treachery before the Empire and he is forced to take his own life, leaving his son Desio sworn to destroy her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4639,7 +4639,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4652,7 +4652,7 @@
       "recaps": {
         "ending": "Uriah Heep's fraud is exposed, allowing Mr Wickfield and Betsey Trotwood to recover much of what he took from them. Dora dies after a long decline, and David later loses both Ham and Steerforth when a violent storm wrecks Steerforth's ship off Yarmouth. Mr Peggotty takes Emily abroad to begin again, accompanied by the Micawbers, whose fortunes improve in Australia. David travels for several years and gradually understands that Agnes has always been the person he trusts and loves most. He returns, declares his love, and marries her. The closing retrospect finds David established as a writer and surrounded by family and enduring friends, with Agnes beside him as the moral center of the home he once lacked.",
         "in_short": "David Copperfield recounts a life shaped by early cruelty, loyal friends, mistaken admiration, and gradual self-knowledge. After his widowed mother marries the harsh Edward Murdstone, David is sent to a brutal school and then to child labor in London. He escapes to his aunt Betsey Trotwood, receives an education, and begins a career. He idolizes the charming Steerforth, loves and marries the childlike Dora, and overlooks the quiet devotion of Agnes Wickfield. Steerforth's betrayal of Emily devastates the Peggotty family, while Uriah Heep gains control over Mr Wickfield through manipulation and fraud. The Micawbers help expose Heep, but David then loses Dora, Ham, and Steerforth. After travel and reflection, he recognizes Agnes as his true partner. They marry, Mr Peggotty and Emily make a new life in Australia, and David becomes a successful author with a secure family of his own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4868,7 +4868,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -4881,7 +4881,7 @@
       "recaps": {
         "ending": "Jiran enters Markhiss's concealed settlement as a prisoner but learns to resist and drain its mana-siphoning restraints. He kills two tier-four bandits, refuses to stand aside when Markhiss orders Dommell's execution, and turns the cage's stored power against the settlement. The cage disintegrates, leaving Oliviala LeCruex, Dommell, and the third captive free but unconscious, while Jiran's attack destroys the barrier hiding the settlement. Markhiss remains unharmed and withdraws when a far stronger crowned emperor arrives. Lenton follows, identifies Jiran to the emperor as his disciple, and renders the injured, depleted boy unconscious. Jiran has survived at tier two with above-cap attributes, Foresight, several elemental techniques, and an active Challenger timer, but the origin and cost of these changes remain unknown. His father has begun repairing their relationship, while his mother remains estranged. Niya continues training with Samris. Markhiss escapes, the captives' recovery is not shown, and Jiran still owes army service. The ancient cube, the nature of density, Brandon's memories, Jiran's neural changes, and the curses shared by the Unique ascenders all remain unresolved.",
         "in_short": "After a disastrous first tiering leaves seven-year-old Jiran scarred, rejected by his family, and carrying memories from a dead man on Earth, the new magistrate Samris shelters and trains him. Jiran heals, develops unconventional mana control, and becomes the pupil of Lenton, another powerful ascender with a Unique curse. At tier two, Jiran gains healing and elemental techniques, discovers that his danger sense is Foresight, and acquires Challenger Density, which rewards difficult kills while feeding a dangerous urge for violence. He teaches Niya direct mana conversion, exceeds normal tier limits, and investigates an ancient elemental cube. A wilderness trial eventually leads him underground and into Markhiss's hidden slaver settlement, where Oliviala LeCruex, Dommell, and another child are imprisoned. Jiran defeats two stronger bandits, drains the captives' cage, frees them, and destroys the barrier concealing the settlement. Markhiss escapes when the emperor arrives. Lenton claims the exhausted Jiran as his disciple, but the captives' recovery and the mysteries surrounding Jiran's powers remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5019,7 +5019,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5032,7 +5032,7 @@
       "recaps": {
         "ending": "The British execute David ben Moshe, so the underground proceeds with its promised retaliation. Elisha enters the cellar before dawn and speaks with John Dawson, encountering him not as an abstract enemy but as a frightened man with a family and memories of his own. Dawson asks Elisha to send a letter to his son. When the appointed hour arrives, Elisha carries out the order and shoots him. The killing does not produce the clear transformation or justification Elisha had imagined. As night gives way to dawn, he looks toward the window and perceives the face associated with death as his own. The reprisal is complete, but Elisha must now live with the knowledge that obedience to his cause has made him a killer.",
         "in_short": "Elisha, a young Holocaust survivor recruited into a Jewish underground fighting British rule in Palestine, is ordered to kill the captured officer John Dawson at dawn. Dawson is being held in response to the British death sentence imposed on underground fighter David ben Moshe: if David dies, Dawson will die as well. Elisha spends the night with Gad, Ilana, Joab, and Gideon, revisiting the dead who shaped him and trying to understand what the act will make of him. The British refuse clemency and execute David. Before carrying out the reprisal, Elisha talks with Dawson in the cellar and recognizes the ordinary human life behind the category of enemy. He nevertheless shoots him at dawn. Looking at the window afterward, Elisha sees the face of death as his own, recognizing that the execution has permanently implicated him in the violence he serves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5122,7 +5122,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5135,7 +5135,7 @@
       "recaps": {
         "ending": "The expedition reaches the guarded island and uncovers its true secret: it hides one of the Dawnshards, ancient powers of pure Command that predate even the world's gods and could reshape reality in the wrong hands. A trusted member of the crew is exposed as a guardian devoted to keeping that secret hidden, and it moves to stop the travelers from carrying the knowledge back, terrified that the enemy god Odium could claim such a power. In the confrontation the Windrunner Lopen speaks a further oath and comes into greater strength. Rather than let the Dawnshard be lost or seized, Rysn accepts it into herself, becoming its living vessel and secret keeper, a role that changes her forever and binds her exotic pet's fate to the island's mysteries as well. The expedition survives and sails home. Rysn returns transformed, now the quiet guardian of one of the most dangerous forces in the cosmos, understanding that the war against Odium has stakes far larger than any single kingdom, and that the enemy hunts for exactly what she now carries.",
         "in_short": "The Thaylen merchant Rysn is commissioned to lead an expedition to a forbidden, supposedly dead island wrapped in legend, to learn what secret it hides. She sails with a wary ship's crew and a guard of Radiants, including the Windrunner Lopen and the archer Cord, past natural hazards and stranger defenses. Breaching the island, they discover it conceals one of the Dawnshards, primal powers of Command older and more fundamental than the gods that shape the world. A member of the crew is revealed as a hidden guardian sworn to keep the secret buried and to stop them from exposing it, fearing the enemy god could seize it. In the crisis Lopen deepens his own oaths, and Rysn makes a fateful choice: she takes the Dawnshard into herself, becoming its new secret bearer and protector. The expedition survives and returns, and Rysn quietly carries one of the most dangerous powers in existence, aware that the enemy is searching for it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5315,7 +5315,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5328,7 +5328,7 @@
       "recaps": {
         "ending": "The fairy war ends with Sookie's rescue and Niall's victory, both paid for heavily. Bill kills Neave and Eric kills Lochlan, but the fairies' blood is poison to vampires and Bill is left dying of it; he survives only because Sookie has Eric find Judith Vardamme, his sister in blood, whose blood heals him. Niall kills Breandan, then tells Sookie that the only way to stop the killing for good is to shut Faery, and closes the doors between the worlds behind him. Sookie loses her fairy godmother Claudine and her bodyguard Tray Dawson in the fighting, and is left physically maimed and badly traumatized by her captivity. Claude and Dermot are among the part-fairies stranded on the human side. In Bon Temps, Mel Hart is exposed as the man responsible for Crystal's death, and the Hotshot panthers deal with him under their own law rather than the state's. Jason is cleared and widowed. Eric's marriage to Sookie by vampire custom stands, which shields her from Felipe de Castro and Victor Madden but binds her further into vampire politics. The two-natured are now public, permanently, and Bon Temps has to decide what it thinks of that.",
         "in_short": "The world's shapeshifters and werewolves announce their existence on television, and Sam Merlotte changes shape in front of his own customers. Days later Jason's pregnant wife Crystal is found crucified in the bar's parking lot, and the search for her killer runs through the whole book alongside a far larger danger: a faction of fairies led by Breandan wants every human-blooded descendant of Prince Niall Brigant dead, and Sookie is at the top of the list. Eric marries Sookie by vampire custom to keep her out of the new Nevada regime's hands, and guards are posted around her home, but the fairies kill her protectors one by one, including her fairy godmother Claudine and the werewolf Tray Dawson. Sookie is captured and tortured by Neave and Lochlan before Niall, Bill and Eric reach her. Bill is poisoned killing Neave and is saved by another of his maker's children. Niall kills Breandan, then closes Faery entirely and says goodbye. Crystal's killer proves to be Jason's friend Mel Hart, who is executed by the Hotshot panthers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/dead-as-a-doornail.json
+++ b/data/works-community/0/dead-as-a-doornail.json
@@ -157,7 +157,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -170,7 +170,7 @@
       "recaps": {
         "ending": "Both threats turn out to have been sitting inside Merlotte's all along. The sniper is Sweetie Des Arts, the short-order cook, who was bitten by a shapeshifter years ago, became something she despises, and has been moving from town to town killing two-natured people ever since. She corners Sookie with a rifle and is killed before she can fire, and the shootings stop. Sam, Calvin Norris and the others she wounded recover. The second threat is Charles Twining, the courteous English vampire Eric lent to the bar. He set the fire at Sookie's house and he attacks her openly at the end: he was sent to Louisiana to avenge Long Shadow, the vampire Eric destroyed at Fangtasia years earlier, and killing Eric's favorite human was the closest he could get. He is destroyed. The werewolf pack ends the book under Patrick Furnan, who cheated his way through the contest; Jackson Herveaux is dead, and Alcide, who blames Sookie for not preventing it, is no longer easy company. Tara Thornton is free of Mickey, bought out of the arrangement by Eric at a price Sookie will owe. Bill is back in Bon Temps and unwelcome. The last word belongs to Eric, who tells Sookie that his memory has come back: he remembers the weeks in her house, their nights together, and Debbie Pelt dying on her kitchen floor, which means Sookie's one real secret is now shared with the most dangerous person she knows.",
         "in_short": "Sookie sees her brother Jason through his first full moon as a bitten werepanther, then finds that someone is shooting shapeshifters across the parish: Sam Merlotte is hit in the leg, Calvin Norris is wounded, and a young woman is killed. Running the bar in Sam's place, Sookie takes on a vampire bartender lent by Eric, an Englishman named Charles Twining. Her house is set on fire in the night and she barely escapes. Meanwhile the Shreveport werewolf pack loses its leader and holds a contest to replace him; Sookie is asked to witness, sees Patrick Furnan cheat, and cannot stop the contest that kills Alcide's father. Private investigators hired by Debbie Pelt's family press her about the disappearance she is responsible for, and she has to get Eric's help to free her friend Tara from a brutal vampire. Sookie works out that the sniper is Sweetie Des Arts, the bar's own cook, a woman bitten years ago who hates what she became; Sweetie is killed. Charles then attacks Sookie, revealed as an assassin avenging a vampire Eric destroyed, and is destroyed himself. Eric ends the book by telling Sookie that he remembers everything.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -338,7 +338,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -349,7 +349,7 @@
       "recaps": {
         "ending": "The Darkhallow fails. On Halloween night, with the city's dead walking, Harry disrupts the ritual that would have made one of Kemmler's disciples a god: the vast well of spiritual power is never claimed, and the storm of necromancy breaks. Grevane and the Corpsetaker fall out and fight among themselves; Grevane dies in the chaos, and Harry personally shoots the Corpsetaker after realizing the mind-swapping necromancer had stolen the body of Warden-Captain Luccio - leaving Luccio alive but permanently housed in the young body the Corpsetaker had been wearing. Cowl is buried in the collapse of his own ritual, no corpse ever confirmed. Harry's improbable cavalry is the book's signature image: using Kemmler's own methods, he animates Sue, the museum's Tyrannosaurus skeleton, and rides her into the battle with Butters drumming the polka beat that sustains the spell. The fallen Denarian Cassius dies in an earlier ambush, spitting a death curse at Harry: die alone. In the aftermath, the decimated White Council drafts Harry into the Wardens as regional commander for the central United States - the wizard cops who once watched him for a chance to execute him now issue him a gray cloak - and Luccio's own sword-forging talent is lost with her old body. Mavra's blackmail hold over Murphy is broken, Butters has found his courage, and Harry has admitted at last that the shadow of Lasciel lives in his head - an enemy inside the walls, still there as the book closes.",
         "in_short": "With Murphy away, the vampire Mavra blackmails Harry - evidence that would destroy Murphy's career against the recovery of The Word of Kemmler, the lost book of history's worst necromancer. Kemmler's surviving disciples - zombie-raising Grevane, the body-stealing Corpsetaker, and the hooded, hugely powerful Cowl - converge on Chicago to use the book for the Darkhallow, a Halloween ritual to devour the city's dead and ascend to godhood. Aided by his brother Thomas, the skull-spirit Bob (who once served Kemmler himself), his Foo dog Mouse, and the timid, polka-loving medical examiner Waldo Butters, Harry fights zombie hordes, survives the Denarian Cassius's ambush and death curse, summons the Erlking's wild hunt into his enemies' path, and finally admits the shadow of the fallen angel Lasciel has been living in his mind since Death Masks. On Halloween night he animates Sue, the museum's T. rex skeleton, rides her into battle, and breaks the Darkhallow: Grevane dies, Harry kills the Corpsetaker - who had body-swapped with Warden-Captain Luccio, leaving her in a young stranger's body - and Cowl vanishes in the collapse. The gutted White Council drafts Harry into the Wardens, and Murphy is safe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -532,7 +532,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -545,7 +545,7 @@
       "recaps": {
         "ending": "The murder case against Sookie falls apart, the group of old enemies working against her is broken up, and the danger to her is ended rather than merely postponed. Her friends and the vampires who still owe her, including Bill, Pam and Karin, are what carry her through it. Mr. Cataliades leaves her with the answer to a question she has had all her life: her telepathy is a gift he made long ago to the descendants of his friend Fintan who were born with the spark to hold it, which is why she has it and Jason does not. Eric's marriage contract with Freyda cannot be broken, and he goes to Oklahoma. He and Sookie part deliberately and finally, each understanding that the other made a choice they could not undo, and the vampire marriage between them is over. Sookie keeps her half of Merlotte's, keeps her house, and stops trying to live in the supernatural world's politics. Sam, alive because of what she spent, is the person she chooses and who chooses her, and the series closes with the two of them together and Sookie's life her own for the first time since the night a vampire first walked into the bar.",
         "in_short": "Sookie's one wish is spent, her fairy relatives are gone, and her marriage to Eric is finished in all but name while the queen of Oklahoma presses the contract that will take him away. Then Arlene Fowler, just out of prison for conspiring to kill her, turns up at Merlotte's asking for her job back and is found strangled behind the bar days later, and Sookie is arrested for the murder. The case against her is part of something arranged: a group of people who hate her, backed by money and by a bargain-maker willing to trade in favors, have set out to destroy her by law first and by force afterward. Her friends, her brother, and the vampires who still stand by her hold the line while the frame comes apart. Mr. Cataliades, a half-demon lawyer, reveals that Sookie's telepathy was his gift to her fairy grandfather's line. In the end Sookie is cleared, Eric leaves for Oklahoma for good, and Sookie makes a life with Sam.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -738,7 +738,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -751,7 +751,7 @@
       "recaps": {
         "ending": "The visit from Eric's maker ends in the woods behind Sookie's house. Alexei, past any control, has already killed Eric's day man Bobby Burnham and the vampire Felicia, and the final fight destroys both him and Appius Livius Ocella, who dies of the wounds his own child gave him. Colman, the fairy who came to avenge Claudine, dies in the same night's violence, ending that debt. Sookie is hurt again but alive, and Eric is left grieving a maker he both loved and could never refuse, with the ties to his own past finally cut. The body buried on Sookie's land is identified as Alcide's second, Basim al Saud, killed by the Long Tooth pack after he was found to be working against Alcide; the pack settles the matter internally and Sookie's land is cleared. Bill's poisoning is finally healed and he begins to recover his strength. Claude and Dermot remain in Sookie's house, Dermot still under whatever was done to his mind, and Sookie has found a place for herself as the person teaching Hunter how to live with telepathy. Victor Madden's rivalry with Eric is unresolved and getting worse.",
         "in_short": "Sookie is recovering badly from her torture when Eric's maker, the Roman vampire Appius Livius Ocella, arrives uninvited with his other child, Alexei Romanov, a boy vampire out of the murdered Russian imperial family whose mind never survived what was done to him. Alexei's presence destabilizes everything: he escapes control, kills Eric's day man and one of his vampires, and forces a hunt through the woods behind Sookie's house that ends with both Alexei and Appius destroyed. Alongside this, a body is found buried on Sookie's land and proves to be Alcide's second, Basim al Saud, killed by his own pack for conspiring against the packmaster, and a grieving fairy named Colman comes to make Sookie pay for Claudine's death and dies in the same night's fighting. Sookie's cousins Claude and Dermot settle into her house, Bill slowly heals, and Sookie begins teaching Hunter to manage his telepathy before he starts school.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -918,7 +918,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -931,7 +931,7 @@
       "recaps": {
         "ending": "Poirot reveals that Sir George Stubbs is really James Folliat, Amy Folliat's son, believed dead after a disreputable past. Amy helped give him a new identity and arranged his marriage to the wealthy Hattie. The woman seen as Lady Stubbs at Nasse House was an accomplice impersonating the real Hattie, who had been killed so James could control her fortune; the real woman's body was concealed beneath the folly. During the fete, the impostor changed clothes and left among the visitors, making Lady Stubbs appear to vanish. Marlene Tucker had learned enough from her grandfather's observations to blackmail Sir George, so he killed her in the boathouse while the murder hunt provided access and confusion. Etienne de Sousa's arrival threatened the impersonation because he knew his true cousin, which forced the conspirators' timetable. Poirot confronts Amy with the consequences of protecting her son. The false Sir George cannot preserve the identity and estate built on the murders, while Amy is left facing the ruin she tried to prevent.",
         "in_short": "Ariadne Oliver asks Poirot to attend a fete at Nasse House because the murder-hunt game she has designed feels as if it is being manipulated for a real purpose. The girl playing the victim, Marlene Tucker, is found strangled in the boathouse, and Lady Hattie Stubbs disappears as her visiting cousin Etienne de Sousa arrives. Poirot eventually connects the crime to the history of the Folliat family and the folly built on the estate. Sir George Stubbs is really James Folliat, Amy Folliat's supposedly dead son. The real, wealthy Hattie was murdered, and another woman had long impersonated her; during the fete the impostor simply changed clothes and departed among the crowd. The real Hattie's body was hidden beneath the folly. Marlene had acquired knowledge that let her blackmail Sir George, so he killed her under cover of the staged game. Etienne's arrival threatened to expose the false Hattie. Poirot's solution leaves Amy Folliat confronting the cost of having protected her son and helped sustain his assumed identity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1242,7 +1242,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CNTZNKPJ",
@@ -1254,7 +1254,7 @@
       "recaps": {
         "ending": "Omega Force stops the fortress extraction. Two of the five founders' descendants are killed, one is delivered alive to Esquarian intelligence, and the unstable prototype synth is destroyed by Lucky and 701. The impostor escapes, acquires Omega Force's contact details, and threatens retaliation, but Jason and Cage give rival syndicates and mercenary interests evidence that turns them against him. Cage disables the remote system controlling the coerced ship crew's explosive implants, although their safe evacuation is not confirmed. Lucky stays with Omega Force, while 701 plans to return to guard the Archive. Crusher gives up the public identity of Felex through a staged death, and Mazer and Morakar return home to preserve the deception. With Satora still holding its base, accounts, and equipment, Omega Force remains united aboard the Phoenix and heads for Esquarian protection, resupply, and refit.",
         "in_short": "Lucky and Cage are held by a crime financier who wants Lucky for a secret recovery operation. Jason Burke and Combat Unit 701 trace the financier's money and infiltrate his hired force, while the rest of Omega Force loses its Satora base and follows aboard the Phoenix. Lucky secures his friends' release by remaining behind, but the reunited crew discovers that the financier is an impostor seeking five syndicate founders' descendants from an ancient fortress. Omega Force stops their extraction, kills the unstable prototype synth, and sends a surviving founder's descendant to Esquarian intelligence. The impostor escapes but loses remote control over his coerced crew and is exposed to rival syndicates and mercenary guilds. Cage disrupts the crew's explosive controls, though their safe evacuation remains unconfirmed. Crusher's death as Felex is staged so he can live under his chosen identity. The displaced crew stays together and accepts Esquarian support.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1469,7 +1469,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1482,7 +1482,7 @@
       "recaps": {
         "ending": "Eric and Pam's conspiracy succeeds: Victor Madden and his entourage are lured to Fangtasia after hours and killed there, with Sookie, Bill, Mustapha, Colton, Immanuel and the Shreveport vampires all taking part. The killing is concealed rather than confessed, so Eric holds Area Five with Felipe de Castro's regent gone and the certainty that the king will eventually ask questions. Pam has lost Miriam, who died before permission to turn her ever came, and her grief is what drove the whole plot. Sandra Pelt's campaign against Sookie is broken and she is taken out of circulation, though nobody expects her to stay quiet forever. In the attic, Sookie has found her grandmother's letter and learned that her real grandfather was the fairy Fintan, along with the gift he left: a cluviel dor, a fairy love token that will grant its holder one wish, which she tells almost no one about. Dermot's curse is broken and he is himself again. The book closes on a document Sookie was never meant to see: Eric's dead maker pledged him in marriage to Freyda, the vampire queen of Oklahoma, an obligation Eric has known about and not mentioned, and which neither of them can simply refuse.",
         "in_short": "Someone throws a firebomb into Merlotte's, and Sookie's attempt to find out why runs into an old enemy's vendetta. At the same time Eric and Pam decide they can no longer live under Victor Madden, the regent Nevada placed over Louisiana, who has spent months strangling Eric's business and who refused Pam permission to turn her dying lover Miriam. Sookie is drawn into the conspiracy against him. Clearing out her attic with her fairy cousins Claude and Dermot, she finds a letter from her grandmother revealing that her real grandfather was the fairy Fintan, and with it a cluviel dor, a fairy token that grants one wish to whoever holds it. Dermot's curse is broken by a ritual the three of them perform. The plot against Victor comes to a head at Fangtasia, where he and his people are ambushed and destroyed. In the aftermath Sookie discovers papers showing that Eric's dead maker promised him in marriage to the vampire queen of Oklahoma.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1701,7 +1701,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1714,7 +1714,7 @@
       "recaps": {
         "ending": "The surviving second part does not provide a completed ending. After returning to schemes involving land, credit, and official documents, Chichikov becomes entangled in a serious forgery case and is arrested under a newly severe governor-general. In confinement he is stripped of the signs of prosperity on which his identity depends and despairs over the collapse of his position. Murazov visits him, identifies his talent and persistence as qualities wasted on fraud, and presses him to make a genuine moral change. Murazov also appeals to the authorities, while other officials continue trying to manipulate the case for money and advantage. The extant manuscript breaks off amid these efforts, with Chichikov's legal fate and promised reform unresolved. Gogol destroyed much of the continuation, so the intended completion of Chichikov's journey and the broader design of the poem cannot be recovered from the text that remains.",
         "in_short": "Pavel Chichikov arrives in a provincial town and charms its officials before visiting nearby landowners with an unusual offer: he will take legal ownership of serfs who have died since the last census but remain taxable on paper. Manilov gives them away, Korobochka sells cautiously, Nozdryov disrupts the scheme, Sobakevich bargains, and the miser Plyushkin gladly transfers many names. Chichikov plans to use these paper holdings as security and present himself as wealthy. Rumor first makes him a celebrated landowner, then turns against him when his dealings are exposed and wild theories spread about his identity; he flees. His history reveals a career built on ingratiation, accumulation, and official fraud. In the unfinished second part he resumes schemes among another group of landowners, is drawn into forged documents, and is arrested. The moralist Murazov urges him to reform, but the surviving manuscript ends before either his legal case or his moral future is settled.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1924,7 +1924,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1937,7 +1937,7 @@
       "recaps": {
         "ending": "The alliance of vampires, werewolves and local Wiccans destroys Hallow Stonebrook's coven in a running fight at their hideout. Mark Stonebrook is killed, Hallow is taken alive, and she is made to undo the spell she cast. Before that happens, Debbie Pelt lets herself into Sookie's house with a rifle. She shoots at Sookie and hits Eric, who puts himself in the way, and Sookie kills her with a shotgun. Eric disposes of the body and the truck so completely that no one will ever find them, and the two of them agree to say nothing. Then the curse is broken. Eric wakes as himself, with his thousand years and his calculation restored, and remembers nothing at all of the weeks he spent in Sookie's house: not their nights together, not the fighting, and not Debbie Pelt. He goes back to Shreveport as the sheriff he was, pays Sookie what he owes her, and is baffled by whatever it is she will not say. Jason is found alive, dumped near his own house after being held and bitten repeatedly by a werepanther, and he will change at the next full moon whether he wants to or not; who took him is still unknown. Sookie is left with a brother turning into something he did not choose, a killing nobody knows about but her, and a memory of Eric that only she carries.",
         "in_short": "Driving home on New Year's Eve, Sookie finds Eric Northman running down a dark road half naked with no memory of who he is, cursed by a coven of witches who are also werewolves and who want a share of his businesses. Pam pays Sookie to hide him at her house, where an unguarded and affectionate Eric becomes her lover. At the same time Sookie's brother Jason vanishes from his home, and the trail leads toward the closed werepanther community of Hotshot. Sookie's telepathy helps a coalition of vampires, werewolves and local Wiccans find and destroy the coven, killing Hallow Stonebrook's brother and taking Hallow alive to lift the curse. On the same night, Debbie Pelt breaks into Sookie's house to kill her, wounds Eric, and is shot dead by Sookie; Eric makes the body disappear. When the curse breaks, Eric returns to himself with no memory of any of it, including the killing and the weeks with Sookie. Jason is found alive but bitten, and will become a werepanther at the next full moon.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2123,7 +2123,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2136,7 +2136,7 @@
       "recaps": {
         "ending": "Sookie catches the truth out of another mind: the killer is Rene Lenier, Arlene's former husband and Jason's workmate. His own sister took a vampire lover, and he strangled her for it; since then he has killed local women who did the same. Maudette Pickens and Dawn Green died that way, and Sookie's grandmother died in Sookie's place, because Sookie was the woman in Bon Temps sleeping with a vampire. Rene attacks her, and she survives the assault only barely, badly injured; he is stopped, and Sookie is healed by being given vampire blood. Two things about her life are permanently changed by the night. Sam Merlotte turns out to be a shapeshifter: the stray collie that has been sleeping at her house was her boss, keeping watch over her. And the vampire world now knows exactly what she can do. Jason is cleared of the murders and released, but he is still on the wrong side of his sister and taking vampire blood as a drug. Bill returns from vampire business in New Orleans having taken on a formal position among his own kind, which will pull him away from Bon Temps more and more. Sookie is left with her grandmother's house, a vampire lover, and no way back to an ordinary life.",
         "in_short": "In small-town Bon Temps, Louisiana, telepathic barmaid Sookie Stackhouse falls for Bill Compton, a Civil War veteran turned vampire who has come home to claim his family's house, and whose mind is blessedly silent to her. Their courtship runs alongside a string of stranglings: local women who have slept with vampires are being murdered, and Sookie's womanizing brother Jason, who knew several of them, becomes the sheriff's favorite suspect. Sookie's grandmother is killed in the family kitchen, apparently in Sookie's place. Bill introduces Sookie to the vampires of Shreveport, including the ancient Eric Northman, who quickly finds uses for her gift. Reading a stray memory, Sookie realizes the murderer is Rene Lenier, who began by killing his own sister for taking a vampire lover. He nearly kills her before he is stopped, and she is saved by vampire blood. In the process she learns that her boss, Sam Merlotte, is a shapeshifter, and that her town has always held far more than she knew.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2306,7 +2306,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2319,7 +2319,7 @@
       "recaps": {
         "ending": "Rachel escapes Trent Kalamack's estate after surviving captivity and the lethal contest arranged for her while she is trapped in animal form. She learns that Trent and Jonathan are elves, a people widely believed to be gone, and that Trent's illicit work is tied to the survival of his species as well as to his criminal business. The discovery gives her knowledge that can hurt him but also makes her valuable enough that he does not simply dispose of her. Her attempt to expose him does not bring down his organization, leaving him as a powerful and ambiguous enemy. Rachel also survives Inderland Security's efforts to enforce its death contract and establishes Vampiric Charms in the church with Ivy and Jenks. Nick has become both an ally and a romantic interest, while Rachel's contact with Algaliarept leaves demon magic as a new source of danger. She ends the book independent and alive, but with Trent, the agency, vampire politics, and a demon all aware of her.",
         "in_short": "Witch and Inderland Security runner Rachel Morgan quits after months of bad assignments. Living vampire Ivy Tamwood and pixy Jenks leave with her, and the agency answers with a death contract. The three establish an independent service in an abandoned church. Seeking leverage that could keep her alive, Rachel investigates wealthy businessman Trent Kalamack for illegal biodrug activity while also tracing a missing employee. Human researcher Nick Sparagmos helps her navigate unfamiliar magic, and repeated attacks show how exposed she is outside the agency. Rachel infiltrates Trent's estate using a transformation charm but is captured and forced into a deadly animal contest. She escapes and discovers that Trent and his aide Jonathan are secretly elves and that his genetic work serves motives more complicated than profit. She cannot destroy Trent's organization, but she survives both him and the immediate contract threat. Vampiric Charms remains open, with Rachel, Ivy, and Jenks committed to their risky new partnership and demon Algaliarept now connected to Rachel's expanding magical troubles.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2513,7 +2513,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2526,7 +2526,7 @@
       "recaps": {
         "ending": "Jannalynn Hopper is exposed as the person who arranged for Kym Rowe to be sent to Eric's party, a scheme meant to discredit Eric in front of the visiting king and clear Sookie out of Sam's life; Kym's death was part of the machinery. Jannalynn does not survive the confrontation that follows, and neither, briefly, does Sam: he is killed in the fighting, and Sookie uses her one wish, the cluviel dor, to bring him back to life. It works, and it costs her everything the token might have been saved for. Eric, whose freedom from the Oklahoma marriage contract was the obvious use for a single wish, understands exactly what she chose and cannot forgive it; their marriage is effectively over from that moment even though neither of them says so outright. Niall Brigant returns from Faery and reveals that Claude has been working against Sookie and after the cluviel dor himself; he takes Claude back through the door for judgment, and Dermot chooses to go home with him, leaving Sookie's house empty of fairies. Felipe de Castro leaves Louisiana without proving anything about Victor Madden's disappearance but without being satisfied either. Sam is alive, changed by having died, and does not yet know what Sookie spent to bring him back.",
         "in_short": "Felipe de Castro comes to Shreveport with his retinue, still curious about the regent who vanished, and at a party at Eric's house a young half-fairy named Kym Rowe offers Eric her blood in front of Sookie. Hours later Kym is found dead in Eric's yard, and Eric is the obvious suspect in front of the one vampire he cannot afford to look guilty to. Sookie investigates while her marriage collapses under the contract pledging Eric to the vampire queen of Oklahoma, while her fairy cousin Claude behaves more and more strangely, and while Sandra Pelt makes one final attempt on her life. The trail behind Kym leads to Jannalynn Hopper, the werewolf enforcer dating Sam, who arranged the whole display to ruin Eric. The confrontation that ends it kills Sam, and Sookie spends her one fairy wish on bringing him back rather than on freeing Eric from Oklahoma. Niall returns to take Claude away for treachery, Dermot goes home to Faery with him, and Sookie and Eric are finished.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2612,7 +2612,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2625,7 +2625,7 @@
       "recaps": {
         "ending": "Gerardo persuades Roberto to produce the confession Paulina demands, privately supplying details from her imprisonment so Roberto can construct an account. Paulina has deliberately altered some details when speaking to Gerardo, however, and Roberto's corrections align with what she remembers, reinforcing her certainty that he was the doctor who abused her. With the deadline she set approaching, Paulina confronts Roberto with this test and insists that only genuine remorse, not performance, can save him. The immediate confrontation ends without providing a simple public verdict. Later, Paulina and Gerardo attend a concert where Schubert's quartet is being performed. The truth commission has completed work within its restricted mandate, leaving many crimes such as Paulina's outside its official account. Paulina sees Roberto in the audience, or imagines seeing him, and the three remain connected by an unresolved past that neither private vengeance nor the new state's limited justice has conclusively settled.",
         "in_short": "In a country newly returned to democracy, lawyer Gerardo Escobar joins a commission limited to investigating abuses that resulted in death. His wife Paulina, a survivor of torture and rape whom the commission cannot help, hears the voice of visiting doctor Roberto Miranda and identifies him as the physician who supervised and joined in her abuse while playing Schubert. She takes Roberto captive, conducts a private trial, and demands a full confession. Roberto denies knowing her, while Gerardo tries to prevent violence and secure his release. Gerardo gives Roberto details of Paulina's ordeal so he can make a convincing statement, but Paulina has planted false details; Roberto corrects them in ways that confirm her suspicions. The confrontation produces no clean legal resolution. In an epilogue at a concert, after the truth commission has reported within its narrow limits, Paulina sees or imagines Roberto across the hall as the music associated with her torture plays, leaving guilt, punishment, and recovery unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2826,7 +2826,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2839,7 +2839,7 @@
       "recaps": {
         "ending": "The Passage is stopped. Melancholia St Clair, made into the Death Bringer by Vandameer Craven's ritual, is beaten and taken into custody with her power broken, and Craven does not survive the collapse of his own plan. Stopping her costs Skulduggery the thing he had spent centuries burying: he puts the armour on and becomes Lord Vile again, and Valkyrie is the one who has to bring him back out of it afterwards. The secret is now hers as well, and their partnership continues on the far side of it, changed and honest for the first time. Solomon Wreath's order is left discredited, its prophecy spent, and Wreath and Valkyrie part badly. Valkyrie ends the book with a newborn sister, Alice, a broken relationship with Fletcher after he learns about Caelan, and Caelan himself dead after his obsession turned into an attempt on her life. Eliza Scorn takes her revenge on China Sorrows by burning her library to the ground, destroying the collection China built her whole life around and leaving her with nothing but her reputation. Tanith Low is still possessed and still at large, still waiting for Darquesse, and Valkyrie's sealed true name is the one thing nobody has managed to touch.",
         "in_short": "The Necromancers have waited generations for the Death Bringer, the one who will end the division between the living and the dead, and Solomon Wreath has long believed it is Valkyrie. When she refuses, the cleric Vandameer Craven turns the resentful young Necromancer Melancholia St Clair into the Death Bringer instead, and the truth of what the prophecy requires comes out: the Passage would kill a great many people to buy immortality for whoever survives it. While Skulduggery and Valkyrie work to stop the Temple, Lord Vile returns in force, and Valkyrie learns who he is. After Serpine murdered Skulduggery's wife and child, Skulduggery came back from death consumed by rage, took up Necromancy and served Mevolent as Lord Vile, killing on an enormous scale while leading the Dead Men, and none of his friends ever knew. Skulduggery has to become Vile again to beat Melancholia, and Valkyrie has to pull him back. The Passage is prevented, Craven dies, Melancholia is broken, Caelan is killed, Valkyrie and Fletcher break up, her sister Alice is born, and Eliza Scorn burns China Sorrows's library.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3045,7 +3045,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3058,7 +3058,7 @@
       "recaps": {
         "ending": "Vaillant remains in Colorado and becomes its first bishop, accepting hardship and exhausting travel as the work for which he is fitted. He dies before Latour, and news of his friend's enormous funeral leaves Latour conscious of both their different temperaments and their lifelong bond. Latour retires after decades of service, living near the cathedral he planned from native golden stone. In old age he is cared for by younger clergy and revisits memories of his journeys, Indigenous friends, and vanished companions. He dies in Santa Fe, not as a stranger defeated by the country but as a person whose identity has become joined to it. His body is placed in the cathedral. The diocese, buildings, and communities continue beyond both missionaries, while the novel closes on the archbishop's peaceful acceptance of death and the enduring shape of his work.",
         "in_short": "French priest Jean Marie Latour is sent to organize the new Catholic diocese of New Mexico, joined by his energetic friend Joseph Vaillant. They cross deserts, visit remote settlements and pueblos, confront undisciplined clergy, and learn to serve communities shaped by Mexican, Indigenous, and American histories. Latour's patient authority contrasts with Vaillant's restless missionary drive. Latour removes the defiant Padre Martínez, protects vulnerable parishioners, and builds a cathedral suited to the landscape; Vaillant ultimately carries the mission into Colorado's mining camps and becomes a bishop there. Their work is entangled with conquest, Navajo suffering, and rapid American expansion, which the church can neither control nor escape. Vaillant dies first. Latour retires in Santa Fe and dies peacefully near the cathedral, having changed the diocese while also being permanently changed by its land and people.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3189,7 +3189,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3202,7 +3202,7 @@
       "recaps": {
         "ending": "As the epidemic worsens, Aschenbach learns the truth from an English travel clerk but chooses neither to leave Venice nor to warn Tadzio's family. His restraint collapses into covert pursuit. After a disturbing dream, he lets a barber dye his hair and apply cosmetics, reproducing the false youth that had disgusted him on the voyage. Sick and exhausted, he continues following the Polish family and eats overripe strawberries in the infected city. On the nearly deserted beach, he watches Tadzio lose a struggle with another boy and then walk alone into the shallow sea. When Tadzio turns and gestures toward the horizon, Aschenbach imagines that the boy is beckoning him onward. He slumps in his chair and dies. The family departs, and the public receives news of the famous writer's death without knowing the private obsession and disintegration that preceded it.",
         "in_short": "Gustav von Aschenbach, a famous writer whose life is governed by discipline, yields to a sudden desire for travel and goes to Venice. At a hotel on the Lido he sees Tadzio, a beautiful Polish adolescent, and begins treating the boy as an embodiment of ideal form. When oppressive weather prompts him to leave, misplaced luggage gives him an excuse to return. His aesthetic admiration becomes an acknowledged infatuation, and he secretly follows Tadzio and his family. Meanwhile cholera spreads through Venice while authorities conceal it to protect tourism. Aschenbach discovers the danger but stays silent rather than risk the family's departure. Abandoning the dignity on which his public identity rests, he dyes his hair, wears cosmetics, and wanders the infected city after the boy. Ill and exhausted, he watches Tadzio from a beach chair, imagines the boy pointing him toward the horizon, and dies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3356,7 +3356,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3367,7 +3367,7 @@
       "recaps": {
         "ending": "Harry recovers the Shroud of Turin and stops Nicodemus from unleashing the plague curse he had bound to it, holding the Denarian off in a fight aboard his escaping train - Nicodemus, nearly unkillable, is driven off rather than destroyed, and remains at large. The victory is bought with Shiro's life: the old Knight traded himself to Nicodemus for Harry's freedom, endured torture without breaking, and dies of it, leaving his sword Fidelacchius in Harry's keeping until its next bearer appears. The duel with Ortega ends in treachery - Ortega breaks the terms when he loses, the duel collapses into open violence, and he fails to kill Harry; the war goes on. Susan, whose control and new strength with the Fellowship of St. Giles carried Harry through the worst of the fight, leaves Chicago again for the Fellowship's war, and she and Harry part as lovers who cannot have a life together. Marcone ends the affair in possession of the Shroud, his reasons still his own. In the final scene, at the Carpenter home, one of the Denarians' coins - Lasciel's, planted deliberately - rolls toward Michael's youngest son, and Harry slaps his bare hand over it to save the boy. He buries the coin under his lab, but the touch was enough: the fallen angel's shadow now lives in his mind, a secret he tells no one.",
         "in_short": "Harry is hired to recover the stolen Shroud of Turin just as the Red Court warlord Ortega arrives to challenge him to a formal duel to end the vampire war. Susan returns, half-turned but trained by the Fellowship of St. Giles; the three Knights of the Cross - Michael, the old swordsman Shiro, and the cheerful Russian Sanya - arrive hunting the Order of the Blackened Denarius, fallen angels in silver coins led by the two-thousand-year-old Nicodemus, who wants the Shroud to power a plague curse. Nicodemus captures and nearly kills Harry; Shiro trades himself for Harry's life and dies under torture. The duel with Ortega ends when the losing vampire breaks its terms, and the war continues. Harry stops the plague and reclaims the Shroud - which ends up in Marcone's hands - while Susan leaves again for the Fellowship's fight. At the last, to keep a planted coin from Michael's young son, Harry covers it with his bare hand and takes the shadow of the fallen angel Lasciel into his own mind - and tells no one.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3516,7 +3516,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3529,7 +3529,7 @@
       "recaps": {
         "ending": "After Biff finally states that neither he nor Willy is destined for exceptional business success, he breaks down and weeps in his father's arms. Willy recognizes Biff's love but misunderstands the confrontation as proof that Biff can still fulfill his ambitions. Convinced that the insurance payment from his death will give Biff the capital and status he lacks, Willy drives away and deliberately crashes his car. Only Linda, Biff, Happy, Charley, and Bernard attend the funeral. Biff concludes that Willy pursued a mistaken dream and intends to return to the outdoor life that suits him. Happy rejects that judgment and vows to prove that Willy's vision of success was right. Charley defends the hopes on which a salesman depends. Linda, unable to understand why Willy died just after the last house payment was made, addresses him at the grave. The family is free of the mortgage but divided over the meaning of Willy's life and death.",
         "in_short": "Exhausted salesman Willy Loman returns to his Brooklyn home as his career and grasp on the present fail. He clings to memories of his sons' promising youth and believes Biff can still become a business success. Biff, now a restless adult, agrees to seek financing, but the meeting fails; on the same day Willy is fired. At dinner Biff tries to tell the truth, while Willy retreats into the memory of Biff discovering his affair in Boston, the event that destroyed the boy's trust and ambitions. Back home Biff rejects the family's inflated dreams and insists that both men accept their ordinary selves. Willy sees Biff's tears as renewed faith in him and kills himself in a car crash so Biff can receive the insurance money. The funeral is sparsely attended. Biff abandons Willy's dream, while Happy vows to continue it, and Linda mourns beside a house whose mortgage has finally been paid.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3667,7 +3667,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3678,7 +3678,7 @@
       "recaps": {
         "ending": "The book ends with the great Danish bid for England defeated in a bleak winter battle. Three years after Alfred's death, the Danes invade in strength, with Aethelwold riding among them as their claimant to the West Saxon throne and King Eohric of East Anglia joined to their cause. The armies meet in a grinding shield-wall battle in which the Danish coalition is broken apart rather than cleanly beaten: Eohric is killed, several Danish leaders fall, Sigurd is wounded, and Uhtred himself kills Aethelwold, ending forever the rival claim that had shadowed Edward's succession. The surviving Danes, unable to keep the field through the winter, withdraw. The title's promise is kept several times over - Alfred dead in his bed, Eohric and the pretender Aethelwold dead in battle - and Edward sits securely as king of Wessex, his father's dream of one England battered but alive. Uhtred, prophesied by the sorceress Aelfadell to be the doom of kings, has been exactly that, though not in the way the Danes who paid for the prophecy hoped. He remains what he was: Aethelflaed's sworn man and lover, the pagan shield of the Christian kingdoms, with Bebbanburg still waiting unclaimed in the north.",
         "in_short": "As the book opens in 899, Alfred is dying and every ambitious man in Britain is waiting. A peace overture from East Anglia proves a trap laid by the jarl Sigurd, which Uhtred fights his way out of; the famed sorceress Aelfadell, whose prophecies foretell Danish victory and the death of kings, turns out to be paid by Sigurd to say so, and Uhtred counters her by staging three women as Christian angels spreading rival prophecy. Alfred dies, rewarding Uhtred and binding him toward his heir; Edward is crowned, and Alfred's embittered nephew Aethelwold - convinced the throne is rightfully his - flees to the Danes, giving Sigurd and Cnut the royal figurehead their invasion needs. Three years later the Danish coalition strikes. In a brutal winter battle the invasion is broken: King Eohric of East Anglia is killed, Sigurd is wounded, and Uhtred personally kills Aethelwold, extinguishing the rival claim. The Danes withdraw, and Edward is secure on his father's throne, with Uhtred still Aethelflaed's sworn man and still dreaming of Bebbanburg.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3872,7 +3872,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3885,7 +3885,7 @@
       "recaps": {
         "ending": "Poirot and Race establish that Simon Doyle and Jacqueline de Bellefort planned everything together. Their public quarrel, the broken engagement and the relentless pursuit across Europe and Egypt were staged so that each would have an unassailable alibi. In the saloon Jacqueline fired a shot that hit nothing; as soon as the witnesses had scattered to fetch help, Simon picked up the pistol, went to his wife's cabin, shot her through the head, returned, scrawled a letter J on the wall to incriminate Jacqueline, and then shot himself through the leg to produce the wound he had been carried away with. Jacqueline retrieved and disposed of the pistol wrapped in a stolen velvet stole. She afterwards killed the maid Louise Bourget, who had tried to blackmail them, and shot Mrs Otterbourne through the door as she was about to name the person she had seen. The purpose was Linnet's fortune, after which Simon would in time have married Jacqueline. Confronted, Simon breaks down. As they are being taken off the steamer, Jacqueline uses a second small pistol to shoot Simon and then herself, sparing them both a trial. The other threads settle: Pennington's frauds are exposed, Miss Van Schuyler's thefts are managed quietly by her nurse, Tim Allerton returns the pearls he had replaced with a copy and is let off by Poirot on condition he goes straight, and Tim and Rosalie Otterbourne leave together, as do Cornelia Robson and Dr Bessner.",
         "in_short": "Linnet Ridgeway, a young and much-envied heiress, marries Simon Doyle, the penniless fiance of her friend Jacqueline de Bellefort, who had asked her to give him a job. Jacqueline follows the honeymoon couple across Europe and up the Nile, appearing wherever they go, until all three are aboard the steamer Karnak with Poirot and Colonel Race. After a boulder narrowly misses Linnet at a temple, Jacqueline drunkenly shoots Simon in the leg one night in the saloon and is taken away sedated. In the morning Linnet is found shot in her bed with the letter J written in blood on the wall. Two more deaths follow: the maid Louise Bourget, stabbed after hinting that she knew something, and Salome Otterbourne, shot as she is about to name a witness. Poirot shows that Simon and Jacqueline committed the murders together, the long public feud having been staged to give each of them an alibi, with Linnet's fortune as the object. Jacqueline shoots Simon and herself rather than face arrest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4037,7 +4037,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4050,7 +4050,7 @@
       "recaps": {
         "ending": "Death attends the cellist's concert in the form of a woman and afterward approaches him. He is drawn to her without knowing why she has entered his life or that she carries the violet notice of his death. They spend the night together. Instead of delivering the letter that should seal his fate, death burns it and lies beside him until morning. Her involvement with one mortal has displaced the impersonal certainty of her task. The novel closes by repeating its opening condition: on the following day, no one dies. It does not explain how long this second interruption will last or how the country will respond, leaving death's choice and her new attachment to the cellist as the decisive change.",
         "in_short": "At the start of a new year, nobody dies in an unnamed country. The apparent blessing soon overwhelms hospitals, care homes, insurers, undertakers, government, and church, while a criminal group profits by taking dying people across the border. Death eventually announces that she will resume work, now sending each intended victim a violet letter one week in advance. The warning system replaces uncertainty with public dread. One letter, addressed to an otherwise unremarkable cellist, repeatedly returns undelivered. Intrigued, death observes him, assumes the body of a woman, and attends his performance. She meets him and spends the night with him, then burns his notice rather than completing her duty. The next day, once again, nobody dies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4335,7 +4335,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00YT8AV8A",
@@ -4347,7 +4347,7 @@
       "recaps": {
         "ending": "Legion Varus destroys Death World's central Nexus, causing the plant collective to fail and releasing the cephalopods from its control. The cephalopods withdraw, Varus retakes and repairs Minotaur, and the legion returns to Earth. McGill learns that his parents escaped the freighter disaster, and he and Della prepare to visit Etta on Dust World. Claver then draws McGill into a disguised assault inside Central. McGill preserves Winslade's revival data but deletes his recent memories of the Galactic Key. Turov, secretly revived, takes the Key, kills Claver, and intends to revive him without his recent memories so he can bear blame for the killings. Nagata remains suspicious of both McGill and Turov, but the disguise technology prevents a conclusive case. He promotes McGill to junior adjunct as Earth prepares a major campaign against the cephalopods. Turov's possession of the Key, the Central cover-up, Claver's planned altered revival, and McGill's promised family visit remain unresolved.",
         "in_short": "A stolen titanium shipment and a lethal freighter crash send James McGill and Legion Varus to a concealed planet controlled by an intelligent plant collective. After plant organisms cripple Minotaur, the stranded legion fights for its revival system, follows the compromised trader Claver, and learns that rare nexus plants command the planetary life. McGill destroys the central Nexus, breaking the plants' control over cephalopod queens and prompting the cephalopods to withdraw. Varus retakes Minotaur and returns to Earth, where McGill discovers his parents survived and plans to meet Etta on Dust World. Claver then coerces him into a disguised attack on Central over the Galactic Key. McGill saves Winslade's revival record but removes his recent Key memories. Turov takes the Key and plans to revive a memory-stripped Claver as the scapegoat. Nagata cannot prove McGill's guilt and instead promotes him to junior adjunct for the coming cephalopod war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4535,7 +4535,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4548,7 +4548,7 @@
       "recaps": {
         "ending": "In prison Paul encounters distorted versions of his earlier life: Philbrick is an inmate, Prendergast has become a chaplain, and Grimes reappears before making another improbable escape. A prisoner kills Prendergast during a disturbance. Margot, whose business caused Paul's conviction, has protected herself by marrying the politically powerful Sir Humphrey Maltravers. She and her allies arrange for Paul to undergo an operation, be declared dead under another identity, and leave custody. Paul returns to Oxford disguised by a moustache and enters his old college as a supposed distant relative of the expelled Paul Pennyfeather. He resumes theological study with little outward change as the university and the club culture that caused his fall continue their familiar routines. Society has moved Paul through disgrace, employment, luxury, and punishment without ever establishing a meaningful connection between guilt and consequence.",
         "in_short": "Oxford student Paul Pennyfeather is expelled after drunken aristocrats steal his trousers, though he has done nothing wrong. Forced to teach at a chaotic Welsh school, he meets the resilient Captain Grimes, the doubtful Prendergast, and wealthy pupil Peter Beste-Chetwynde. Peter's glamorous mother Margot hires Paul as a tutor and becomes engaged to him. Paul remains incurious about her international entertainment business until he is arrested for assisting its traffic in women and accepts punishment rather than implicate her. In prison he meets former colleagues in new roles, while Margot protects herself by marrying an influential politician. Her circle arranges Paul's false death and release after an operation. He returns to Oxford under the identity of his own distant relation and resumes theology, while the institutions that arbitrarily expelled and punished him continue unchanged.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4733,7 +4733,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4746,7 +4746,7 @@
       "recaps": {
         "ending": "After Jacob's trial collapses, Andy learns that Leonard Patz's confession was forced by a man acting for Billy Barber, and that Patz was killed to make the confession convincing. Andy keeps this from Laurie, but her confidence in Jacob continues to erode. During a family trip to Jamaica, Jacob becomes the last known person to have been with Hope Connors before she disappears. Hope is eventually found dead, although there is no proof that Jacob killed her. On the drive home, Laurie asks Jacob about Hope and then deliberately sends the car into a concrete barrier. Jacob dies; Laurie survives with severe injuries and says she cannot remember the crash. The grand-jury testimony threaded through Andy's story is an inquiry into Laurie's actions. Andy protects her by describing the crash as an accident and concealing his reason to think otherwise. No indictment follows. He remains beside Laurie, bearing the knowledge of what his father arranged, what Laurie did, and the uncertainty that was never resolved about Jacob.",
         "in_short": "Massachusetts prosecutor Andy Barber takes charge after Ben Rifkin, a boy from his son's school, is stabbed to death. Evidence and classmates' accounts soon make Andy's fourteen-year-old son Jacob the suspect, costing Andy his job and isolating the family. Andy supports Jacob without reserve, while his wife Laurie becomes increasingly troubled by Jacob's emotional distance and by violence in Andy's family history. At trial, the defense attacks the uncertain evidence and points to local offender Leonard Patz. The case ends when Patz apparently confesses and dies, but Andy later learns that his imprisoned father arranged the confession and murder. On a later family trip, a girl last seen with Jacob disappears and is found dead. Laurie, convinced Jacob may be dangerous, deliberately crashes their car. Jacob dies and Laurie survives. In the grand-jury scenes framing the novel, Andy hides his suspicion that Laurie caused the crash, leaving both crimes legally unresolved and the family destroyed by doubt.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/defiance-of-the-fall-14.json
+++ b/data/works-community/0/defiance-of-the-fall-14.json
@@ -323,7 +323,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0DPNC8Y29",
@@ -335,7 +335,7 @@
       "recaps": {
         "ending": "Zac ends the book as a middle hegemon and the secret terminal son of the Empyrean Chalice. Instructor Rava has awakened the Hall of Service and begun a three-week program to repair the foundations of Zac, Ogras, and 200 selected Atwood cultivators. Joanna remains in a separate inheritance test. Emily, the Mavai chieftain, Galau, Harrow, and the surviving Atwood forces are alive, while Vivi and Sap Trang are dead. Zekia's military position continues to collapse. Zac, Ogras, Esmeralda, and Kator are preparing an operation that will draw Vilari's Epiclesis bell to the Zerber sector, use its heavenly backlash to breach the Kan'Tanu wall, and enter the Imperial Graveyard in search of the foreign gods. Vilari remains alive inside the bell. Zac conceals his new Imperial status and postpones any attempt to claim the Seed of the Apocalypse after Rava warns that its will could enslave him. He also recognizes that his Dao is flawed by taking without reciprocity, leaving the reform of his path as an immediate unresolved task.",
         "in_short": "Separated from Emily inside a failing Limitless Empire fortress, Zac reaches her and joins Galau's stranded survivors in launching the Centurion Spear. The weapon destroys a Kan'Tanu worldfort, but Vivi dies protecting Zac and the crisis exposes more of his dual identity and Void Emperor bloodline. Zac learns that Leandra and the Sindris shaped his engineered origin, reaches middle hegemony, and returns to a war sliding toward defeat. Vilari remains trapped in a providence-consuming bell, so Zac plans to draw it to the Imperial Graveyard and use the resulting heavenly attack to breach Kan'Tanu defenses while seeking ancient foreign gods. Before departure, he opens an Imperial Hall of Service, survives five brutal pilgrimages, and becomes the Empyrean Chalice's secret terminal son. Instructor Rava begins three weeks of remedial training and warns him away from the Seed of the Apocalypse until he repairs the one-sided nature of his Dao.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -687,7 +687,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0FBMLJH36",
@@ -699,7 +699,7 @@
       "recaps": {
         "ending": "Zac kills Kator inside a temporary void realm, ending the Solidarity Link, but the struggle leaves his late-hegemony breakthrough and cosmic core badly damaged. The expedition activates the Centurion defenses, destroys the two immediate foreign gods, and disrupts the Kan'Tanu Pope's Dao confirmation, although the Pope may have escaped after sacrificing much of his cultivation. A complete nine-person seal cycle opens access to the Left Imperial Palace. Catheya, Ogras, Emily, Joanna, Kruta, Galau, Velary, Carl, and the other surviving allies regroup aboard an imperial destroyer as the Centurion base collapses. Catheya and Ogras recover the final treasures needed to keep Zac alive, and Catheya uses her master's safeguard to freeze him. He finishes the book stable and slowly strengthening, but not healed, while the fifth-pillar contest begins. Elsewhere, Tavza remains wounded on a separate Graveyard route, Velary's forbidden inheritance remains unresolved, and the Atwood Empire prepares for self-sufficient expansion after learning that the Sangha deliberately helped engineer Zekia's collapse.",
         "in_short": "Zac enters the Imperial Graveyard to complete a seal cycle and bring the Centurion Project's weapons against the Kan'Tanu. A confrontation around the Epiclesis Bell lets him advance his Dao, destroy the entity within the Bell, and rescue Velary, but Kator then forces him into a lethal partnership. After a hazardous voyage, the Aphelion reaches a corrupted Centurion base. Zac's scattered allies restore its systems while he learns more about Ultum, the Void Emperor Kars, and the Lost Era. They activate the base's defenses, defeat two foreign gods, and ruin the Kan'Tanu Pope's attempted ascension. Kator betrays Zac for the Flame Bearer seal and dies in their final battle. Zac survives only with a catastrophically damaged core and unfinished breakthrough. Catheya freezes him in a stable restorative stasis as the full seal cycle opens the Left Imperial Palace and the fifth-pillar contest begins.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1098,7 +1098,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0G5ZQCT65",
@@ -1110,7 +1110,7 @@
       "recaps": {
         "ending": "Zac, Esmeralda, Ogras, and their fate-calculating companion reach the Mercurial Court region, but a decaying ocean blocks ordinary passage. Zac seeks a court seal or other entry credentials so he can avoid spending his accumulated destiny, while a Templar order quietly suspects his disguise. His gains include the Fertile Earth seal, a limited Fushi Mountain Gate, a completed fifth body-tempering layer, and Alea's still-developing regalia form. Elsewhere, Velary carries Thea Marshall's report and message, Joanna is summoned to a spear-court test, Emily survives the Order of Dawn operation, and Carl and Iz remain bound for the Far Sea Court. The Terran's Loom node and the immediate Joyful Gardens murderer are stopped, but the natural curse, soul-devouring grimoire, and escaped black threads remain wider threats. Rival factions continue altering memory karma and court awakenings. The royal claimant resumes delaying a court, while the Realm Keeper observer uses a temporal dream to change a scholar's warning and moves closer to the Mercurial Court. The trial remains active, and the origins of Zac's Gate, his connection to the Eight Hells, Thea's conflict with the Sangha, and the Imperial selection are unresolved.",
         "in_short": "Zac and Esmeralda enter a trial built from Imperial memory domains, where corrected histories grant real identities, objects, merit, and destiny. Zac gains a Wendemar seal, reunites with Joanna and Ogras, helps the Earth spirit Roan restore the Fushi Mountain Gate, and survives the collapse of Dipper Seven after absorbing the void half of an Eclipse Twin. A realm lord linked to Kala Sutra heals him and grants access to the Nine Gardens and eight hells. Zac later stops a sacrificial curse at Terran's Loom and reforges Alea, then exposes the corrupted disciple behind murders in the Joyful Gardens and completes his fifth body-tempering layer. Thea Marshall is alive and sends information through Velary. By the end, Zac's group reaches the Mercurial Court region but still needs entry credentials. Other seal bearers advance along separate routes, while a royal claimant, the Sangha, and other hidden actors manipulate memory karma and court awakenings. The immediate crises are contained, but the court selection and several larger threats remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1585,7 +1585,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -1596,7 +1596,7 @@
         "work": "defiance-of-the-fall-2"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/defiance-of-the-fall-3.json
+++ b/data/works-community/0/defiance-of-the-fall-3.json
@@ -294,7 +294,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -307,7 +307,7 @@
       "recaps": {
         "ending": "Zac and Ogras kill Salvation in the Cradle of God, but Ogras suffers a severe soul injury and Salvation's hidden puppets detonate across his territory. More than a million people die, with New Washington suffering a catastrophic loss. Zac conceals Salvation's body and the control inscription that stored origin Dao, leaving him in possession of an origin funnel that hostile forces may be able to track. Port Atwood retains Verdant Fields, its Tal-Eladar contingent, and its alliances while allied armies continue containing the undead hordes. The Great Redeemer, the Dominators, and Void's faction remain active threats, and enemies plan to enter the sealed mystic realm. Zac is injured but has reached the peak of F-grade and carries Ariel's demanding life-death cultivation plan, the Draugr mystery, and the dangerous Oblivion splinter. Ogras must recover from his soul wound and adapt to the shadow entity fused to him. Vasidas Medhin remains at large, Emily's siblings and Zac's mother remain missing, and Emily's report that the Underworld has been found sets the immediate next objective.",
         "in_short": "Zac enters the Eastern Trigram treasure hunt, allies with Thea Marshall, survives attacks by Salvation and Inevitability, and claims a dangerous sect inheritance that exposes his Draugr nature and leaves him carrying an Oblivion splinter. He joins Beruv Ylvas and Billy to kill Nenothep Medhin, wins the hunt overall, and returns wealthy to Port Atwood. After uncovering clues about his altered body, Zac becomes Ariel's terminal disciple and receives a life-death cultivation path. Port Atwood then builds a broad alliance against the undead and hostile incursions. Zac's covert force destroys Thanzo's slaveholding regime, annexes Verdant Fields, and reaches an accord with Verana Tir'Emarel's Tal-Eladar. Zac and Ogras finally kill Salvation, but his distributed puppets explode and kill more than a million people while Ogras suffers a soul wound. Zac conceals Salvation's origin funnel as enemy factions prepare for a sealed mystic realm, and Emily announces that the Underworld has been found.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -693,7 +693,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -706,7 +706,7 @@
       "recaps": {
         "ending": "Zac and Ogras remain inside the Tower of Eternity at chapter 98. Galau has revealed his concealed thievery specialty, left the group at level 31, and opened a shop in a Tower oasis after giving Zac a token to Nal Avadar. Zac and Ogras begin their next trial on the back of a colossal ancestral beast, with orders to redirect it. Zac holds the Prajna cherry, which may heal Alea, and a crystallized Pathfinder Oracle eye that may help his Duplicity Core, but neither problem is resolved. His Oblivion splinter has already caused a fatal loss of control and has lost one of its containing runes. Alea remains unconscious in stasis. On Earth, the Undead Empire's self-sustaining conversion array is active, and only destruction of its Dead Zone core can stop it. Kenzie and Ilvere escape a powerful undead ambush after sacrificing her mecha, leaving her combat resources depleted. Port Atwood also faces a hostile fleet formed by undead and Holy Church forces. Leandra, Jeeves's origin, Sivis's inert transformed body, the Great Redeemer's possible links, and Zac's balanced class evolution all remain open.",
         "in_short": "Zac expands Port Atwood's reach into the Underworld, destroys the Union's slave-trading regime, closes multiple incursions, and survives a hidden technocrat operation connected to his missing mother, Leandra. He rescues Port Atwood's battered army, but Alea suffers a shattered soul. A dangerous Origin Dao experiment gives Zac an Axe Fragment at the cost of deaths, comas, and possible links to the Great Redeemer. Zac and Ogras enter the Tower of Eternity seeking advancement and a cure. The Oblivion splinter drives Zac into a lethal rampage, yet he emerges with the Prajna cherry for Alea and a treasure that may improve his core. On Earth, the Undead Empire activates its planetary conversion array, and Kenzie can only slow it. The book ends with Galau leaving the Tower group to become a merchant while Zac and Ogras begin an unfinished trial atop a colossal ancestral beast.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1220,7 +1220,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B09YJ48ZRK",
@@ -1232,7 +1232,7 @@
       "recaps": {
         "ending": "Zac's team destroys the Dead Zone fortress, kills the Lich King and the known female general, and dismantles the planet-conversion array. Zac binds the ghost custodian to lifelong service, removes the Seed of Undeath, completes Death Defiance, and brings his Draugr level even with his human level. The last zombies leave through the nexus before it vanishes, ending the immediate Undead Empire incursion. Kenzie, Ogras, Emily, and Joanna survive, but Zac needs time to recover from severe pathway damage. One undead general remains unaccounted for, and the custodian cannot reveal that general's plans. The Everlasting Dao leader and one companion escape their destroyed vessel. Alea's awareness within Love's Bond remains uncertain, Ogras still cannot evolve because of his shadow companion, and conflicting accounts leave Leandra's motives and Kenzie's significance unresolved. Zac also retains the contained creation and Oblivion remnants and receives bloodline marrow that he will not use until he understands his unusual inherited traits. Intelligence suggesting that a local faction may bargain with another incursion leaves Earth facing further danger.",
         "in_short": "Zac climbs the Tower of Eternity, strengthens his Dao, and survives both a Technocrat vessel and a public bounty at the exit. He steals a shard of creation, whose clash with his Oblivion splinter produces a System-bound cage that restrains both forces. Back on Earth, he ends an assault on Port Atwood, remakes the dying Alea as the spirit tool Love's Bond, and evolves into paired epic E-grade classes. After learning conflicting information about his mother Leandra, Zac leads Kenzie, Ogras, Emily, Joanna, and a Valkyrie squad into the Dead Zone. They breach the undead fortress, kill the Lich King, dismantle the conversion array, and remove the Seed of Undeath. The undead nexus disappears, but an Everlasting Dao leader escapes, Zac is badly injured, Alea's fate is unresolved, and new evidence points toward hidden bloodline history and possible dealings between a local faction and another incursion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1619,7 +1619,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0B433SWDM",
@@ -1631,7 +1631,7 @@
       "recaps": {
         "ending": "Zac returns beyond the base wall with Leviala and the surviving scouts after the base turns its defenses against the Collector. Two members of his expedition have died, the Collector's ultimate fate is unknown, and Zac's annihilation attack has worsened the unexplained cracks in his body. Witnesses cannot retain how that attack works. Thea and Emily are recovering from the lunar-wolf battle, Joanna remains with the field-station force, and Ogras is still unable to fight while Spare reconstructs his pathways. Rhubat and the surviving Anointed support the expedition, but no cure has been found for the damage caused by their elixir. Kenzie retains limited access through Jeeves, while Leandra's token lets Zac operate technocrat equipment as a Council Inspector. A mapper taken from the Lunar Tribe reveals routes toward the inner laboratories. Zac selects the Inner Lab 16 branch of his Path Strider training, forfeiting the best reward tier and shortening the chain. He now heads toward the base core before the dimensional seed matures. Adcarkas and Inevitability remain active in the realm, Church survivors still seek the seed, the route to Earth is deteriorating, and the Collector remains an unresolved danger behind them.",
         "in_short": "After defeating Earth's undead invasion, Zac closes the Church of Everlasting Dao's last incursion and secures an S-grade integration result. He then supports the Zhix Crusade against the Dominators, kills Harbinger with a dangerous annihilation attack, and survives heavenly punishment after committing to a boundless path of life, death, and war. Adcarkas escapes a later ambush, while Ogras survives fatal injuries through his shadow companion, Spare. Zac's allies reopen the expanding Mystic Realm, where rival Earth factions, native peoples, cultists, and Dominators seek a maturing dimensional seed. A repository trial exposes Zac's corrupted Void Emperor bloodline. Inside the realm, he gains a Spiritual Void node and compulsory Path Strider quests, rescues Leviala and most of a captured scouting party, and escapes the Collector with two followers dead. Using Leandra's technocrat credential and a captured mapper, he chooses the Inner Lab 16 route toward the base core, giving up the training chain's highest reward to confront the greater threat before the seed matures.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/defiance-of-the-fall-7.json
+++ b/data/works-community/0/defiance-of-the-fall-7.json
@@ -295,7 +295,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0BHJMX1L3",
@@ -307,7 +307,7 @@
       "recaps": {
         "ending": "Zac leaves Earth in his concealed Draugr identity with Velary and reaches Twilight Harbor, where he adopts the name Arkhas Black. Cathaya traces him through an old token, but he prevents her from exposing him and conditionally joins her Twilight Ocean expedition in exchange for skills, auction access, and a chance to seek life-death pearls. Cathaya does not know that her master expects her route to mark a ley line for the Twilight Lord. The Twilight Ascent is becoming a wider contest over the Twilight Lord's attempt to reach autarky, with the Eternal Clan and other powers moving to interfere. On Earth, Joanna and Velary's forces have arranged cooperation, while Triv and the Zhix remain among its defenders. Kenzie is training off-world under her mother's control, with Jeeves still retaining an autonomous core. Thea is alive but stranded on Goldblade Continent, although Earth and the System regard her as dead. Ogras and Billy remain alive inside the dimensional seed's future pocket world. Voridis A'Heliophos is still at large. Zac intends to grow strong enough to recover those taken from him while preserving Earth through its coming assimilation.",
         "in_short": "Zac leads Port Atwood through the collapse of the Mystic Realm, defeats Adcarkas, and survives the dimensional seed's escape after awakening a corrupted Void Emperor bloodline. Rhubat sacrifices the other Anointed to kill Adcarkas, while Ogras saves Kenzie and is swallowed by the seed; he and Billy are later confirmed alive inside it. Three years later, Earth is stable under Zac, but Kenzie's attempt to evolve Jeeves draws their mother, who takes Kenzie off-world and secretly strands the surviving Thea on Goldblade Continent. Zac completes a perfect soul reincarnation, upgrades his skills, expands his economic power, and prepares Earth for his absence. Traveling as a Draugr with Velary, he reaches Twilight Harbor and conditionally joins Cathaya's expedition for the Twilight Ascent. The expedition is unknowingly tied to the Twilight Lord's pursuit of autarky, drawing the attention of major outside powers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -731,7 +731,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0BRD94VQW",
@@ -743,7 +743,7 @@
       "recaps": {
         "ending": "Zac survives the destruction of the hidden valley and leaves the Twilight Chasm with a stronger soul, an E-grade Void Emperor bloodline, and Branch of the War Axe. Love's Bond and Varun's Bite gain opposite death and life imprints. His interference destroys the egg apparatus and implicates Va Tapek in the Evening Tide Asura's larger purification scheme, but does not stop the autarky attempt. Zac later absorbs a second Creation shard from the volcanic site. The shard remains hostile, clashes with his imprisoned Oblivion power, and contributes to the opening of an incomplete Quantum Gate in his human form. Catheya and her surviving followers move toward the City of Ancients after leaving Zac a cache and a chart of the surrounding jammers. At the ravine, Zac learns that the Eternal Clan vampire has already taken the Oblivion splinter and summoned him to the City to fight for it. Zac remains alive and heads toward that confrontation while rival factions converge. Ogras and Billy are alive inside the dimensional seed, and Port Atwood's Valkyries and Einherjar prepare for an incursion without Zac.",
         "in_short": "Zac enters the Twilight Ascent under the Draugr identity Arcaz Black, seeking life-death pearls while carrying a sealed egg that Va Tapek has forced him to deliver into the Twilight Chasm. Catheya's sabotage mission fractures after betrayal, but she and Zac survive, harvest pearls, and form a secrecy pact after she learns his dual identity. Zac then travels alone, strengthens both Dao and bloodline, delivers and later alters the egg, and becomes entangled in the Evening Tide Asura's attempt to use Twilight Harbor for autarky. He survives the Chasm, gains Branch of the War Axe, and takes a second Creation shard, but its instability opens an incomplete Quantum Gate. Catheya heads toward the City of Ancients. At the ravine, Zac discovers that the Eternal Clan vampire has stolen the Oblivion splinter he needs and challenged him to recover it at the City.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1194,7 +1194,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0BXT8N9X9",
@@ -1206,7 +1206,7 @@
       "recaps": {
         "ending": "Zac wins Kaldor's Oblivion splinter and obtains Three Virtues's Creation shard, then waits for Orom's defenses to weaken under an external assault. He absorbs both remnants, resists their attacks on his convictions, and combines all six remnant forces into a third glimpse of chaos. A chaos wisp destroys his prison brand, and the glimpse turns a wound in space into an escape gate. Heda passes through the gate after leaving Vivi in Zac's care, while Kaldor and Pavina remain behind for their own undisclosed mission. Zac is diverted beside the fire-wielding golem attacking Orom, which has been badly wounded but not conclusively killed. The System finally removes the glimpse, seals Zac's three exhausted remnant sets with a new rune, awards him the fifth Nine Reincarnations layer, and activates his escape bangle. Zac teleports away heavily injured but free and headed toward home. He still carries the weakening twin realm-spirit crystal and responsibility for Vivi and Harrow. Catheya continues protecting his Arcaz identity, Ogras and Emily remain on separate unresolved paths, and both the Undead Empire and the Buddhist Sangha retain an interest in Zac's fate.",
         "in_short": "Zac enters the City of Ancients to reclaim an Oblivion splinter from Uona. He kills her through a System descent, takes the splinter, and rescues a crystal holding twin nascent realm spirits, but the Evening Tide Asura uses the wider catastrophe to ascend and destroy Twilight Harbor. Stranded in the void, Zac is swallowed into Orom, a prison-realm inside a primordial spatial beast. Years of forced cultivation follow. He perfects another Nine Reincarnations layer, develops life and death Dao branches, rebuilds his combat foundations, and earns new Creation and Oblivion remnants from Three Virtues and Kaldor. During an external attack on Orom, Zac absorbs both remnants, forms a third glimpse of chaos, destroys his prison brand, and opens a chaos gate. The System ultimately takes the glimpse, reseals all three depleted remnant sets, grants the fifth Nine Reincarnations layer, and teleports the badly injured but free Zac toward home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1589,7 +1589,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0C78GDB5G",
@@ -1601,7 +1601,7 @@
       "recaps": {
         "ending": "Zac remains stranded in the Void Star with Vivi, a living space-attuned ferric Worldeater, two Left Imperial Palace seal fragments, and a tattered temple scroll. His new Void Vajra Sublimation works, and his life and death Dao branches have advanced, but his cosmic-core design and vessel remain unfinished. Vi has been taken alive and leaves a deliberate spatial trail for him to follow. Ogras reappears as an altered shadow attacker who only gradually recognizes Zac, while the goblin spirit within Shadewar carries the same corruptive aura as the madness released by the collapsing temple. Ensolus is stable and subordinate to the Atwood Empire, but Kenzie remains abducted, Janos remains missing, and the wider Million Gates war is approaching. Catheya is searching for Zac under an Undead Empire edict that demands his allegiance to death. Outside factions and blood-cursed invaders are also pursuing the Left Imperial Palace and Ultum, leaving Zac caught in an inheritance contest that now threatens Zekia.",
         "in_short": "After escaping Orom, Zac returns to rebuild his position and resolves the Ensolus incursion by stabilizing the planet and bringing its native powers into the Atwood Empire. Seeking a living Worldeater for a future vessel, he borrows Gaun Sorom's identity and joins Voidgate's Task 1032. Saboteurs destroy a spatial cortex, stranding Zac and researcher Vi deep in the Void Star. They uncover blood-cursed infiltrators, capture a rare space-attuned Worldeater, and follow signals from the Left Imperial Palace. Zac claims a second seal fragment and creates Void Vajra Sublimation after discovering that the original Sangha technique would imprison his consciousness. The second temple collapses into a pillar of contained madness. Vi is abducted but leaves Zac a trail, and Zac encounters Ogras alive but altered as competing factions converge on the inheritance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1820,7 +1820,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1833,7 +1833,7 @@
       "recaps": {
         "ending": "Winzik's rule ends. The alliance that humanity, the UrDail and the kitsen began, widened to include people from inside the Superiority who never consented to what was being done in their name, is enough to break his hold on the fleets and on the taynix that make interstellar travel possible, and his authority collapses along with the fear he built it on. The delvers are the harder problem and they are not solved by force. Spensa's answer is the one she has been carrying since the nowhere: a delver is not a weapon but the remnant of a people who gave up individuality and time, and what they need is to be seen and spoken to rather than fought. The delvers are reached, they stop being a threat that can be aimed at anyone, and M-Bot, who is now a mind that needs no machine, is among those who stay with them. Brade, who was raised as a weapon and never given a choice she could believe in, finally has one. Humanity comes out of the quarantine it has lived under for generations: Detritus is no longer a prison, the Superiority's grip on who may travel between stars is broken, and the species it graded and contained are free to negotiate as equals. Spensa and Jorgen have each other and a future that is not simply the next battle, and the long war that began with drones over a cavern city is over.",
         "in_short": "Spensa returns from the nowhere changed, carrying the truth about the delvers and a piece of one merged into her mind, to find Winzik effectively ruling the Superiority and preparing to use delvers as weapons. Humanity, the UrDail and the kitsen have an alliance but not a fleet that can match his, and the ordinary citizens of the Superiority have been taught to see her species as a contagion. While Jorgen, FM and the rest hold Detritus and widen the coalition to people inside the Superiority itself, Spensa works on the one advantage nobody else has: she knows delvers were once a living civilization that gave up individuality, and that they can be spoken to. Winzik's weapon is Brade, a human cytonic raised to believe she was never entitled to a choice. The alliance breaks Winzik's hold on the fleets and on the taynix, the delvers are reached rather than destroyed, and humanity emerges from generations of quarantine free, at the cost of leaving M-Bot behind among the minds of the nowhere.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2052,7 +2052,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2065,7 +2065,7 @@
       "recaps": {
         "ending": "Peter Threadgill's quarrel with his wife ends in open fighting at the Queen's headquarters in New Orleans. Sookie is caught in it, is badly hurt, and survives; Bill is nearly destroyed protecting her; and Sophie-Anne Leclerq kills her husband herself and keeps her throne. The mystery of Hadley's last months is closed: Hadley made Jake Purifoy into a vampire to save his life after he was mauled, an act that was both a crime among the Weres and a disaster for her standing with the Queen, and she stole the diamond bracelet that gave Threadgill his pretext for war. Jake, unwilling and resentful, is taken in by the vampires. The Pelt family's private investigation ends with the Pelts formally accepting that Debbie is gone, though Sandra Pelt does not accept anything, and Sookie's part in it stays hidden. Sookie ends the book with two permanent changes. Amelia Broadway comes home with her to Bon Temps as a tenant, bringing her cat, and becomes a friend and a live-in witch. And Sookie finally learns why Bill Compton came back to Bon Temps at all: Hadley told the Queen that her cousin could read minds, and Bill was sent to seduce Sookie and secure her for Louisiana. Everything that followed grew out of an assignment. Sookie throws him out of her life for good, and starts seeing Quinn.",
         "in_short": "Sookie meets Quinn, a weretiger who officiates supernatural ceremonies, just as she learns she has inherited the New Orleans estate of her cousin Hadley, who became a vampire and the lover of Sophie-Anne Leclerq, Queen of Louisiana, before dying. Clearing out the apartment, Sookie is attacked by a newly risen vampire hidden there, and befriends the landlady, a witch named Amelia Broadway, whose reconstruction of the past reveals that Hadley made the young werewolf Jake Purifoy into a vampire and stole a diamond bracelet belonging to the Queen. That theft has given the Queen's new husband, Peter Threadgill of Arkansas, the excuse he wants for a war. Debbie Pelt's sister has Sookie abducted and interrogated about the disappearance, and Sookie is rescued. At the Queen's compound the quarrel between Sophie-Anne and Threadgill turns into a battle; Sookie is injured, Bill is nearly destroyed shielding her, and Sophie-Anne kills her husband. Afterward Sookie learns that Bill originally came to Bon Temps under the Queen's orders, to seduce a telepath Hadley had told her about. She ends things with Bill permanently, takes up with Quinn, and brings Amelia home as her tenant.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2240,7 +2240,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2253,7 +2253,7 @@
       "recaps": {
         "ending": "After the raid Lena is boarded into her room at her aunt's house and her procedure is brought forward to the following morning; her family has decided the operation will fix what she has become. Grace, the small cousin everyone treats as simple, gets a message to her and helps her, and Alex comes for her. The two of them run through Portland with regulators behind them, heading for the border fence and the Wilds beyond it, where they had planned to disappear together. They reach the fence with the pursuit closing. Alex gets Lena up and over, and then stays on the city side to hold the guards off so that she can run. Lena hears gunfire behind her as she goes. She lands in the Wilds alone, uncured, with nothing, believing Alex is dead and knowing she can never go back: Portland is closed to her, her family will be told what she is, and the only life she has left is on the wrong side of the fence.",
         "in_short": "In a United States where love is diagnosed as a disease and every citizen is given a procedure at eighteen that removes the ability to feel it, seventeen-year-old Lena Haloway is counting the days to her own operation. Her mother died of the disease and Lena wants nothing more than to be safe and ordinary. At her evaluation she notices a young man watching her, and when he turns up again he is Alex, a guard at the laboratories who claims to be cured. He is not: he is an Invalid, born in the Wilds outside the fences, living in the city under a dead boy's identity with a forged scar. Alex shows Lena the country beyond the border, they fall in love, and everything she believed about the disease and the government stops holding. She discovers that her mother was not a suicide but a prisoner in the Crypts for years, and that she escaped. With Lena's procedure days away, she and Alex plan to run for the Wilds. They are caught, Lena is locked up, and their escape ends at the fence, where Alex stays behind so that Lena can get over it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2427,7 +2427,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2440,7 +2440,7 @@
       "recaps": {
         "ending": "Ed, Bobby, and the badly injured Lewis reach Aintry with a story that presents Drew's disappearance and their injuries as the results of a canoeing accident. The sheriff doubts parts of the account, and Deputy Queen suspects that the visitors encountered his missing relative, but a search produces no body or decisive evidence. The sheriff lets the men leave while warning them not to return. Lewis recovers from his broken leg, though his former physical certainty is diminished. Bobby withdraws from contact with Ed and Lewis. Ed returns to Martha, his son, and his advertising work with a stronger sense of attachment to ordinary life, yet the river remains present in his dreams and in the secret shared by the survivors. The completed dam eventually floods the valley, submerging the river, the town, and the concealed dead beneath a reservoir, putting the physical evidence beyond recovery without erasing Ed's memory of it.",
         "in_short": "Atlanta art director Ed Gentry joins his formidable friend Lewis Medlock and acquaintances Bobby Trippe and Drew Ballinger on a canoe trip down a wild Georgia river soon to be dammed. The expedition turns violent when two local men capture Ed and Bobby and assault Bobby; Lewis kills one with an arrow, while the other escapes. Soon afterward Drew falls from his canoe and Lewis is badly injured in a rapid. Believing the surviving attacker is shooting from above the gorge, Ed climbs the cliff, kills a man with an arrow, and hides the body. The group recovers Drew's body, sinks it to preserve their cover story, and struggles to Aintry. A suspicious sheriff cannot prove that their account of an accident is false and releases them. Ed returns to his family and work changed by what he did, Lewis recovers with reduced physical power, and Bobby breaks off contact. When the dam floods the valley, the bodies and evidence disappear beneath the new lake.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2567,7 +2567,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2580,7 +2580,7 @@
       "recaps": {
         "ending": "The inward community around Demian and Frau Eva anticipates a violent transformation of European society, and the outbreak of the First World War gives that expectation a terrible form. Sinclair enters military service and is wounded during a bombardment. In a field hospital he finds Demian in the bed beside him. Demian says that Sinclair may no longer find him physically when he needs help, but can look within himself instead. He gives Sinclair a kiss that he says comes from Frau Eva. By morning another wounded man occupies the bed. Sinclair understands that Demian has become part of his own inner life: when he looks into himself, his reflection resembles his friend and guide. The novel closes without establishing Demian's literal fate, but Sinclair no longer depends on his external presence to reach the self Demian helped him recognize.",
         "in_short": "Emil Sinclair grows up between the orderly, religious world of his family and a forbidden world that both frightens and attracts him. After the bully Franz Kromer traps him in blackmail, the unusually perceptive Max Demian frees him and challenges his conventional ideas about good and evil. Separated from Demian, Sinclair passes through drinking, loneliness, idealized love, painting, and study with the organist Pistorius. A recurring image of a bird breaking from an egg leads him toward the god Abraxas, a symbol joining opposites. He eventually reunites with Demian and meets Demian's mother, Frau Eva, whose circle treats self-knowledge as a demanding spiritual vocation. Their expectation of collective upheaval is fulfilled by the First World War. Wounded in battle, Sinclair meets Demian once more in a hospital and receives a farewell kiss from Frau Eva through him. Demian disappears, and Sinclair recognizes that his guide now lives within his own identity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2798,7 +2798,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2811,7 +2811,7 @@
       "recaps": {
         "ending": "After Dori's death and the collapse of his addicted life, Demon accepts help and leaves Lee County for treatment. Recovery takes time, distance, and repeated effort rather than a single transformation. He reconnects with his gift for drawing and, working with Tommy, turns the experiences of local children into a successful comic strip. Emmy is rescued from the exploitation surrounding Fast Forward, but the confrontation at Devil's Bathtub kills both Fast Forward and Hammer: Fast Forward falls, and Hammer dies trying to save him. Years later Demon returns with a steadier life and a clearer understanding of the people and systems that failed him. Angus has built an independent future of her own, and their long friendship becomes an acknowledged love. The novel closes with the two of them setting out for the Atlantic coast, where Demon will finally see the ocean he has imagined since childhood.",
         "in_short": "Damon Fields, known as Demon Copperhead, grows up poor in rural southwest Virginia. After his young mother's marriage turns abusive and she dies from an overdose, the foster-care system moves him through homes that exploit his labor and leave him hungry. He eventually reaches his paternal grandmother, who arranges a home with Coach Winfield. Demon becomes a football star and finds intellectual and artistic encouragement, but a knee injury leads to prescribed opioids and then addiction. His relationship with Dori binds two vulnerable young people in a life organized around drugs, ending with her overdose. Addiction also damages the Peggot family, while the admired Fast Forward is exposed as a destructive force; a final confrontation kills Fast Forward and Hammer. Demon enters treatment, gets sober, and builds a career from his drawing with Tommy. Returning years later, he recognizes that Angus has been his most steadfast companion. They begin a life together and drive toward the ocean.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3021,7 +3021,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3034,7 +3034,7 @@
       "recaps": {
         "ending": "After Shatov's murder, the conspirators begin to break under fear and guilt. Kirillov kills himself after Pyotr forces him to leave a false confession that shields the group. Shatov's abandoned wife and her newborn also die, and information from the surviving conspirators allows the authorities to reconstruct much of the plot, although Pyotr escapes abroad. Stepan Trofimovich leaves town in a final effort to free himself from dependence, falls ill on the road, and undergoes a religious change before dying with Varvara Petrovna beside him. Nikolai Stavrogin withdraws to his family estate. Darya receives a letter proposing that she join him in a secluded life, but before any plan can be carried out he hangs himself. A note at the scene emphasizes that he acted deliberately. The provincial conspiracy is exposed and dispersed, but the ending presents its violence as the result of broader moral and intellectual disintegration rather than a danger removed with one organizer's flight.",
         "in_short": "In a provincial Russian town, the returning radical organizer Pyotr Verkhovensky exploits the vanities, grievances, and ideas surrounding the enigmatic Nikolai Stavrogin. He persuades a small local cell that it belongs to a nationwide revolutionary network and seeks to bind it through crime. Stavrogin refuses the leadership Pyotr imagines for him, while his secret marriage to the vulnerable Marya Lebyadkina entangles his relations with Liza and Darya. During a disastrous public fête, fires spread through the town; Marya and her brother are murdered, and Liza is killed by a hostile crowd after leaving Stavrogin. Pyotr then leads the cell in murdering Shatov as a supposed informer and coerces Kirillov's suicide note to conceal the crime. The conspiracy collapses and Pyotr escapes. Stepan Trofimovich dies after a late spiritual awakening, and Stavrogin, unable to accept any sustaining commitment, hangs himself. The town survives, but its social pretensions and abstract doctrines have been converted into manipulation, isolation, and death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3168,7 +3168,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3181,7 +3181,7 @@
       "recaps": {
         "ending": "Abbie kills her infant son because Eben has come to believe that she conceived the child only to secure the farm, and she thinks removing the baby will prove that Eben matters more to her than property. Horrified, Eben goes to summon the sheriff. While waiting, he recognizes that her act grew from the same absolute love he feels and regrets betraying her. When the sheriff arrives, Eben claims responsibility as well and insists on sharing her punishment. Abbie accepts his renewed love, and the two are taken away together, emotionally united even as they face judgment. Ephraim is left alone on the farm he mastered but could never turn into a loving home. The sheriff's admiration of the property gives the final irony: the land remains desirable to outsiders despite the possessiveness, labor, and deaths attached to it.",
         "in_short": "On a hard New England farm, Eben Cabot resents his elderly father Ephraim for taking land that Eben associates with his dead mother. Eben buys out his half-brothers, who leave for California, but Ephraim returns with a young third wife, Abbie Putnam, who also wants the farm. Eben and Abbie begin as enemies and become lovers, eventually conceiving a child. Ephraim believes the boy is his own heir. When his boasting convinces Eben that Abbie used him only to gain the property, Eben rejects her and threatens to leave. Desperate to prove that her love is greater than her ambition, Abbie kills the baby. Eben reports her, then understands both her motive and his continuing love. He confesses alongside her, and the sheriff takes them away together. Ephraim remains alone with the farm, while the tragedy shows that none of the family's attempts to possess land or another person can provide security.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3315,7 +3315,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3328,7 +3328,7 @@
       "recaps": {
         "ending": "Leopard survives the southern-ocean chase only because Jack turns on the far more powerful Waakzaamheid at the instant a great sea makes the Dutch ship vulnerable; the pursuer is overwhelmed and sinks with all hands. Survival is followed by collision with ice, grave structural damage, and the loss of normal steering. Lieutenant Grant eventually leaves in boats with a party of men rather than continue under Jack's decisions, and their fate remains unknown. Jack brings the leaking, undermanned Leopard into shelter at remote Desolation Island. The crew uses the anchorage and local resources to repair the hull and contrive the means to sail again. Stephen's intelligence operation around Louisa Wogan has continued amid epidemic and shipwreck conditions, with false information placed where the American network may carry it. Leopard leaves the island capable of continuing east toward New South Wales, but she is badly reduced, Grant and his followers are missing, and Jack's commission remains an unfinished passage rather than a completed voyage.",
         "in_short": "Jack Aubrey takes command of the ageing Leopard to carry convicts, troops, and passengers to New South Wales. Stephen Maturin uses the voyage to watch the American agent Louisa Wogan and feed deceptive intelligence into her network; her young American admirer Michael Herapath has secretly followed her aboard. A gaol fever spreads from the prisoners and devastates the crowded ship, forcing Stephen and Herapath into exhausting medical work. In southern waters the Dutch seventy-four Waakzaamheid pursues Leopard through a prolonged gale. Jack finally turns to fight, and a huge sea overwhelms the Dutch ship. Leopard then strikes ice, is nearly lost, and can barely steer. After deepening conflict with Jack, Lieutenant Grant departs in boats with part of the company. Jack reaches remote Desolation Island, where the survivors repair the damaged ship sufficiently to resume the voyage. Leopard sails east with a diminished crew, Grant missing, and Stephen's intelligence deception still in motion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3426,7 +3426,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3439,7 +3439,7 @@
       "recaps": {
         "ending": "Hermann's supposedly perfect crime collapses because its central perception was false: Felix did not look like him to other people. The body is identified as Felix rather than Hermann, and the substitution that was meant to produce insurance money instead exposes a murder. Hermann also learns that evidence he treated carelessly has helped the police reconstruct his movements. Lydia and Ardalion do not join him in the triumphant new life he imagined. Hiding in France, Hermann writes the account that forms the novel, still trying to convert failure into proof of artistic genius and searching for an audience that will validate his design. Newspaper reports make clear that the authorities are closing in. In the final pages police surround his refuge and a crowd gathers outside. Hermann attempts one last transformation of reality by imagining the scene as a film production and himself as its director or performer. The fantasy cannot change his position: capture is imminent, and the manuscript ends with his control reduced to rhetoric.",
         "in_short": "Hermann, a Russian émigré chocolate manufacturer in Berlin, meets a poor wanderer named Felix and becomes convinced that the man is his exact double. No one else confirms this perception, but Hermann treats it as evidence of his unique insight and builds a crime around it. At home he condescends to his wife Lydia and refuses to face the likelihood that she and her cousin Ardalion are lovers. He recruits Felix with promises of work, plans to kill him, dress the corpse as himself, and let Lydia collect his life insurance. Hermann carries out the murder and flees, expecting his design to be admired as flawless art. Instead the police identify Felix because the two men do not resemble each other, and other evidence leads back to Hermann. Alone in France, he writes the book as a defense of his genius while reports track the investigation. Police surround his hiding place; he retreats into a fantasy that the arrest is a film scene, but his capture is imminent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3593,7 +3593,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3606,7 +3606,7 @@
       "recaps": {
         "ending": "After surviving the attack at Jenner's, Sebastian can no longer pretend that his protectiveness toward Evie is merely part of their bargain. His injury gives Evie the chance to care for him with the same determination he showed when she was exhausted and ill, and both acknowledge that the marriage has become a love match. The Maybricks make a final effort to regain control of Evie and her inheritance, but Sebastian, Cam, and the couple's allies thwart them and end the immediate threat. Sebastian accepts responsibility for Jenner's and for a life built with Evie rather than continuing his self-destructive idleness. Evie, no longer isolated or easily intimidated, claims her place in the club and in her marriage. Her Wallflower friends recognize that Sebastian's conduct has changed, though they do not erase what he did before the book began. Evie and Sebastian finish securely united, financially independent through the renewed club, and welcomed back into the circle of friends their impulsive elopement initially shocked.",
         "in_short": "To escape relatives determined to seize her inheritance, shy heiress Evie Jenner proposes a practical marriage to Sebastian St. Vincent, the disgraced rake who urgently needs money. They elope to Scotland, where Sebastian's care during the punishing journey begins to challenge both their assumptions about the bargain. At the London gaming club owned by Evie's dying father, Sebastian takes charge of a failing business with help from Cam Rohan. Evie loses her father, inherits the club, and grows more confident, while Sebastian discovers work, fidelity, and protectiveness he never expected to value. Their attraction becomes love despite Evie's distrust and the hostility of her Wallflower friends. Threats from her controlling family and corruption around the club culminate in violence; Sebastian is gravely wounded protecting her, and Evie nurses him. A final attempt to control her fails. Sebastian and Evie openly choose one another, preserve Jenner's, and transform a desperate bargain into a secure marriage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3797,7 +3797,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3810,7 +3810,7 @@
       "recaps": {
         "ending": "Pyotr Verkhovensky's conspiracy collapses after Shatov's murder. Kirillov kills himself after being forced to leave a false confession, but the conspirators are exposed; most are arrested, while Pyotr escapes abroad. Shatov's wife and newborn son survive his death. Stepan Trofimovich leaves town, meets the Bible seller Sofya Matveyevna, recognizes the emptiness of much of his life, and dies after a final reconciliation with Varvara. Liza is killed by a mob after leaving Stavrogin and approaching the scene of the Lebyadkins' murder. Stavrogin withdraws to his estate, rejects Darya's offer to help him begin again, and hangs himself, leaving a note denying responsibility by anyone else. The town's disorder is thus revealed not as a successful popular revolution but as a small, manipulated circle whose ideas, vanities, and crimes destroyed both its victims and many of its participants.",
         "in_short": "In a Russian provincial town, old liberal Stepan Verkhovensky and his patron Varvara Stavrogina help create a climate of vanity and fashionable radicalism. Their sons bring its consequences: the charismatic but spiritually empty Nikolai Stavrogin unsettles everyone around him, while Pyotr Verkhovensky organizes a secret cell through lies about a national revolutionary network. Pyotr uses Stavrogin's prestige, encourages arson and murder, and convinces his followers that former member Shatov must die. The town's public fête collapses into humiliation, fire, and mob violence. Shatov is murdered just after his estranged wife gives birth; Kirillov is coerced into suicide and a false confession. The conspirators are caught, though Pyotr escapes. Stepan dies after a late spiritual awakening. Stavrogin, unable to commit to responsibility or renewal, rejects Darya's help and hangs himself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3993,7 +3993,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4006,7 +4006,7 @@
       "recaps": {
         "ending": "Bond and Tiffany leave America aboard the Queen Elizabeth, but Mr. Wint and Mr. Kidd follow them and try to kill Tiffany. Bond intervenes, kills both men, and arranges the scene to distance the deaths from their intended victim. Although his relationship with Tiffany has become personal, Bond returns to the assignment. He travels to West Africa to close the pipeline at its source, identifies Jack Spang behind another name, and attacks as Spang attempts to escape by helicopter. The aircraft is destroyed and Spang is killed, ending the brothers' control at both ends of the operation. Bond watches the recovered diamonds and reflects that the stones themselves endure while the people who pursue them do not.",
         "in_short": "British intelligence sends James Bond undercover as diamond courier Peter Franks to trace stones being smuggled from African mines through London to the United States. His contact Tiffany Case directs him into a payment system run by the Spangled Mob. In New York and Saratoga, Bond reconnects with Felix Leiter and learns that the syndicate joins smuggling to fixed racing and other rackets. The trail leads to Las Vegas, where Bond wins conspicuously, is seized by Seraffimo Spang, and is taken to the gangster's private ghost town. He escapes, and Tiffany turns against the mob to help him. Seraffimo dies during their flight, but killers Wint and Kidd pursue the couple onto the Queen Elizabeth; Bond kills them when they attack Tiffany. He then returns to Africa and kills Jack Spang as the remaining brother tries to escape, closing the diamond pipeline.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4189,7 +4189,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4202,7 +4202,7 @@
       "recaps": {
         "ending": "After escaping the Spangled Mob's western base, Bond and Tiffany sail for Britain aboard the Queen Elizabeth. Mr. Wint and Mr. Kidd enter their cabin intending to kill them, but Bond defeats both assassins and makes their deaths look like the result of a quarrel. Tiffany reaches Britain safely and reveals that Rufus B. Saye is Jack Spang, Seraffimo's brother and the other leader of the mob. Bond then follows the first stage of the diamond pipeline to West Africa, where the smuggling route begins. He attacks as Jack tries to escape by helicopter and kills him, bringing the operation to an end. The immediate trafficking network is broken, and Bond survives with his cover discarded and his relationship with Tiffany left as a personal attachment rather than part of the mission.",
         "in_short": "The Secret Service sends James Bond undercover as diamond smuggler Peter Franks to trace a pipeline running from African mines through London to an American crime syndicate. His contact, Tiffany Case, guides him into the organization, while Felix Leiter helps him investigate a fixed horse race and the mob's interests in Las Vegas. Bond learns that the Spangled Mob, led by the Spang brothers, uses casinos, threats, and the enforcers Wint and Kidd to control the traffic. When his cover fails, Bond is tortured and taken to Seraffimo Spang's desert base, but Tiffany helps him escape; Seraffimo dies during the pursuit. On the voyage home, Bond kills Wint and Kidd when they attack the couple. Tiffany identifies Rufus B. Saye as Jack Spang, and Bond travels to West Africa, where he kills Jack as he attempts to flee by helicopter, ending the smuggling operation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4343,7 +4343,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4356,7 +4356,7 @@
       "recaps": {
         "ending": "The notebook reveals that its reader and listener are Noah and Allie late in life. Allie wrote their history down after learning that dementia would take her memories, and Noah now uses it in the hope of bringing her back to herself. For a brief interval she recognizes him and remembers their life, but panic returns when the clarity fades. After Noah suffers a heart attack and recovers, he makes his way to Allie's room at night. She recognizes him again, accepts that their love has survived her illness, and lets him remain beside her. The novel closes with the two together in her bed, sharing a final calm, intimate night. It does not explicitly settle what happens after they fall asleep; its last note is Noah's renewed faith in the moments of recognition they can still share.",
         "in_short": "In a care facility, an elderly Noah Calhoun reads from a notebook to a woman with severe memory loss. Its story follows young Noah and Allie Nelson, who fall in love during a summer in New Bern but are separated by class, her parents, and years of missed letters. Fourteen years later, Allie is engaged to lawyer Lon Hammond when she sees that Noah has restored the house they once imagined together. She visits him, their love returns, and her mother finally gives her the letters Noah wrote. Allie chooses Noah over Lon, and they build a life and family. The listener is Allie herself: she recorded their story before dementia erased it, while Noah reads in hopes that she will recognize him. Briefly she does. After illness separates them again, Noah reaches her room and another moment of recognition allows them to end the book together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4478,7 +4478,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -4489,7 +4489,7 @@
       "recaps": {
         "ending": "The book closes at the end of the school year. Greg and Rowley have fallen out over the safety-patrol incident - Greg let Rowley take the blame for frightening kindergartners, then was thrown off the patrol when the truth emerged - and Rowley has won the school paper's cartoonist job with Zoo-Wee Mama, the comic they created together. On the playground, the teenagers who chased the boys at Halloween catch them and force Rowley to eat the Cheese, the mouldy playground relic whose touch makes a student an outcast. When the other students notice the Cheese is gone, Greg announces that he threw it away, deliberately drawing the 'Cheese Touch' onto himself to spare Rowley. The gesture restores the friendship, and Greg ends the year shunned by classmates but reconciled with his best friend, with his family life - Rodrick's torments, Manny's free pass, his parents' projects - carrying on unchanged into the next book.",
         "in_short": "Greg Heffley's journal of his first year of middle school records one misfired scheme after another as he chases popularity: a disastrous Halloween that ends with teenagers chasing him and his best friend Rowley, a poor showing in the wrestling unit, a humiliating turn as a tree in the school play, and a game gone wrong that breaks Rowley's arm. In the spring a safety-patrol incident Greg caused gets blamed on Rowley, and when the truth comes out Greg is thrown off the patrol and the friendship breaks. It is mended on the last days of school: the Halloween teenagers force Rowley to eat the infamous playground Cheese, and Greg publicly claims he threw the Cheese away so that the dreaded 'Cheese Touch' falls on him instead of his friend. The year ends with the two boys best friends again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4621,7 +4621,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4634,7 +4634,7 @@
       "recaps": {
         "ending": "Older teenagers who clashed with Greg and Rowley on Halloween return and corner them at the school. They force Rowley to eat the moldy cheese that has long been avoided by the other students. When classmates later notice that the cheese has vanished, Greg protects Rowley from humiliation by claiming responsibility for touching and removing it. The feared Cheese Touch consequently falls on Greg, but his lie repairs the friendship he had damaged through jealousy and dishonesty. Rowley remains popular through his comic and receives public recognition at school, while Greg finishes the year with a lower social standing than he wanted. Even so, choosing to absorb the ridicule for Rowley's sake is one of his few genuinely selfless decisions in the book.",
         "in_short": "Greg Heffley begins middle school determined to become popular, while regarding his kindhearted friend Rowley as socially inexperienced. His plans repeatedly misfire: wrestling exposes his lack of strength, a homemade haunted house causes trouble, and his attempts to exploit Rowley's broken arm make Rowley more popular instead. Greg and Rowley join the Safety Patrol, but Greg frightens younger children while wearing Rowley's coat and initially allows Rowley to be blamed. Their friendship breaks down, and Rowley finds success with a comic idea the boys once shared. At the end of the school year, teenagers force Rowley to eat a notorious piece of moldy cheese. Greg tells their classmates that he removed it, taking the resulting Cheese Touch upon himself and shielding Rowley from ridicule. The gesture restores their friendship, though Rowley rather than Greg ends the year with the recognition Greg wanted.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/defiance-of-the-fall.json
+++ b/data/works-community/0/defiance-of-the-fall.json
@@ -286,7 +286,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -299,7 +299,7 @@
       "recaps": {
         "ending": "Port Atwood survives the Hive Queen's assault after Zac, Ogras, Alea, and Janos destroy its protected core from within. Alea and Janos escape injured but alive, while Sap Trang and his fishing group remain part of the settlement's growing human population. Ogras buys the remaining Fruit of Ascension and enters seclusion to absorb it. The concealed creator shipyard, crystal wealth, demon defenders, and coastal scouting program give Port Atwood a stronger foundation, but Zac's three-month lord defense is still unfinished. Emily trains under Alan while awaiting the age when she can enter the System, and her siblings remain missing. Mackenzie knows Zac survived but remains in Kingsbury, and Zac has found neither her nor his father. Fort Roger remains under Roger's rule after Zac warns but spares him. Zac recovers the invasion's reserve resources, keeps a treasure-hunt token, and leaves through his private teleportation array for New Washington. The altered scarlet tree, later horde phases, Ogras's loyalties, the family search, and an unidentified observer at Zac's departure remain unresolved.",
         "in_short": "The Integration strands Zac on a reshaped island, where a freak System lottery gives him the strength and obligations of a defier. He builds an outpost, takes the rare Hatchet Man class, develops three early Dao seeds, and wages a solitary campaign against a demon incursion. After killing the heralds and surviving a battle for two Fruits of Ascension, he evolves to Human E and forms a guarded alliance with Ogras and the stranded demons. Their settlement becomes Port Atwood, gains a hidden creator shipyard and merchant headquarters, and survives a vast wolf horde. Zac then opens a private teleportation route, helps Winterleaf Village, confronts the abusive ruler Roger, and brings Emily home with him. Port Atwood's second horde is a Hive Queen tunneling toward its Nexus vein. Zac and his allies destroy the queen's core from inside the hive. With Ogras secluded and the settlement recovering, Zac leaves for New Washington to seek information about his missing family while his lord defense remains incomplete.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -751,7 +751,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0CLYMGRZM",
@@ -763,7 +763,7 @@
       "recaps": {
         "ending": "Zac finishes his immediate cultivation preparations with three Dao branches at middle mastery and a quantum-core design tailored to his alternating human and Draugr states. He postpones forming that core until the Perennial Vastness. His Ultum cycle stands at eight of nine, with the last bearer unidentified. Ogras returns from Million Gates stronger but with Shadewar emitting more dangerous curse energy. Emily is home with two Radiant Court seal pieces and a frontline command, Joanna has an Indomitable Court lead, Velary has repaired her blocked soul bloodline, Carl holds a Radiant Court fragment, and Jowl is bound to Zac as a follower and navigator. Catheya's safety remains uncertain amid Undead Empire factional maneuvering. Kenzie is still held through Leandra's connection to the Six Profundity Empire, and the Kantanu invasion remains delayed rather than stopped. Zac, Ogras, Joanna, Velary, and Emily assemble for departure. Zac and Ogras activate their tokens and enter the Perennial Vastness.",
         "in_short": "Reunited in a corrupted Void Star realm, Zac and Ogras help Billy, Jemmy, Vi, Layara, and Iz Tayn defeat the Kantanu operation and close a Lost Plane gateway. Jemmy survives by converting much of her realm into portable subspace, but Zac returns to Earth with severe foundation damage. During his recovery he prepares the Atwood Empire for war, integrates living and undead populations, secures a wary alliance with the Undead Empire, and learns that his Eos bloodline is both valuable and politically dangerous. Ogras leads a costly Million Gates expedition while Zac develops a quantum-core blueprint suited to his human and Draugr states. Emily, Jowl, and other seal holders bring Zac's Ultum cycle to eight of nine. After completing both hidden Gates of Rebirth trials, Zac gains two more middle-mastery Dao branches. The book ends with the Kantanu war, Kenzie's captivity, Catheya's safety, and the final Ultum member unresolved as Zac and Ogras enter the Perennial Vastness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1086,7 +1086,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0CVBK1NBT",
@@ -1098,7 +1098,7 @@
       "recaps": {
         "ending": "Zac finishes the volume as a newly ascended hegemon. His middle-quality but highly unique quantum life-death core is integrated with the Duplicity Core. For his two Arcane classes, he selects Evolutionary Precursor and Inexorable Apostle. Ogras remains his ally and a future palace participant. Catheya is alive, committed to Zac, and continuing her own cultivation while Undead Empire politics remain unresolved. Kruta holds the Indomitable Court seal and is training as the sole disciple of a Tain supremacy. Esmeralda has gone to Zekia under her contract to accompany Zac into the Left Imperial Palace, while Thea's cooperation with the Sangha remains conditional. Zac has completed his nine-bearer Ultum cycle, but the palace contest itself has not begun. The Hollow Court objective may offer leverage for Catheya's freedom, Sendor's warning about the Terminus remains unexplained, and Zac still intends to confront the wider war and rescue Kenzie.",
         "in_short": "Zac and Ogras enter the Perennial Vastness, where they reunite with Catheya and gather mana for Zac's unprecedented life-death cosmic core. He survives a dual soul breakthrough, claims the Calamity Core, uncovers a First People inheritance, and gains Cosmic Forge and the Void Engine. Kruta joins him in the Stand of Saeward, where they ruin Saeward's sacrificial ritual and Zac kills Imperial princess Valsa Planur. Sendor protects Zac's identity, and Kruta claims the ninth seal in Zac's Ultum cycle. Esmeralda contracts to join the palace venture, while Catheya and Zac commit to a shared future. Zac finally combines the Calamity Core, Warstone, and Void Engine into a quantum life-death core, survives tribulation with help from Leandra's hidden array, and ascends to hegemony as an Evolutionary Precursor and Inexorable Apostle. The Left Imperial Palace, the wider war, the Hollow Court, and Kenzie's rescue remain ahead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1553,7 +1553,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0D42L3J98",
@@ -1565,7 +1565,7 @@
       "recaps": {
         "ending": "Zac breaks the death-sworn isolation array with an unstable fractal, but the escape divides his group. Emily deliberately takes a separate spatial fracture and remains missing. Vilari stays behind, kills three Hallowed Flesh hegemons, places the Acheron Company under its commander, and enters the ancient bell. She bargains with its corrupting resident for strength in return for confronting its enemies and helping it pursue something in the Anima Courts. Tussar dies before completing his attempt to steal the Starfall Court seal, which the Mavai chieftain successfully claims. Zac and the wounded chieftain survive the spatial storm, kill two pursuers, and emerge beside the damaged Limitless Empire fortress. Zac is badly injured and missing a foot, while the fortress remains active and dangerous. General Dawson recognizes that outside powers have shaped the operation and sends a direct warning to Archduke Everfast. An unnamed imperial prince adjusts the failed plot, intending to isolate the flame-bearer and reach Ultum's courtyards himself. Kenzie's Sanctuary route, Ogras's compulsory training, Zac's incomplete seal cycle, the Void Mountain, the Undead Empire's internal struggle, Vilari's bargain, and Emily's fate all remain unresolved.",
         "in_short": "Zac's rise to hegemony splits his human and Draugr aspects into two bodies sharing one identity, core, and memories. He turns the accident into the public Zac and Arcaz partnership, strengthens the Atwood Empire's war organization, and gains an extraordinary Draugr awakening through the Abyssal Pond. His forces conquer Kan'Tanu worlds before the widening war compels them into a catastrophic red-zone offensive and a contest for a damaged Limitless Empire fortress. Along the way, Zac acquires a genuine-bond Court Cycle Token, encounters the Void Mountain and a warning about the Terminus, while Ogras, Joanna, Harrow, and Vilari advance along separate paths. The fortress expedition is compromised by infiltrators, an ancient bell, Tussar's attempted seal theft, and a death-sworn ambush. Zac escapes into a spatial storm with the Mavai chieftain, who claims the Starfall Court seal, but Emily is separated and missing. Vilari enters the bell under a dangerous bargain. Badly wounded, Zac reaches the still-armed fortress as General Dawson exposes outside involvement and a hidden imperial prince revises his plan.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/diary-of-a-wimpy-kid-cabin-fever-book-6.json
+++ b/data/works-community/0/diary-of-a-wimpy-kid-cabin-fever-book-6.json
@@ -58,7 +58,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -69,7 +69,7 @@
       "recaps": {
         "ending": "The book ends with the storm over and the panic deflated. The blizzard trapped Greg, his mother, Rodrick, and Manny in a powerless house for days across Christmas, with Greg's father away; the low point turned comic when Manny was found to have flipped the circuit breakers so that only his room had electricity, his revenge for never being taught to tie his shoes. The family made do through the blackout and dug itself out when the weather broke. Back in ordinary life, the school-wall damage that Greg had built up into a police matter comes to far less than his imagination promised, and the fear that drove the whole book dissolves. The Heffleys end the winter intact and unchanged, ready for the next instalment.",
         "in_short": "Broke before the holidays, Greg tries a string of money-making schemes ending in a holiday bazaar he and Rowley promote with a homemade banner - which bleeds ink onto the school wall and leaves Greg convinced the police are after him. Then a massive snowstorm buries the house and knocks out the power, trapping Greg, his mother, and his brothers inside for days over Christmas while his father is away. Supplies dwindle, tempers fray, and the family discovers Manny flipped the breakers so only his own room had power. When the storm clears and life resumes, the school-damage scare Greg dreaded all month amounts to far less than he feared, and the household returns to normal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -201,7 +201,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -214,7 +214,7 @@
       "recaps": {
         "ending": "Near the end of the school year, Greg and Rowley's friendship is already damaged by Greg's conduct on Safety Patrol and his jealousy over Rowley's successful school-paper comic. The older teenagers whom they angered at Halloween return and corner them beside the school. They force Rowley to eat the decaying cheese that students have avoided all year, then leave. When classmates notice that the cheese has disappeared, Greg realizes that the truth would make Rowley a social outcast. He claims that he picked up and discarded it himself. The feared Cheese Touch therefore falls on Greg, but his decision shields Rowley and repairs their friendship. Rowley receives public credit for his comic and finishes the year with the recognition Greg wanted. Greg's own campaign for status ends unsuccessfully, yet his final lie is an unusually unselfish act: he accepts ridicule to protect the friend he had repeatedly taken for granted.",
         "in_short": "Greg Heffley begins middle school determined to improve his popularity, while treating his loyal friend Rowley as both companion and social liability. His plans repeatedly reverse on him: wrestling reveals his lack of preparation, a haunted house fails, the school play becomes a humiliation, and an accident that breaks Rowley's arm makes Rowley more popular. Greg and Rowley later join Safety Patrol, but Greg frightens younger children while wearing Rowley's coat and initially lets Rowley take the blame. Their friendship collapses, and Rowley gains further attention with a comic idea they once shared. At year's end, teenagers force Rowley to eat the notorious moldy cheese from the schoolyard. Greg tells their classmates that he removed it, taking the resulting Cheese Touch onto himself and saving Rowley from humiliation. The gesture reconciles the boys, although Rowley ends the year with the popularity and public praise Greg had pursued for himself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -313,7 +313,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -324,7 +324,7 @@
       "recaps": {
         "ending": "The book ends in the aftermath of the talent show. Rodrick's party was exposed when a photograph from it turned up in a developed roll of film, and he was punished, though his band Loded Diper was still allowed to perform. The performance video that was meant to launch the band instead features the boys' mother dancing, making it useless to Rodrick, and he blames Greg. In retaliation he finally does what he has threatened all book: he tells the whole school Greg's embarrassing summer secret. The revenge fizzles - the story warps as it spreads, and the version that reaches everyone is so distorted that Greg escapes real embarrassment. The brothers settle back into their normal uneasy rivalry, the Mom Bucks experiment has run its course, and family life at the Heffley house returns to its usual state heading into the next book.",
         "in_short": "Greg starts a new school year with his older brother Rodrick holding an embarrassing summer secret over his head. Their mother introduces Mom Bucks, a chore-reward currency meant to improve both boys. The centrepiece is a party Rodrick throws while the parents are away for a weekend: the brothers cover it up together afterward - even swapping a scribbled-on bathroom door - and the shared secret briefly unites them, until a developed photograph exposes the party and Rodrick is punished. His band, Loded Diper, still gets to play the local talent show, but the video is ruined for him by their mother dancing in it. In revenge Rodrick spreads Greg's summer secret at school, but the story mutates as it passes from student to student until the version everyone hears no longer embarrasses Greg. The brothers end the book back at their usual rivalry.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -456,7 +456,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -469,7 +469,7 @@
       "recaps": {
         "ending": "A photograph from Rodrick's party exposes the brothers' cover-up, and their parents punish Rodrick. He is nevertheless allowed to perform with Löded Diper in the talent show. The recording of the performance focuses heavily on Susan dancing in the audience, so Rodrick does not get the promotional video he expected. Blaming Greg for the result, Rodrick finally tells other students the story he has withheld all year: during Greg's summer stay at Leisure Towers, Greg accidentally entered the women's restroom and had to flee. As the account passes through the school, its details change until Greg is credited with deliberately entering a girls' locker room at a high school. The distorted version makes him seem daring rather than ridiculous, so Rodrick's revenge fails to cause the intended humiliation. The brothers return to their familiar rivalry, but their temporary cooperation over the party shows that they can protect each other when their interests align.",
         "in_short": "Greg begins a new school year with Rodrick threatening to reveal an embarrassing incident from Greg's summer. Their mother tries to improve the brothers' relationship with Mom Bucks, a reward currency for chores and good behavior. When their parents leave town, Rodrick throws a party and confines Greg to the basement. The brothers then cooperate to hide the evidence, including replacing a marked bathroom door, and their shared secret briefly brings them closer. A developed photograph eventually exposes the party. Rodrick is punished but still performs with Löded Diper at the talent show, where the family video highlights their mother's enthusiastic dancing rather than the band. Rodrick retaliates by spreading Greg's summer story at school. The tale becomes so exaggerated in circulation that it improves Greg's reputation instead of ruining it, leaving the brothers back in their ordinary uneasy relationship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -573,7 +573,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -584,7 +584,7 @@
       "recaps": {
         "ending": "The book ends with the road trip abandoned and the family back home. The journey Greg's mother envisioned - spontaneous, wholesome, and bonding - collapsed under a live pig won at a county fair, a seagull invasion of the van, a dismal motel, a running feud with a bearded family they kept encountering, and an accumulating toll on the van and the family's belongings. The Heffleys never reached the destinations they talked about; they simply ran out of trip and drove home. Even so, the shared catalogue of disasters leaves the family closer than when they set out, and Manny's pig is kept as a household pet - a souvenir that outlasts the vacation itself into the later books.",
         "in_short": "Greg's mother packs the family into the van for a spontaneous, screen-free summer road trip with no fixed destination, and nearly everything about it goes wrong: Manny wins a live pig at a county fair that then rides along with them, seagulls invade the van after a snack, a night is spent in a dismal motel, and the family keeps crossing paths with a bearded rival family. The second half of the trip adds more mishaps with the van and their belongings until the itinerary is abandoned and the Heffleys head home. The planned destinations are never reached, but the shared ordeal draws the family closer, and the pig comes home with them as a pet.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -692,7 +692,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -703,7 +703,7 @@
       "recaps": {
         "ending": "The book ends in the wake of the Valentine's dance. Greg's long campaign for a date produced only a shared arrangement: he and Rowley escorting Abigail together after her original date dropped out. The dance itself unravelled, finished off by a chickenpox scare that broke up the evening and sent everyone home early. The clear winner of the night is Rowley, who ends the book as Abigail's boyfriend; Greg ends it as the leftover third of the trio, dateless and mildly bitter about how the arithmetic worked out. At home, Uncle Gary is still living in the basement and the family is unchanged, leaving Greg's world exactly as unsettled as usual going into the next book.",
         "in_short": "After opening with stories from before and just after his own birth, Greg spends this book angling for a date to the school's Valentine's dance while his out-of-work uncle Gary moves into the family basement. The date search fails until Abigail, a girl whose escort pulled out, agrees to be taken to the dance by Greg and Rowley together. The evening sours and a chickenpox scare breaks the dance up early; by the time the dust settles, Rowley and Abigail are a couple and Greg is the odd one out - the third wheel of the title. The book ends with Greg dateless and Rowley attached, while home life with Uncle Gary carries on.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -802,7 +802,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -813,7 +813,7 @@
       "recaps": {
         "ending": "The book ends at Uncle Gary's wedding. Greg has spent the whole book without Rowley - his tryouts for a new best friend went nowhere - while adjusting to his mother's return to college and enduring the school's awkward lessons about adolescence. At the wedding the two estranged friends are pushed together by the family occasion, the ice breaks, and the falling-out that opened the book is finally over. Greg comes away with his best friend back and with a grudging acceptance that the changes of growing up are arriving whether he wants them or not. The family returns home with its usual dynamics intact, ready for the winter that opens the next book.",
         "in_short": "Greg begins the book estranged from Rowley and holds unsuccessful tryouts for a replacement best friend. At home his mother goes back to school, leaving Greg, his brothers, and his father to cope with chores and cooking; at school the class endures lessons and talks about adolescence that Greg finds mortifying, and a much-hyped school lock-in disappoints. The book builds to Uncle Gary's latest wedding, where Greg and Rowley are thrown together by the family occasion and finally patch up their friendship. It ends with the two boys reconciled and Greg resigned to the fact that growing up cannot be put off.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1135,7 +1135,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002UZYVTE",
@@ -1147,7 +1147,7 @@
       "recaps": {
         "ending": "Reacher kills Bo Borken before Borken can execute Holly, and McGrath frees her. The supposed dynamite barrier around her room is gone because it has been turned into a mobile bomb. Milosevic then takes Holly hostage, admits accepting money from Brogan, and is killed by Holly during her escape. Reacher, Holly, McGrath, General Garber, and General Johnson pursue Stevie by helicopter. They identify a Federal Reserve branch in San Francisco as the intended target, locate the repainted truck, and Reacher detonates it on an empty highway. Stevie dies and the public attack fails. Military forces secure and dismantle the militia enclave, recover its weapons, and remove the missile unit. Holly receives treatment, returns to the FBI, and later lives with McGrath. Reacher says goodbye and resumes travelling alone, reaching Wisconsin.",
         "in_short": "Jack Reacher is accidentally abducted with FBI agent Holly Johnson and chooses to protect her rather than escape alone. Their captors deliver them to Bo Borken's fortified Montana militia, which plans to declare independence while using Holly's ties to General Johnson and the President as leverage. Reacher and Holly resist from inside as federal officials struggle with a leak, political restrictions, and stolen Stinger missiles. Reacher destroys the militia's mobile missile capability, rescues McGrath, exposes Brogan as Borken's mole, and kills Borken before Holly can be executed. Holly kills Milosevic after he takes her hostage and admits paid cooperation. The militia siege proves to be cover for Stevie's dynamite attack on a Federal Reserve branch in San Francisco. Reacher destroys the bomb truck on an empty highway, the enclave is dismantled, Holly later lives with McGrath, and Reacher leaves alone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1337,7 +1337,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1350,7 +1350,7 @@
       "recaps": {
         "ending": "Leah's manipulation of the custody fight is exposed in the final confrontation. Kristof Nast is killed when the conflict he helped create turns against him, and Leah is also killed, ending the immediate campaign against Paige and Savannah. With Kristof gone and the scheme discredited, the Nast Cabal no longer has a viable claim that can remove Savannah from Paige. Paige has nevertheless lost her former place in the American Coven: its elders chose distance and secrecy when she needed support, and she will not return to their narrow rules. She retains guardianship of Savannah and accepts a life built through relationships beyond the Coven. Lucas has proven that his loyalty is personal rather than an extension of the Cortez Cabal, and he and Paige acknowledge their romantic partnership. The household that remains is smaller and less institutionally protected, but Paige and Savannah are together, Leah can no longer threaten them, and their ties to Lucas and the wider supernatural community offer a new foundation.",
         "in_short": "After Ruth Winterbourne's death, young Coven leader Paige becomes guardian to powerful thirteen-year-old witch Savannah Levine. The Nast Cabal, led by Savannah's biological father Kristof, launches a custody claim and a campaign of occult incidents and public accusations designed to make Paige appear dangerous. Sorcerer lawyer Lucas Cortez offers help, challenging Paige's inherited distrust of sorcerers. As the pressure spreads through courts, neighbors, media, and the supernatural community, the American Coven values secrecy over defending Paige. She and Lucas discover that escaped half-demon Leah O'Donnell is driving the attacks and using the Cabal's claim for her own purposes. The final confrontation kills both Kristof and Leah, ending the immediate custody campaign. Paige keeps Savannah but breaks with the Coven that abandoned them. She and Lucas become partners and begin a relationship, forming an independent household for Savannah beyond the old division between witches and sorcerers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1649,7 +1649,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002V8LAAI",
@@ -1661,7 +1661,7 @@
       "recaps": {
         "ending": "Roic captures the Ba alive aboard the Idris, and Graf Station searchers contain its biological device in the Minchenko Auditorium. Greenlaw releases the Barrayaran force, prisoners, evidence, and stolen replicators in exchange for leaving the contaminated Idris behind and postponing the financial settlement. Miles, Ekaterin, Bel, Gupta, the captive, and the fetal cargo travel to Rosita. Cetagandan treatment cures Miles and Bel, though Miles retains an elevated circulatory risk and Bel suffers more serious damage that may require recovery in low or zero gravity. The stolen children are returned to their haut constellations, and Benin's decoy evidence establishes Barrayaran innocence, ending the threat of war. Corbeau and Garnet Five remain committed to one another, but Miles's proposal to make Corbeau the Barrayaran consul in quaddie space is not confirmed. Bel and Nicol resume their shared life without a recorded resolution of Bel's Union citizenship and ImpSec obligations. Miles and Ekaterin return home, where their twins Aral Alexander and Helen Natalia are born safely.",
         "in_short": "Imperial Auditor Miles Vorkosigan is diverted to Graf Station, where a Barrayaran escort has provoked an impoundment while responding to Lieutenant Solian's unexplained disappearance. The inquiry uncovers fabricated blood evidence, a disguised Cetagandan Ba, and a thousand stolen haut fetuses aboard the Idris. Russo Gupta reveals the smuggling trail, while Bel Thorne is found infected by an engineered parasite. The Ba seizes the Idris and threatens Graf with a biological device, but Corbeau aids Miles and Roic in capturing it. The station bomb is contained, and Miles carries the captive, the children, and the evidence to Rosita. Cetagandan treatment saves Miles and Bel, the children are restored, and proof of planted decoys clears Barrayar and averts war. Bel returns to Nicol with lasting injuries, while Miles and Ekaterin reach Vorkosigan House for the safe births of Aral Alexander and Helen Natalia.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1809,7 +1809,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1822,7 +1822,7 @@
       "recaps": {
         "ending": "David returns to Lucy's farm after visiting Melanie's family and finding his Cape Town home stripped and damaged. Lucy is pregnant as a result of the attack and has decided not to leave. She accepts Petrus's proposal that she become, in local terms, part of his household and surrender her land to him in exchange for the use of the house and a measure of protection. David regards the arrangement as a humiliating dispossession, but Lucy insists on choosing the conditions under which she will begin again. David resumes helping Bev Shaw euthanize unwanted animals and personally takes their bodies for respectful disposal. He also continues composing his chamber opera, though it has narrowed far from his original ambitions. In the final scene he brings Driepoot, the dog that has become attached to him, for euthanasia rather than postponing the inevitable for his own comfort. His surrender of the animal does not resolve his relations with Lucy or the wider social order, but it marks a changed capacity to attend to another creature without claiming possession or reward.",
         "in_short": "Cape Town academic David Lurie loses his post after pursuing his student Melanie Isaacs and refusing to offer the penitence demanded by a disciplinary committee. He retreats to the Eastern Cape farm of his daughter Lucy, where he helps at Bev Shaw's animal clinic and slowly becomes involved in the disposal of euthanized dogs. Three men attack the farm, assault Lucy, burn David, and kill the dogs. Lucy refuses to report the sexual assault or abandon her home. When one attacker, Pollux, appears under the protection of her neighbour Petrus, she chooses accommodation over the justice David wants. Pregnant from the attack, she agrees to give Petrus title to her land and enter his household in exchange for protection and continued residence. David, unable to dictate her response, visits Melanie's family and returns to assist Bev. The novel ends as he gives up a dog he has come to love to be euthanized, accepting a painful act of care without expecting redemption.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2173,7 +2173,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -2186,7 +2186,7 @@
       "recaps": {
         "ending": "Earth has permanently closed all three Malfon portals after defeating the invading armies in Brazil, India, and Moscow, but more than one hundred million people have died and the recovery burden remains immense. Silas restores every recoverable allied casualty at Moscow, though seven dragon souls remain in Nico's vault. Nico becomes his permanent ally, while Samvek, Cece, and Jiang bond with dragons. Lily's body is destroyed after a Duchess of the Fourth Hell possesses her. Silas saves Lily's soul, and Abel Kalestian later removes it from him and preserves it in a gem, ending the immediate danger to Silas's soul. Selena and Lana remain close partners without a settled romantic or political commitment. Silas is ascendant-assured, follows a partly primordial and heretical path, owes future service to the System and a favor to an underworld corporation, and has attracted the attention of Hell and death powers. The next urgent task is Galen. Dory, Crag, Nevin, and a mixed team begin evacuation work, but Earth lacks room for all thirty million Galenians and has no answer to the Abhorrent or the Forlorn.",
         "in_short": "After learning that Galen faces a real future catastrophe, Silas searches for evacuation resources while powerful families compete to bind him. An off-world auction gives his allies portal scrolls and teleportation teams, but it also distributes dangerous access rights to Earth and leads an Ascendant Malfon matron to attack him. House Malfon then launches a three-front invasion. Silas develops independent primordial and hybrid cultivation powers, becomes ascendant-assured, and fights beside Selena, Lana, Urg, Earth's defenders, allied cultivators, and Nico's dragons. Lily's apparent betrayal proves to be possession by a Duchess of the Fourth Hell; her body dies, but Silas preserves her soul. Earth defeats the invasion and closes every Malfon portal at a cost of more than one hundred million lives. Silas resurrects the recoverable allied dead at Moscow, attracting attention from death powers. Abel Kalestian takes custody of Lily's soul and offers a possible long-term alliance. Silas then turns toward the urgent, still-unsolved evacuation of Galen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2509,7 +2509,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -2522,7 +2522,7 @@
       "recaps": {
         "ending": "Felix and Pit reach Shelem's essence anchor after Magda stays outside the central door to delay the Risi. The captive woman reveals herself as the Unending Maw, a primordial that manipulated Felix's race and hunger-based abilities to prepare him as a vessel. The Risi chieftain dies during a failed transformation. With Pit's bond strengthening into Etheric Concordance, Felix becomes a Dawnwalker and God-Eater, consumes part of the Maw, and uses the anchor against it. The act removes the Foglands fog and skill suppression and restores the region, but banishes Felix and Pit into a featureless void with the surviving weakened Maw. Calesca Boscal finds Magda cold and without a heartbeat. Harn Kastos, Evie Aren, and Atar V'as are outside with the rescued prisoners and do not know Felix's or Magda's fate. Illia carries the unconscious Vessilia toward Harwatch while intending to profit from the outcome. An unidentified speaker recruits surviving Risi to serve a new father belowground, while the Archon and Felix's unfinished temple objective also remain unresolved.",
         "in_short": "After an altered summoning pulls Felix Nevarre from Earth, a system makes him Nym and strands him in the Foglands. He survives by developing skills, gains the Tenku companion Pit, and joins Magda Aren's guild party against a Risi occupation. Their rescue of the Risi prisoners leads Felix, Pit, and Magda into a labyrinth beneath Shelem. At its center, the Unending Maw reveals that it engineered Felix's hunger and intended to use him as a vessel. Felix and Pit resist it, and Felix activates the essence anchor, clearing the Foglands and saving the continent. Magda is found without a heartbeat, Illia abducts Vessilia Dayne, and surviving Risi answer a new underground summons. Felix and Pit survive but are banished into a void with the weakened Maw.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2894,7 +2894,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -2907,7 +2907,7 @@
       "recaps": {
         "ending": "More than 35.6 million people from Galen have been evacuated, the three Overminds are dead, and Silas Renner has destroyed the remaining invasion without shattering Galen. The planet survives with severe damage, while the outcome of the higher-power struggle around the Abhorrent remains unresolved. Ryan leaves to seek allies in other realms. Lana remains with the House Kalestian force, Vex is still adapting as Earth's guardian, and Asta still owes an accounting for her research. Nico kills Tiamat after fighting beside her, and her chromatic remains advance Silas's sealed primordial aspect. Abel Kalestian is removed by a goddess and his fate is unknown. The goddess reveals that Earth was meant to be destroyed and attempts to erase Silas because his Architect authority and alliances threaten the existing order. The Voice acts through Lily's soul gem to open an escape. Silas enters it with Selena, Samvek, and Urg, leaving their destination unknown. He carries seven concealed, non-system soul gems, remains bound by obligations to several powers, and is separated from the system connection the goddess severed.",
         "in_short": "Silas Renner begins by evacuating Galen, then learns that the Forlorn plan to use the Abhorrent to return from the void. He secures the lunar House of Evolution, defeats an outside-backed attack on Earth, survives a hybrid legendary evolution, and builds alliances spanning Turga, House Kalestian, cultivators, dragons, and Hell. Selena becomes his fiancée, while Vex becomes Earth's guardian. After reaching legendary tier, Silas leads the defense of Galen. The allies kill three Overminds, and Silas destroys the uncontrolled Forlorn before they can annihilate the planet. Nico then kills Tiamat, whose remains strengthen Silas's sealed primordial aspect. A goddess removes Abel Kalestian, reveals that Earth was intended to die, and tries to erase Silas for bridging systems. The Voice intervenes through Lily's soul gem, allowing Silas, Selena, Samvek, and Urg to escape through a portal to an unknown destination.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3111,7 +3111,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3124,7 +3124,7 @@
       "recaps": {
         "ending": "The Erudite plan is unleashed: a transmitter serum injected into the Dauntless turns them into an unthinking army that marches on Abnegation to wipe out its leaders. Tris and Four, immune because they are Divergent, are caught in the middle. Tris's mother, revealed to have been born Dauntless, frees her from execution and is killed getting her to safety, and her father dies moments later helping her reach the Dauntless control room. There Tris is captured by Jeanine, who has placed Four under a far stronger simulation and turned him against Tris; he nearly kills her before her willingness to die for him breaks the program's hold. Earlier in the chaos Tris is forced to shoot her friend Will, who attacks her under the serum's control, a death that will haunt her. She and Four shut down the master simulation, stopping the slaughter, but Jeanine escapes and the war between the factions is only beginning. Tris's parents are dead, her brother Caleb had sided with Erudite before turning back, and the survivors, including Tris, Four, Caleb, Marcus, and the injured Peter, escape the city by train toward the fence, the old faction system in ruins behind them.",
         "in_short": "In a walled city divided into five factions, each built around a single virtue, sixteen-year-old Beatrice Prior takes the aptitude test that guides her lifelong choice and learns she is Divergent, fitting several factions and dangerous to a system that depends on people fitting only one. Warned to keep it secret, she leaves her Abnegation family to join the fearless Dauntless, renaming herself Tris, while her brother Caleb chooses Erudite. She endures a savage initiation of combat and fear simulations, makes friends and enemies, hides her Divergence, and grows close to her instructor Four, whose real name is Tobias. She uncovers a plot by the Erudite leader Jeanine Matthews to use a mind-control serum to turn the Dauntless into a private army against Abnegation. When the attack comes, Tris and Four resist because they are Divergent. Her mother dies saving her and her father dies helping her; she is forced to kill her friend Will under the serum's control; and together she and Four shut down the master program, halting the assault. Jeanine survives, the faction order is shattered, and the survivors flee the city.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3324,7 +3324,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3337,7 +3337,7 @@
       "recaps": {
         "ending": "Adrian completes The Lamentation of Doctor Faustus, a work that turns the affirmative ending of Beethoven's Ninth Symphony toward grief and negation. He summons friends and acquaintances to Pfeiffering and, before they hear the piece, declares that his career arose from a compact with the Devil sealed through deliberate infection. Most listeners take the speech for madness and leave in distress. Adrian collapses at the piano and never recovers his independent mind. His mother takes him home and cares for him for ten years in a state of helpless mental darkness; he dies in 1940. Zeitblom writes the biography as Germany approaches military ruin in 1945. He closes by linking his friend's catastrophe with that of the nation, yet he leaves a narrow hope that the lament itself may contain an indirect possibility of grace beyond despair.",
         "in_short": "During the Second World War, humanist scholar Serenus Zeitblom writes the life of his friend Adrian Leverkühn, a brilliant composer born in imperial Germany. After studying theology, Adrian turns to music and deliberately seeks a woman who has warned him of her syphilis, contracting the illness that shadows his career. In an ambiguous encounter he speaks with the Devil, who claims the infection seals a twenty-four-year bargain: revolutionary artistic power in exchange for love. Adrian develops a rigorously ordered new musical language and produces major works while remaining emotionally isolated. Attempts at closeness end disastrously: violinist Rudi Schwerdtfeger is murdered after acting as Adrian's romantic intermediary, and Adrian's beloved nephew Nepomuk dies of meningitis. Adrian answers with The Lamentation of Doctor Faustus. In 1930 he confesses the pact to his friends, collapses into insanity, and spends his remaining decade in his mother's care. Zeitblom completes the story as Nazi Germany falls, treating Adrian's fate as a parallel to the nation's self-destruction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3514,7 +3514,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3527,7 +3527,7 @@
       "recaps": {
         "ending": "Bond survives Doctor No's engineered endurance course and escapes into the guano-loading complex. Taking control of a crane, he sends a mass of guano down on Doctor No and buries him. Honey, who had been left to die in a crab-infested area, escapes because the crabs do not attack her as No expected. Bond finds her, and the two flee Crab Key in the armed vehicle used to maintain the island's legend of a dragon. They reach Jamaica and safety. Bond intends to report the destruction of No's base and the truth behind Strangways's disappearance, while also anticipating official displeasure over the disorder left behind. Honey is alive and free, and the threat to the American missile tests has ended with Doctor No's death.",
         "in_short": "After Jamaican station chief John Strangways and his secretary are murdered, M sends a recently recovered James Bond to investigate. Evidence points to Crab Key, a privately owned island whose guano operator, Doctor No, has frightened away scrutiny. Bond survives attempts on his life, exposes secretary Miss Taro as an enemy agent, and lands secretly on the island with his old ally Quarrel. There they meet shell collector Honeychile Rider. Doctor No's armored flame-throwing vehicle kills Quarrel and captures Bond and Honey. No reveals that he is disrupting American guided-missile tests for Soviet interests, then subjects Bond to a lethal obstacle course. Bond survives, escapes into the industrial works, and buries No beneath guano using a loading crane. Honey also escapes her intended death, and she and Bond flee the island together, ending No's operation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3719,7 +3719,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3732,7 +3732,7 @@
       "recaps": {
         "ending": "After returning to Moscow, Yury lives for a time with Marina and has two daughters with her, but his health and ability to sustain an ordered life continue to fail. Evgraf arranges a medical position that might let him begin again. On the way to his first day, Yury suffers a fatal heart attack after struggling to leave a crowded tram; he dies in the street without reaching a woman he recognizes as she passes nearby. Lara comes to his funeral and helps Evgraf sort Yury's writings. She tells Evgraf about the daughter she bore after leaving Yuriatin, a child lost during the upheavals, and then disappears, apparently becoming one of the countless victims of the purges. Years later, during the Second World War, Gordon and Dudorov meet a young laundry worker named Tanya whose history strongly suggests that she is Yury and Lara's daughter. Evgraf undertakes to care for her. After the war, the two old friends read Yury's collected poems, finding in them a surviving expression of the life and era that destroyed him.",
         "in_short": "Orphaned Yury Zhivago becomes a Moscow doctor and poet, marries his childhood companion Tonya, and serves in the First World War, where he meets the nurse Lara Antipova. Revolution and civil war drive Yury's family east to Varykino. Near Yuriatin he renews his bond with Lara and begins an affair, but partisans abduct him and force him to work as their doctor. He escapes to find his family deported and Lara alone. Komarovsky offers Lara protection from the authorities; Yury deceives her into leaving with him while remaining behind. Lara's husband, the revolutionary commander Strelnikov, visits Yury and then kills himself. Back in Moscow, Yury's life and health decline. He dies of a heart attack in the street, and Lara later disappears in the purges. Years afterward, their friends encounter Tanya, almost certainly the lost daughter of Yury and Lara, while Yury's poems preserve his private response to Russia's transformation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3893,7 +3893,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3906,7 +3906,7 @@
       "recaps": {
         "ending": "Leila's conflict with her family over marriage and education can no longer be treated as a private disagreement. After she leaves home, friends and responsible adults help bring her to safety, and outside intervention prevents her future from being decided without her consent. Simone begins resisting the shame and unrealistic expectations surrounding her body. Amal's friendship with Mrs Vaselli deepens through their shared recognition of how migrants can be reduced to stereotypes. At school, Amal no longer measures every choice by Tia's reaction. She and Adam acknowledge their feelings, but Amal holds to the boundaries of her faith rather than entering a relationship on terms that do not suit her. Wearing hijab has not ended prejudice or removed Amal's own moments of doubt, yet it has made her more confident about explaining who she is. She finishes the school period with Eileen and Simone beside her, her family supportive, and a clearer ability to oppose both anti-Muslim assumptions and coercion carried out in the name of tradition.",
         "in_short": "Sixteen-year-old Amal Abdel-Hakim decides to wear hijab full-time at her elite Melbourne school. The choice is personally meaningful, but it brings intrusive questions, hostility from classmate Tia, anxiety about public reactions, and new complications in Amal's attraction to Adam. Supported by Eileen, Simone, and her parents, she learns to answer prejudice without allowing every encounter to define her. Her friendships also reveal pressures unlike her own: Simone struggles with body shame, while Leila faces family efforts to control her education and marriage. When Leila leaves home, intervention protects her ability to determine her future. Amal's friendship with elderly Greek neighbor Mrs Vaselli shows how different immigrant histories can overlap. By the end, Amal maintains her religious boundaries with Adam, stands more firmly beside her friends, and remains committed to hijab. Her confidence comes not from making hostility disappear but from refusing stereotypes imposed by either wider Australian society or restrictive cultural expectations.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4063,7 +4063,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4076,7 +4076,7 @@
       "recaps": {
         "ending": "Greg's summer has not followed his ideal of uninterrupted games and comfort. His misuse of the Jeffersons' hospitality leads to a bill, failed efforts to earn repayment money, and a disastrous seaside visit that leaves his friendship with Rowley strained. The Heffleys' new dog, Sweetie, also proves too disruptive for the household and ultimately goes to live with Grandma, where he is thoroughly indulged. Frank's repeated attempts to share outdoor activities with Greg produce frustration rather than the close father-son relationship he wants. Even so, the conflicts do not cause a permanent family break. Susan later presents the vacation as a collection of successful family memories, selecting photographs that make the difficult outings appear cheerful. Greg recognizes that the official family version bears little resemblance to his own experience, but he reaches the end of vacation with home life and his important relationships still intact. Summer closes as another period that disappointed Greg's plans without becoming the total failure he often claimed it was.",
         "in_short": "Greg plans to spend summer vacation indoors playing video games, while Susan organizes reading, exercise, and low-cost family outings. Time with Rowley at the country club seems promising until Greg learns that the drinks he has been ordering created a substantial bill. Attempts to earn repayment money through a lawn-care business go badly. The Heffleys acquire an energetic dog named Sweetie, whose presence adds another source of household disorder before Grandma takes him in. Greg later joins the Jeffersons on a seaside trip, but his selfish decisions and clashes with Mr. Jefferson spoil the invitation and strain his friendship with Rowley. Frank also tries to arrange father-son activities, only to discover how different his and Greg's ideas of recreation are. By summer's end, Susan's carefully chosen photographs turn the family's mishaps into a cheerful record. Greg remains skeptical, but the family and friendships survive the vacation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4291,7 +4291,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4304,7 +4304,7 @@
       "recaps": {
         "ending": "James Carker's schemes end with his flight and death beneath a train, while the concealed damage to Dombey and Son contributes to the firm's collapse. Dombey loses his commercial power, his social household, and the pride that kept him apart from Florence. Walter and Florence marry and go abroad; Susan Nipper eventually marries Mr. Toots. After a period of illness and isolation, Dombey finally accepts Florence's continued love and is reconciled with her. In the final chapter, years have passed. Florence and Walter have children, including a son named Paul, and the family lives in comfort after Walter's successful career. The older Dombey is physically diminished but emotionally transformed, tender toward his grandchildren and especially attached to the little girl who resembles Florence. Edith remains apart but sends Florence a loving message. The family name continues through affection rather than through the rigid commercial dynasty Dombey once tried to impose.",
         "in_short": "Merchant Paul Dombey values his long-awaited son as heir to Dombey and Son while neglecting his loving daughter Florence. The frail boy, also named Paul, forms a deep bond with Florence but dies after an oppressive education, destroying his father's dynastic hopes. Young employee Walter Gay loves Florence, is sent abroad, and is feared lost. Dombey then marries the proud widow Edith Granger in a loveless match encouraged and manipulated by his manager James Carker. The marriage becomes a contest of control; Edith flees with Carker to punish Dombey, then rejects Carker, while Dombey drives Florence from home. Walter returns alive and later marries Florence. Carker dies while fleeing, and Dombey's firm collapses. Stripped of status and left alone, Dombey finally receives the forgiveness Florence has always offered. Years later he is a gentle grandfather within Florence and Walter's family, valuing the daughter and granddaughter whom his former idea of succession would have overlooked.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/domestication.json
+++ b/data/works-community/0/domestication.json
@@ -264,7 +264,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -277,7 +277,7 @@
       "recaps": {
         "ending": "John returns to Sutton Farm after reclaiming the ornate box and tower token from Catherine. Reese and Sandra die fighting Thomas Little, Ferdie, and Sigvald, while Ellie kills Grimes with a curse and survives the resulting mana injury after John intervenes. Haver reaches the farm alive, sees that its defenders have prevailed, and withdraws. The household and dairy remain secure, with Thomas and Evan working alongside John, Ellie, and Ben. Red Coral's assault is ended, but Catherine's fate is unconfirmed and Earl Vosik remains connected to the tower scheme. Ellie learns that her interrupted class ceremony may still permit a future magical class, probably involving water, while Ben is revealed not to be her biological brother. John identifies Tower Master Kelvis as Storm Master Kelvis and opens the recovered box to find six water-magic spell scrolls. Kelvis's testament points toward an undiscovered inverted tower containing his student's research and connects that work to the world-changing summoning. John still must develop food that can withstand mana and prevent his doom total from reaching the apocalypse threshold.",
         "in_short": "John Sutton, a discharged mage seeking retirement, claims a neglected Fairford farm and makes Ellie and Ben part of its household. He recovers stolen cattle, develops a dairy and cheese business, and learns that peaceful human bonds can reduce the doom points that threaten to begin an apocalypse. His crop experiments and recovered mage research point toward food able to survive a mana-altered world. After fighting Haver, John later joins him and Red Coral on a tower expedition. Red Coral betrays them and sends attackers toward Sutton Farm, but John and Haver survive. The farm's defenders kill Reese, Sandra, and Grimes, and Ellie survives using dangerous curse magic. John recovers the expedition's ornate box and discovers water-magic scrolls. He also identifies Tower Master Kelvis as Storm Master Kelvis and learns of an inverted tower holding further research tied to the summoning. The farm is secure, but the apocalypse, Ellie's unfinished magical development, Earl Vosik, and the hidden tower remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -493,7 +493,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -506,7 +506,7 @@
       "recaps": {
         "ending": "In Barcelona, Samson Carrasco defeats Don Quixote while disguised as the Knight of the White Moon and makes him swear to abandon knight-errantry for a year. Don Quixote keeps his promise and travels home with Sancho, still interpreting much of the world through enchantment but unable to resume his calling. Back in his village he falls ill. Plans for a pastoral life with his friends give way to a final recovery of judgment: he identifies himself as Alonso Quixano, rejects the romances that shaped his delusion, confesses, and makes a will. He provides for Sancho and his household, but dies before the squire's pleas can draw him into another adventure. His friends mourn and bury him. Cide Hamete's concluding words close the history and insist that no later author should revive the knight, making Don Quixote's death the explicit end of both his wandering and the fictional chronicle built around it.",
         "in_short": "Alonso Quixano reads so many romances that he renames himself Don Quixote and rides out to revive knight-errantry, interpreting inns as castles, windmills as giants, and ordinary conflicts as enchanted adventures. A farmer, Sancho Panza, becomes his loyal squire in hope of governing an island. Their injuries and mistakes are mixed with acts of courage and encounters with people whose own stories test the boundary between fiction and life. Friends bring them home after a first long expedition, but a published account of their fame inspires another. A duke and duchess exploit that fame with elaborate deceptions, including a mock governorship in which Sancho nevertheless judges wisely. The pair eventually reach Barcelona, where Samson Carrasco defeats Don Quixote and forces him to retire. At home the knight falls ill, recovers his identity as Alonso Quixano, renounces chivalric romances, and dies, while Sancho urges him in vain to seek another adventure.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -766,7 +766,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -779,7 +779,7 @@
       "recaps": {
         "ending": "After the Knight of the White Moon defeats him in Barcelona, Don Quixote must abandon knight-errantry for a year and return home. He and Sancho travel back through places marked by earlier adventures, briefly considering a pastoral life they might begin when the enforced retirement ends. At the village Don Quixote becomes ill. Following a long sleep, he says that his madness has left him, rejects the romances that shaped his career, and identifies himself again as Alonso Quixano. He makes a will that provides for his household and niece, with a condition intended to keep books of chivalry out of her marriage. Sancho pleads with him not to die and urges them to take up the proposed shepherds' life, but his friend remains lucid and resigned. Alonso Quixano receives the last rites and dies in bed among Sancho, his niece, the housekeeper, the priest, the barber, and Samson Carrasco. The narrator closes the history by insisting that no further adventures should be falsely attached to Don Quixote's name.",
         "in_short": "A country gentleman maddened by romances renames himself Don Quixote and rides out to revive knight-errantry, interpreting inns as castles, windmills as giants, and ordinary conflicts as enchantments. He recruits the practical farmer Sancho Panza with promises of an island to govern. Their two major journeys bring beatings, mistaken rescues, stories of other lovers and captives, and an increasingly affectionate partnership. Friends eventually return Don Quixote home in a cage. In a second part, the pair discover that a book about their earlier adventures has made them famous. People now stage deceptions for them, most extravagantly a Duke and Duchess who give Sancho a mock governorship; he governs sensibly but abandons it. In Barcelona, Samson Carrasco defeats Don Quixote while disguised as the Knight of the White Moon and compels him to retire. Back home, Don Quixote recovers his sanity, resumes the name Alonso Quixano, renounces chivalric romances, makes his will, and dies while Sancho begs him to keep imagining new adventures.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1019,7 +1019,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1032,7 +1032,7 @@
       "recaps": {
         "ending": "After the Knight of the White Moon defeats Don Quixote in Barcelona, the terms of the combat require him to abandon knight-errantry for a year. Don Quixote and Sancho travel home, briefly imagining a pastoral life they might take up instead. Once in his village, Don Quixote falls ill. He sleeps, wakes with his reason restored, rejects the chivalric romances that governed his adventures, and identifies himself again as Alonso Quijano. Sancho urges him to rise for another outing, but his former master calmly makes his will, provides for his household, and dies in his bed among his friends. The narrator closes the history by insisting that Don Quixote's story has reached its definitive end and should not be subjected to false continuations. Sancho survives him, having lost both the promised rewards of adventure and a companion he had come to love.",
         "in_short": "A country gentleman maddened by chivalric romances renames himself Don Quixote and rides out to revive knight-errantry. With the farmer Sancho Panza as his squire, he transforms inns into castles, windmills into giants, and chance encounters into quests, often causing injuries while sincerely trying to serve justice. Friends eventually return him home, but a published account of the adventures helps inspire a second expedition. Aristocrats who know the book stage cruel entertainments around the pair, while Sancho briefly and capably governs a mock island. Don Quixote continues toward Barcelona, where Samson Carrasco, disguised as the Knight of the White Moon, defeats him and compels him to stop adventuring. Back in his village, Don Quixote becomes ill, regains his sanity, renounces the romances, makes his will, and dies as Alonso Quijano. Sancho, who has grown loyal beyond his original hope of profit, tries in vain to revive his master's old dream.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1292,7 +1292,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1305,7 +1305,7 @@
       "recaps": {
         "ending": "After the Knight of the White Moon defeats him in Barcelona, Don Quixote must abandon knight-errantry for a year and return home. He and Sancho travel back through places marked by earlier adventures, briefly considering a pastoral life they might begin when the enforced retirement ends. At the village Don Quixote becomes ill. Following a long sleep, he says that his madness has left him, rejects the romances that shaped his career, and identifies himself again as Alonso Quixano. He makes a will that provides for his household and niece, with a condition intended to keep books of chivalry out of her marriage. Sancho pleads with him not to die and urges them to take up the proposed shepherds' life, but his friend remains lucid and resigned. Alonso Quixano receives the last rites and dies in bed among Sancho, his niece, the housekeeper, the priest, the barber, and Samson Carrasco. The narrator closes the history by insisting that no further adventures should be falsely attached to Don Quixote's name.",
         "in_short": "A country gentleman maddened by romances renames himself Don Quixote and rides out to revive knight-errantry, interpreting inns as castles, windmills as giants, and ordinary conflicts as enchantments. He recruits the practical farmer Sancho Panza with promises of an island to govern. Their two major journeys bring beatings, mistaken rescues, stories of other lovers and captives, and an increasingly affectionate partnership. Friends eventually return Don Quixote home in a cage. In a second part, the pair discover that a book about their earlier adventures has made them famous. People now stage deceptions for them, most extravagantly a Duke and Duchess who give Sancho a mock governorship; he governs sensibly but abandons it. In Barcelona, Samson Carrasco defeats Don Quixote while disguised as the Knight of the White Moon and compels him to retire. Back home, Don Quixote recovers his sanity, resumes the name Alonso Quixano, renounces chivalric romances, makes his will, and dies while Sancho begs him to keep imagining new adventures.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1563,7 +1563,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1576,7 +1576,7 @@
       "recaps": {
         "ending": "In Barcelona, Samson Carrasco defeats Don Quixote while disguised as the Knight of the White Moon and makes him swear to abandon knight-errantry for a year. Don Quixote keeps his promise and travels home with Sancho, still interpreting much of the world through enchantment but unable to resume his calling. Back in his village he falls ill. Plans for a pastoral life with his friends give way to a final recovery of judgment: he identifies himself as Alonso Quixano, rejects the romances that shaped his delusion, confesses, and makes a will. He provides for Sancho and his household, but dies before the squire's pleas can draw him into another adventure. His friends mourn and bury him. Cide Hamete's concluding words close the history and insist that no later author should revive the knight, making Don Quixote's death the explicit end of both his wandering and the fictional chronicle built around it.",
         "in_short": "Alonso Quixano reads so many romances that he renames himself Don Quixote and rides out to revive knight-errantry, interpreting inns as castles, windmills as giants, and ordinary conflicts as enchanted adventures. A farmer, Sancho Panza, becomes his loyal squire in hope of governing an island. Their injuries and mistakes are mixed with acts of courage and encounters with people whose own stories test the boundary between fiction and life. Friends bring them home after a first long expedition, but a published account of their fame inspires another. A duke and duchess exploit that fame with elaborate deceptions, including a mock governorship in which Sancho nevertheless judges wisely. The pair eventually reach Barcelona, where Samson Carrasco defeats Don Quixote and forces him to retire. At home the knight falls ill, recovers his identity as Alonso Quixano, renounces chivalric romances, and dies, while Sancho urges him in vain to seek another adventure.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1796,7 +1796,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1809,7 +1809,7 @@
       "recaps": {
         "ending": "The priest and barber persuade Don Quixote that an enchanted cage is carrying him toward a great destiny, allowing them to transport him home in an ox cart. A canon who meets the party questions both the literary quality of popular chivalric romances and the harm caused by Don Quixote's literal belief in them, but reason does not alter the knight's certainty. After hearing another pastoral story, Don Quixote attacks a procession of penitents because he mistakes a religious image for an abducted lady. He is knocked down, and Sancho briefly fears that he has died. Don Quixote recovers and the party finally reaches their village, where his housekeeper and niece receive him while Sancho returns to his own family. Don Quixote is physically home but not cured: he continues to understand his defeats as enchantments and remains disposed toward further adventures. The narrator closes without completing his later history, while indicating that Don Quixote and Sancho will ride out again.",
         "in_short": "A country gentleman of La Mancha reads so many romances that he remakes himself as Don Quixote, a knight-errant serving the imagined lady Dulcinea. After a brief first expedition ends in a beating, he recruits the farmer Sancho Panza with promises of an island. Together they mistake windmills for giants, inns for castles, sheep for armies, and a barber's basin for a legendary helmet. Don Quixote's efforts to impose chivalric justice usually injure himself or bystanders, though his defense of the independent shepherdess Marcela shows the generosity within his delusion. He frees galley prisoners who rob him, performs penance in the Sierra Morena, and becomes entangled in the real betrayals linking Cardenio, Luscinda, Dorotea, and Don Fernando. Those lovers are reconciled at an inn that also hosts a captive soldier and Zoraida, who helped him escape Algiers. The priest and barber finally cage Don Quixote under the pretense of enchantment and return him to his village, not cured and likely to seek another adventure.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1984,7 +1984,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1997,7 +1997,7 @@
       "recaps": {
         "ending": "Ozma brings Dorothy and her companions safely to Oz, where Zeb and Jim meet Dorothy's extraordinary friends. Jim races the Sawhorse and learns that an enchanted wooden horse has advantages an ordinary animal cannot match. Suspicion then falls on Eureka when one of the Wizard's nine tiny piglets disappears. At a formal trial the kitten is found guilty after seeming to admit the deed, but the Wizard produces the missing piglet alive from his coat pocket and clears her. The Wizard chooses to remain in Oz and study real magic under Glinda. Zeb is too homesick for ordinary life to settle in the fairyland, while Jim also longs for his familiar stable. Ozma uses the Magic Belt to send Zeb and Jim back to their California ranch and Dorothy and Eureka home to Kansas. The underground party therefore separates safely, with Dorothy able to visit her friends in Oz again and the Wizard at last becoming one of them.",
         "in_short": "An earthquake in California drops Dorothy, her cousin Zeb, the horse Jim, and the kitten Eureka into a succession of countries beneath the earth. They meet Dorothy's old friend the Wizard, whose balloon has also fallen, and together escape the glass city of the vegetable Mangaboos. Their route passes through a valley of invisible people, a country of wooden Gargoyles, and a cavern of young dragons. When they can go no farther, Ozma magically carries them to Oz. After reunions and contests, Eureka is accused of eating one of the Wizard's tiny piglets, but the animal is found unharmed. The Wizard stays in Oz to learn magic, while Ozma sends homesick Zeb and Jim back to California and returns Dorothy and Eureka to Kansas.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2115,7 +2115,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2128,7 +2128,7 @@
       "recaps": {
         "ending": "The rescued Bonforte never recovers enough to resume his public life and dies, making the supposedly temporary performance a permanent political necessity. Lorenzo has by then moved beyond imitation: studying Bonforte's convictions and acting on his responsibilities has changed his own values, including his former contempt for Martians. He agrees to continue as Bonforte rather than expose the substitution and destroy the coalition's work. Maintaining the identity requires Lorenzo Smythe to disappear from public life, but the actor accepts that personal erasure as part of the role. As Bonforte, he leads the Expansionists to electoral victory and becomes head of government. The secret remains confined to the small group that arranged the substitution. The closing perspective shows that the performance endures as a life rather than a single assignment: the public Bonforte survives and governs, while Lorenzo's former identity is surrendered to preserve the ideals he once merely pretended to hold.",
         "in_short": "Struggling actor Lorenzo Smythe is hired to impersonate interplanetary politician John Joseph Bonforte, who has been kidnapped just before crucial public appearances. Bonforte's aides Dak Broadbent, Penny Russell, and Dr. Capek train and physically prepare him. Lorenzo begins as a vain performer with strong anti-Martian prejudice, but successfully completes Bonforte's Martian adoption ceremony and later faces imperial and political duties while the real man remains incapacitated after rescue. Immersion in Bonforte's memories, relationships, and principles changes Lorenzo's outlook, and he conducts an election campaign as more than a mimic. When Bonforte dies, Lorenzo agrees to preserve the identity permanently. He wins office as Bonforte and continues the statesman's work, giving up his own name and career so completely that the role becomes the rest of his life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2255,7 +2255,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2268,7 +2268,7 @@
       "recaps": {
         "ending": "Lanyon's narrative reveals that Hyde came to him under Jekyll's instructions, mixed a drug from materials retrieved from Jekyll's laboratory, and transformed into Jekyll before his eyes. The experience destroyed Lanyon's health. Jekyll's final statement explains that he created the drug to separate the conflicting sides of his nature and used the form of Hyde to act without the restraints attached to his own identity. Hyde gradually grew stronger, and the changes began occurring without the drug. After Hyde murdered Carew, Jekyll tried to stop transforming, but he could not maintain control. The original potion depended on an unidentified impurity in one chemical, and later supplies would not reproduce it. Trapped in the laboratory and nearly out of the effective mixture, Jekyll wrote his confession while he still could. By the time Utterson and Poole forced entry, Hyde had taken poison and died in Jekyll's clothes. Jekyll was gone, leaving the two identities' shared life ended with Hyde's body.",
         "in_short": "London lawyer Gabriel Utterson investigates the connection between his respectable friend Dr Henry Jekyll and the violent Edward Hyde, whom Jekyll's will names as heir. Hyde murders Sir Danvers Carew and disappears, while Jekyll briefly returns to society before shutting himself inside his laboratory. After Dr Lanyon dies from the shock of a secret encounter and Jekyll's butler fears foul play, Utterson and the servant break into the laboratory and find Hyde dead in Jekyll's clothes. Documents explain that Jekyll invented a potion that transformed him into Hyde, a separate body through which he indulged impulses he wished to conceal. The transformations eventually began without his consent, and the effective drug could not be recreated after its original ingredients ran out. Losing the struggle for control and facing exposure, Hyde kills himself; Jekyll's confession records the end of both identities.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2428,7 +2428,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2441,7 +2441,7 @@
       "recaps": {
         "ending": "Bond survives Doctor No's engineered endurance course, escapes into the island complex, and reaches the guano-loading area while No is supervising operations. He takes control of machinery and sends a mass of guano down on No, burying and killing him. Bond then finds Honey Rider, who has survived the ordeal arranged for her, and the two escape in the armored vehicle the guards used to impersonate a dragon. They reach the Jamaican authorities and expose what happened on Crab Key. With the island's secret operation broken, Bond chooses to delay his formal report long enough to recover with Honey, while London receives proof that the missing station officers were victims of No's conspiracy.",
         "in_short": "After surviving a previous poisoning, James Bond is sent to Jamaica to investigate the disappearance of station chief John Strangways and his secretary. Strangways had been examining Crab Key, a private guano island owned by Doctor Julius No and guarded by men who spread tales of a dragon. Attempts on Bond's life confirm that the case is active. With his former ally Quarrel, Bond secretly lands on the island and meets shell collector Honey Rider. No's armored vehicle finds them and kills Quarrel; Bond and Honey are captured. No reveals that his hidden installation interferes with American missile tests and that he works with Soviet intelligence. He subjects Bond to a lethal obstacle course, but Bond survives, escapes, and kills No by burying him beneath guano. Bond rescues Honey, and they flee Crab Key in the supposed dragon vehicle.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2602,7 +2602,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2615,7 +2615,7 @@
       "recaps": {
         "ending": "Dr No explains that he is disrupting American missile tests for the Soviet Union and intends to kill his captives through staged ordeals. Bond is forced through a hazardous obstacle route built into the installation and survives a final struggle with a giant squid. Honey, left to be eaten by crabs, escapes because the animals do not attack as Dr No expected. Bond reaches the working area, takes control of a loading machine, and sends Dr No into the flow of guano, where he is buried and killed. Bond reunites with Honey, and they escape Crab Key in the armoured vehicle used to frighten intruders before sailing back toward Jamaica. Bond arranges for the authorities to take control of the island and frames the immediate report to protect the mission's sensitive elements. He and Honey recover together after the operation.",
         "in_short": "After station chief John Strangways and his secretary disappear in Jamaica, Bond is sent to investigate. The trail leads to Crab Key, the private guano island of Dr Julius No, who is suspected of killing intruders and interfering with American missile tests. Bond and his old ally Quarrel land secretly and meet shell collector Honey Rider. Dr No's armoured flame-throwing vehicle kills Quarrel, and Bond and Honey are captured. No reveals that he works with Soviet interests and intends to dispose of them through elaborate ordeals. Bond survives an obstacle course and a fight with a giant squid; Honey escapes a separate attempt on her life. Bond commandeers machinery and buries Dr No in guano, killing him. He and Honey flee the island and return to Jamaica, leaving the authorities to secure the installation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2788,7 +2788,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2801,7 +2801,7 @@
       "recaps": {
         "ending": "The hunters chase Dracula back to Transylvania, guided by the psychic bond he forced on Mina, whom Van Helsing hypnotizes to sense the Count's surroundings. Van Helsing destroys the three vampire women in the castle. At sunset the group overtakes the gypsies hauling Dracula's box of earth toward his home and fights through them. Jonathan Harker slashes the Count's throat and Quincey Morris drives his knife into the heart just before dark; Dracula's body dissolves into dust, ending his power, and the mark on Mina's forehead disappears, showing she is cleansed. Quincey Morris, wounded in the final struggle, dies among his friends, glad that their effort has saved Mina. In a closing note set some years later, Mina and Jonathan are happily married with a young son whose names honor the men of the company, especially Quincey. The survivors reflect that the record they kept is a mass of ordinary documents, yet it stands as testimony to what they endured together.",
         "in_short": "English solicitor Jonathan Harker travels to Count Dracula's castle in Transylvania and discovers his host is a vampire who imprisons him and then sets off for England. In England the Count preys on Lucy Westenra, who sickens and dies despite the efforts of Professor Van Helsing and her suitors, and rises as an Un-Dead until the men stake her. Van Helsing unites Lucy's suitors, Dr Seward, Arthur Holmwood, and Quincey Morris, with Harker and his wife Mina to hunt Dracula. They sterilize the boxes of earth he sleeps in, but Dracula attacks Mina and binds her to his mind before fleeing back to Transylvania. Using Mina's hypnotic link to track him, the group pursues him across Europe and overtakes his coffin at sunset near his castle, destroying him just before nightfall. Dracula crumbles to dust and Mina is freed, though Quincey Morris dies of his wounds.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2968,7 +2968,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2981,7 +2981,7 @@
       "recaps": {
         "ending": "Dracula retreats from England toward his castle with the hunters following by train, boat, horse, and carriage. Mina's psychic link helps them predict his route but also places her at risk of becoming like him. Van Helsing protects Mina near the castle, enters it, and destroys the three vampire women. At sunset Jonathan, Seward, Arthur, and Quincey intercept the group carrying Dracula's box. Jonathan cuts Dracula's throat while Quincey drives a knife into his heart; the Count's body disintegrates and Mina's mark disappears. Quincey has been mortally wounded in the struggle and dies knowing that Mina is free. Seven years later, Jonathan and Mina have a son whose names commemorate their companions, especially Quincey, and the surviving friends return to Transylvania together. Their assembled records are the chief evidence of what happened, while their shared survival and the child give the ordeal a peaceful human conclusion.",
         "in_short": "Solicitor Jonathan Harker visits Count Dracula in Transylvania and discovers that his host is a vampire preparing to move to England. Dracula travels to Whitby, preys on Lucy Westenra, and leaves her to rise as a vampire despite the efforts of her fiancé Arthur, her other suitors Seward and Quincey, and Professor Van Helsing. After freeing Lucy from that state, they join Jonathan and Mina Harker to hunt Dracula through London and destroy his hiding places. Dracula retaliates by forcing Mina to drink his blood, creating a link that threatens her but also lets the hunters track him. He escapes toward Transylvania in his last box of native earth. The group pursues him to the castle, where Van Helsing destroys the three vampire women and the others intercept Dracula before sunset. Jonathan and Quincey kill him; Mina is released from the curse, though Quincey dies from his wounds. Years later the surviving friends remain united, and Jonathan and Mina name their son in memory of him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3156,7 +3156,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3169,7 +3169,7 @@
       "recaps": {
         "ending": "After Dracula attacks Mina, the hunters use her involuntary psychic connection to track his retreat from England. They destroy or sanctify all but one of his boxes of native earth, follow his ship to Galatz, and divide into teams for the pursuit across Transylvania. Van Helsing takes Mina near Castle Dracula, wards her against the three vampire women, and destroys them while the other men close on the gypsies transporting Dracula's final box. Just before sunset, Jonathan and Quincey reach the cart. Jonathan cuts Dracula's throat and Quincey strikes his heart, causing the Count to disintegrate. Mina sees a look of peace on his face, and the sacred burn on her forehead vanishes, showing that the curse has ended. Quincey has suffered a fatal wound and dies beside his friends, comforted by Mina's recovery. An epilogue set seven years later shows Jonathan and Mina as parents of a boy named Quincey. Arthur and Seward have married, and the survivors return together to Transylvania, carrying their records as the principal evidence of their struggle.",
         "in_short": "Solicitor Jonathan Harker visits Count Dracula's Transylvanian castle and discovers that his client is a vampire preparing to move to England. Jonathan escapes, but Dracula reaches Whitby and preys on Lucy Westenra. Dr. Seward, Arthur Holmwood, Quincey Morris, and Professor Van Helsing repeatedly try to save Lucy; after she dies and returns as a vampire, they free her by destroying her undead body. Mina Harker assembles the group's records, helping them trace Dracula's London refuges, but Dracula attacks her and forces a blood bond that threatens to transform her. The hunters ruin his boxes of earth and pursue his last refuge back toward his castle, using Mina's psychic connection to follow him. Van Helsing destroys Dracula's three vampire women. Jonathan and Quincey intercept Dracula's box before sunset and kill him, breaking the curse on Mina. Quincey dies from a wound received in the fight. Seven years later, Jonathan and Mina have a son named for him, and the surviving friends remain united by the ordeal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3344,7 +3344,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3357,7 +3357,7 @@
       "recaps": {
         "ending": "After Dracula attacks Mina, the hunters use her involuntary psychic connection to track his retreat from England. They destroy or sanctify all but one of his boxes of native earth, follow his ship to Galatz, and divide into teams for the pursuit across Transylvania. Van Helsing takes Mina near Castle Dracula, wards her against the three vampire women, and destroys them while the other men close on the gypsies transporting Dracula's final box. Just before sunset, Jonathan and Quincey reach the cart. Jonathan cuts Dracula's throat and Quincey strikes his heart, causing the Count to disintegrate. Mina sees a look of peace on his face, and the sacred burn on her forehead vanishes, showing that the curse has ended. Quincey has suffered a fatal wound and dies beside his friends, comforted by Mina's recovery. An epilogue set seven years later shows Jonathan and Mina as parents of a boy named Quincey. Arthur and Seward have married, and the survivors return together to Transylvania, carrying their records as the principal evidence of their struggle.",
         "in_short": "Solicitor Jonathan Harker visits Count Dracula's Transylvanian castle and discovers that his client is a vampire preparing to move to England. Jonathan escapes, but Dracula reaches Whitby and preys on Lucy Westenra. Dr. Seward, Arthur Holmwood, Quincey Morris, and Professor Van Helsing repeatedly try to save Lucy; after she dies and returns as a vampire, they free her by destroying her undead body. Mina Harker assembles the group's records, helping them trace Dracula's London refuges, but Dracula attacks her and forces a blood bond that threatens to transform her. The hunters ruin his boxes of earth and pursue his last refuge back toward his castle, using Mina's psychic connection to follow him. Van Helsing destroys Dracula's three vampire women. Jonathan and Quincey intercept Dracula's box before sunset and kill him, breaking the curse on Mina. Quincey dies from a wound received in the fight. Seven years later, Jonathan and Mina have a son named for him, and the surviving friends remain united by the ordeal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3532,7 +3532,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3545,7 +3545,7 @@
       "recaps": {
         "ending": "After Dracula attacks Mina, the hunters use her involuntary psychic connection to track his retreat from England. They destroy or sanctify all but one of his boxes of native earth, follow his ship to Galatz, and divide into teams for the pursuit across Transylvania. Van Helsing takes Mina near Castle Dracula, wards her against the three vampire women, and destroys them while the other men close on the gypsies transporting Dracula's final box. Just before sunset, Jonathan and Quincey reach the cart. Jonathan cuts Dracula's throat and Quincey strikes his heart, causing the Count to disintegrate. Mina sees a look of peace on his face, and the sacred burn on her forehead vanishes, showing that the curse has ended. Quincey has suffered a fatal wound and dies beside his friends, comforted by Mina's recovery. An epilogue set seven years later shows Jonathan and Mina as parents of a boy named Quincey. Arthur and Seward have married, and the survivors return together to Transylvania, carrying their records as the principal evidence of their struggle.",
         "in_short": "Solicitor Jonathan Harker visits Count Dracula's Transylvanian castle and discovers that his client is a vampire preparing to move to England. Jonathan escapes, but Dracula reaches Whitby and preys on Lucy Westenra. Dr. Seward, Arthur Holmwood, Quincey Morris, and Professor Van Helsing repeatedly try to save Lucy; after she dies and returns as a vampire, they free her by destroying her undead body. Mina Harker assembles the group's records, helping them trace Dracula's London refuges, but Dracula attacks her and forces a blood bond that threatens to transform her. The hunters ruin his boxes of earth and pursue his last refuge back toward his castle, using Mina's psychic connection to follow him. Van Helsing destroys Dracula's three vampire women. Jonathan and Quincey intercept Dracula's box before sunset and kill him, breaking the curse on Mina. Quincey dies from a wound received in the fight. Seven years later, Jonathan and Mina have a son named for him, and the surviving friends remain united by the ordeal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3723,7 +3723,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3736,7 +3736,7 @@
       "recaps": {
         "ending": "Mina's psychic connection to Dracula lets Van Helsing's party track him as he flees toward his Transylvanian castle in a box of native earth. The hunters divide to intercept the routes taken by ship and overland. Near sunset outside the castle, Jonathan and Quincey reach the wagon carrying Dracula's box and fight its guards. Jonathan cuts Dracula's throat while Quincey drives a knife into his heart; Dracula's body crumbles, and the mark on Mina's forehead disappears, showing that his hold over her has ended. Quincey has been mortally wounded in the struggle and dies after seeing Mina freed. Seven years later, Jonathan and Mina have a son named Quincey, and the surviving friends reunite in Transylvania. Jonathan notes that their assembled records are the chief evidence of what happened, while Van Helsing says that the character of the friends and the life of the child honor the man who died helping them.",
         "in_short": "Solicitor Jonathan Harker visits Count Dracula in Transylvania and discovers that his host is a vampire preparing to move to England. Dracula reaches Whitby, preys on Lucy Westenra, and defeats the efforts of Van Helsing and Lucy's friends to save her. After Lucy becomes a vampire, they release her from that state and unite with Jonathan and Mina to hunt Dracula. They destroy his London refuges, but Dracula attacks Mina and forces her to drink his blood, creating a psychic bond and threatening to transform her. The bond also allows Mina to help track him as he retreats to Transylvania. Jonathan, Van Helsing, Seward, Arthur, and Quincey pursue him. Van Helsing destroys the three vampire women at the castle; Jonathan and Quincey intercept Dracula's box and kill him moments before sunset. Mina is freed, but Quincey dies from his wounds. Seven years later Jonathan and Mina return with their son, named for their fallen friend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3914,7 +3914,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3927,7 +3927,7 @@
       "recaps": {
         "ending": "Mina's psychic connection to Dracula lets Van Helsing's party track him as he flees toward his Transylvanian castle in a box of native earth. The hunters divide to intercept the routes taken by ship and overland. Near sunset outside the castle, Jonathan and Quincey reach the wagon carrying Dracula's box and fight its guards. Jonathan cuts Dracula's throat while Quincey drives a knife into his heart; Dracula's body crumbles, and the mark on Mina's forehead disappears, showing that his hold over her has ended. Quincey has been mortally wounded in the struggle and dies after seeing Mina freed. Seven years later, Jonathan and Mina have a son named Quincey, and the surviving friends reunite in Transylvania. Jonathan notes that their assembled records are the chief evidence of what happened, while Van Helsing says that the character of the friends and the life of the child honor the man who died helping them.",
         "in_short": "Solicitor Jonathan Harker visits Count Dracula in Transylvania and discovers that his host is a vampire preparing to move to England. Dracula reaches Whitby, preys on Lucy Westenra, and defeats the efforts of Van Helsing and Lucy's friends to save her. After Lucy becomes a vampire, they release her from that state and unite with Jonathan and Mina to hunt Dracula. They destroy his London refuges, but Dracula attacks Mina and forces her to drink his blood, creating a psychic bond and threatening to transform her. The bond also allows Mina to help track him as he retreats to Transylvania. Jonathan, Van Helsing, Seward, Arthur, and Quincey pursue him. Van Helsing destroys the three vampire women at the castle; Jonathan and Quincey intercept Dracula's box and kill him moments before sunset. Mina is freed, but Quincey dies from his wounds. Seven years later Jonathan and Mina return with their son, named for their fallen friend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4313,7 +4313,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BLG6X49D",
@@ -4325,7 +4325,7 @@
       "recaps": {
         "ending": "Hadjar's duel with the Dragon Emperor exposes memories proving that Chin'Ameh manufactured the conflict between the Emperor and Traves. Minister Ju and other officials acted under mental control, Traves's family was deliberately destroyed, and the command to kill the Emperor was planted so that a future descendant would carry it out. The Emperor turns on Chin'Ameh while Hadjar confronts the Seven Empires force, kills its leader, preserves the last king's spirit, and shares the conspiracy memories with the invaders. Mortally wounded after fighting Chin'Ameh, the Emperor guides Hadjar's hand to his throat. This satisfies Hadjar's compelled oath while allowing him to live. Tened receives the ruler's mark and becomes Empress, with Tash'Magan surviving beside her. A shadowed figure immediately transports Hadjar to the Demon Lands. His wife and unborn child remain unrecovered, later stages of the Path Through the Stars remain unfinished, the First Darkhan still threatens his identity, and the demon prince's summons is unresolved. Chin'Ameh's fate is not established. A final childhood memory shows him accepting an unverified shadow's command to destroy the related Thundercloud and Magic Dawn bloodlines, both original path scrolls, and eventually himself.",
         "in_short": "After Princess Tened poisons him, Hadjar follows her into Ruby Mountain, where he joins Princess Edlet's revolution and survives the Mother Mountain's trials. Tened then takes him to the Ruby Palace, and the Dragon Emperor sends him through the Path Through the Stars. In an ancient-war reconstruction, Hadjar trains with Gevestus, rejects an alluring false family life, and helps destroy an Ifrit coven. His return reveals him as Traves's descendant and a claimant to the Ruby Throne. Boreas advances him and names him Wind of the Northern Valleys, but his duel with the Emperor uncovers Chin'Ameh's manipulation of Traves, the imperial court, and Hadjar's own oath. Hadjar shares the truth, defeats the invading army's leader, and returns to the palace. The wounded Emperor uses Hadjar's hand to end his own life, fulfilling the oath without destroying Hadjar. Tened becomes Empress, and a shadowed figure takes Hadjar to the Demon Lands. Chin'Ameh's childhood memory reveals a mission to eliminate two bloodlines and destroy both original path scrolls.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4569,7 +4569,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4582,7 +4582,7 @@
       "recaps": {
         "ending": "The expedition finds what it was sent for. Beyond a stretch of dry, open country unlike anything in the Rain Wilds, a broad river runs past the ruins of a great Elderling city, and Rapskal, flying above it on Heeby, sees it whole. Kelsingra is real, largely intact, and on the far bank of a river too wide, cold and fast for the dragons and keepers to cross; the company settles instead in a smaller Elderling village on the near side, with stone buildings, remembered voices in the walls and a view of the city they cannot reach. The dragons that survived the journey are hunting for themselves, several are flying, and their keepers have finished becoming something new: scaled, long-lived, no longer Rain Wilders but Elderlings. Greft's attempt to found a new order among them has ended with his death, and the keepers are left to work out their own arrangements about pairing, children and leadership. Alise has left her marriage behind in every way that matters and is openly with Leftrin, who has told her the truth about Tarman. Sedric has confessed what he came upriver to do, been bonded to the copper queen Relpda, changed into an Elderling himself, and found in Carson a life he never planned for. Leftrin will take Tarman back down the river to claim the Traders' payment and bring back supplies, leaving dragons and keepers to hold a city they can only look at, while in Bingtown, Chalced and the Rain Wild councils other people are already deciding what a rediscovered Elderling city and a herd of recovering dragons are worth.",
         "in_short": "The dragons, keepers and Leftrin's barge Tarman push further up the Rain Wild River. A violent flood sweeps Sedric overboard into the acid water, and the copper dragon Relpda saves him; the dragon blood he had stolen and swallowed binds the two of them mind to mind, which destroys his ability to think of dragons as merchandise. When the hunter Jess turns out to be running the same trade and tries to force him into it, the confrontation ends with Jess dead, Sedric's theft exposed, and Alise learning both what her husband is and what Sedric has been to him. Among the keepers, Greft's attempt to found a new society founders on Jerd's pregnancy and on his own hardening authority, and he dies before he can settle it. The dragons begin to hunt and then to fly, Rapskal's small red Heeby first, and the keepers finish changing into Elderlings. Alise and Leftrin become lovers; Sedric and Carson do too. At last the company comes out of the swamp into open country and finds Kelsingra: a vast Elderling city, intact, on the far bank of a river they cannot cross. They settle in a smaller village opposite it, and Leftrin turns Tarman downriver for supplies and payment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4925,7 +4925,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1630153710",
@@ -4937,7 +4937,7 @@
       "recaps": {
         "ending": "Leen's destruction of the fort breaks the nomad assault, but fewer than 300,000 of her original two million soldiers survive. Dogar is presumed dead. Leen lives with severe facial scars and without her left hand, while Hadjar and Nero recover and help the wounded. Three months later, the army is rebuilding at Spring Town with fewer than 500,000 troops, many of them untrained recruits. Hadjar has become a senior officer at the fragment stage of Formation, Nero remains his closest friend, Serra is Nero's lover and Hadjar's trusted ally, and Azrea remains in Hadjar's care. The depleted force has been ordered toward the Balium border despite inadequate supplies, raising the prospect of conflict involving Black Gates. Primus still rules Lidus, Elaine remains separated from Hadjar, and rumors point to royal loyalists in the northwestern mountains. Larvie continues seeking revenge for Colin through increasingly powerful Ax Clan assassins. Hadjar, Nero, and Serra intend to travel to Larvie's castle after receiving their new tiger-fang blades. Their confrontation and the army's next deployment remain unresolved.",
         "in_short": "Born crown prince of Lidus with memories of another life, Hadjar trains for Black Gates until Primus overthrows Haver with imperial support. Mutilated and enslaved, Hadjar survives years of captivity before South Wind finds him, but an attack destroys Innocent Meadow and kills South Wind, Senta, and Eina. A dragon heart restores Hadjar's body. After recovering in Robin's village, he joins the army, befriends Nero, adopts the tiger cub Azrea, and receives powerful techniques from Traves's surviving will. Hadjar kills Colin to avenge Eina, making Larvie his enemy. He, Nero, and Serra then expose corruption at a border fort and help Leen defeat a nomad invasion by luring the attackers into the fort before its destruction. The victory costs most of Leen's two million soldiers, and Dogar is presumed dead. Hadjar ends as a Formation-stage senior officer, still hiding his royal identity. With the depleted army ordered toward Balium and Larvie sending Ax Clan assassins, Hadjar, Nero, and Serra prepare to confront the general's vendetta.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5383,7 +5383,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09DZ2V12S",
@@ -5395,7 +5395,7 @@
       "recaps": {
         "ending": "Hadjar returns from the spirit world after reconciling with his divided self, breaking the alien sword mark, and training with Orune during decades of subjective time. He and Annette kill Derek, causing the undead army, ghost fleet, and storm to vanish. Galkad is released from Derek's control but dies from the damage inflicted during his captivity. Hadjar, Einen, Dora, Karine, Tom, and Annette survive and gather for Galkad's funeral, where his pregnant lover lights the pyre. Elaine remains concealed and pregnant. The Tree of Life and its ruins are gone, but the wider war with Laskan continues, and its senior heroes still surpass Hadjar. Morgan's manipulation of the war leaves Hadjar's imperial position uncertain. The First Darkhan remains a threat within his unresolved soul, while obligations to the Winter Court queen and the flower spirit remain open. Dragonlands sends agents to recover a hidden rootless dragon, and the last Stepwolf survivor seeks orc support for revenge against the human empires.",
         "in_short": "Laskan invades as Hadjar is sent into Karnak to secure an ancient tomb before Derek. Separated from his companions, Hadjar is rescued by Annette and learns that his soul was divided at birth. In the tomb, Derek gains the Word of the Dead while Hadjar receives a dragon legacy. Derek later takes a leaf from the destroyed Tree of Life, enslaves Galkad, and raises an undead army. A renegade alchemist strips Hadjar's true name, but Einen's hidden counter-plan kills the alchemist and sends Hadjar into the spirit world. Hadjar reconciles with his other soul half, breaks the sword mark, and returns with his own blue wind sword power. Annette helps him kill Derek, ending the undead assault. Galkad dies after being freed, while the surviving companions mourn him. Laskan's war continues, Dragonlands begins hunting a hidden rootless dragon, and Hadjar still faces the First Darkhan and unpaid spirit-world obligations.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5899,7 +5899,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09GPXQQFR",
@@ -5911,7 +5911,7 @@
       "recaps": {
         "ending": "Hadjar's restored Sakashim and the Moon Stream Army survive the immediate threat. He defeats and kills Stepfang in their honor-bound duel, fulfilling his brother's wish for a worthy death and compelling the great hunt to turn toward Laskan. The assembled orcs honor both men, accept Hadjar as an orc-brother, and ask him to preserve their history. Morgan uses their redirected march as cover for a covert attack on Laskan's golem production. Dragonlands agents have also identified Hadjar's human-dragon ancestry and decide to watch him while seeking the first volume of a technique tied to their imperial family. Einen and Dora remain in the capital expecting a child; Annis rules the weakened Predatory Blades clan; Paris is alive in secret; Karine remains in the Feylands under a vast service debt; Archimea is free of her demon bargain; and White Fang's promised duel remains pending. The final scene leaves Hadjar critically wounded by an unidentified white-haired swordsman whose attack evades his magical senses. His system estimates a ninety-nine percent probability of death, and neither his survival nor the attacker's identity is resolved.",
         "in_short": "Hadjar reunites his divided soul, completes decades of inner training, and returns as a lord, only to face overlapping obligations to Annis, a demon creditor, and Emperor Morgan. He helps Annis seize the Predatory Blades clan, secretly spares Paris, rescues Karine from a demonic sacrifice, and discharges his soul debt. Morgan then forces him and the imperial princess to recover the Ever-Seeking Spear. Hadjar destroys the Moonlight Sect, while the princess pays for the spear with her ability to cultivate. Exiled to ruined Sakashim, Hadjar rebuilds it and forms the Moon Stream Army. He learns that the imprisoned Fae Adagir was his ancestor and that his lineage includes a dragon heart. When Stepfang leads an orc great hunt toward the empire, the sworn brothers duel over its destination. Hadjar kills Stepfang, sending the orcs toward Laskan. At the funeral, an unidentified white-haired swordsman ambushes Hadjar and leaves him with an estimated ninety-nine percent chance of death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/dragon-heart-book-12-path-to-the-glory.json
+++ b/data/works-community/0/dragon-heart-book-12-path-to-the-glory.json
@@ -396,7 +396,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09NF7HPG7",
@@ -408,7 +408,7 @@
       "recaps": {
         "ending": "Hadjar kills the Scarlet Swordsman in the strongest-warrior duel, but the fight has stripped both armies of their defenses. The Laskan regent ignites the World River, killing herself, devastating both forces, and causing hundreds of millions of deaths. Tom destroys his own core to save the Moonstream skyship and dies. Morgan then exposes the Dragonlands' hidden rule, kills four concealed dragons, and uses an ancient spear to petrify the five-headed overseer before dying himself. Two years later, Morgan's son is emperor. The Ruby Palace suppresses the truth about the Dragonlands and enforces fifty years of peace among the seven empires. Einen and Dora are raising their son, while Erhard remains with Aria and Lita. Hadjar resigns and arranges his public death, accepting exile from both his empire and former homeland. He deliberately falls back to the Formation Seed stage to gain time for creating his own sword style, then departs with his grown tiger companion in search of the Seventh Heaven. The First Darkhan, the Raven sect, the Fae courts, the Dragonlands, and the dark gods remain unresolved threats.",
         "in_short": "Hadjar survives Erhard Darkhan's forced meditation and gains a deeper bond with the wind. An imperial mission to abduct Laskan's child emperor leads through a dragon confrontation, a dark-god summoning, and the destruction of the Delphi factory, where Morgan's daughter kills the child and dies. Years of war culminate in Hadjar killing the Scarlet Swordsman, only for the Laskan regent's trap to ignite the World River and kill Tom along with hundreds of millions. Morgan exposes the Dragonlands' control, destroys its agents, petrifies their five-headed overseer, and dies. Two years later, Morgan's son rules under a fifty-year peace. Hadjar resigns, fakes his death, reduces his cultivation, and leaves with his tiger companion to seek the Seventh Heaven and build a sword path of his own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -820,7 +820,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09VK2FT9X",
@@ -832,7 +832,7 @@
       "recaps": {
         "ending": "Hadjar's wife and their unborn son Nero remain alive but soul-bound inside Icy Sorrow. The Lord of Nightmares hides the prison in an ice palace, and the fire flower is unavailable after the Summer Court queen orders the Dark Woods keeper to consume it. Hadjar therefore accepts a six-century deadline to reach the Seventh Heaven, confront his estranged daughter, and rescue his family. He pursues godhood through the Path Through the Stars.\n\nThe Magic Dawn Pavilion sage joins Hadjar in a plot against the Dragon Emperor. Hadjar wins the Hero Challenge when his armored opponent is exposed as the woman barred by tradition, then takes a life-binding oath to escort the imperial princess to the Ruby Mountains and return her safely. Success should earn a wish that can open the Emperor's treasury, although the Emperor recognizes Hadjar and is deliberately allowing the scheme to advance. Erhard remains at war with the Dragonlands, Hadjar's tiger companion has left and may be drawn into Durger's service, and the demon prince's response to the destroyed Demon City gate remains unresolved.",
         "in_short": "Hadjar lives in concealment as Sedent's aging sword master, racing to create a personal style before Orune's legacy kills him. A wounded demon hunter draws him into the hidden Demon City, where they incite an uprising and stop its lord from opening a gate to the mortal world. Hadjar founds the Music of the Wind Sword, destroys the gate, and later marries the hunter in a remote village. His attempt at peace ends when their unborn son Nero and his mother are sealed in Icy Sorrow by Hadjar's estranged daughter. With six centuries to reach the Seventh Heaven or find another cure, Hadjar seeks the Path Through the Stars. He allies with the Magic Dawn Pavilion sage against the Dragon Emperor, wins the Hero Challenge after an excluded woman is exposed in the final, and swears to return the Emperor's daughter safely from the Ruby Mountains. The oath opens a possible route to the imperial treasury, but the Emperor already knows Hadjar's purpose and intends to use him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1233,7 +1233,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0B3NGZV82",
@@ -1245,7 +1245,7 @@
       "recaps": {
         "ending": "Hadjar gives the imprisoned First Warrior the battle-death that ends Durger's punishment and releases Tened and Itia unharmed. Outside the prison, the apparent rescue becomes a betrayal. Tash'Magan is exposed as an organizer of the assassination scheme, and Tened admits her own part by stabbing Hadjar with a poisoned dagger. Tash pushes him from the cliff, but Hadjar's white tigress catches him and carries him away. Abraham Shensie's group later finds Hadjar alive but critically poisoned, while Tened and Tash escape. Sin'Magan, Shi'ak Min, and Tash's wounded sister have no confirmed final condition. Hadjar's wife and unborn child remain imprisoned in Icy Sorrow. His six-century lifespan limit, the identity-threatening First Darkhan inheritance, the demon-prince bargain, the Dragon Emperor's designs, and the wider conflict involving Ash, Helmer, and Durger all remain unresolved.",
         "in_short": "Hadjar joins an imperial delegation to protect Princess Tened on the road to the Ruby Mountains while seeking a route to rescue his imprisoned family. After surviving the Red Mist and stopping the Raven Sect from taking the First Darkhan's North Wind Country inheritance, he returns burdened by a six-century lifespan limit. A Highlander coup destroys the delegation, forcing Hadjar and Tened into Abraham Shensie's caravan and through the Port of the Dead. In a dead god's prison, Hadjar borrows the First Darkhan's law without surrendering his identity and grants the First Warrior a freeing death. The rescued Tened then reveals her complicity in the assassination plot: she poisons Hadjar, and Tash'Magan throws him from a cliff. Hadjar's white tigress saves him from the fall, but Abraham's group finds him critically poisoned as Tened and Tash escape.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1695,7 +1695,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1541437659",
@@ -1707,7 +1707,7 @@
       "recaps": {
         "ending": "Black Gates is destroyed after Hadjar kills its patriarch, but the Moon Army pays for victory with immense losses. The cavalry commander dies stopping the sect's decay cloud. Hadjar survives gravely wounded, and the Neuronet functions that guided his final exchange will be unavailable for an estimated 1,754 days. He carries the patriarch's spatial ring but cannot open it. The island witch reveals herself as a white horned wolf, parts from Hadjar, and follows her own path. Nero, now Hadjar's blood brother, remains with Serra and chooses the capital over inheriting command. Hadjar accepts the end of his generalship and gives Leen's medallion to Leon, who leads fewer than 600,000 remaining Moon Army soldiers. Hadjar, Nero, Serra, Azrea, and the general staff messenger travel toward the capital under an order tied to Elaine's birthday and Hadjar's baronial retirement. Hadjar expects political danger from the summons. His hidden royal identity, Primus's rule, the unopened ring, the Lord of Nightmares' interest, and the two remaining tests and eventual price demanded by Traves all remain unresolved.",
         "in_short": "Hadjar and Nero build an elite unit, survive Larvie's attempt to kill them, and are drawn into a northern war. After Leen dies in a duel, Hadjar takes command, absorbs enemy defectors, captures a border city, and turns the army against Black Gates. He sacrifices an immortal inheritance to save the poisoned Nero, allies with mountain villagers, survives a vast beast migration, and commits himself permanently to the sword spirit. The Moon Army defeats Black Gates at Black Gorge, breaks the Snake Gates, and reaches the patriarch's stronghold. Hadjar kills the patriarch with help from the Neuronet, which then shuts down for years. The victory leaves the army shattered. The island witch departs after revealing her wolf form, Nero becomes Hadjar's blood brother, and Leon inherits command. Badly wounded and carrying an unopened spatial ring, Hadjar leaves with Nero, Serra, and Azrea for the capital, where Primus's court and Elaine's birthday summons await.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2051,7 +2051,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1705204724",
@@ -2063,7 +2063,7 @@
       "recaps": {
         "ending": "Nero persuades Hadjar to abandon revenge and leave Lidus with Serra and Elaine, but the Darnassus governor seals the palace and murders Nero. Serra enhances Moonbeam, destroys the governor and his remaining legionnaires with blue fire, and dies in the attack. Hadjar then defeats Primus, losing Moonbeam and suffering nearly fatal wounds. He restores Elaine's memories, but allows her attack to cast him into the lake so the kingdom can accept a public account in which the false prince died and Elaine became its rightful queen. Leen supports Elaine as military counselor, and Darnassus accepts her reign while appointing another governor. Elaine reforms the mines and forms the Northern Moon force with a neighboring kingdom. Azrea rescues Hadjar, who secretly reunites with Elaine before leaving Lidus. Carrying Serra and Aaron's wedding bracelets, he continues as Hadjar Traves and sets out to reach the gods' realm. Elaine keeps his survival secret and awaits his return.",
         "in_short": "Hadjar returns covertly to the Lidus capital, confronts Primus's oppressive rule, and learns that Nero is Crown Prince Aaron while Elaine is his own lost sister. A royal hunt leads Hadjar and Elaine to an ancient tree, where Elaine inherits the ancestral sword. After witnessing the mines' violence, she begins questioning the kingdom she knows. Hadjar infiltrates the northern rebels, hears Atticus's account of the coup and a demonic disaster, then kills him in a duel. Primus recognizes Hadjar and sentences him to burn, but the people and Moon Army rise in his defense. The Darnassus governor kills Nero, and Serra destroys the governor at the cost of her life. Hadjar kills Primus, restores Elaine's memories, and lets the world believe he dies so she can rule. Azrea rescues him. Elaine becomes queen and begins reforms, while Hadjar leaves with Azrea to seek the gods' realm.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2449,7 +2449,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1705204740",
@@ -2461,7 +2461,7 @@
       "recaps": {
         "ending": "Hadjar kills the Heaven Soldier commanding the caravan's western attackers, exposing the supposed bandits as troops of the desert king. The victory immediately collapses when an illusionist who has replaced Ilmena murders the caravan owner, seizes Serra, and calls a sand dragon. The dying owner identifies Serra as an ancient magical key tied to a library and asks Hadjar to use the sought elixir to make her human. Hadjar consumes the body of a divine messenger in a desperate response. A black-armored manifestation drives back the dragon, and Einen removes the exhausted Hadjar through shadow to Underworld City. Both arrive injured, Einen unconscious and Hadjar subject to the city's judgment. The real Ilmena's fate is unknown. The caravan's expedition toward Mage City has lost its leader, and its survivors' position is unstated. The desert king's daughter delivers Serra to her father, whose army continues its conquests and whose ambition is immortality or godhood. Serra remains captive as Hadjar wakes in Underworld City calling her name.",
         "in_short": "Hadjar joins a caravan crossing the Sea of Sand and forms a durable partnership with Einen. After raids, a tribal duel, and the defense of a sentient oasis, Hadjar earns the name Darkhan, gains the sword Mountain Wind, and masters a brief call upon his Dark Storm dragon inheritance. The caravan owner then reveals a hidden expedition to Mage City for a legendary god-making elixir and forces the guards to participate. During an attack by soldiers disguised as bandits, an illusionist posing as Ilmena kills the owner, abducts Serra, and summons a sand dragon. A Black General-linked manifestation repels the dragon, while Einen carries the exhausted Hadjar to Underworld City. The illusionist is the desert king's daughter, and Serra remains her father's captive as Hadjar awakens far away calling for her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2888,7 +2888,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:170524906X",
@@ -2900,7 +2900,7 @@
       "recaps": {
         "ending": "Hadjar reaches the collapsing library's power complex alone, survives an apparently fatal blow, and advances to heaven soldier. Unable to defeat Sankesh directly, he destroys the crystals sustaining the flying island and shatters the god-making elixir. Sankesh's memories reveal how abandonment by Rahaim, enslavement, Aisha's suffering, and the loss of their daughter shaped his pursuit of absolute strength. When that purpose fails, his cultivation path breaks and he dies. Serra uses her power as the library's key to expel Hadjar before the island explodes, remaining behind after placing one elixir drop in his ring. Einen's group finds Hadjar three weeks later. They return to Underworld City, where the sage identifies himself as the real Rahaim and explains the disastrous choice made by his golem. He also confirms that Hadjar's incomplete soul prevents him from using the true path of cultivation. Hadjar still carries the Black General's inheritance, the dragon-heart debt, and his House of Blade Fury oath. Rahaim's promised reward sends Hadjar and Einen to Holy Sky School, opening their next search for advancement and knowledge of the immortals.",
         "in_short": "Hadjar and Einen survive captivity beneath Underworld City and join a dangerous expedition to Mage City's lost library. Traveling with mistrustful specialists, they cross the Sea of Sand, encounter surviving allies and enemies, and use Serra's stone to penetrate the city's defenses. Inside the library, Glen betrays the party to Sankesh, whose pursuit of a god-making elixir grew from abandonment, enslavement, and the loss of Aisha. Hadjar advances to heaven soldier, destroys the elixir and the island's power, and survives when Serra sacrifices herself to send him away with one remaining drop. Sankesh dies as his cultivation path collapses. Back in Underworld City, the sage reveals himself as the true Rahaim and explains that Hadjar's incomplete soul blocks the true cultivation path. Rahaim rewards Hadjar and Einen with recommendations to Holy Sky School, where they arrive at the close.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3320,7 +3320,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1705249086",
@@ -3332,7 +3332,7 @@
       "recaps": {
         "ending": "Einen survives Tom's attack and receives further healing arranged by Dora, leaving him alive but separated from Hadjar for the border mission. Tom also survives after Hadjar breaches the sanctioned duel and cuts through his imperial armor. Hadjar accepts an elder lord as a prospective mentor, but must gain inner-circle status before receiving his sword-spirit instruction. He also owes Dora for Einen's care and remains bound to the seven-year deadline imposed by the elf healer: he must reach lord level before the protective poison becomes fatal. The ancient enemy's soul fragment, the raven ancestor, rival inheritors, Helmer's Tournament of Twelve obligation, and the Raven sect remain unresolved. Hadjar departs alone to retrieve a Wastelands scroll from Fort Derrigan, but an unknown client hires pirates to capture him alive. After Rook's Wings is attacked, Hadjar kills the pirate sent for him and escapes on her flying mount. The mount crashes beyond the border, breaking Hadjar's bones. Rook's Wings also falls, and the fates of its commander and crew are unknown. Hadjar ends the book stranded in hostile territory while war with Laskin approaches.",
         "in_short": "Hadjar and Einen enter the Holy Sky School at its lowest rank, survive extortion, house vendettas, a disastrous giant hunt, and war with rival disciples, then earn promotion to full disciples. Dora becomes their ally and fulfills her promise to replace Hadjar's spatial ring. A massacre in the capital reveals that rival descendants of the Black General hunt one another. Elven leaders discover a large fragment of that ancient enemy's soul sealed inside Hadjar, and a healer gives him seven years to reach lord level before her conditional poison kills him. Tom later defeats and nearly kills Einen in a sanctioned duel. Hadjar breaks into the arena, wounds Tom, and attracts an elder sword mentor, who sends him toward Fort Derrigan for an ancient scroll. Pirates attack his transport on behalf of an unknown client who wants him alive. Hadjar kills the retrieval agent but crashes beyond the western border, injured and alone in hostile territory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3690,7 +3690,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:170526610X",
@@ -3702,7 +3702,7 @@
       "recaps": {
         "ending": "The Black Star ritual ends when Hadjar kills Irma, preventing the altered child within her from founding the king's lawful demon empire. The wounded king is trapped in a revelation-ore cell, but his death is not confirmed, and the queen's fate is also unknown. Helmer rescues Hadjar, Derek, and the orc hunter from the collapsing gorge and reveals that the prophecy and expedition served his plan to extract the half-human demon woman. She survives, but her destination and Helmer's larger purpose remain unclear.\n\nDerek survives scarred and missing an eye. Grieving Aaliyah and Irma, he takes a blood oath to kill Hadjar and leaves alone. The orc hunter returns alive to his pregnant wife, though he has lost an arm, part of a leg, and an eye. Hadjar learns that only three of his weapon-essence seal's 999 lines are broken, while the caged first Darkhan fragment claims it can seize him in six years and eleven months unless he reaches lordhood. After advancing and settling a Raven Sect challenge, Hadjar reports to the border fort, refuses to betray the tribes, and accepts an urgent dispatch. He destroys a pirate attack and continues toward the capital as sole courier, with the seal calculation underway.",
         "in_short": "After surviving a fall near a contested border, Hadjar repays the three school disciples who save him by joining an orc campaign against a demon kingdom. An orc hunter becomes his partner and spiritual teacher, helping him awaken his blue-bird spirit and begin resisting the seal on his sword path. The party infiltrates the demon palace with the king's half-human daughter, but Aaliyah dies and Irma is taken for a ritual intended to legitimize a demon empire. Hadjar kills Irma to stop it, and the survivors trap the wounded king in revelation ore. Helmer then admits that he arranged the expedition to extract the half-human daughter. Derek loses an eye, blames Hadjar for both women's deaths, and swears to kill him. Hadjar returns the maimed hunter to his tribe, advances his cultivation, and resumes his military obligation. He ends the volume traveling alone toward the capital with an urgent sealed scroll while his neural network calculates how to dismantle the remaining 996 lines of his weapon-essence seal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4146,7 +4146,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1705279686",
@@ -4158,7 +4158,7 @@
       "recaps": {
         "ending": "Hadjar passes the repository's trials, but the First Darkhan forces him to accept an inheritance by threatening Dora. The pact grants Hadjar Flying Sword while obliging him to keep studying the ancestor's knowledge, and the ancestor intends to use him as a vessel. Hadjar plans to turn that power against its owner. Dora remains alive after shielding Einen from Tom's attack, but her chest wound is fatal without rapid treatment. Einen, Annis, the Dinos siblings, the giant cultivator, and other allies escape aboard Dora's ship to seek her aunt's aid. Hadjar stays behind at the fort and spends nearly all his strength resisting the demon horde released by the repository's collapse. Helmer intervenes as the Demon Prince's emissary, erases the invading army, and gives Hadjar the rebel commander's core. Hadjar helps hide Helmer's role. The demon gates remain a wider threat, while Helmer's debts, the divine interest in Hadjar, the Dead Moon contract, Derek's oath, Dora's survival, and the First Darkhan's plan all remain unresolved. A famed swordsman finally claims Hadjar as his disciple and takes him to Storm Mountain for two years of dangerous training.",
         "in_short": "Hadjar returns to the Holy Sky School and joins Einen, Dora, Annis, and Tom in a search for Emperor Decatur's tomb. The expedition exposes imperial manipulation, a Winter Court fae, rival clans, assassins, and evidence that the tomb is actually the Last King's repository. Inside, Hadjar abandons revenge as his central purpose and adopts the identity North Wind. Dora is critically wounded saving Einen, while the First Darkhan coerces Hadjar into an inheritance pact that grants Flying Sword and prepares him as a future vessel. The repository's collapse reopens the demon gates. Einen and other allies carry Dora toward urgent treatment as Hadjar remains to defend the fort. Helmer destroys the invading horde for the Demon Prince and gives Hadjar its commander's core. Hadjar conceals this intervention, then leaves for two years of training on Storm Mountain with a new swordsman master.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4521,7 +4521,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:170529538X",
@@ -4533,7 +4533,7 @@
       "recaps": {
         "ending": "Orune uses an old law of masters and disciples to take responsibility for Hadjar's crimes, then kills himself with Morgan's sword. His sacrifice secures Hadjar's pardon, and Morgan orders a state funeral while retaining control of the empire. Hadjar enters the fourth tournament round immediately afterward and kills a Dinos heir with a newly manifested barony of the sword, leaving the Blue Wind Sword on the field. Einen, Dora, Annis, and the giant heir survive, while Annis's clan struggle and the giant heir's break with Eternal Mountain remain unresolved. Tom stood with them after Orune's death, but his later condition is not established. Hadjar is an initial-stage Spirit Knight with only a lead toward Path Through the Stars and about four years to overcome his divided-soul damage. The First Darkhan still seeks freedom through him, Helmer's obligations remain open, and a dragon emissary expects to revisit Hadjar's imperial lineage after the war. The book closes as Morgan orders general mobilization because Laskan has crossed the border.",
         "in_short": "Hadjar enters the Tournament of the Twelve after two years under Orune, joins Annis's conspiracy against her clan head, and destroys an undead potter fragment beneath the Lake of Dreams. A palace assassination attempt draws him into Morgan's ruthless preparations for war. Hadjar becomes a Spirit Knight, learns that he descends from a purged dragon imperial line, and refuses to support a dragon rebellion. He later gains a route toward Path Through the Stars, which may repair his divided soul. At an auction, Hadjar and Einen demand citizenship for neglected peoples in exchange for an ancient fae core, prompting Morgan to order their arrest. Orune assumes Hadjar's crimes and dies by Morgan's sword to absolve him. Grieving, Hadjar kills a Dinos heir in the tournament's fourth round and manifests barony of the sword. Morgan then announces mobilization as Laskan troops cross the border.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4800,7 +4800,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4813,7 +4813,7 @@
       "recaps": {
         "ending": "The expedition is committed and well up the Rain Wild River. Fifteen or so heavily marked young keepers, the stunted dragons, Leftrin's barge Tarman, two hired hunters and two Bingtown passengers are strung out along a poisonous river with no map beyond the dragons' unreliable ancestral memories of a city called Kelsingra. Thymara has been claimed by the blue queen Sintara and is learning that a dragon's affection is a form of hunger; the keepers are already changing physically from constant contact with them, growing more scaled and less human. Greft is quietly gathering the younger keepers around the argument that Rain Wild law, including the rule that the marked must never breed, has no force out here. Alise has seen enough of Leftrin's plain competence and enough of her husband's letters to understand what her marriage actually is, and Leftrin, who has troubles of his own concerning how his barge came to be what he is, has fallen in love with her. Sedric, sick of the river and desperate for the money that would buy him a different life, has begun secretly taking from the dragons the blood and scales he was sent to get, which is theft from a sentient being and, if the dragons ever learn of it, a killing matter. Nobody aboard yet knows whether Kelsingra exists, and Trehaug and Cassarick are already discussing how conveniently the whole problem has floated away upriver.",
         "in_short": "Generations after the last dragons vanished, the sea serpents finally return up the Rain Wild River to cocoon, but they come too late and too weak, and what hatches at Cassarick is a clutch of stunted dragons that cannot fly or hunt. The Rain Wild Traders, sick of feeding them, contract a company of heavily marked young outcasts as keepers and pay Captain Leftrin's barge Tarman to escort dragons and keepers upriver in search of the legendary Elderling city of Kelsingra, hoping the whole burden simply disappears. Among the keepers is Thymara, a girl who should have been exposed at birth and who is claimed by the imperious blue queen Sintara. Alise Kincarron, a Bingtown scholar trapped in a hollow marriage to the rich Hest Finbok, comes north to study the dragons and joins the expedition, accompanied by Hest's secretary Sedric, who has his own commission: to steal dragon blood and scales worth a fortune in Chalced. The expedition sets out into unmapped river country, the keepers begin to change into something not quite human, Alise and Leftrin fall in love, and Sedric quietly begins to take what he came for.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4987,7 +4987,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5000,7 +5000,7 @@
       "recaps": {
         "ending": "Piemur is found alive in the Southern Continent by Menolly, Sebell and the Masterharper, after months in which the Harper Hall had no idea whether he had survived. He comes back with a queen fire lizard, a half-tame runnerbeast, an eyewitness account of what the exiled riders and their northern trading partners have been doing, and, most valuable of all, first-hand knowledge of an enormous stretch of country no northerner has ever seen. Instead of being returned to the drumheights or to the Hall's classrooms, he is given the south: the Harper Craft needs the continent explored and mapped, and he is the only person who has done it. The loss of his treble voice, which began the book as the end of his career, turns out to have redirected it rather than finished it, and his standing in the craft now rests on what he can do rather than on how he sounds. Along the way he works out that Sebell is in love with Menolly. Left open are Lord Meron's disputed succession at Nabol, the exiled riders in the south, Toric's quietly expanding hold, and the fact that Piemur has seen a white dragon in the Southern Continent and cannot yet explain it to anyone.",
         "in_short": "Piemur's celebrated treble voice breaks, ending the only future he had ever expected, and the Masterharper reassigns him to learn the drum code in the Harper Hall's drum tower, where the other apprentices resent him and one of them puts him out of action. The posting is partly cover: Robinton and the journeyman Sebell have been using Piemur, who is small, quick and unremarkable, for errands that need a harper nobody notices. Sent to Nabol while its Lord Holder Meron is dying, he comes away with a fire-lizard egg that hatches into a queen he names Farli. Travelling south concealed among trade goods to observe the traffic between certain northern holders and the riders exiled to the Southern Continent, he is left behind and stranded. He survives alone for months, raising an orphaned runnerbeast, exploring a vast tract of unmapped country and observing the exiles, including a glimpse of a white dragon that should not be there. When the harpers finally find him, he is given the south to explore and map, his career redirected rather than ended.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5176,7 +5176,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5189,7 +5189,7 @@
       "recaps": {
         "ending": "Lessa rides Ramoth four hundred Turns into the past, using an ancient Ruathan tapestry as her reference point, and survives a crossing long enough to nearly kill them both. In the past she finds the five Weyrs at full strength at the close of a Pass, facing four hundred Turns with nothing left to fight, and convinces their leaders to bring every dragon and rider forward. They arrive at Benden as an army: enough dragons to cover all of Pern for the whole of the new Pass. F'lar is confirmed as the leader who was right about Thread and who now commands a force capable of fighting it, and Lessa's gamble closes the loop that made the old riddle-song a question in the first place. The holds' contempt for the Weyrs is broken by the plain demonstration that the riders are all that stands between Pern and the spore. What is left unresolved is what Pern will do with several thousand riders displaced from four centuries in its own past, who expect the customs, the authority and the deference of their own time and have arrived in a world that changed without them.",
         "in_short": "On Pern, a long-isolated world, the deadly spore called Thread falls from a neighbouring planet whenever its wandering orbit brings it close, and the only defence is dragons and their bonded riders. After four hundred Turns without a Fall, five of the six Weyrs stand empty and the holds despise the riders they are obliged to support. Convinced Thread is about to return, the Benden bronze rider F'lar searches for a new queen's rider and finds Lessa, the last heir of Ruatha Hold, hiding as a drudge under the conqueror Fax. F'lar kills Fax, Lessa Impresses the queen Ramoth, and when Ramoth flies to mate F'lar becomes Weyrleader. Thread returns as he predicted, and Benden's two hundred dragons cannot cover a planet. After the riders discover that dragons can travel in time as well as in space, Lessa works out from an old riddle-song that the five missing Weyrs went forward in time, rides Ramoth four hundred Turns into the past and persuades them to come. Pern gains the dragons it needs, and with them thousands of riders out of its own distant past.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5418,7 +5418,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5431,7 +5431,7 @@
       "recaps": {
         "ending": "On the eve of Culloden, Jamie and Claire make a last attempt to stop the battle by poisoning Charles Stuart. Dougal MacKenzie overhears them, accuses Claire of witchcraft and treason, and attacks her; Jamie kills him and leaves the body hidden. With the army about to be destroyed, Jamie writes a deed transferring Lallybroch to his nephew and sends Murtagh to see the paper safe. He then takes Claire to Craigh na Dun. She is pregnant again, and he refuses to let the child be born on a battlefield. He tells her he intends to see the Lallybroch men off the field and then die in the fighting, and he asks her to name the child for his father. Claire goes through the stones and returns to 1948 and to Frank, who agrees to raise the child as his own. In 1968 the story catches up with itself: Roger's research turns up a record showing that James Fraser was not killed at Culloden after all. Claire, Brianna and Roger are left with the knowledge that Jamie survived the battle, and that the twenty years since could be crossed again.",
         "in_short": "In 1968 Claire Randall returns to Inverness with her daughter Brianna and, helped by the young historian Roger Wakefield, finally tells the story of the two years she has never explained. In 1744 she and Jamie Fraser were living in Paris, working to bankrupt and discredit Charles Stuart before he could launch the Jacobite rising they knew would end in slaughter. Their schemes cost them their first child, a daughter born dead after Claire ran to stop a duel, and cost Jamie months in the Bastille. The rising came anyway, and they returned to Scotland and rode out with it, winning at Prestonpans and then watching the army starve and retreat through an English winter. On the eve of Culloden, with the cause lost, Jamie killed Dougal MacKenzie to protect Claire, then sent her back through the standing stones carrying their second child while he went to die with his men. Claire returned to 1948 and to Frank, who raised Brianna as his own. Twenty years on, Roger finds proof that Jamie did not die at Culloden.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5662,7 +5662,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5675,7 +5675,7 @@
       "recaps": {
         "ending": "F'lar defeats T'ron in a knife duel in front of an audience of Lord Holders, craftmasters and riders and, badly wounded, uses the victory to settle the Oldtimer question: the riders who cannot accept the modern world are exiled to the Southern Continent, and the affected Weyrs pass to leaders willing to work with the holds and crafts, among them the young bronze rider N'ton. The search for a permanent answer to Thread produces two results. F'nor and Canth reach the Red Star and find conditions no living thing can survive, closing off any dragon-borne attack for good. Against that, the grubs of the Southern Continent are shown to consume Thread where it burrows, which suggests Pern's ancestors designed a defence in two parts and that the dragons were only the visible half. At a Benden Hatching, Jaxom, the boy Lord Holder of Ruatha, opens an undersized egg with his own hands and Impresses the white dragon Ruth, a pairing that satisfies neither the holds nor the Weyrs and that nobody knows how to undo. Brekke, not chosen by the new queen, accepts that she will never ride again and begins to recover with F'nor. Fire lizards are spreading everywhere, the Pass goes on, and the exiled riders sit in the south unreconciled.",
         "in_short": "Seven Turns after the five lost Weyrs were brought forward through time, Pern is fighting Thread successfully but coming apart socially: the transplanted Oldtimer riders expect an obedience the modern holds and crafts will not give. F'lar of Benden pushes for craft invention and for attacking Thread at its source. F'nor finds a clutch of fire-lizard eggs in the south, and the small telepathic dragon-cousins spread rapidly across Pern. Kylara's neglect of her queen leads to a mating flight in which two queens fight and both die, leaving Brekke dragonless and Kylara destroyed. F'nor's attempt to fly a dragon to the Red Star nearly kills him and ends that hope, but the discovery that Southern's grubs devour Thread in the soil offers a lasting defence. When the Oldtimer leader T'ron challenges F'lar to a knife duel and loses, the irreconcilable riders are exiled to the Southern Continent. At a Benden Hatching, the boy Lord Holder Jaxom helps a tiny white dragon out of its shell and Impresses him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5933,7 +5933,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -5946,7 +5946,7 @@
       "recaps": {
         "ending": "At Garton Knoll, the rebels defeat King Caydean's two contingents after Wesson kills Battle Master Rhone and the Sen is removed from the fighting. The Sen escapes the collapsed ruins after opening a pathway. Caydean comes through that passage, but Rezkin forces him back into it before the device collapses. The surge of pathway energy and demonic force leaves Rezkin motionless, and the spirit leader declares him dead. Farson chooses to bury him at Garton Knoll, while Tieran assumes the title of emperor. Tam is alive and travelling with the freed quarry prisoners toward Kyle and his new eastern command in Gendishen. Wesson, Kai, Farson, Reaylin, the spirit companions, and the bonded wolf-shifter survive the battle. Frisha and Prince Thresson remain together in an unknown rune-protected prison. Caydean's destination is unknown, and the missing Sen may possess knowledge capable of restoring Rezkin, leaving Rezkin's death uncertain. The demon threat, pathway technology, fragile alliance of shifting tribes, and danger attached to spiritua power all remain active concerns.",
         "in_short": "After surviving an attempted poisoning, Rezkin accepts Gendishen's crown and sets out to recover Tam. Hidden spirit people identify him as a human-born spiritua whose growing power may eventually drive him mad. He rescues Tam from an Asshaian quarry, heals his damaged mind, and appoints him to command Gendishen's eastern forces. Frisha is secretly kidnapped and replaced by a clay double, then imprisoned with Prince Thresson. Wesson survives the fall of the Asshaian mage academy, unites the mages at Benbrick, and learns that he was fused with a demon before birth. Rezkin builds support among animal-shifting tribes and joins the rebels at Garton Knoll. Wesson kills Battle Master Rhone, while Rezkin wounds the Sen and forces King Caydean through a magical pathway. Its collapse leaves Rezkin motionless and declared dead. The rebels win and Tieran becomes emperor, but Caydean and the Sen remain at large, Frisha and Thresson remain captive, and the possibility of restoring Rezkin is unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/dragonsdawn.json
+++ b/data/works-community/0/dragonsdawn.json
@@ -127,7 +127,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -140,7 +140,7 @@
       "recaps": {
         "ending": "The genetically created dragons prove able to bond permanently with human riders, fly, breathe flame after chewing firestone, and travel between places. Sorka and Faranth, Sean and Carenath, and the other first pairs turn Kitti Ping's experiment into a workable defense against Thread. Sean's authority among the riders grows from experience rather than appointment, while Sorka becomes the leading queen rider. The old colony at Landing can no longer remain the center of settlement, so people, animals, and salvageable equipment move north. The dragonriders take the great volcanic caverns above Fort as their home, creating the pattern later known as a Weyr. Avril Bitra's attempt to seize a way off Pern ends in space, and Sallah Telgar dies preventing her escape. The settlers lose much of their connection to advanced interstellar life, but they survive by combining what remains of that knowledge with dragons and new social institutions. Pern's later Holds, Weyrs, and founding legends begin in those choices.",
         "in_short": "Earth colonists arrive on Pern intending to build a permanent low-technology society at Landing. Children Sorka Hanrahan and Sean Connell grow up as the settlement prospers and form bonds with native fire-lizards. Years later, Thread begins falling without warning, consuming living matter and overwhelming the colony's limited aircraft and fuel. Geneticist Kitti Ping enlarges and reshapes fire-lizard embryos to create intelligent defenders. At the first hatching, Sorka bonds with the gold Faranth, Sean with bronze Carenath, and other young people become the first dragonriders. The dragons learn to fly, breathe flame using firestone, and move instantly between locations, giving Pern a renewable defense. Political division and Avril Bitra's attempted escape cost lives, including pilot Sallah Telgar's. Environmental danger and failing technology force the colonists to leave Landing and cross north. Sean, Sorka, and the riders settle in caverns above Fort, establishing the first Weyr and the institutions that will shape Pern after its origins become legend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -350,7 +350,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -363,7 +363,7 @@
       "recaps": {
         "ending": "Menolly's standing at the Harper Hall is settled in her favour on every count. Her hand, treated properly by Masterhealer Oldive and worked steadily, recovers enough for her to play as she used to. The craftmasters who set out to test her, Domick and Morshal in particular, are satisfied by what she can actually do: she sight-reads and performs Domick's demanding new work and holds her own in theory, instrument-making and voice. The trouble at the girls' cottage ends with her out of it and lodged in the Hall itself, and Pona's clique loses its ground. Fire lizards spread further under her instruction, including a queen for Lord Groghe of Fort Hold, and Menolly's own songs are being sung across Pern by harpers who have no idea who wrote them. At the Hall's evening meal the Masterharper ends her apprenticeship after a matter of days and walks her to the journeymen's tables, making her a journeywoman of the Harper Craft, the first woman to hold the rank. Her fear that she was brought to the Hall only as the keeper of nine fire lizards is put to rest: she was brought there to write. What is not settled is what the Masterharper actually intends to do with a journeywoman whose songs travel faster than his harpers do.",
         "in_short": "Menolly arrives at the Harper Hall as the Masterharper's apprentice, the first girl the craft has taken, with nine fire lizards, a scarred hand and no idea what she is entitled to. Lodged among Lord Holders' daughters who resent her, tested by craftmasters who assume she is a fashionable indulgence, and convinced she was brought only because of her fire lizards, she works through a punishing few days of examinations in composition, theory, voice and instrument-making. Master Oldive treats her hand so that it will heal properly; Silvina, the apprentice Piemur, the journeyman Sebell and the kitchen helper Camo take her side; the bullying at the girls' cottage comes to a head and she is moved into the Hall itself. She teaches others to Impress fire lizards, including the Lord of Fort Hold, and she discovers that songs she wrote alone on a beach are already being sung across Pern. At the end of the week the Masterharper ends her apprenticeship and walks her to the journeymen's tables, making her the Harper Craft's first journeywoman.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -647,7 +647,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BVDPGHJS",
@@ -659,7 +659,7 @@
       "recaps": {
         "ending": "Kazimir's false portal signal draws the young dragon to an isolated field, but the same magic intensifies the cold and fog, ruining the planned rifle attack. Kazimir shocks the chaotic energy clinging to the creature, Macarius and Duke stop it from escaping, and Kazimir places it into a magical sleep. The party transports it to the former breach, where Kazimir opens a portal and sends the awakened dragon back to the Nether alive.\n\nAn elder Nether god seizes Kazimir's will and forces him to hold the portal open. Kazimir breaks the control by injuring himself until he loses consciousness, closing the passage before the god can enter. The escaped-creature crisis is resolved, but traces of both animals remain vulnerable to public discovery. Kazimir survives with a likely concussion and accepts the Convergence as a world-level threat. Duke, Mike, the injured agent, Macarius, and Giselle remain with him. Azib and the Nether feline decline the chance to return to the Nether, while the remote leader's allied network and the federal contact remain allies under continuing security pressure. Kazimir intends to strike the hostile organization, whose magical archives, compromised operations, and wider plans remain unresolved.",
         "in_short": "After sealing a portal created by a hostile organization, Kazimir Wolfe and his allies discover that a wyvern, a young dragon, and a speaking Nether feline crossed into this world. The wyvern dies in a road collision, while the group follows the dragon to a later search region amid public sightings, enemy attacks, and the arrival of a time-displaced assassin. Kazimir develops new control over chaotic energy and devises a false portal signal to lure the dragon. With Macarius and Duke, he captures it alive and opens a real portal to return it to the Nether. An elder Nether god then takes control of Kazimir and tries to enter through the opening. Kazimir knocks himself unconscious to close the portal. Injured but convinced that the Convergence is real, he resolves to lead an offensive against the hostile organization, while Azib and the Nether feline choose to remain with his group.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -834,7 +834,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -847,7 +847,7 @@
       "recaps": {
         "ending": "Menolly, taken to Benden Weyr after being caught in the open during Threadfall, recovers there with her nine fire lizards, and the Weyr proves to be the first place that finds her useful rather than embarrassing: her hand loosens with work and healing, and her ability with the creatures is exactly what the Weyr wants explained. The Masterharper of Pern, who has been searching since the old harper Petiron's death for the composer of two songs sent to him from Half-Circle, comes to Benden and identifies the songwriter as Menolly. He takes her into the Harper Craft on the spot as his apprentice. Half-Circle Sea Hold, which had assumed her dead, loses any claim on her, and her family's judgement that a girl cannot be a harper is overturned by the Masterharper himself. She leaves for the Harper Hall with Beauty and the rest of her clutch, no longer hiding what she can do. What remains open is whether a Hall full of boys and craftmasters will actually make room for her, and what Pern will make of a girl who has proved that fire lizards can be Impressed by anyone who reaches them at hatching.",
         "in_short": "Menolly, youngest child of the Sea Holder at the isolated Half-Circle Sea Hold, is a gifted musician and songwriter taught in secret by the hold's old harper. When he dies, her family forbids her to play, insisting that no girl can be a harper, and a badly treated gash across her palm seems to end the question permanently. Forbidden her music and with nothing left at the hold, she runs away. Sheltering in a cliff cave from Threadfall, she is present when a clutch of fire-lizard eggs she had rescued from the tide hatches, and she Impresses nine of the little creatures, something no one on Pern had known was possible. She lives wild on the coast, feeding them and exercising her scarred hand back into use, until she is caught in the open during a Fall and rescued by a dragonrider who takes her to Benden Weyr. There her fire lizards make her remarkable rather than shameful, and the Masterharper of Pern, who has been hunting for the author of two songs sent to him from her hold, identifies her and takes her into his craft as an apprentice.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -931,7 +931,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -944,7 +944,7 @@
       "recaps": {
         "ending": "The test works far past anything Solomon predicted. The drive lights and does not stop, the acceleration climbs beyond what a body can take, and the couch he is pinned to becomes the whole of his world. His controls are out of reach, there is no cutoff he can get to, and the drugs and the ship's systems cannot compensate for a burn that simply continues. He works out what he has built while he is dying of it: a drive efficient enough to make the entire solar system reachable, to put Mars in a position to become a real power, and to change what human beings are capable of doing off-planet. He also works out that he will not be there for any of it, and that Caitlin will hear about it after the fact. He dies under acceleration. The yacht keeps burning, carrying his body out of the solar system on a course nothing will ever intercept, and it is still going. The design survives him because the data went out before he did, and the drive that bears his name becomes the foundation of everything the novels take for granted: cheap, fast travel between the planets, a settled Belt, and a Mars strong enough to leave Earth.",
         "in_short": "Solomon Epstein, a Martian engineer, has spent his spare time modifying the fusion drive on his private yacht, and he takes it out alone for a test. It works far better than he expected and then does not stop. The ship accelerates past the limits of what a human body can survive, and with his controls out of reach and no way to shut the burn down, Solomon is pinned to his couch while the drive runs. In the time he has left he understands what he has done: he has built the engine that will make the whole solar system reachable, transform Mars into a genuine power, and open the outer planets to settlement. He also understands that he will not survive it and that his wife Caitlin will learn about it as news. He dies under acceleration, and the yacht carries his body out of the solar system, still burning. The design survives because the data was already transmitted, and the Epstein Drive becomes the technology the entire series rests on.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1122,7 +1122,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1135,7 +1135,7 @@
       "recaps": {
         "ending": "Jamie, Claire and Young Ian follow Roger north into Iroquois country and find him held in a Mohawk village. Jamie's attempts to buy him back fail, and in the end Young Ian offers himself in Roger's place, is adopted into the village, and stays behind; the parting is permanent as far as any of them know. Roger, who has had months to decide whether he wants a wife carrying a child that may be another man's, chooses to come back. He returns to Fraser's Ridge, where Brianna has borne a son she names Jeremiah, called Jemmy, and accepts the boy as his own without needing to know whose he is. Brianna and Roger are married. Nobody can say whether the child's father is Roger or Stephen Bonnet, and Bonnet himself is still alive and free somewhere in the colonies, with Claire's stolen ring and a grudge. Claire and Jamie remain on the Ridge, holding a newspaper notice from a future decade that reports their own deaths in a house fire, and beginning to build something that they know history says will burn.",
         "in_short": "Shipwrecked into the American colonies, Jamie and Claire refuse a rich inheritance from Jamie's aunt at her slave-worked plantation and take a land grant in the North Carolina mountains instead, founding Fraser's Ridge. In 1969, Roger finds a newspaper notice recording that James and Claire Fraser died in a fire on that Ridge in 1776, and hides it from Brianna. She finds it herself, follows her mother through the standing stones to warn them, and Roger goes after her. In Wilmington the two quarrel and part after handfasting; that same night Brianna is raped by Stephen Bonnet, a pirate the Frasers once helped escape hanging. Arriving pregnant at the Ridge, she cannot say whose the child is. Her young maid misidentifies Roger as the man who attacked her, and Jamie beats him and lets Young Ian sell him to the Mohawk. When the mistake comes to light, Jamie and Claire go north to buy him back, and Ian trades himself for Roger's freedom. Roger returns, claims Brianna's newborn son as his own, and the two are married.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1376,7 +1376,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1389,7 +1389,7 @@
       "recaps": {
         "ending": "The final story closes after Gabriel and Gretta Conroy leave the Morkan sisters' holiday party for a hotel. Gabriel expects intimacy, but Gretta has been shaken by hearing an old song at the party. She tells him about Michael Furey, a frail young man who loved her when she lived in Galway. Before she left, he came out in severe weather to see her despite being ill, and he died soon afterward. Gabriel realizes that Gretta has carried a depth of feeling he never understood and that his own confident image of their marriage was incomplete. While she sleeps, his jealousy gives way to humility and an enlarged awareness of mortality. Watching the snow, he imagines it falling across Ireland on the living and the dead alike, including Michael's grave. The collection ends with Gabriel contemplating movement westward, the past's hold on the present, and the boundary between life and death.",
         "in_short": "Across fifteen stories, Dublin children and adults confront death, frustrated escape, money, work, family duty, religion, politics, and disappointed ambition. Boys discover that adventure and romance do not match their fantasies; Eveline cannot board the ship that might carry her from an abusive home; and social climbers, petty exploiters, clerks, parents, and cultural organizers find their plans compromised by vanity or dependence. Maria's holiday visit exposes loneliness beneath ritual, while James Duffy understands too late the human cost of refusing intimacy. Public life appears equally stalled in election talk, a mismanaged concert, and a businessmen's religious retreat. At the Morkan sisters' party, Gabriel Conroy moves from social confidence to painful self-knowledge when Gretta reveals her enduring memory of Michael Furey. His final meditation on snow, Ireland, and the dead expands the collection's repeated private failures into a shared awareness of memory and mortality.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1595,7 +1595,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1608,7 +1608,7 @@
       "recaps": {
         "ending": "At the close of the collection, Gabriel Conroy and his wife, Gretta, leave the Morkan sisters' holiday party for a hotel. Gabriel expects intimacy, but Gretta explains that the song heard before their departure reminded her of Michael Furey, a frail boy who loved her when she was young in Galway. He came to see her in bad weather shortly before she left, and soon died. Gabriel's jealousy gives way to humility as he recognizes that this dead boy may have felt a depth of love he himself has never known. Watching Gretta sleep, he reflects on his own identity, his aging relatives, and the nearness of death. Snow is falling across Ireland, joining Dublin, the western landscape, and the graves in one image. The ending leaves Gabriel less certain of his superiority and more conscious of the private histories carried by the living and the dead. It also gathers the collection's separate lives into a shared condition of loneliness, memory, thwarted desire, and mortality.",
         "in_short": "Across fifteen stories, Dublin children seek mystery, young adults imagine escape, and older residents confront work, family, politics, religion, and disappointed hopes. A boy learns of a priest's troubled death; another meets a disturbing stranger; a trip to a bazaar punctures romantic fantasy. Eveline cannot board a ship with Frank. Jimmy Doyle loses heavily after a night with wealthy companions, while Corley exploits a servant and Mrs Mooney maneuvers Bob Doran toward marriage. Little Chandler's envy turns into shame, Farrington passes workplace humiliation on to his son, Maria's Halloween visit exposes her isolation, and Mr Duffy recognizes too late the cost of rejecting Mrs Sinico. Political, cultural, and religious gatherings reveal compromise and self-interest. In the final story, Gabriel Conroy learns that his wife Gretta still remembers Michael Furey, a boy who died after braving bad weather to see her. Gabriel's wounded pride broadens into an awareness of love, mortality, and the hidden past as snow falls across Ireland.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1807,7 +1807,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1820,7 +1820,7 @@
       "recaps": {
         "ending": "The final story closes after Gabriel and Gretta Conroy leave the Morkan sisters' holiday party for a hotel. Gabriel expects intimacy, but Gretta has been shaken by hearing an old song at the party. She tells him about Michael Furey, a frail young man who loved her when she lived in Galway. Before she left, he came out in severe weather to see her despite being ill, and he died soon afterward. Gabriel realizes that Gretta has carried a depth of feeling he never understood and that his own confident image of their marriage was incomplete. While she sleeps, his jealousy gives way to humility and an enlarged awareness of mortality. Watching the snow, he imagines it falling across Ireland on the living and the dead alike, including Michael's grave. The collection ends with Gabriel contemplating movement westward, the past's hold on the present, and the boundary between life and death.",
         "in_short": "Across fifteen stories, Dublin children and adults confront death, frustrated escape, money, work, family duty, religion, politics, and disappointed ambition. Boys discover that adventure and romance do not match their fantasies; Eveline cannot board the ship that might carry her from an abusive home; and social climbers, petty exploiters, clerks, parents, and cultural organizers find their plans compromised by vanity or dependence. Maria's holiday visit exposes loneliness beneath ritual, while James Duffy understands too late the human cost of refusing intimacy. Public life appears equally stalled in election talk, a mismanaged concert, and a businessmen's religious retreat. At the Morkan sisters' party, Gabriel Conroy moves from social confidence to painful self-knowledge when Gretta reveals her enduring memory of Michael Furey. His final meditation on snow, Ireland, and the dead expands the collection's repeated private failures into a shared awareness of memory and mortality.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2026,7 +2026,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2039,7 +2039,7 @@
       "recaps": {
         "ending": "The final story closes after Gabriel and Gretta Conroy leave the Morkan sisters' holiday party for a hotel. Gabriel expects intimacy, but Gretta has been shaken by hearing an old song at the party. She tells him about Michael Furey, a frail young man who loved her when she lived in Galway. Before she left, he came out in severe weather to see her despite being ill, and he died soon afterward. Gabriel realizes that Gretta has carried a depth of feeling he never understood and that his own confident image of their marriage was incomplete. While she sleeps, his jealousy gives way to humility and an enlarged awareness of mortality. Watching the snow, he imagines it falling across Ireland on the living and the dead alike, including Michael's grave. The collection ends with Gabriel contemplating movement westward, the past's hold on the present, and the boundary between life and death.",
         "in_short": "Across fifteen stories, Dublin children and adults confront death, frustrated escape, money, work, family duty, religion, politics, and disappointed ambition. Boys discover that adventure and romance do not match their fantasies; Eveline cannot board the ship that might carry her from an abusive home; and social climbers, petty exploiters, clerks, parents, and cultural organizers find their plans compromised by vanity or dependence. Maria's holiday visit exposes loneliness beneath ritual, while James Duffy understands too late the human cost of refusing intimacy. Public life appears equally stalled in election talk, a mismanaged concert, and a businessmen's religious retreat. At the Morkan sisters' party, Gabriel Conroy moves from social confidence to painful self-knowledge when Gretta reveals her enduring memory of Michael Furey. His final meditation on snow, Ireland, and the dead expands the collection's repeated private failures into a shared awareness of memory and mortality.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2206,7 +2206,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2219,7 +2219,7 @@
       "recaps": {
         "ending": "Poirot proves that Bella Tanios killed Emily Arundell. Bella had stretched a cord across the stairs and placed Bob's ball nearby so that Emily's first fall would be blamed on the dog. When Emily survived and changed her will, Bella later poisoned her with phosphorus, producing symptoms that passed as a recurrence of liver disease. The luminous effect witnessed during the Tripps' séance came from the poison rather than a spirit, while Bob's habits showed that the ball had been planted. Poirot eliminates Charles and Theresa despite their greed, Dr Donaldson despite his knowledge, Miss Lawson despite inheriting, and Dr Tanios despite Bella's efforts to make him appear threatening. Faced with Poirot's conclusion and unwilling to expose her children to a public trial, Bella takes her own life after leaving an admission. Poirot treats the death as the final consequence of the case rather than a victory. Miss Lawson, who retains Emily's estate under the valid will, chooses to distribute substantial shares to the family. Bob is given a secure home with Hastings, who has been his firm advocate throughout the investigation.",
         "in_short": "Poirot receives a delayed letter from Emily Arundell, an elderly woman who wrote after falling down the stairs at Littlegreen House. By the time he investigates, Emily has died of what was called liver disease and has disinherited her family in favour of her companion, Wilhelmina Lawson. Poirot studies Emily's indebted nephew Charles, his sister Theresa and her doctor fiance, and their cousin Bella Tanios with her husband Jacob. The fall was blamed on the terrier Bob's ball, but Bob's behaviour shows the scene was arranged. Poirot discovers that Bella stretched a cord across the stairs and later killed Emily with phosphorus, hoping to inherit for herself and her children. The poison also explains the glow seen during a spiritualist séance. Bella had tried to turn suspicion toward her husband; when Poirot confronts her, she takes her own life and leaves an admission. Lawson shares much of the inheritance, and Hastings provides Bob with a home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2408,7 +2408,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2421,7 +2421,7 @@
       "recaps": {
         "ending": "Paul Atreides, now known to the Fremen as Muad'Dib, has become the master of Arrakis and a leader believed to be a living prophet. After his father's murder and his house's fall, he raised the desert people into an unstoppable force and awakened immense prescient powers by surviving the poisonous Water of Life. In the final battle on the plain before the capital, his Fremen shatter the Emperor's armies, and Paul slays the Harkonnen heir Feyd-Rautha in single combat while the vile old Baron Harkonnen is killed by Paul's uncanny young sister Alia. By threatening to destroy the spice on which the whole empire depends, Paul forces the Padishah Emperor to abdicate. He agrees to marry the Emperor's daughter, Princess Irulan, to secure the throne, though it is Chani, the mother of his child, who remains his true beloved and wife in all but name. Paul ascends as the new ruler of the known universe, having fulfilled the prophecy laid upon him. Yet his triumph is darkened by a vision he cannot escape: his rise will loose a fanatical holy war in his name across countless worlds, a slaughter he foresees but fears he is powerless to stop.",
         "in_short": "House Atreides takes over the desert planet Arrakis and its priceless spice, but the move is a trap. Betrayed from within by his trusted doctor, whose wife is held hostage by the Harkonnens, Duke Leto is overthrown and killed when Harkonnen forces and the Emperor's elite soldiers storm the planet. Paul and his mother Jessica escape into the deep desert and are taken in by the Fremen, the tough, water-hoarding native people. Immersed in the spice that saturates their world, Paul's latent powers awaken into true prescience, and he takes the Fremen name Muad'Dib. Over the following years he forges the scattered Fremen into a fearsome guerrilla army, learns to ride the giant sandworms, and grows into a messianic leader whom the Fremen believe is a prophesied savior. He and the Fremen woman Chani become lovers. After surviving the deadly Water of Life, Paul emerges with vast, terrible foresight. When the Emperor comes to crush the rebellion, Paul defeats his armies, kills the Harkonnen heir in single combat, and seizes control of the spice and thus the empire itself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2540,7 +2540,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2553,7 +2553,7 @@
       "recaps": {
         "ending": "Paul's reign ends in loss. Blinded by the conspirators' stone burner, he continues to function through prescient vision alone, but the futures he sees close in around him. His beloved Chani, whose pregnancy had been secretly delayed by Irulan, dies giving birth to twins, a son and daughter named Leto and Ghanima, both born with the ancestral awareness of the pre-born. Grief-stricken, Paul confronts the Tleilaxu Face Dancer Scytale, who offers to recreate Chani as a ghola if Paul will surrender his throne. Paul is nearly broken by the temptation, but Hayt, the ghola of Duncan Idaho, throws off the murderous conditioning laid on him, recovers his true self, and kills Scytale, becoming fully Duncan again. Paul's inner sight finally gives out, leaving him wholly blind, and by Fremen law a blind man belongs to the desert. Refusing the diminished life his enemies would allow him, he walks out alone into the sand to die rather than cling to power. His sister Alia, a powerful young Reverend Mother, and the restored Duncan Idaho take up the regency, ruling the empire in the name of the infant twins. The failed conspirators are left to face judgment, and the future now rests on the two prescient children Paul has left behind.",
         "in_short": "Twelve years after seizing the throne, Paul Muad'Dib rules as Emperor while the holy war waged in his name has killed billions across the galaxy. A conspiracy forms against him, drawing in the Spacing Guild, the Bene Gesserit sisterhood, the shapeshifting Bene Tleilax, and his unloved wife Irulan. The Tleilaxu present Paul with a ghola, Hayt, grown from the corpse of his dead swordmaster Duncan Idaho and secretly conditioned to strike at him. The plotters use a forbidden weapon, a stone burner, whose radiation destroys Paul's eyes, though his prescience lets him move as if he can still see. Chani, denied children by Irulan's hidden sabotage, finally conceives, but she dies bearing twins, Leto and Ghanima. Confronted by the conspirators, Paul resists the temptation to trade his rule for a Tleilaxu offer to restore Chani; Hayt's buried identity as Duncan reasserts itself, breaking his conditioning, and he kills the agent Scytale. When his prescient sight fails at last, the now truly blind Paul follows the Fremen custom of walking alone into the desert to die, leaving his sister Alia and Duncan to rule as regents for his children.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2997,7 +2997,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0DMQH457W",
@@ -3009,7 +3009,7 @@
       "recaps": {
         "ending": "Hal's party and the Adventurers Guild survive the Merchant Guild counterattack. The apparent destruction of the guildhall is a planned deception: Elora, the guild service helper, and the small companion protect and repair the courtyard while the fire hides their work. The harple informant only pretends to betray Hal, using the operation to free the former leader before disabling the attacking house scion's protection. Hal kills the scion and the surrounding force with Anvil Lightning, then nearly loses himself to rage until Noth, Vorax, and another companion restrain him. The victory raises the guild from F grade to C grade and restores access to the Lamplighters' runic keys, dungeons, ruins, and towers. The former leader rejoins, but Hal remains guild leader. Mira, Ashera, Elora, Hermes, and the rest of Hal's group survive. The guild also holds an exclusive dark-steel agreement with an oasis settlement. Hal still has no safe route to Brightsong, where Val continues facing the tribes. Besal's concealed spire mission, Ashera's class decision, the mistress's return, and retaliation from the Merchant Guild and great houses remain unresolved.",
         "in_short": "After destroying the Tower of Blight, Hal and his companions are displaced through the Fathomways into the Dunes of Midnight while Val impersonates him to protect Brightsong from the twelve tribes. Hal becomes the unwilling leader of a ruined Adventurers Guild and turns it into a challenge to the desert city's guild monopolies. His allies clear its debt and hall, win territory, ally with the Lamplighters, and secure an exclusive dark-steel supply. Hal masters Anvil Lightning, but its power worsens the strain that threatens his self-control without Besal. A staged storehouse raid and false guildhall fire draw the Merchant Guild into an ambush. Hal kills the attacking house scion, and the surviving Adventurers Guild rises to C grade with restored access to runic keys and dungeons. Hal remains far from Brightsong, Val's tribal trials continue, Besal pursues a covert spire operation, and the absent mistress has yet to respond.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3202,7 +3202,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3213,7 +3213,7 @@
       "recaps": {
         "ending": "The book ends with Carl and Princess Donut completing the second floor and descending the stairs to the third. Behind them, the second floor's great crisis is resolved: Carl destroyed the rampaging Rage Elemental with a vehicle rigged full of bombs and an exploit the whole universe watched, after the creature killed Yolanda and other members of the Meadow Lark group. The surviving Meadow Lark residents, shepherded by Imani and the Andrews brothers, went down ahead of them. On the way to the stairs Carl gambled his celebrity on a rival show to help the trapped crawlers Li Jun, Li Na, and Zhang escape, earning the enmity of the Maestro, a prince of the porcine Skull Empire, and Carl's on-air insolence toward the Empire is already infamous. Donut has tamed Mongo, a young dinosaur who joins the party as her pet. In an epilogue on Odette's talk show, the pair discuss the coming race and class selection that will reshape every crawler on the third floor, and Odette leaves Donut with a private piece of advice about choosing a class. The crawler population has fallen below a million, the game's operators are both profiting from and unsettled by the pair's popularity, and Carl goes down the stairs resolved not just to survive the dungeon but to beat the people who built it.",
         "in_short": "The alien Borant Corporation collapses every building on Earth, kills most of humanity, and turns the planet into an eighteen-floor dungeon broadcast across the galaxy as entertainment. Carl, caught outside in his boxer shorts chasing his ex-girlfriend's show cat, enters the dungeon with the cat, Princess Donut, who gains human intelligence from an early reward and becomes a talking spellcaster who insists on leading their party. Guided by Mordecai, a gruff tutorial-guild manager, they fight through the first floor's goblins and bosses, ally with the elderly survivors of the Meadow Lark care facility, and become breakout stars of the broadcast. On the second floor Carl kills a devastating Rage Elemental with a bomb-rigged vehicle in front of the whole universe, the pair appear on Odette's intergalactic talk show, Carl makes an enemy of the Skull Empire's Prince Maestro while rescuing trapped crawlers on a rival program, and Donut tames a pet dinosaur, Mongo. The book closes with the trio descending to the third floor, where every surviving crawler must choose a new race and class.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3418,7 +3418,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3431,7 +3431,7 @@
       "recaps": {
         "ending": "Silo 1 falls. Juliette, having crossed the surface with a small crew, reaches the facility that has governed every silo for five hundred years and finds Donald Keene dying there, with Thurman awake and trying to take back control. Donald gives her what she needs: the drones' proof that the poisoned ground is a bounded zone maintained deliberately around the silo complex, and the means to end Silo 1's power over the rest. He stays behind and brings the facility down, and does not survive it. With that, no one is left who can shut a silo off from the outside. Silo 18 is already dead, gassed on Thurman's order, with Lukas and most of its population lost, and Silo 17 is a shelter rather than a home, its lower levels flooded and its stores finite. So the survivors leave. Juliette leads them out through the airlock in suits and walks them over the hills, past the invisible line the drones found, until the suits can be opened. Beyond it the air is breathable, the sky is blue, and the ground is green. Charlotte, Solo, Elise, Rickson, Shirly, Courtnee, Raph and the rest come out with her, carrying seeds and tools, and begin a settlement in the open. The remaining silos are still buried and still sealed, and what to do about the people inside them is the question the survivors are left holding.",
         "in_short": "Juliette Nichols is mayor of Silo 18 and spends her time in Mechanical, driving a buried excavator toward the derelict Silo 17 so she can reach Solo and the children stranded there. The silo is divided over it, and Lukas, who runs IT, is fielding radio calls from Silo 1, which wants the digging stopped. In Silo 1, Donald Keene governs under a dead man's name and has secretly woken his sister Charlotte, who flies salvaged drones out over the landscape and discovers that the poisoned ground is a bounded region rather than a dead world. Charlotte broadcasts the truth to the silos; Silo 1 hunts for the source, Thurman is woken, and Silo 18 is shut down and gassed. Lukas and most of the population die, and the survivors escape through Juliette's tunnel into Silo 17. Juliette crosses the surface to Silo 1, where Donald confirms what the drones found and destroys the facility at the cost of his own life, ending its power over the silos. Juliette then leads the survivors out through the airlock, over the hills and past the edge of the poisoned zone, into open air and living land, where they begin again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3718,7 +3718,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00JEKVZKQ",
@@ -3730,7 +3730,7 @@
       "recaps": {
         "ending": "The Nairb hearing accepts that Dust World was settled before Earth's treaty with the Galactic Empire. Its human population and nanotechnology give humanity a second world and a second trade good, raising it to level-two status and preventing the ordered permanent deaths of Legion Varus and the colonists. Tribune Drusus accepts regional enforcement duties because the usual imperial fleet is unavailable. He recognizes Hydra's ownership of the captured cephalopod ship, and Varus technicians begin teaching the colonists to operate it. Under its first enforcement obligation, Varus destroys the cephalopods' homeworld in punishment for their attack on an imperial vessel. James McGill survives and returns to a rapidly recovering Earth, where he and Natasha Elkin resume their relationship. Della remains with Hydra, and McGill refuses to renew their connection after her apology. Graves, Turov, Drusus, Carlos, and the colonists remain active under the new order. Hydra is secure for now but distinct from Earth, while humanity must police its region amid signs that the imperial core and Battle Fleet 921 are under strain.",
         "in_short": "Economic collapse sends James McGill back to Legion Varus, which is dispatched to a lost human colony in Zeta Herculis. Cephalopods seize and doom Corvus, stranding the legion on Dust World amid hostile Hydra colonists and a slaving army. McGill repeatedly crosses the human divide, helping restore revival capacity and forge the alliance that defeats the invaders and captures their ship. Varus then plans to destroy Hydra before a Galactic inspection, so McGill warns the colonists and triggers a new conflict. The Nairbs halt the fighting and initially order mass execution, but Dust World's pre-treaty settlement and nanotechnology establish humanity as a two-world, level-two civilization. Hydra keeps the captured ship, humanity becomes a regional imperial enforcer, and Varus exterminates the cephalopod homeworld. McGill returns to Earth with Natasha Elkin and rejects Della's attempt at reconciliation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3875,7 +3875,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3888,7 +3888,7 @@
       "recaps": {
         "ending": "Alex gets aboard the presidential aircraft, where Cray has taken control and is minutes from launching American missiles at the drug-producing regions of the world, an attack that would kill millions of people who have nothing to do with the trade. Yassen Gregorovich, hired to protect the operation, turns on Cray instead and is shot for it. Alex fights Cray in the body of the aircraft and Cray is killed there; the launch never happens and the aircraft is brought down safely. The lasting consequence is not Cray's death but Yassen's. Dying, he tells Alex that he knew his father: John Rider was a contract killer, that they worked together, and that John Rider once saved his life, which is why Yassen has never been able to kill his son. He tells Alex to go to Venice and find Scorpia if he wants to know who his father really was, and dies. Alex is left with the ashes scattered at sea, a friendship with Sabina that has survived being told the truth, and one word he cannot leave alone.",
         "in_short": "On holiday in the south of France with Sabina Pleasure and her family, Alex recognises the assassin Yassen Gregorovich aboard a yacht in the bay. Days later a bomb wrecks the villa and leaves Sabina's father, an investigative journalist, badly injured. MI6 will not act, so Alex investigates alone, and the trail leads to Damian Cray: pop star, philanthropist and the most admired anti-drugs campaigner in the world. In Amsterdam, Cray forces Alex into a live version of his new console's game, with real traps and real weapons, and Alex survives it. Cray has bribed an American official for the codes to the United States nuclear arsenal and intends to seize control of the presidential aircraft and launch missiles at the world's drug-producing regions, killing millions in the name of his crusade. Alex gets aboard and stops him, and Cray dies. Yassen, mortally wounded, tells Alex that his father was an assassin, that John Rider saved his life, and that the answers are in Venice with an organisation called Scorpia.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4033,7 +4033,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4046,7 +4046,7 @@
       "recaps": {
         "ending": "At the Akishina house, Natsuki, Tomoya, and Yuu cut themselves off from the families and institutions they call the Factory. Their effort to discard ordinary rules becomes violent and physically destructive. When relatives come to force them back, the confrontation ends in deaths, and the trio consume human flesh as they pursue an increasingly literal idea of becoming nonhuman. By the time the authorities enter the house, they find a scene of death, filth, and cannibalism. Natsuki experiences the trio not as defeated social outcasts but as beings whose bodies and perceptions have changed, ready for a spaceship from Popinpobopia. The closing perspective does not confirm an extraterrestrial rescue; it leaves her alien identity as the reality through which she interprets the extremity of trauma, shared delusion, and resistance.",
         "in_short": "As a child, Natsuki survives family cruelty and sexual abuse by believing she is a magical alien, encouraged by her plush hedgehog Piyyut and her cousin Yuu, who also claims to come from another planet. Their intense childhood pact is forcibly broken. As an adult she enters a sexless marriage of convenience with Tomoya, who shares her refusal of the social system they call the Factory: the pressure to work, marry, have sex, and produce children. They return to her dead grandmother's mountain house and reunite with Yuu. Isolated there, the three try to abandon the rules and even the habits of ordinary human life. Their experiment descends into killing, cannibalism, and a shared conviction that they are transforming into aliens. The authorities eventually discover the devastated house and its survivors, while Natsuki interprets their altered state as preparation for departure to Popinpobopia.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4362,7 +4362,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -4373,7 +4373,7 @@
       "recaps": {
         "ending": "Reacher exposes Hack Walker as the organizer of the current killings and the remaining participant in older murders of migrants committed with Sloop Greer and Al Eugene. Walker admits hiring a local surveillance group, having the professional crew eliminate it, arranging Eugene's death, staging Sloop's shooting, and using Ellie's abduction to force Carmen's confession. Rusty shoots Walker after learning the truth, and her remaining shots start the fire that destroys the Red House. Bobby, Rusty, and the maid escape. Reacher and Alice locate the kidnappers' motel near Fort Stockton. Reacher saves Ellie, keeps the surviving crew member alive, and forces a confession that supports Carmen's release. Carmen reunites with Ellie and intends to move to Pecos, settle Sloop's affairs, and consider work or law school. Alice continues handling the legal aftermath. Rusty faces arrest for Walker's death, with leniency expected, while Bobby survives. Authorities connect the conspiracy to more than fifty deaths across seven states. Reacher leaves Carmen, Ellie, and Alice together and resumes hitchhiking west. His relationship with Jodie Garber remains unchanged and unresolved.",
         "in_short": "After escaping trouble with Lubbock police, Jack Reacher accepts a ride from Carmen Greer, who fears her abusive husband Sloop's return from prison and wants him killed. Reacher refuses murder but stays to protect Carmen and her daughter Ellie. Sloop is shot after returning, and a case built from Carmen's confession, medical records, and trust funds appears to prove her guilt. Reacher instead uncovers a frame-up. District attorney Hack Walker, Sloop, and Al Eugene murdered migrants together years earlier. Walker hired professionals to kill Eugene and Sloop, manipulated the evidence against Carmen, and abducted Ellie to compel a confession. Reacher kills two members of the team in an ambush. Rusty Greer kills Walker, accidentally setting the Red House ablaze. Reacher and Alice Amanda Aaron find Ellie, capture her remaining guard, and secure evidence that frees Carmen. Carmen and Ellie plan a new life in Pecos, while Reacher hitchhikes west.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4604,7 +4604,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4617,7 +4617,7 @@
       "recaps": {
         "ending": "Waits's knowledge of Marie Gesto was manufactured as part of an escape and misdirection scheme. The field trip gives him access to a hidden weapon; he breaks free, kills again, and retreats to the Echo Park property tied to his childhood and murders. Bosch and Rachel Walling identify the location and stop him after a final pursuit through its concealed spaces. The evidence proves that Waits was a serial killer, but he did not kill Marie. Her disappearance leads back to Anthony Garland, the suspect Bosch could not charge in 1993. Thomas Rex Garland's money and influence helped build the false confession that would shift Marie's murder onto Waits and permanently protect Anthony. The plot also depended on concealed or mishandled information in the old case, forcing Bosch and Rider to confront institutional choices that diverted the original inquiry. Marie's fate is finally separated from Waits's genuine victims and assigned to the man responsible. Rider survives the field-trip attack but chooses a new role in the department, ending her partnership with Bosch. Bosch closes his oldest open case while facing the damage caused by years in which the wrong interests controlled its evidence.",
         "in_short": "Serial killer Raynard Waits offers prosecutors a deal: in exchange for avoiding execution, he will identify his victims and show police where he buried Marie Gesto, whose 1993 disappearance Harry Bosch never solved. Waits supplies persuasive detail, making Bosch fear that an overlooked report in the old file allowed years of later murders. During a supervised trip to recover Marie, Waits reaches a planted gun, escapes, and leaves Kiz Rider wounded. Bosch and FBI profiler Rachel Walling track him to an Echo Park property connected to his childhood and kill him after a final confrontation. Waits was responsible for multiple murders, but his Gesto confession was false. The story was fed to him to protect Anthony Garland, Bosch's original suspect, with Anthony's wealthy father using influence and intermediaries to move Marie's murder onto a condemned serial killer. Bosch exposes that scheme and finally establishes Marie's fate. Rider survives but leaves their partnership for a different departmental role.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5154,7 +5154,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00302DO5I",
@@ -5166,7 +5166,7 @@
       "recaps": {
         "ending": "Honor's improvised Hades squadron ambushes the State Security recovery expedition at close range. The enemy commanders are killed, its fighting force is effectively destroyed, and Honor stops the attack in time to rescue survivors and capture two troop transports. Those ships provide the remaining capacity needed to evacuate everyone who has chosen to leave. At Trevorstar, Honor personally identifies herself and requests urgent help for overcrowded captured vessels carrying about 106,000 liberated prisoners. A further group of roughly 250,000 is expected within eleven days. The Alliance and White Haven finally learn that Honor survived, ending the false account of her execution. Honor and Nimitz remain permanently injured, and Warner Caslet has committed himself to her force, though his future is unresolved. Amos Parnell still intends to expose the Haven regime's role in the coup. Grayson's succession and genetic-treatment questions remain open, while Haven's long offensive has retaken key systems and left Eighth Fleet unable to regain the initiative.",
         "in_short": "Haven announces Honor Harrington's execution and supports the claim with fabricated footage, leaving Manticore and Grayson to mourn and settle her affairs. In fact, Honor and her injured companions are hiding on Hades. They recruit the resistance prisoners of Camp Inferno, capture the prison base and orbital defenses, impose disciplined trials, and discover Amos Parnell and evidence implicating Haven's rulers in the coup. Meanwhile, Grayson expands its war industry, Allison Harrington uncovers the genetic cause of the planet's skewed birth ratio, and Haven's Operation Icarus devastates several Allied systems. Honor captures incoming ships, builds an improvised fleet, and begins evacuating hundreds of thousands of prisoners. She defeats a State Security recovery force, takes the transports needed for the rest, and reaches Trevorstar alive with about 106,000 liberated inmates while another roughly 250,000 follow. Her return exposes the execution lie, but Haven retains the wider war's momentum.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/eclipse.json
+++ b/data/works-community/0/eclipse.json
@@ -103,7 +103,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -116,7 +116,7 @@
       "recaps": {
         "ending": "Victoria's newborn army is destroyed by the combined forces of the Cullens and the wolves, and Edward personally kills Victoria and her manipulated lieutenant Riley at the mountaintop where Bella was hidden, ending the long threat of revenge for James's death. Jacob is gravely injured shielding another wolf during the fight but survives. The Volturi arrive after the battle, having allowed the army to form in hopes of weakening the Cullens, and leave with a pointed reminder that Bella has still not been turned. Forced at last to choose between the two people she loves, Bella tells Jacob that although she loves him, she has chosen a life and eventual immortality with Edward. Jacob, unable to accept it, withdraws and then, on receiving their wedding invitation, flees into the forest as a wolf. Bella and Edward remain engaged and at peace with their decision, and Bella is now reconciled to marrying Edward and becoming a vampire. The way is clear for their wedding, with the grief of Jacob's departure and the Volturi's lingering attention carrying into the final book.",
         "in_short": "As Bella and Edward plan their future, a wave of killings in Seattle proves to be an army of newborn vampires secretly created by Victoria, who still wants Bella dead in revenge for her mate James. The threat forces the Cullens and the Quileute wolf pack into an alliance, and Jasper trains them to fight newborns. Throughout, Bella is torn between Edward, whom she has agreed to marry and who will then change her into a vampire, and her best friend Jacob, a werewolf who loves her and makes her admit she loves him too. Hidden away during the battle and guarded by Edward, Jacob, and young Seth, Bella survives when Victoria and her lieutenant Riley track her down; Edward kills them both, and the newborn army is destroyed, though Jacob is badly hurt. Bella finally chooses Edward, and the two remain engaged as Jacob, brokenhearted, runs away.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -220,7 +220,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -233,7 +233,7 @@
       "recaps": {
         "ending": "In the closing tale, the narrator has escaped suspicion after murdering a man with a poisoned candle and inheriting his estate. Years of security end when he idly thinks that he is safe unless he confesses. Repetition turns that thought into a compulsion to speak. He tries to distract himself and then runs through the streets, pursued by onlookers, but the pressure continues until he blurts out a complete admission before witnesses. He collapses after revealing the crime and is tried and sentenced to death. The confession embodies the destructive impulse discussed at the start of the tale: knowledge of the ruin an act will cause can itself become the motive for doing it. This follows the collection's first story, in which Madeline and Roderick Usher die together and the family mansion breaks apart and sinks, ending both the bloodline and its house.",
         "in_short": "This two-story collection pairs physical collapse with psychological self-destruction. In “The Fall of the House of Usher,” a visitor finds Roderick Usher terrified and ill in his decaying family mansion. Roderick's twin Madeline is placed in a vault after an apparent death, but she had been buried alive. She escapes, reaches her brother, and falls upon him; both die as the visitor flees and the house splits and sinks. “The Imp of the Perverse” presents a murderer who killed a man with a poisoned candle and inherited his property without attracting suspicion. Years later, the narrator becomes obsessed with the idea that only a confession could bring exposure. That very thought creates an irresistible urge to confess publicly, leading to conviction and a death sentence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -330,7 +330,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -343,7 +343,7 @@
       "recaps": {
         "ending": "The collection closes with the narrator of “Eleonora” leaving the valley where his cousin died and entering a royal city. There he falls in love with Ermengarde and marries her, despite the vow he made never to love or marry another woman after Eleonora. He expects the punishment he had invoked upon himself, but none comes. Instead, Eleonora's voice returns one final time and releases him from the promise, telling him that the reason for his absolution will be made known after death. The marriage remains intact and the tale ends on that assurance. This gentler release follows the disturbing close of “Ligeia,” in which Rowena's corpse repeatedly revives, rises, and assumes Ligeia's appearance, apparently fulfilling the first wife's determination to resist death while leaving the exact cause and reality of the transformation uncertain.",
         "in_short": "Two stories examine love that appears to continue after death. In “Ligeia,” a grieving widower remarries and settles with Lady Rowena in a remote abbey. Rowena dies after a strange illness, but her body repeatedly shows signs of returning life and finally rises transformed into the dark-haired Ligeia, the narrator's brilliant first wife. His opium use and hostility toward Rowena leave the event deliberately uncertain. In “Eleonora,” a man and his cousin grow up together in an isolated, beautiful valley and become lovers. As she dies, he vows never to love or marry another and accepts a curse if he breaks the promise. Years later he leaves the valley, meets Ermengarde, and marries her. Eleonora's voice then absolves him and says that the reason will be revealed after his own death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -473,7 +473,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -486,7 +486,7 @@
       "recaps": {
         "ending": "The volume closes with “The Cask of Amontillado.” During carnival, Montresor exploits Fortunato's pride in his knowledge of wine and leads him into the family catacombs to inspect a supposed purchase of Amontillado. Deep underground, Montresor chains him inside a recess and walls up the opening. Fortunato's disbelief gives way to pleas, but Montresor finishes the masonry, replaces the bones that concealed the site, and reveals that no one has disturbed it for fifty years. This follows the rescue of the Inquisition's prisoner by General Lasalle in the first story and the second story's catastrophic end, when the mesmerist releases Valdemar after seven months of suspended death and Valdemar's body immediately collapses into decay.",
         "in_short": "This volume collects three tales of confinement at the edge of death. In “The Pit and the Pendulum,” a prisoner of the Spanish Inquisition survives darkness, a hidden pit, a descending blade, and closing heated walls until General Lasalle rescues him as French troops enter Toledo. In “The Facts in the Case of M. Valdemar,” an experiment holds the dying Valdemar in a mesmeric suspension for seven months; when the mesmerist finally releases him, his body instantly decays. In “The Cask of Amontillado,” Montresor uses Fortunato's vanity about wine to lure him beneath a carnival into family catacombs, chains him in a recess, and seals him alive behind masonry. Montresor reports that the concealed remains have gone undisturbed for fifty years.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -798,7 +798,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774247674",
@@ -810,7 +810,7 @@
       "recaps": {
         "ending": "Legion Varus survives the sanctioned battle after James McGill secretly adds Shadowlander combat drones to the fight. When Galactic investigators obtain proof, McGill and Galina Turov kill them after Natasha Elkin blocks their report. Governor Knox suppresses their revival and claims victory, allowing the Skae to remove the dead entity embedded in Earth's moon. McGill forces a direct bargain with the Skae: it restores the moon in exchange for immediate possession of Edgeworld. With fewer than six days before the transfer, he returns alone to warn the Shadowlanders. Their leaders initially reject evacuation and try to kill him, but he overpowers them and offers a gateway route to Earth. In the trailing unnumbered section, the ruler and her daughter visit Central and begin negotiating emigration and revival-machine trade with Drusus. Turov remains in command, Winslade's position is unresolved, and the inspector killings remain a concealed Galactic liability. The Shadowlander population has a possible refuge, but its mass evacuation is not yet complete.",
         "in_short": "James McGill investigates a dead alien construct hidden inside Earth's moon, whose distress signal draws competing Galactic claimants and exposes Earth's dependence on revival machines made at 91 Aquarii. Legion Varus deploys to that world, rescues Galina Turov from the Shadowlanders, and becomes one side of a Galactic-sanctioned surface war. McGill repeatedly relies on unauthorized technology, covert alliances, and deception, culminating in secret use of Shadowlander drones to defeat the opposing Saurian force. He and Turov kill investigators who uncover the cheating. When the Skae begins removing Earth's moon, McGill trades Edgeworld for its return. He then races back to warn the Shadowlanders and offers evacuation through gateways. After the final numbered chapter, their ruler and her daughter travel to Earth to negotiate resettlement and continued revival-machine trade, leaving the evacuation underway and the political consequences unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -955,7 +955,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -968,7 +968,7 @@
       "recaps": {
         "ending": "Lift succeeds in thwarting the Herald Nale's hunt. After maneuvering through the city and protecting those he would kill, she confronts him and argues that his logic has collapsed: the great storm marking the return of the ancient enemy has already come, so slaughtering fledgling Radiants can no longer delay anything. Faced with this, the rigid immortal falters and withdraws, his grim purpose broken. In choosing to listen to and defend the overlooked and the helpless, Lift speaks a further Ideal of the Edgedancers and comes more fully into her power, with her spren Wyndle at her side. She sheds a little of her insistence on staying a careless child and accepts, on her own terms, that she has a part to play. The novella closes with Lift deciding to make her way toward the gathering Knights Radiant and the war taking shape against the returned enemy, no longer running from who she is becoming.",
         "in_short": "Lift, a young thief who has quietly become an Edgedancer, one of the reborn Knights Radiant, travels east to an Azish city in search of good food and an aimless kind of freedom. There she learns that the immortal executioner Nale, who hunts and kills emerging Radiants to hold back the world's coming catastrophe, is stalking the city for his next victim. Rather than flee, Lift decides to find and shield the person Nale is hunting. Using her powers and her stubborn compassion, she interferes with his hunt and finally confronts him directly, pointing out that the very disaster he kills to prevent has already begun, making his crusade pointless. Shaken, Nale relents. In the course of protecting the vulnerable and forcing herself to care, Lift speaks a deeper oath of her order and grows into her calling, accepting that she cannot stay a heedless child forever. She leaves resolved to seek out the growing company of Radiants gathering to face the true enemy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1087,7 +1087,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1100,7 +1100,7 @@
       "recaps": {
         "ending": "Rebecca's invitation brings Eileen not to a friendly Christmas visit but to the Polk house, where Rebecca has restrained Lee Polk's mother and is trying to force an admission about the abuse behind Lee's crime. Rebecca draws Eileen into the confrontation and then leaves her to manage its consequences. Armed with her father's gun and overwhelmed by the situation, Eileen shoots Mrs. Polk, wounding her. She puts the woman in the trunk of her father's car and drives away, eventually abandoning the vehicle and its captive rather than returning home. Mrs. Polk's ultimate fate is left unknown. Eileen catches a ride out of the area and begins the escape she had long imagined. Rebecca never becomes the companion or rescuer Eileen projected onto her; she simply disappears from Eileen's life. The older narrator confirms that she survived, took a new name, and built a life far removed from the fearful, self-punishing young woman she calls Eileen.",
         "in_short": "In 1964, twenty-four-year-old Eileen Dunlop works at a Massachusetts correctional facility for boys and lives in misery with her alcoholic, threatening father. Lonely and ashamed of herself, she escapes into fantasies about a guard named Randy and dreams of leaving town. The arrival of Rebecca Saint John, Moorehead's glamorous new psychologist, seems to offer friendship and transformation. Rebecca takes an intense interest in inmate Lee Polk, who killed his father, and invites Eileen to meet her outside work. At the Polk house, Eileen discovers that Rebecca has imprisoned Lee's mother and wants to expose the abuse surrounding the killing. Rebecca draws Eileen into the crisis but abandons her to finish it. Eileen shoots and wounds Mrs. Polk, places her in her father's car, and leaves the car behind with the woman's fate unresolved. She then flees town and eventually makes a new life under another name, while Rebecca vanishes from her story.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1297,7 +1297,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1310,7 +1310,7 @@
       "recaps": {
         "ending": "Raoden works out why Elantris fell. A decade earlier a vast chasm opened in the land, changing the shape of the country that the Aons are derived from, so every Aon drawn since has been missing one line and has therefore failed. Elantris itself was built as a single enormous Aon, so adding the missing line to the city's own plan completes it. The magic returns: the city shines again and every Elantrian, Raoden and Sarene included, is restored to health. The Fjordell invasion led by Dilaf, whose warriors have been physically reshaped by their order's own magic, is broken by the restored Elantrians. Hrathen turns fully against the empire he served, saves Sarene from Dilaf, and dies of his injuries having chosen against everything he came to Arelon to accomplish. Raoden reveals that he is alive, takes the throne of Arelon and marries Sarene, joining Arelon and Teod against Fjorden. The country is left with a working Elantris, a working magic and a great deal of rebuilding to do after both the fall of the city and the invasion. Wyrn's empire has lost Arelon but is not defeated, and remains the standing threat to both kingdoms.",
         "in_short": "Ten years after the shining city of Elantris fell and its people became grey, permanently wounded near-immortals, Prince Raoden of Arelon is taken by the same transformation and thrown inside its walls. Declared legally dead, he hides his identity behind the name Spirit, befriends the pessimistic Galladon, and sets about turning the city's scavenging factions into a working community while studying the failed Elantrian magic. Outside, Princess Sarene of Teod arrives to find herself Raoden's legal widow and stays to fight both the merchant-king Iadon and Hrathen, a Fjordell high priest with three months to convert Arelon or see it destroyed. Hrathen's manoeuvring brings down Iadon and installs a compliant duke; the reformers' counter-plot collapses; and Sarene is eventually taken by the transformation herself and reunited with Raoden inside Elantris. When Fjorden invades under the fanatic Dilaf, Raoden discovers that the magic failed because the land itself changed shape and every Aon needs one more line. He adds it to Elantris, which is one enormous Aon, restoring the city and its people. Hrathen turns on his empire and dies saving Sarene, and Raoden takes the throne.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1525,7 +1525,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1538,7 +1538,7 @@
       "recaps": {
         "ending": "At the close of this first portion, none of the three central struggles has been resolved. Raoden, living as Spirit, has survived Elantris and turned a growing group of its inhabitants toward cooperation, work, and mutual protection, but he still cannot explain why AonDor failed or reverse the Shaod. Sarene has built a political coalition from Raoden's old allies and the court's disaffected nobles while openly countering Hrathen's conversion drive; she still believes her husband died before she reached Arelon and does not know that Spirit is Raoden. Hrathen's planned conquest through persuasion is faltering as Sarene answers his public moves and Dilaf pushes the Derethi faction toward fanaticism. King Iadon's authority and Arelon's economy remain unstable. The two threatened kingdoms therefore approach the second half with Raoden's identity hidden, Elantris still broken, and Hrathen's deadline continuing to narrow.",
         "in_short": "Ten years after the magic of Elantris failed and its radiant inhabitants became undying sufferers, Arelon's prince Raoden is struck by the same transformation and secretly thrown into the ruined city. Calling himself Spirit, he joins Galladon and begins organizing the starving Elantrians into a community while investigating why their Aons no longer work. Princess Sarene arrives from Teod to marry Raoden, is told he has died, and becomes his legal widow under their treaty. She allies with his friends and with nobles opposed to King Iadon, then turns her political skill against Hrathen, the Derethi priest charged with converting Arelon before Fjorden takes it by force. Hrathen seeks an orderly religious victory, but his militant subordinate Dilaf encourages fear and hatred. By the midpoint, Raoden has restored purpose but not magic inside Elantris, Sarene has become a major force in court, and Hrathen is running out of time as all three unknowingly shape the same national crisis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1716,7 +1716,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1729,7 +1729,7 @@
       "recaps": {
         "ending": "Dilaf's Dakhor monks attack Arelon and Teod, killing Duke Roial and many others. Hrathen rejects the slaughter, saves Sarene, and kills Dilaf with the altered strength hidden in his arm, but receives a fatal wound and dies after finally acting against Fjorden's design. Raoden realizes that the earthquake-created chasm changed the land on which every Aon is based; adding a matching line repairs the symbols. He completes the enormous Aon formed by Elantris and its surrounding cities, restoring AonDor and transforming the fallen Elantrians to health and power. He then reaches Teod and uses restored magic to defeat the remaining invaders. Karata dies from injuries too severe for the restoration, while Galladon, Saolin, and the other survivors are healed. Raoden openly resumes his identity, and he and Sarene rule Arelon together with Elantris alive again. The immediate Fjordell conquest is stopped, though the wider religious empire and the mystery of the force behind the Dor remain beyond the restored city's borders.",
         "in_short": "Raoden continues rebuilding society inside fallen Elantris while Sarene resists Hrathen's attempt to convert Arelon and King Iadon's government collapses. Sarene is eventually made to appear afflicted by the Shaod and is cast into Elantris, where she comes to know Spirit before learning that he is Raoden. Hrathen loses control of the campaign to Dilaf, a magically altered Dakhor monk who launches the violent conquest Hrathen had hoped to avoid. As Dakhor forces massacre Arelon's defenders and invade Teod, Hrathen turns against Dilaf, saves Sarene, and dies after killing him. Raoden discovers that the earthquake-created chasm changed the geography encoded in every Aon. He adds the missing line to the vast design centered on Elantris, restoring AonDor and healing its inhabitants. With his powers returned, he defeats the invaders in Teod. Raoden and Sarene survive to rule together, Elantris shines again, and Hrathen is remembered for choosing to oppose the atrocity his own campaign enabled.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1887,7 +1887,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1900,7 +1900,7 @@
       "recaps": {
         "ending": "The Battle of the Burning Plains brings every thread together. Nasuada, now leading the Varden in alliance with Surda, commits her forces against the Empire's army, and Eragon and Saphira, newly trained and physically transformed by elven magic, fight at the front. Roran, having saved his village and led its people across the land, arrives in time to join the battle and reunite with Eragon. A red dragon and its Rider appear on the enemy side and prove terrifyingly strong; when Eragon finally confronts the rider, the helmet comes off to reveal Murtagh, alive and forced into Galbatorix's service by oaths the king wrung from him. Murtagh tells Eragon that they are brothers, both sons of the king's dead servant Morzan, and, sparing Eragon, takes his sword Zar'roc and withdraws. The battle ends without a decisive victor. Eragon is left shaken by the claim about his parentage and by the loss of his blade, Roran resolves to march on to rescue Katrina, and the war grinds forward with the Varden's cause still hanging in the balance.",
         "in_short": "While the Varden mourn the death of their leader, Eragon and Saphira travel to the elven forest, where the hidden Rider Oromis and his dragon Glaedr train them in magic, lore, and combat. During an elven celebration, Eragon's crippling back wound is not only healed but his body is transformed, giving him elf-like grace and strength. Meanwhile his cousin Roran, hunted by the Empire, rallies their village to fight off soldiers and then leads the survivors on a hard journey to join the Varden, driven on because the king's servants have seized his beloved Katrina. Nasuada takes command of the Varden and moves them to ally with the land of Surda. The threads converge at the Battle of the Burning Plains, where Eragon faces a new enemy Rider on a red dragon. The rider is revealed to be Murtagh, alive and bound into Galbatorix's service, who claims that he and Eragon are both sons of the dead traitor Morzan and seizes Eragon's sword before departing.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2048,7 +2048,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2061,7 +2061,7 @@
       "recaps": {
         "ending": "After Eleanor recognizes that Richie has been writing the obscene messages left among her belongings, she understands that the danger at home has become immediate. Her siblings help her get out, and Tina and Steve unexpectedly shelter her while she contacts Park. Park takes his father's truck and drives Eleanor to relatives in Minnesota, knowing that separation is the only safe choice available. They say goodbye after a final kiss. Eleanor settles with her uncle's family and stops answering Park's letters and packages, unable to sustain the relationship while recovering from what happened. Park remains in Omaha, where his family helps Sabrina and the younger children leave Richie. He continues to miss Eleanor and sends one last letter before trying to move forward. Months later, Eleanor sends him a postcard containing three words that the novel does not specify, offering a small but genuine reopening after a year of silence.",
         "in_short": "In 1986 Omaha, sixteen-year-old Eleanor returns to the impoverished home ruled by her abusive stepfather and becomes a target at her new school. Park reluctantly lets her sit beside him on the bus. Their silence turns into shared comics and music, then hand-holding and an intense first love. Park defends Eleanor from bullying and welcomes her into his more secure family, while Eleanor hides how dangerous and deprived her home life is. Their different fears cause arguments, but they repeatedly choose each other. When Eleanor discovers that the obscene notes left for her were written by her stepfather Richie, she flees. Park drives her to relatives in Minnesota, where she can live safely. Eleanor cannot answer his letters for a year, though Park continues to care for her and his family helps her mother and siblings escape Richie. At last Park receives a postcard from Eleanor bearing three unspecified words, leaving open the possibility of renewed connection.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2213,7 +2213,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2226,7 +2226,7 @@
       "recaps": {
         "ending": "Therapy helps Eleanor revisit the fire without relying on the version of events she has carried since childhood. Raymond researches the case and confirms that Eleanor's abusive mother deliberately started the blaze and died in it. Eleanor's younger sister Marianne also died, while Eleanor alone was rescued. The weekly calls from Mummy have therefore not been real conversations but an internal continuation of her mother's controlling voice. Eleanor finally confronts that voice and refuses to keep obeying it. She grieves for Marianne and begins to understand that surviving the fire was not her fault. Her recovery remains gradual: she continues counseling, returns to work, cares for Glen, and accepts friendship rather than retreating into vodka and isolation. She and Raymond acknowledge how important they have become to each other, with the possibility of a closer relationship left open instead of being forced into a conventional romantic conclusion. Eleanor is not suddenly cured, but she is connected to other people and able to imagine a life shaped by her own choices rather than her mother's abuse.",
         "in_short": "Eleanor Oliphant is a lonely Glasgow accounts clerk whose rigid routines and weekend drinking keep painful memories at a distance. She develops an imagined romance with musician Johnnie Lomond and starts remaking herself to meet him. When she and coworker Raymond help an elderly stranger named Sammy, Eleanor is drawn into real friendships with Raymond and Sammy's family. These ordinary connections challenge the contemptuous lessons reinforced by her abusive mother's weekly calls. Seeing Johnnie as he actually is destroys Eleanor's fantasy, and she retreats into alcohol and despair, but Raymond finds her and supports her recovery. Counseling, friendship, work, and caring for a rescued cat help Eleanor face the childhood fire that scarred her. She learns that her mother deliberately caused it and died alongside Eleanor's younger sister Marianne; the telephone conversations existed only in Eleanor's mind. By rejecting that internal voice and accepting help, Eleanor begins building a connected life, with her bond with Raymond still growing.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2366,7 +2366,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2379,7 +2379,7 @@
       "recaps": {
         "ending": "After the infant Otto drowns while in her care, Ottilie interprets the death as the consequence of the household's disordered desires. She gives up any hope of union with Eduard and resolves inwardly to renounce him. Although she returns to the estate, she stops eating and eventually dies. Her body is placed in the estate chapel, where reports of healing make her grave a place of local reverence. Eduard cannot recover from her loss. He withdraws from ordinary life, is found dead, and is buried beside Ottilie. Charlotte arranges the burial and survives to manage what remains. The Captain, now a major and still connected to Charlotte by mutual feeling, does not receive the marriage that once seemed possible. The novel closes on Eduard and Ottilie lying together in death, while the living characters are left with the consequences of passions they tried and failed to reconcile with their existing bonds.",
         "in_short": "Eduard and Charlotte invite his friend the Captain and her ward Ottilie to their country estate, upsetting the balance of their marriage. Like the substances discussed in the book's chemical metaphor, the four form new attractions: Eduard falls in love with Ottilie, while Charlotte and the Captain develop a restrained attachment. Charlotte becomes pregnant, the Captain leaves for employment, and Eduard removes himself rather than end his pursuit of Ottilie. The child, Otto, is born with features recalling the two absent objects of the parents' desire. When the Captain returns as a major, plans for divorce and new marriages seem possible. While carrying Otto across the lake, however, Ottilie drops him into the water and he drowns. She renounces Eduard, refuses food, and dies. Eduard soon dies as well and is buried beside her. Charlotte and the Captain remain alive but apart, their disciplined affection unable to undo the destruction surrounding the more absolute passion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2558,7 +2558,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2571,7 +2571,7 @@
       "recaps": {
         "ending": "Jane and Chip overcome their disagreement about her pregnancy and commit to raising the child together. Their romance becomes the basis for a return to the reality program Eligible, which turns their Cincinnati wedding and the Bennet family's conflicts into televised entertainment. Lydia attends with Ham, whom she has married, and the production creates pressure for a public family reconciliation despite Mrs. Bennet's prejudice against him. Liz has meanwhile learned that Jasper Wick's account of his history with Darcy concealed his own betrayals, and she recognizes that her judgments of both men were distorted by attraction and resentment. At the wedding Liz and Darcy finally speak honestly and choose a real relationship rather than the detached arrangement they had maintained before. The family emerges without all its disagreements resolved, but Jane has the partner and child she wanted, Lydia remains with Ham, and Liz leaves the cycle of Jasper and secrecy for a future with Darcy. Fred Bennet's illness and finances force the household to acknowledge that its old way of life cannot continue unchanged.",
         "in_short": "After Fred Bennet suffers a heart attack, New York sisters Liz and Jane return to Cincinnati and confront their parents' unhealthy, financially unstable household. Jane falls for emergency doctor and former reality-show contestant Chip Bingley while pursuing pregnancy through donor insemination. Liz clashes with Chip's friend, neurosurgeon Fitzwilliam Darcy, then begins a secret sexual relationship with him even as she remains entangled with married journalist Jasper Wick. The younger sisters create another crisis when Lydia marries Ham Ryan, a transgender CrossFit coach whom Mrs. Bennet refuses to accept. Liz eventually learns that Jasper has misrepresented his history with Darcy and recognizes Darcy's loyalty beneath his reserve. Jane and Chip reconcile and agree to marry on a new Eligible television special, using the production to bring the divided family together. During the televised wedding, Liz and Darcy admit their love and begin a committed relationship. Jane prepares for marriage and motherhood, Lydia stays with Ham, and the Bennets face the end of their long denial about health, money, and one another.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2739,7 +2739,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2752,7 +2752,7 @@
       "recaps": {
         "ending": "At the last royal ball, Ella's disguise fails and Char follows her home. He asks her to marry him and, without knowing the danger, turns the request into a command. Ella understands that marrying him while still enchanted would give any enemy a way to control the future queen and the kingdom. Her determination to protect Char finally lets her refuse, breaking Lucinda's spell through her own will. Ella then accepts Char freely and explains the secret she has guarded throughout her life. Lucinda has by now experienced the misery her coercive gifts can cause and abandons that practice. Ella and Char marry, but Ella declines to become a conventional, idle princess; they build a life that leaves room for her independence, work, and friendships. Mandy remains with them, and Ella is reunited with Areida and the other people who helped her. The ending recasts the familiar royal marriage as the result of Ella gaining the ability to choose rather than simply receiving a magical rescue.",
         "in_short": "The fairy Lucinda curses Ella of Frell with absolute obedience, forcing her to follow any command. After her mother dies, Ella befriends Prince Charmont but is sent to finishing school with Hattie, who discovers and exploits the spell. Ella escapes, survives ogres by using their own persuasive language against them, and grows closer to Char. Her merchant father later marries Hattie's mother, Dame Olga, leaving Ella mistreated in her own home. While Char travels, friendship deepens into love through their letters, but Ella rejects his proposal because anyone who learned her secret could use her to harm him and the kingdom. Disguised, she attends royal balls and meets him again. When Char finally commands her to marry him, Ella's need to protect him becomes stronger than the enchantment: she refuses and breaks the curse herself. Free to choose, she marries Char and keeps the independent life and relationships she values.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2916,7 +2916,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2929,7 +2929,7 @@
       "recaps": {
         "ending": "Ellen succeeds in placing herself with the foster mother she calls her new mama, joining a busy household where care is dependable and no one makes her earn the right to feel safe. From this secure present she reassesses the people and ideas that shaped her. She invites Starletta to stay overnight and prepares a pleasant visit, then recognizes how deeply racist assumptions once distorted her view of her friend's family despite their generosity to her. Starletta, whom Ellen had patronized in her own mind, has grown while Ellen has been preoccupied with survival. Ellen's realization does not erase the losses of her mother or the abuse and rejection that followed, but it marks a widening moral awareness. She has built the home she repeatedly imagined and can now see both the harm done to her and harm embedded in beliefs she accepted. The book closes with Ellen safer, connected to a chosen family, and beginning to understand friendship across the racial boundary her community taught her to enforce.",
         "in_short": "After her sick mother dies and her alcoholic father becomes still more dangerous, young Ellen moves through a succession of inadequate homes. Her art teacher Julia and Julia's husband offer temporary safety, but relatives and authorities repeatedly decide her future. Ellen's bitter maternal grandmother makes her work in the fields and punishes her for being her father's child; after the grandmother dies, Aunt Nadine and cousin Dora take Ellen in but reject her when she will not flatter them. Throughout, Ellen plans for survival and finds intermittent refuge with her Black friend Starletta's family. She eventually identifies a loving foster household and persuades its mother to accept her. In the secure home of her new mama, Ellen invites Starletta to visit and confronts the racism that once made her consider herself superior to the friend whose family had shown her such generosity. She ends with the stable chosen family she sought and a more honest understanding of herself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3080,7 +3080,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3093,7 +3093,7 @@
       "recaps": {
         "ending": "At the height of his Zenith ministry, Elmer turns a campaign against alcohol and sexual misconduct into a source of influence while privately pursuing Hettie Dowler. Hettie and her associates use the encounter to accuse and blackmail him, and the resulting scandal appears capable of ending his ministry and marriage. The accusation collapses when Hettie's own history and motives are exposed, allowing Elmer to present himself as the innocent victim of a plot. Cleo remains with him, his congregation rallies, and his standing recovers. Frank Shallard, by contrast, follows his doubts out of the ministry and is brutally injured after publicly challenging organized religion. Elmer absorbs no lasting humility from either man's fate. Restored to the pulpit, he resumes his declarations against sin and looks toward still greater moral and institutional authority. The close leaves him publicly vindicated, privately unchanged, and better positioned to continue the hypocrisy on which his success depends.",
         "in_short": "Elmer Gantry begins as a hard-drinking Baptist college athlete and discovers during a revival that his voice, physical confidence, and instinct for crowds can carry him into the ministry. At seminary he seduces Lulu Bains and escapes responsibility, then loses his first clerical path through misconduct. After a period in sales, he joins the spectacular evangelist Sharon Falconer as preacher and lover. Her death in a tabernacle fire ends their campaign, but Elmer later enters the Methodist ministry, marries Cleo Benham, and rises to a prominent Zenith pulpit. He builds power through a public crusade against vice while the honest minister Frank Shallard loses faith and suffers for speaking openly. A blackmail scheme involving Hettie Dowler briefly threatens Elmer with exposure, but her accusation is discredited. Cleared and celebrated by his congregation, Elmer returns to preaching morality without changing his own conduct.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3249,7 +3249,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3262,7 +3262,7 @@
       "recaps": {
         "ending": "Emily brings her involvement with the courtly Folk of Ljosland to a conclusion, recovering what had been taken from Hrafnsvik and ending the danger that had shaped the village's life for generations. Her method throughout is scholarly rather than heroic: she knows the shape of the stories these beings live inside better than they expect a mortal to, and she uses the rules within them. The village that began by resenting her ends by treating her as one of its own, and her encyclopaedia, the work of years, is finished. Wendell Bambleby stops pretending to be a human academic: he is an exiled faerie king, driven out of his own realm by his stepmother, who holds it and has no intention of letting him live to reclaim it. He asks Emily to marry him. She neither accepts nor refuses, and the proposal is left standing. They return to Cambridge together with nothing about his position resolved. He is still exiled, still unable to reach his own realm, and still within reach of the people his stepmother sends, and Emily now has a personal stake in a problem she previously regarded as a fascinating case study. That exile, and the question of whether a door back into his kingdom can be found at all, is what the next book takes up.",
         "in_short": "Emily Wilde, a Cambridge dryadologist compiling the first comprehensive encyclopaedia of faeries, spends the winter of 1909 in Hrafnsvik, a remote village in the northern country of Ljosland, to document the one class of Folk her book still lacks. Brilliant at research and hopeless at people, she alienates most of the village within a week, is rescued from her own impracticality by the villagers' patience, and cultivates a small local faerie named Poe as a source. Her Cambridge rival Wendell Bambleby arrives uninvited and charms everyone effortlessly, confirming Emily's long-held suspicion that he is not human but an exiled faerie king. Investigating Hrafnsvik's losses to the courtly Folk, Emily goes further into their territory than any scholar has, and uses her knowledge of how faerie stories work to recover the villagers who had been taken and end the threat the village has lived under for generations. Her encyclopaedia is completed, the village adopts her, and Bambleby, no longer hiding what he is, asks her to marry him. She gives no answer, and they return to Cambridge with his exile unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3386,7 +3386,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3399,7 +3399,7 @@
       "recaps": {
         "ending": "Emily finds the door, and the party reaches Wendell's realm. Wendell takes back his throne and his stepmother's hold on the kingdom is broken, but the victory is spoiled at once: she has poisoned the land itself, and the realm is sick and dying in a way that simply reclaiming it does not fix. Because a faerie king and his kingdom are not separable things, that sickness is also Wendell's, so the problem he spent two books trying to solve turns out to have been the easy half. Emily, who has spent two books declining to answer him, accepts his proposal and with it the position that comes attached to it. Danielle de Grey's fate is settled and her work is finally in the hands of someone able to use it, and Ariadne has her fieldwork and rather more of it than she bargained for. Farris Rose's objections have been overtaken by events. The book closes with Emily in a faerie kingdom rather than in Cambridge, no longer a visiting scholar of the Folk but a resident of their world with a title, and with her scholarship pointed at a problem no dryadologist has ever had access to: how to heal a poisoned faerie realm before it takes its king with it.",
         "in_short": "Back at Cambridge with her encyclopaedia published, Emily Wilde takes on a new problem: Wendell Bambleby, now openly an exiled faerie king, cannot return to his own realm, his stepmother's agents can still reach him, and the exile is doing him real harm. Emily's answer is research. She begins reconstructing the work of Danielle de Grey, a dryadologist who vanished decades earlier while studying the doors between worlds, on the theory that de Grey's lost map could locate a way into Wendell's kingdom. The search takes Emily, Wendell, her niece Ariadne and the sceptical senior scholar Farris Rose into the Austrian Alps, to a village living under severe rules alongside its own Folk. The expedition is attacked, Wendell's health fails, and Emily crosses into faerie territory in pursuit of de Grey's route. She finds de Grey herself, still alive inside a faerie realm, and with what she knows the door becomes findable. Wendell reclaims his throne, but his stepmother has poisoned the land, which is dying. Emily accepts his proposal and stays.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3572,7 +3572,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3585,7 +3585,7 @@
       "recaps": {
         "ending": "Frank Churchill and Jane Fairfax's secret engagement becomes public after Mrs Churchill dies, freeing Frank from dependence on her approval. Emma recognizes how thoroughly she misread their conduct and is relieved to discover that she never loved Frank. Harriet then reveals that the man she hopes to marry is Mr Knightley. This shocks Emma into realizing that she loves Knightley herself. Knightley, believing Emma distressed over Frank, comes to comfort her and instead proposes; she accepts. Harriet briefly withdraws, then reconciles with Emma after Robert Martin proposes again and she accepts him. Jane and Frank prepare to marry once family arrangements permit. Because Mr Woodhouse cannot bear Emma's departure, Knightley agrees to live at Hartfield after their marriage. A local poultry theft helps persuade Mr Woodhouse that another man in the house is desirable. Emma and Knightley marry, with their equality and long knowledge of one another replacing Emma's earlier fantasies about directing other people's lives.",
         "in_short": "Emma Woodhouse, wealthy and confident in her judgment, befriends Harriet Smith and tries to raise her socially. She persuades Harriet to refuse the farmer Robert Martin and imagines that Mr Elton loves her, only to discover that Elton wants Emma herself. Emma next entertains a flirtation with Frank Churchill while disliking the reserved Jane Fairfax. Her guesses repeatedly mislead her: Frank and Jane are secretly engaged, and his attentions to Emma disguise their relationship. After Emma cruelly jokes at Miss Bates's expense, Mr Knightley's rebuke forces her to confront her selfishness. Harriet's admission that she loves Knightley finally reveals Emma's own love for him. Knightley proposes to Emma, while Harriet accepts a renewed proposal from Robert Martin. Frank and Jane are reconciled and prepare to marry. Knightley moves to Hartfield so Emma need not abandon her anxious father, and Emma's marriage rests on greater humility and self-knowledge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3776,7 +3776,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3789,7 +3789,7 @@
       "recaps": {
         "ending": "Frank Churchill's explanatory letter confirms that he and Jane Fairfax had been secretly engaged throughout his stay in Highbury. His apparent courtship of Emma helped conceal the relationship, while his aunt's opposition made secrecy seem necessary. Emma and Jane reconcile, and Jane can now marry Frank because Mrs. Churchill's death has removed the chief obstacle. Emma accepts Mr. Knightley's proposal, but concern for Mr. Woodhouse prevents her from leaving Hartfield; Knightley agrees to live there after their marriage. Harriet spends time in London, recovers from her hopes of Knightley, and renews her connection with Robert Martin. She accepts Martin's second proposal, satisfying Knightley and finally convincing Emma that the match is right. Mrs. Weston gives birth to a daughter. After a nearby poultry theft makes Mr. Woodhouse more receptive to Knightley's protection at Hartfield, he consents to the wedding. Harriet and Robert marry first, and Emma and Knightley then marry with their families and friends in agreement.",
         "in_short": "Emma Woodhouse, a wealthy young woman certain of her insight into others, befriends Harriet Smith and discourages her from marrying the farmer Robert Martin. Emma instead imagines that Mr. Elton loves Harriet, only to discover that he wants Emma herself. After rejecting him, she turns her attention to Frank Churchill, whose flirtation distracts her from his secret engagement to Jane Fairfax. Emma repeatedly misreads Harriet's feelings as well, first believing Harriet attached to Frank and then learning that Harriet hopes to marry Mr. Knightley. This shock makes Emma recognize her own love for Knightley. Her growth is sharpened when he rebukes her for humiliating the kind but vulnerable Miss Bates at Box Hill. Frank and Jane's engagement becomes public after his controlling aunt dies. Knightley proposes to Emma and she accepts. Harriet reunites with Robert Martin and accepts his second proposal, while Knightley agrees to live at Hartfield so Emma need not abandon her anxious father. The novel closes with both couples married and Emma's confidence tempered by greater humility and self-knowledge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/emma-classic-tales-edition.json
+++ b/data/works-community/0/emma-classic-tales-edition.json
@@ -136,7 +136,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -149,7 +149,7 @@
       "recaps": {
         "ending": "Frank Churchill's explanatory letter confirms that he and Jane Fairfax had been secretly engaged throughout his stay in Highbury. His apparent courtship of Emma helped conceal the relationship, while his aunt's opposition made secrecy seem necessary. Emma and Jane reconcile, and Jane can now marry Frank because Mrs. Churchill's death has removed the chief obstacle. Emma accepts Mr. Knightley's proposal, but concern for Mr. Woodhouse prevents her from leaving Hartfield; Knightley agrees to live there after their marriage. Harriet spends time in London, recovers from her hopes of Knightley, and renews her connection with Robert Martin. She accepts Martin's second proposal, satisfying Knightley and finally convincing Emma that the match is right. Mrs. Weston gives birth to a daughter. After a nearby poultry theft makes Mr. Woodhouse more receptive to Knightley's protection at Hartfield, he consents to the wedding. Harriet and Robert marry first, and Emma and Knightley then marry with their families and friends in agreement.",
         "in_short": "Emma Woodhouse, a wealthy young woman certain of her insight into others, befriends Harriet Smith and discourages her from marrying the farmer Robert Martin. Emma instead imagines that Mr. Elton loves Harriet, only to discover that he wants Emma herself. After rejecting him, she turns her attention to Frank Churchill, whose flirtation distracts her from his secret engagement to Jane Fairfax. Emma repeatedly misreads Harriet's feelings as well, first believing Harriet attached to Frank and then learning that Harriet hopes to marry Mr. Knightley. This shock makes Emma recognize her own love for Knightley. Her growth is sharpened when he rebukes her for humiliating the kind but vulnerable Miss Bates at Box Hill. Frank and Jane's engagement becomes public after his controlling aunt dies. Knightley proposes to Emma and she accepts. Harriet reunites with Robert Martin and accepts his second proposal, while Knightley agrees to live at Hartfield so Emma need not abandon her anxious father. The novel closes with both couples married and Emma's confidence tempered by greater humility and self-knowledge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -347,7 +347,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -360,7 +360,7 @@
       "recaps": {
         "ending": "Frank Churchill's explanatory letter confirms that he and Jane Fairfax had been secretly engaged throughout his stay in Highbury. His apparent courtship of Emma helped conceal the relationship, while his aunt's opposition made secrecy seem necessary. Emma and Jane reconcile, and Jane can now marry Frank because Mrs. Churchill's death has removed the chief obstacle. Emma accepts Mr. Knightley's proposal, but concern for Mr. Woodhouse prevents her from leaving Hartfield; Knightley agrees to live there after their marriage. Harriet spends time in London, recovers from her hopes of Knightley, and renews her connection with Robert Martin. She accepts Martin's second proposal, satisfying Knightley and finally convincing Emma that the match is right. Mrs. Weston gives birth to a daughter. After a nearby poultry theft makes Mr. Woodhouse more receptive to Knightley's protection at Hartfield, he consents to the wedding. Harriet and Robert marry first, and Emma and Knightley then marry with their families and friends in agreement.",
         "in_short": "Emma Woodhouse, a wealthy young woman certain of her insight into others, befriends Harriet Smith and discourages her from marrying the farmer Robert Martin. Emma instead imagines that Mr. Elton loves Harriet, only to discover that he wants Emma herself. After rejecting him, she turns her attention to Frank Churchill, whose flirtation distracts her from his secret engagement to Jane Fairfax. Emma repeatedly misreads Harriet's feelings as well, first believing Harriet attached to Frank and then learning that Harriet hopes to marry Mr. Knightley. This shock makes Emma recognize her own love for Knightley. Her growth is sharpened when he rebukes her for humiliating the kind but vulnerable Miss Bates at Box Hill. Frank and Jane's engagement becomes public after his controlling aunt dies. Knightley proposes to Emma and she accepts. Harriet reunites with Robert Martin and accepts his second proposal, while Knightley agrees to live at Hartfield so Emma need not abandon her anxious father. The novel closes with both couples married and Emma's confidence tempered by greater humility and self-knowledge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -558,7 +558,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -571,7 +571,7 @@
       "recaps": {
         "ending": "Frank explains that he and Jane have been secretly engaged since meeting at Weymouth. His dependence on Mrs. Churchill made an open engagement impossible, and many of his attentions to Emma were a disguise that caused Jane real pain. After Mrs. Churchill's death, the engagement can be acknowledged. Emma discovers that Harriet's new attachment is not to Frank but to Mr. Knightley. Forced to recognize her own love for Knightley, Emma fears she has harmed both Harriet and herself. Knightley instead declares his love for Emma, and they become engaged. Harriet spends time away from Hartfield, reunites with Robert Martin, and accepts his renewed proposal, restoring a match Emma had wrongly prevented. Jane and Frank prepare to marry, and Emma makes peace with Jane. To avoid leaving Mr. Woodhouse distressed, Knightley agrees to move into Hartfield after marrying Emma. A local poultry theft makes the added protection seem welcome to Mr. Woodhouse, and the novel closes with Emma and Knightley's wedding and the community's approval.",
         "in_short": "Emma Woodhouse, wealthy and confident in her judgment, befriends Harriet Smith and persuades her to refuse the farmer Robert Martin. Emma then imagines that Mr. Elton loves Harriet, only to learn that he wants Emma herself; he soon marries the boastful Augusta Hawkins. The arrivals of reserved Jane Fairfax and charming Frank Churchill create fresh speculation. Emma flirts with Frank and repeatedly misreads the attachments around her, while Mr. Knightley challenges her carelessness. After Emma humiliates Miss Bates during an outing, Knightley's rebuke makes her confront her conduct. Frank is eventually revealed to be secretly engaged to Jane, and Harriet confesses that she hopes to marry Knightley. Emma finally understands that she loves him. Knightley proposes to Emma, while Harriet and Robert Martin find their way back to each other. Jane and Frank reconcile, and Knightley agrees to live at Hartfield so Emma can continue caring for her father. Emma and Knightley marry with the misunderstandings resolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -762,7 +762,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -775,7 +775,7 @@
       "recaps": {
         "ending": "Frank Churchill's explanatory letter confirms that he and Jane Fairfax had been secretly engaged throughout his stay in Highbury. His apparent courtship of Emma helped conceal the relationship, while his aunt's opposition made secrecy seem necessary. Emma and Jane reconcile, and Jane can now marry Frank because Mrs. Churchill's death has removed the chief obstacle. Emma accepts Mr. Knightley's proposal, but concern for Mr. Woodhouse prevents her from leaving Hartfield; Knightley agrees to live there after their marriage. Harriet spends time in London, recovers from her hopes of Knightley, and renews her connection with Robert Martin. She accepts Martin's second proposal, satisfying Knightley and finally convincing Emma that the match is right. Mrs. Weston gives birth to a daughter. After a nearby poultry theft makes Mr. Woodhouse more receptive to Knightley's protection at Hartfield, he consents to the wedding. Harriet and Robert marry first, and Emma and Knightley then marry with their families and friends in agreement.",
         "in_short": "Emma Woodhouse, a wealthy young woman certain of her insight into others, befriends Harriet Smith and discourages her from marrying the farmer Robert Martin. Emma instead imagines that Mr. Elton loves Harriet, only to discover that he wants Emma herself. After rejecting him, she turns her attention to Frank Churchill, whose flirtation distracts her from his secret engagement to Jane Fairfax. Emma repeatedly misreads Harriet's feelings as well, first believing Harriet attached to Frank and then learning that Harriet hopes to marry Mr. Knightley. This shock makes Emma recognize her own love for Knightley. Her growth is sharpened when he rebukes her for humiliating the kind but vulnerable Miss Bates at Box Hill. Frank and Jane's engagement becomes public after his controlling aunt dies. Knightley proposes to Emma and she accepts. Harriet reunites with Robert Martin and accepts his second proposal, while Knightley agrees to live at Hartfield so Emma need not abandon her anxious father. The novel closes with both couples married and Emma's confidence tempered by greater humility and self-knowledge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1225,7 +1225,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -1238,7 +1238,7 @@
       "recaps": {
         "ending": "Felix's three rescue missions break several parts of the Hierocracy's system without securing every Unbound. Harn's force destroys the Overlord and frees the Poison Fields prisoners, but Imara abducts Kevin and Shadow. Pit claims Sunara, ends its corrupted storm, and saves Euphonia, only for Imara to take the Sylphan princess. Felix destroys the Violet Tower's oath anchor, frees Elowen, and reaches Master Tier. In the mana well, he evolves his bloodline into a stronger primordial state before killing the goddess of fortune. Experience from her death is then consumed by an unstable advancement, leaving his displayed level in error and releasing a dangerous cardinal beast from his shadow. Gabby remains oath-constrained but has recovered her will and covertly signals Felix. She delivers the three captives and the Thonic Star to the Hierophant's Tower of True Faith, where the gods demand the last Unbound target. Felix's alliance knows where the captives were taken, but his unstable advancement is the immediate danger. The Ruin still approaches, the remaining gods remain active, and Felix must recover the prisoners, restore more true seals, and find the rest of the Empyrean Regalia.",
         "in_short": "After restoring the Crown of Elysium, Felix expands his campaign against the Hierophant, the gods, and the approaching Ruin. He restores Nagast after sabotage, reunites Garion, strengthens the Shadowgate network, and sends three forces to rescue endangered Unbound. Harn's group liberates the Poison Fields and kills its Overlord. Pit's fleet finds Euphonia, claims Sunara, and ends its corrupted storm. Felix infiltrates the Violet Tower, destroys its mass-oath anchor, and frees the seer Elowen. The rescues are undercut when Imara abducts the Sylphan princess and the kobold twins Kevin and Shadow. Felix reaches Master Tier, then later evolves his primordial bloodline before killing the goddess of fortune. Experience from the kill feeds an unstable advancement that releases a cardinal beast from his shadow. Gabby, secretly herself despite her oaths, has delivered the captives and the Thonic Star to the Hierophant, leaving Felix's coalition poised for another rescue while the Ruin closes in.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1461,7 +1461,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1474,7 +1474,7 @@
       "recaps": {
         "ending": "John Voss brings a gun to school after prolonged neglect and humiliation, killing and wounding students before the attack is stopped. Tick survives, but the violence ends any illusion that the town's cruelties remain harmless when ignored. The crisis draws Miles out of his habitual passivity and back toward his daughter and family. The past also becomes clear: Charlie Mayne was C. B. Whiting, whose relationship with Grace Roby shaped Francine Whiting's long manipulation of Miles. A severe flood strikes Empire Falls, and Francine is swept away while trying to protect Whiting property. With her control finally ended, Miles is able to approach the restaurant and his life as something other than a debt inherited from his mother. Janine's marriage to Walt does not provide the transformation she expected, while David continues building a steadier future. The town remains economically damaged, but Miles and Tick emerge with a more honest bond and with room to choose what comes next.",
         "in_short": "Miles Roby manages the Empire Grill in a Maine town hollowed out by closed mills and dominated by Francine Whiting, who owns the restaurant and much of the community. His wife Janine is leaving him for Walt Comeau, his father Max creates constant trouble, and his daughter Tick faces pressure from Zack Minty while befriending the isolated John Voss. Memories of Miles's mother Grace and a mysterious man named Charlie Mayne gradually explain why Mrs. Whiting has kept Miles dependent. Charlie was C. B. Whiting, and his bond with Grace fueled Francine's control of the Robys after his death. In the present, the town's habit of overlooking cruelty culminates when John carries out a school shooting; Tick survives, but several students do not escape the violence. A flood later sweeps Francine away and breaks her hold on Miles and the town. Miles, no longer bound by the same bargain with the Whitings, turns toward his daughter, brother, and the possibility of rebuilding on his own terms.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1709,7 +1709,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1722,7 +1722,7 @@
       "recaps": {
         "ending": "The book ends with Aelin in chains. At the coast, with the ritual to forge the Lock finally within reach, Maeve arrives with a fleet, having been told exactly where to find her by Lorcan. Aelin surrenders herself to spare her court and her allies, and Maeve has her beaten, bound in iron, and sealed inside an iron coffin, taking her away by ship along with Fenrys, whose blood oath forces him to go. Rowan, Aedion, Lysandra, Elide, and Gavriel are left alive on the shore with nothing but the promise to find her. Lorcan is exiled from the court for the betrayal, with Elide the one who names the sentence. It emerges that Aelin had prepared for a version of this: Lysandra will wear her face and hold Terrasen together, buying the kingdom time it does not know it needs. Manon Blackbeak survives her grandmother's attempt to kill her and learns that she is the daughter of the last Crochan Queen, half of the people the Ironteeth have hunted for five hundred years; she and the Thirteen become outcasts and turn west to find the Crochans and, if they will have her, a crown. Dorian is left carrying the war on the northern front with a witch's help and no plan. Erawan holds Morath, one Wyrdkey, and an army nobody has yet slowed down.",
         "in_short": "Refused recognition by Terrasen's lords, Aelin gambles everything on alliances she cannot pay for: she wins Rolfe's pirate fleet at Skull's Bay by destroying a Valg armada, courts the sea dragons and the Fae, and marries Rowan. Elide Lochan travels north with Lorcan Salvaterre, Maeve's exiled warrior, carrying a Wyrdstone shard toward a queen she has never met. Dorian, driven out of a fallen Rifthold, falls in with the witch Manon Blackbeak, and the two raid the Ferian Gap and turn toward Morath after the third Wyrdkey. Manon's defiance finally provokes her grandmother, who tries to kill her and reveals that Manon is the daughter of the last Crochan Queen; Manon and the Thirteen break with the Ironteeth. Aelin learns from Elena the true price of forging the Lock and closing the Wyrdgate: her own life. She spends the book concealing that from everyone. At the coast, on the verge of the ritual, Lorcan's message brings Maeve's fleet down on them. Aelin gives herself up to save her court, and is chained in iron and shipped away in a coffin, leaving Rowan and the others to find her and Lysandra to wear her face.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1888,7 +1888,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1901,7 +1901,7 @@
       "recaps": {
         "ending": "After Japan's surrender, Jim survives the abandoned Olympic stadium and makes his way back toward Lunghua through a landscape filled with displaced prisoners, armed groups, and the remains of the war. The camp briefly draws him because its routines have become more familiar than his former home. Basie reappears among men looting American supply drops and offers Jim a place, but Basie's protection is still governed by advantage rather than loyalty. Jim eventually returns to Shanghai and is reunited with his parents. They are physically altered by imprisonment, and Jim's own habits and perceptions show that reunion cannot restore the sheltered child who was separated from them. He prepares to leave China for England while the city fills with returning residents and new occupying forces. The war has ended officially, but Jim remains alert to aircraft, violence, and the possibility that conflict will continue in another form; Shanghai and Lunghua persist in his mind as the world that taught him how unstable ordinary civilization can be.",
         "in_short": "When Japan occupies Shanghai after Pearl Harbor, British schoolboy Jim Graham is separated from his parents and survives alone in the family's empty house until hunger drives him into the city. American sailor Basie helps him enter the prisoner system, and Jim is eventually interned at Lunghua. Over several years he adapts to camp life, trading, carrying messages, helping in the hospital, and turning his fascination with aircraft into a way of interpreting the war. Doctor Ransome tries to preserve his health and humanity, while Basie teaches a harsher economy of usefulness. As American attacks intensify and Japan collapses, the prisoners are marched to an abandoned stadium. Jim survives starvation, death, and the confusion after surrender, then returns through a violent landscape to Shanghai. He is reunited with his parents, but the resourceful, war-absorbed survivor who comes home is profoundly separated from the protected child he was.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2059,7 +2059,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2072,7 +2072,7 @@
       "recaps": {
         "ending": "Bill follows Brady's trail to a remote hunting camp even as pancreatic cancer weakens him. Brady, controlling Felix Babineau's body, prepares to expand the hypnotic Zappit program into a mass-casualty event and tries to force Bill into suicide. Holly and Jerome reach the camp in time. Holly again strikes Brady with the weighted sock she used years earlier, fatally injuring Babineau's body and ending Brady's last attempt to survive through another person. Evidence at the camp enables the authorities to interrupt the electronic suicide scheme and understand the recent deaths. Bill's cancer cannot be stopped. He spends his remaining time close to Holly, Jerome, Barbara, and his other friends and dies months later. At his funeral Holly delivers a loving, direct tribute despite the social difficulty of speaking publicly. She continues Finders Keepers with greater confidence, carrying forward the work and the chosen family Bill helped her build. Brady is gone, but the conclusion centers equally on Bill's acceptance of death and Holly's ability to continue after him.",
         "in_short": "Retired detective Bill Hodges and Holly Gibney investigate a murder-suicide involving a woman paralyzed in Brady Hartsfield's Mercedes attack. Similar deaths are linked to obsolete Zappit game devices carrying a hypnotic program. Brady, outwardly helpless in a brain-injury clinic, has developed the ability to move objects, influence minds, and occupy other bodies after an experimental treatment. He uses hospital worker Al Brooks and neurologist Felix Babineau to distribute the devices and plans to drive thousands of vulnerable people to suicide through an online game. As Bill conceals terminal pancreatic cancer, Holly and Jerome help trace Brady to a remote camp. Brady, controlling Babineau, tries to make Bill kill himself, but Holly intervenes and fatally strikes him, ending the scheme. Bill dies of cancer months later among friends. Holly speaks at his funeral and continues their Finders Keepers agency, more able to trust her own judgment and sustain the life Bill helped her claim.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2250,7 +2250,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2263,7 +2263,7 @@
       "recaps": {
         "ending": "Ender's final training exercise turns out to have been the real war: unknowingly commanding actual human fleets he believed were only simulations, he fires a planet-destroying weapon at the buggers' homeworld, annihilating their entire species. The adults had concealed the truth so that he would fight without the moral weight of committing genocide. Ender is left shattered by what he was tricked into doing. On Earth, the alliance that fought the aliens fractures into war, and his brother Peter, working through politics and propaganda, rises toward ruling the world. Refusing to be used again or to go home, Ender leaves with his sister Valentine to help colonize one of the buggers' abandoned worlds. There he discovers that the aliens had come to understand him and had preserved a single dormant hive queen, leaving her in his care along with a plea for their revival. Ender accepts the burden of carrying the queen egg to find her a new home one day, and he writes a book told from the aliens' point of view that recasts them as victims rather than monsters. Under the name Speaker for the Dead, he begins a life of atonement, leaving open the possibility of the buggers' eventual return.",
         "in_short": "In a future still recovering from two invasions by an insectlike alien species, the world's military trains brilliant children to command the war against a feared third attack. Six-year-old Ender Wiggin, chosen for his rare mix of empathy and ruthlessness, is taken to an orbiting Battle School, where Colonel Graff deliberately isolates him to forge him into a leader. Ender rises through the school's zero-gravity war games, enduring bullying, manipulation, and crushing pressure, and eventually commands his own army with unmatched skill, though the strain nearly breaks him. Promoted to Command School, he is trained by Mazer Rackham, the hero of the last war, and directs entire fleets through grueling battle simulations. In a final test against overwhelming odds, Ender destroys the enemy's home planet, only to learn afterward that the simulations were real and that he has wiped out the entire alien species. Devastated by the deception, he refuses to return to Earth and leaves to help settle a new world, where he discovers the aliens were not the monsters humanity believed and dedicates himself to honoring the dead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2384,7 +2384,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2397,7 +2397,7 @@
       "recaps": {
         "ending": "Jed Parry enters Joe and Clarissa's home and holds Clarissa with a knife, demanding that Joe end his life. Joe uses the illegally acquired gun and shoots Parry in the arm, stopping the immediate threat without killing him. The attack finally supplies undeniable evidence that Joe's warnings were accurate, but it also forces Joe and Clarissa to confront the distrust and isolation that developed while Parry's obsession dominated their lives. Parry is confined in a secure psychiatric hospital and is diagnosed with de Clérambault's syndrome; years later, he remains convinced that Joe returns his love and continues writing to him. Joe and Clarissa repair their relationship and later adopt a child. Joe also resolves the doubt tormenting Jean Logan: the evidence in John's car came from innocent passengers he had helped, not an affair, allowing his widow to recover an honest understanding of the courage he showed at the balloon accident.",
         "in_short": "Science writer Joe Rose and Keats scholar Clarissa Mellon witness a runaway balloon accident in which doctor John Logan dies after holding on longer than the other rescuers. Another participant, Jed Parry, becomes convinced that Joe loves him and begins calling, writing, and watching him. Joe identifies the fixation as a psychiatric delusion, but the lack of evidence makes the police dismiss him and Clarissa question whether his fear and guilt are distorting his judgment. Parry escalates, arranging an attack that mistakenly hits another man. Feeling unprotected, Joe obtains a gun. Meanwhile, John Logan's widow asks Joe to investigate signs that seem to suggest her husband was unfaithful; Joe eventually proves the evidence came from people John innocently helped. Parry finally invades Joe and Clarissa's home and threatens Clarissa with a knife. Joe shoots and disables him. Parry is committed and remains delusional, while Joe and Clarissa reconcile and later adopt a child.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2535,7 +2535,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2548,7 +2548,7 @@
       "recaps": {
         "ending": "Simon's gift for magical theory grows so strong that it draws the attention of the Things from the Dungeon Dimensions, mindless entities that hunger to invade the world through the openings his thinking creates. When his magic pulls him into that cold, formless other place, Esk follows to bring him back, using her own staff and the connection between them. Granny Weatherwax reaches them by borrowing her way into the University and lending Esk her strength. Working together, Esk's instinctive witch craft and Simon's raw power drive the invaders back and close the breach. Both children survive, changed by the experience. The confrontation forces the wizards to recognize that the strict division of magic by sex is neither natural nor safe: Esk has done what no rule said she could. The story closes with the barrier between wizardry and witchcraft cracked open, Esk accepted as something new, and the way cleared for women to be taught at the University at last.",
         "in_short": "A dying wizard passes his staff and power to what he believes is the eighth son of an eighth son in a small mountain village, only for the newborn to be a girl, Eskarina Smith. Since custom holds that women can only be witches and men only wizards, Esk's wizardly gift is treated as impossible. The village witch, Granny Weatherwax, tries to raise her as a witch, but the wizard magic keeps breaking loose. Granny finally takes Esk to the Unseen University in Ankh-Morpork and demands she be admitted, only to be turned away because she is a girl. At the University Esk befriends Simon, a brilliant but sickly student whose powerful theoretical magic accidentally opens the way to the Dungeon Dimensions, letting alien creatures reach toward the world. Esk is drawn into that other realm to save him. Combining witch sense with wizard power, she and Granny pull Simon back and drive the creatures off. In the aftermath the rigid line between the two kinds of magic begins to soften, and the University edges toward admitting women.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2680,7 +2680,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2693,7 +2693,7 @@
       "recaps": {
         "ending": "Eragon reaches the Varden's mountain stronghold of Farthen Dur, where Arya is healed and he meets their leader, Ajihad. An army of the king's monstrous Urgals soon assaults the fortress. In the vast battle underground, Eragon and Saphira face the Shade Durza, who wounds Eragon terribly across the back; distracted at the crucial moment, Durza is stabbed through the heart, and his death breaks the enemy's will and turns the tide. As Eragon recovers, a distant presence reaches into his mind: a teacher who calls himself the Cripple Who Is Whole, summoning him to the elven forest of Du Weldenvarden to finish learning what it means to be a Rider. Eragon has survived his first war, lost his mentor Brom, gained an uneasy friend in Murtagh, and glimpsed the scale of the fight against Galbatorix. He and Saphira prepare to leave for their training, their part in the rebellion only beginning.",
         "in_short": "Eragon, a farm boy in a remote valley, finds a blue stone that hatches into a dragon he names Saphira, making him the first new Dragon Rider in a generation. When the king's servants kill his uncle and burn his home hunting the dragon, Eragon flees with Brom, the village storyteller, who is secretly a former Rider and teaches him swordplay and magic as they pursue the killers. Brom dies in an ambush, and a mysterious young man, Murtagh, joins Eragon. Guided by visions, Eragon frees a captive elf, Arya, and races to deliver her to the Varden, the rebels opposing King Galbatorix, in their hidden dwarf city beneath the mountains. There an enemy army attacks, and in the battle Eragon confronts and destroys the Shade Durza, though he is badly wounded. Recovering, he is contacted mind to mind by a hidden teacher who summons him to the elves' forest to complete his training.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2879,7 +2879,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2892,7 +2892,7 @@
       "recaps": {
         "ending": "The apparent ransom failure is exposed as a conspiracy rather than an Araluen betrayal. Yusal arranged for the payment to be stolen and worked with the Tualaghi to destroy the parties who could reveal what happened. The scattered Araluens, Selethen and their desert allies reunite, survive the wastes and defeat the force holding Erak. The ransom is recovered and Erak is freed, preserving both his life and the alliance between Skandia and Araluen. Will is also reunited with Tug after believing the sandstorm and desert might have taken his horse from him. The mission demonstrates that he can operate beyond Halt's direction, make decisions under extreme pressure and carry responsibility for others. After the party returns to Araluen, Will completes his apprenticeship. Halt formally gives him the silver oakleaf of a full Ranger, placing the chronological ending immediately before Will's first independent posting in The Sorcerer in the North.",
         "in_short": "Set after The Battle for Skandia but before Will's first posting, the story begins when Erak returns to raiding and is captured in Arrida. Svengal asks Araluen to provide a ransom, and Cassandra travels with Halt, Will, Horace and Gilan to represent her father. Selethen, an Arridi commander, guides them through unfamiliar customs and desert country. The exchange becomes a trap when the ransom is stolen and Tualaghi raiders pursue the party. A sandstorm scatters friends, separates Will from Tug and turns the mission into a struggle for water, direction and reunion. The survivors learn that Yusal engineered the theft and allied himself with the Tualaghi. With Selethen and Bedullin aid, they recover the ransom, defeat the conspirators and free Erak. Will finds Tug alive and returns with confidence earned independently of Halt. At home he finishes his apprenticeship and receives the silver oakleaf of a full Ranger.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3030,7 +3030,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3043,7 +3043,7 @@
       "recaps": {
         "ending": "Having decided that his association with forbidden machinery puts him in danger, the narrator prepares a balloon in secret and persuades Arowhena to leave Erewhon with him. Their flight carries them over the mountains and out to sea, where they are eventually rescued by a ship. Back in the familiar world, the narrator marries Arowhena and publishes his account. His response to Erewhon remains compromised by the same acquisitive confidence with which he began: he imagines returning through a commercial and missionary enterprise, presenting conversion as its public purpose while also contemplating the exploitation of the Erewhonians. Arowhena is safe with him, but the closing scheme makes clear that the supposedly civilized outsider has not escaped the satire directed at either society.",
         "in_short": "An unnamed English traveler crosses a remote mountain range and enters Erewhon, a prosperous country whose customs invert many Victorian assumptions. Illness is punished as wrongdoing, while crime is treated medically; education rewards hypothetical reasoning; musical banks preserve prestige despite little practical use; and machines were destroyed after thinkers feared that technology might evolve beyond human control. Initially detained because he carries a watch, the traveler gains favor through his unusual appearance and lives with the wealthy Nosnibor family, falling in love with their daughter Arowhena. As his connection with prohibited machinery becomes dangerous, the pair escape in a balloon and are rescued at sea. They marry after reaching the outside world. The narrator then proposes returning with a venture that combines missionary language with plans for profit and coercion, ending the account with a final satire on his own culture's claims to moral superiority.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3201,7 +3201,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3214,7 +3214,7 @@
       "recaps": {
         "ending": "In Hell, Rincewind and Eric discover that the whole sequence of wishes was arranged by Astfgl, the King of Hell, who wanted Rincewind brought within reach and used Eric's summoning to do it. Astfgl's real weakness is not the two of them but his own court: the ancient demon lords, led by Duke Vassenego, have had enough of his committees, forms and improving schemes. Rather than depose him, they promote him. Astfgl is elevated to Supreme Life President of Hell, a magnificent title with an enormous office, ceremonial honours and no authority over anything at all, and the old lords quietly take the running of the underworld back into their own hands. With Astfgl neutralised, the new management has no further interest in the pair and sends them home. The Luggage, which has crossed the Dungeon Dimensions and Hell itself to reach its owner, is reunited with Rincewind. Eric returns to his grandfather's cellar with his three wishes technically granted and thoroughly regretted, and Rincewind is back on the Discworld, alive, unimproved, and once again in possession of a piece of luggage he did not ask for.",
         "in_short": "Rincewind, lost in the Dungeon Dimensions, is hauled back into the world by Eric Thursley, a teenage demonologist who has summoned what he believes is a demon and demands the traditional three wishes: to rule the world, to meet the most beautiful woman who ever lived, and to live forever. To Rincewind's alarm the wishes work. The first drops them in the Tezuman Empire, where Rincewind is briefly worshipped as a god and the actual god, Quezovercoatl, comes to a sudden end. The second takes them to the siege of Tsort, where the legendary Elenor turns out to be middle-aged, contented and uninterested in rescue, and where the strategist Lavaeolus, an ancestor of Rincewind, ends the war with a wooden horse. The third puts them at the beginning of time, watching the Creator assemble the Discworld, which is what living forever actually means. The wishes were engineered by Astfgl, King of Hell, who has turned the underworld into a bureaucracy of tedium. In Hell the old demon lords remove Astfgl by promoting him to a grand and powerless title, and the pair are sent home, with the Luggage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/eskau-an-unplanned-infiltration-progression-fantasy.json
+++ b/data/works-community/0/eskau-an-unplanned-infiltration-progression-fantasy.json
@@ -362,7 +362,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -375,7 +375,7 @@
       "recaps": {
         "ending": "Tala deliberately prevents the mortally wounded Be-thric from recovering, ending his control but triggering the caller-collar. The released Doskanok consumes her bodily iron and disables her inscriptions and Alat. The House of Blood treats her as doomed and deposits her in the broken realm with the exiled Thron. Tala uses void sight to follow reality threads back to Zeme, pays Thron with a concept weapon and an advancement book, restores her inscriptions and Alat through Kit, and parts from him on good terms as he leaves for his homeland.\n\nTravelling north with Terry and Kit, Tala finds that a completed Archon Star can hold the Doskanok in a continuing stalemate, though the creature remains lodged in her left hand. She crosses the Leshkin Forest, returns the power she absorbed there, and receives a warning that she will be hunted in a future war. At the close, Tala has restored Archive contact and distributed arcane knowledge to her human allies. Holly, Rain, Lynn, Boma, Q, Ingrid, and Grediv know of her return or receive her messages, and Tala is roughly two hours from a human city. House of Blood retaliation, the regrowing automaton hidden in Kit, the Doskanok, and the larger instability of Zeme remain unresolved.",
         "in_short": "Tala awakens in Platoiri as Be-thric's memory-altered human Eskau candidate. With Alat restoring her true self, she wins his elevation, conceals her recovery, reunites with Terry, and turns Kit into a portable sanctum while gathering power and resources. Her victories make Be-thric a Pillar, but the House bars her from the mission she hoped would carry her home. During an attack on the House of Blood, Tala ensures Be-thric's death. His collar releases the Doskanok, which destroys her inscriptions and traps her iron in a lethal contest. Exiled into the broken realm with Thron, Tala finds a route out, restores Alat and her inscriptions, and begins the journey north. A completed Archon Star holds the Doskanok in an unstable stalemate. Tala survives the Leshkin Forest, restores Archive contact, and ends the book about two hours from a human city, while Thron departs for his homeland and House warfare continues behind her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -596,7 +596,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -609,7 +609,7 @@
       "recaps": {
         "ending": "Miguel returns to the California camp with Abuelita, having used Esperanza's saved money to bring her from Mexico. Esperanza's anger over the missing money gives way to joy when she understands what he has done. Abuelita is reunited with Ramona, whose health has improved enough for her to leave the hospital, and the extended family is together again. On Esperanza's next birthday, one year after Sixto's death, the family marks both what has been lost and what they have rebuilt. Esperanza no longer defines herself by the wealth and rank she once expected to inherit. She has learned difficult work, accepted help, and found dignity and hope within the laboring community. She takes Isabel into the hills and repeats her father's lesson about listening to the earth, now able to feel the connection she could not grasp as a child. Miguel's future is still constrained by prejudice, and the workers' larger struggle remains unresolved, but Esperanza faces uncertainty with patience rather than fear.",
         "in_short": "Esperanza Ortega grows up wealthy on her family's Mexican ranch, but her father is killed and her powerful uncle tries to force her mother into marriage. Their home is burned, and Esperanza and her mother escape with trusted family servants to a farm-labor camp in California, leaving her injured grandmother behind. Esperanza initially struggles with poverty, manual work, and the prejudice faced by Mexican laborers. A dust storm leaves her mother gravely ill, so Esperanza works and saves to bring her grandmother north. She also witnesses a strike and immigration raid that show how vulnerable the workers are. After Esperanza lashes out at Miguel over the limits placed on them, he disappears with her savings. He returns having used the money to fetch her grandmother. With her mother recovering and the family reunited, Esperanza reaches her next birthday transformed: she accepts both loss and hope, and passes her father's lesson about listening to the earth on to Isabel.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -985,7 +985,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -998,7 +998,7 @@
       "recaps": {
         "ending": "Omega escapes the Ornu shipyard with a newly installed short-range jump drive after destroying Pertinax's flagship. The drive causes Omega pain and structural strain, so its use is limited, and Pertinax survives by fleeing in a small craft. Bill remains captain and king within Omega's governing framework. Bina, Alden Stone, Hans Norder, Felicia Keating, James Riding, and the surviving core Marines remain aboard. Funnybone, Splat, and Termite are alive in medical care, while Sally Longfield died during the earlier coup. Riding has put aside his remaining resentment toward Bina, although Keating's distrust is unresolved. The human-Roughback alliance remains in force, but Tull and the last Roughback crew refuse Bill's offer to return and defend their world. They give humanity their remaining military support so Omega can seek a home and eventually oppose the Imperium. Omega sets course for a habitable, resource-rich settlement world. The Ornu pursuit remains active, and an ancient Konami rival reaches Philo's imprisoned nephew, reveals knowledge of Omega's destination, and forms an alliance with him to destroy the ship.",
         "in_short": "After Earth is lost, Bill Henderson commands Omega and its roughly two million refugees through famine, a Slovenian militia coup, and repeated Imperial attacks. Bina Chakravarti reaches into Omega's ancient Konami past and secures food-producing nourishers, while Omega restores contact through Val and requires Bill to rule the refugees as king. The crew defeats the coup, publicly confronts Bina's betrayal of James Riding, and wins a formal alliance with the Roughbacks after surviving a combined fleet and ground invasion. Omega then seizes an Ornu shipyard for a short-range jump drive. During the siege, Splat captures an enemy warship, the Roughbacks suffer devastating losses, and the completed drive lets Omega destroy Pertinax's flagship and rescue its surviving ground force. Pertinax escapes. Tull sends humanity onward to an Omega-selected settlement world while the Roughbacks remain behind. An ancient Konami rival knows that destination and recruits Philo's imprisoned nephew to help destroy Omega.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1193,7 +1193,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1206,7 +1206,7 @@
       "recaps": {
         "ending": "Unable to secure money for an escape, Ethan prepares to take Mattie to the station while Zeena remains determined to send her away. Ethan and Mattie prolong their last journey and go sledding. Mattie proposes that they steer into a large elm so they can die together rather than be separated. Ethan agrees, but their suicide attempt fails: both survive with severe injuries. More than twenty years later, the frame narrator enters the Frome farmhouse and discovers the result. Ethan is crippled and worn down, Mattie is also disabled and has become bitter and demanding, and Zeena—formerly the household's invalid—cares for them. Ruth Hale observes that the three might have been better off if Mattie had died. The attempted escape has fixed all three in the same impoverished house, with their earlier roles grimly reversed and no prospect of release.",
         "in_short": "In wintry Starkfield, the young Ethan Frome is trapped by poverty and a joyless marriage to the sickly Zeena. He falls in love with Zeena's cousin Mattie Silver, whose warmth briefly transforms his isolated life. After Zeena travels to consult a doctor, Ethan and Mattie spend an evening alone, but their hope is shadowed when Zeena returns and announces that she will dismiss Mattie and hire another girl. Ethan considers fleeing with Mattie but cannot obtain the money and cannot abandon his obligations. Driving her to the station, he agrees to Mattie's proposal that they die together by steering a sled into an elm. They survive the crash, permanently injured. Decades later, Ethan is crippled, Mattie has become an embittered invalid, and Zeena cares for both of them in the decaying Frome farmhouse.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1338,7 +1338,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1351,7 +1351,7 @@
       "recaps": {
         "ending": "Unable to secure money for an escape, Ethan prepares to take Mattie to the station while Zeena remains determined to send her away. Ethan and Mattie prolong their last journey and go sledding. Mattie proposes that they steer into a large elm so they can die together rather than be separated. Ethan agrees, but their suicide attempt fails: both survive with severe injuries. More than twenty years later, the frame narrator enters the Frome farmhouse and discovers the result. Ethan is crippled and worn down, Mattie is also disabled and has become bitter and demanding, and Zeena—formerly the household's invalid—cares for them. Ruth Hale observes that the three might have been better off if Mattie had died. The attempted escape has fixed all three in the same impoverished house, with their earlier roles grimly reversed and no prospect of release.",
         "in_short": "In wintry Starkfield, the young Ethan Frome is trapped by poverty and a joyless marriage to the sickly Zeena. He falls in love with Zeena's cousin Mattie Silver, whose warmth briefly transforms his isolated life. After Zeena travels to consult a doctor, Ethan and Mattie spend an evening alone, but their hope is shadowed when Zeena returns and announces that she will dismiss Mattie and hire another girl. Ethan considers fleeing with Mattie but cannot obtain the money and cannot abandon his obligations. Driving her to the station, he agrees to Mattie's proposal that they die together by steering a sled into an elm. They survive the crash, permanently injured. Decades later, Ethan is crippled, Mattie has become an embittered invalid, and Zeena cares for both of them in the decaying Frome farmhouse.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1561,7 +1561,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002UZL0U2",
@@ -1573,7 +1573,7 @@
       "recaps": {
         "ending": "Millisor, Rau, Setti and Okita are dead, ending the Cetagandan pursuit. Helda's sabotage is exposed, Techie survives his abduction, and Elli Quinn leaves Kline Station after medical treatment and payment of fines. She carries data and a tissue sample from Terrence Cee, but he declines the Dendarii offer. Ethan and Cee find the nine Bharaputra containers in external storage and take them to Athos, where they secretly present 450 legitimate cultures bought on Beta Colony instead. Ethan reserves Elli's successful culture for his own future sons and retains the recovered cultures for a gradual, concealed introduction of the telepathy complex. Janos has departed for the Outlands and will not return. Cee settles on Athos under his own identity, supported by Ethan, and the two consider becoming designated alternates in future parenting. Athos's immediate reproductive crisis is solved, while its planned genetic transformation remains secret and unresolved.",
         "in_short": "When Athos's aging ovarian cultures begin failing and a Bharaputra shipment arrives as worthless biological material, reproductive physician Ethan Urquhart is sent off-world to buy replacements. On Kline Station he joins Dendarii agent Elli Quinn, survives a Cetagandan intelligence team led by Luyst Millisor, and grants refuge to Terrence Cee, an engineered telepath whose dead partner's genes were placed in the missing shipment. Biocontrol warden Helda admits substituting the cargo to force her emigrant son home. Millisor's attempt to recapture Cee ends with Millisor, Rau and Setti dead. Ethan and Cee then recover the supposedly discarded cultures from external storage. They return to Athos with legitimate Beta Colony cultures hidden in their place, preserving the recovered telepathy genes for gradual secret use. Elli contributes a viable ovarian culture and departs, while Cee chooses a possible family future with Ethan on Athos.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1713,7 +1713,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1726,7 +1726,7 @@
       "recaps": {
         "ending": "Onegin writes repeatedly to Tatyana and receives no answer. He finally enters her rooms unannounced and finds her reading one of his letters in tears. Tatyana acknowledges that she still loves him, but she also contrasts his present pursuit with his rejection of her when she was an unknown country girl. She suspects that her elevated social position has helped awaken his desire. Whatever her private feelings, she has married and will not betray her husband. She leaves Onegin stunned and alone. Her husband then enters, and the narrator breaks off the story without arranging a reconciliation or a new beginning. Lensky remains dead, Olga has long since married another man, and Tatyana chooses fidelity and self-command over the romantic fulfillment she once sought. Onegin is left to confront both the finality of her refusal and the consequences of his earlier emotional detachment.",
         "in_short": "Bored St Petersburg aristocrat Eugene Onegin inherits a country estate and befriends the idealistic poet Vladimir Lensky. Through Lensky he meets the Larin sisters: Lensky's cheerful fiancée Olga and the reserved, imaginative Tatyana. Tatyana falls in love with Onegin and writes him an unguarded confession, but he rejects her in a cool lecture. Later, irritated at a crowded name-day celebration, Onegin flirts with Olga to punish Lensky. The insult leads to a duel that neither friend has the courage to stop, and Onegin kills Lensky. He leaves Russia to travel; Olga soon marries someone else. Tatyana studies Onegin's books, begins to understand the poses behind his personality, and is taken to Moscow, where she marries a prince. Years later Onegin meets her as an assured society figure and falls desperately in love. Tatyana admits she still loves him, but refuses to betray her husband, leaving Onegin alone with the consequences of his past choices.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1893,7 +1893,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1906,7 +1906,7 @@
       "recaps": {
         "ending": "After years abroad, Charles returns wealthy but morally altered and plans to marry into the impoverished d'Aubrion family for a title. He dismisses his youthful promises and assumes Eugénie remains an insignificant provincial. Eugénie answers without pleading. She pays the remaining creditors of Charles's father, preserving the family honor that Charles was prepared to ignore, and releases him to his chosen marriage. She then marries President de Bonfons under an agreement that leaves the union unconsummated. He expects eventually to control her fortune but dies after a few years, making her still richer. Eugénie remains in the austere Saumur house with Nanon, continues many of her father's economical habits, and uses substantial sums for charity and local good works. She is respected and relentlessly pursued for her wealth, yet the love and family life she once imagined never arrive. The novel closes with her materially powerful and morally generous, but personally isolated within the social world that has always treated her inheritance as its chief concern.",
         "in_short": "In Saumur, the miser Félix Grandet keeps his wife and daughter Eugénie in austerity while two local families compete to marry their sons to his presumed heiress. The arrival of Eugénie's Parisian cousin Charles awakens her first love, but Charles's father has died ruined. Eugénie gives Charles her gold before he leaves to seek a fortune overseas. Her father discovers the gift, confines her, and yields only when her mother's illness and Eugénie's inheritance threaten his control. After both parents die, Eugénie becomes immensely wealthy and waits faithfully for Charles. He returns hardened by colonial commerce and chooses an aristocratic marriage instead. Eugénie pays his father's creditors and lets him go, then enters a celibate marriage with President de Bonfons. Widowed soon afterward, she lives simply in the old house and gives generously to others. She controls a great fortune but remains alone, her constancy surviving both her father's avarice and Charles's abandonment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2019,7 +2019,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2032,7 +2032,7 @@
       "recaps": {
         "ending": "Many years after the Acadians are scattered, Evangeline settles in Philadelphia and serves the suffering as a Sister of Mercy. During an epidemic she walks among the sick and recognizes Gabriel, now an old man, lying near death. He wakes long enough to know her, and the two embrace before he dies. Evangeline accepts that their earthly search is over and soon dies herself. They are buried together in Philadelphia, while the poem returns to the distant Acadian landscape and the memory of the displaced community. Their reunion does not restore the life taken from them, but it gives a final spiritual resolution to Evangeline's lifelong fidelity.",
         "in_short": "In the Acadian village of Grand-Pré, Evangeline Bellefontaine is about to marry Gabriel Lajeunesse when British authorities order the French-speaking population expelled. Their homes are destroyed, Evangeline's father dies, and separate ships carry the lovers away. Evangeline spends years following reports of Gabriel through the American interior. She reaches Basil's new Louisiana home only after Gabriel has departed and repeatedly misses him as her search moves across rivers, prairies, missions, and towns. Time turns her personal quest into a broader life of faith and service. As a Sister of Mercy in Philadelphia, she tends victims during an epidemic and at last finds Gabriel among them. Now elderly and dying, he recognizes her and dies in her arms. Evangeline later dies and is buried beside him, their shared grave preserving the memory of a love and homeland broken by forced exile.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2154,7 +2154,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2167,7 +2167,7 @@
       "recaps": {
         "ending": "After years of following reports of Gabriel across North America, Evangeline abandons the hope of finding him through travel and joins the Sisters of Mercy in Philadelphia. She devotes herself to caring for the poor and sick, growing old in service while retaining her love for him. During an epidemic, she works among patients in an almshouse and recognizes an aged, dying man as Gabriel. Their long separation ends only at the edge of death. Gabriel recognizes her, attempts to speak, and dies in her arms. Evangeline accepts the reunion with grief and religious gratitude, believing that their bond has survived exile and time even though they cannot share an earthly life. They are buried together in Philadelphia. The poem closes by returning to the vanished Acadian landscape and to the story preserved among the descendants of the exiles.",
         "in_short": "In the Acadian village of Grand-Pré, Evangeline Bellefontaine and Gabriel Lajeunesse are betrothed just before British forces confiscate the community's land and deport its people. The confusion of embarkation separates the lovers, and Evangeline's father dies as their home burns. Scattered among distant colonies, Evangeline spends years traveling with Father Felician and following reports of Gabriel. In Louisiana she finds Gabriel's father Basil, but Gabriel has just departed; later she unknowingly passes close to him and continues across forests, rivers, and prairies as each lead fails. Gabriel's restless wandering keeps him beyond reach. Eventually Evangeline becomes a Sister of Mercy in Philadelphia and serves the sick. During an epidemic she discovers Gabriel, now an old man, dying in an almshouse. He recognizes her and dies in her arms. Their shared grave becomes the earthly end of a love sustained through displacement, separation, and a lifetime of searching.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2342,7 +2342,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2355,7 +2355,7 @@
       "recaps": {
         "ending": "Rachel, Trent, Bis, and their allies repair the catastrophic magical imbalance and prevent the ever-after from continuing toward destruction. The solution clears Rachel of the claim that she deliberately caused the collapse and exposes Ku'Sox as the force exploiting the damaged lines. Ku'Sox is finally defeated, ending the immediate threat that survived Pale Demon. Victory carries severe losses: Ceri and Pierce are killed during the conflict, leaving Quen, the Kalamack household, and Rachel grieving. Lucy and Ray are recovered alive. Rachel's use of both demon and elven approaches saves lives but leaves old prejudices inside demon society unsettled, particularly in her relationship with Al. Trent has chosen Rachel's side repeatedly at significant political cost, and the emotional bond between them is now explicit even though elven obligations remain around him. Rachel returns from the crisis with the ever-after stabilized and the children safe, but without the friends Ku'Sox murdered. The old war between elven and demon power has become part of her personal future rather than distant history.",
         "in_short": "The ever-after is shrinking as magical energy drains through damaged ley lines, and the demons blame Rachel for creating the failure during her earlier struggle with Ku'Sox. Given little time to repair it, Rachel works with gargoyle Bis, Trent, Al, and her church partners to map the damage. Ku'Sox exploits the crisis, turning demon suspicion against Rachel and attacking the families closest to her. Ceri, Quen, Pierce, and the young girls Lucy and Ray are drawn into the conflict, making the repair effort a rescue as well as a struggle over the demons' survival. Rachel and Trent combine demon, elven, and ley-line knowledge to expose Ku'Sox's role and stop the collapse. Ku'Sox is defeated and the children are brought home alive, but Ceri and Pierce are killed. The ever-after stabilizes, while Rachel's use of elven methods strains her place among demons. Trent's commitment to her becomes personal and unmistakable, leaving them closer but facing the political consequences of an elf choosing a witch-born demon practitioner.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2482,7 +2482,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2495,7 +2495,7 @@
       "recaps": {
         "ending": "The Superiority's move on Evershore is beaten off, and the kitsen commit. What Jorgen went there hoping for turns into something larger than a rescue: humans, UrDail and kitsen come out of the fight as a working alliance rather than three isolated worlds each waiting its turn, and the taynix that were at stake stay out of Superiority hands. Jorgen's own cytonic ability, which he had been treating as a liability to be managed, becomes something he can use deliberately, in partnership with Alanik and with the slugs. The harder resolution is personal: he stops trying to be the officer who follows every instruction from Detritus and accepts that leading means deciding, including deciding against his own government when it is wrong, and he finally lets himself grieve. The Assembly's authority over the DDF is left contested, which will matter. Winzik's war has not begun in earnest, the delvers remain the threat behind everything, and Spensa is still gone. What has changed is that the coalition needed to face all of it now exists.",
         "in_short": "Word comes from Evershore, homeworld of the kitsen, and Jorgen takes Skyward Flight and Alanik there, hoping to turn a possible ally into a real one before the Superiority settles the question for them. He finds a species governed by a senate that debates everything and decides nothing, a Superiority force already present, and a stake neither side will give up: the taynix, on whose teleporting the whole war now turns. Jorgen has to negotiate, fight and learn to use his own cytonic abilities at the same time, while carrying a recent death in his family and a National Assembly at home that wants him obedient rather than effective. The Superiority attack is repulsed, the kitsen join, and humans, UrDail and kitsen end the book as an alliance. Jorgen comes out of it having accepted that leadership means making the decision himself, and having finally allowed himself to grieve.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2652,7 +2652,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2665,7 +2665,7 @@
       "recaps": {
         "ending": "Rachel turns the conflict between demon practitioners back on Lee Saladan. Algaliarept takes Lee as his familiar, removing Lee from the human struggle and ending his immediate threat to Rachel and Trent. The outcome prevents Al from claiming Rachel in the same way at this point, but it does not erase her demon marks or the demon's continuing interest in her. Rachel also learns that her history with Trent began in childhood: her father worked with Trent's father, and the Kalamack family's hidden genetic program was connected to treatment that saved Rachel from Rosewood syndrome and to Trent's own survival as an elf. The knowledge replaces a simple criminal rivalry with an inherited, deeply personal connection, without establishing trust between them. Rachel accepts that Nick has left their relationship and begins a romance with Kisten. Ivy remains emotionally unstable as Piscary's old influence and the vampire power struggle persist, but she and Rachel keep their partnership. Ceri continues building an independent life, and Vampiric Charms survives the case.",
         "in_short": "Rachel must pay the service she owes demon Algaliarept, relying on Ceri's ancient knowledge to survive the encounter without becoming his permanent property. Piscary's imprisonment has unsettled Cincinnati's vampires and strained Ivy and Kisten, while Nick's absence leaves Rachel's old relationship collapsing. Trent Kalamack hires Rachel for protection against Lee Saladan, a rival with his own command of demon magic. Working close to Trent exposes links between their families that he has long withheld. Lee tries to manipulate the competing demon bargains and turn Rachel's connection to Al against her. Rachel ultimately redirects Al's claim: the demon takes Lee as his familiar, ending Lee's immediate threat but leaving Rachel marked and still of interest to the demon world. Rachel learns that her father worked with Trent's father and that the Kalamacks' genetic work was involved in saving her from Rosewood syndrome when she was a child. She accepts Nick's departure and begins a relationship with Kisten, while her partnership with Ivy and Jenks continues amid unresolved vampire instability.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2845,7 +2845,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2858,7 +2858,7 @@
       "recaps": {
         "ending": "The message from Dr. Melissa Francis leads Maddy to obtain an independent medical assessment. The evidence shows that she does not have SCID and never received the diagnosis that defined her childhood. Her immune system is vulnerable because of lifelong isolation, but the sealed house itself created much of that vulnerability. Records and family history reveal that Pauline, shattered by the deaths of her husband and son, became convinced that she had to protect her remaining child from every danger and constructed the illness around that fear. Carla returns and helps Maddy face the truth. Maddy leaves the house and begins learning to live with ordinary uncertainty; she cannot restore the stolen years or immediately repair her trust in her mother, though she comes to understand the grief behind Pauline's actions. Olly's mother takes him and Kara away from their abusive father, and they move to New York. Maddy flies there on her own and arranges a reunion with Olly in a bookshop, using one of her characteristic book notes to lead him to her. The two meet again, while Maddy chooses an open life whose real risks are no longer confused with a fabricated disease.",
         "in_short": "Eighteen-year-old Maddy Whittier has supposedly lived with SCID since infancy and cannot leave her sealed home. When Olly Bright moves next door, they begin messaging; nurse Carla secretly permits meetings, and the teenagers fall in love. After Maddy's doctor mother Pauline discovers them and fires Carla, Maddy decides that a short life fully lived is worth more than endless confinement. She falsely claims access to an experimental treatment and takes Olly to Hawaii, where they explore, become intimate, and then face Maddy's medical collapse. Back home, she cuts Olly off until the Hawaii doctor reports that Maddy's records do not support a SCID diagnosis. Independent testing and missing documentation reveal that Pauline, traumatized by the deaths of Maddy's father and brother, invented the illness and kept her daughter isolated. Maddy begins life outside and later flies alone to New York, where Olly has moved after his family leaves his abusive father. They reunite in a bookshop.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3015,7 +3015,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3028,7 +3028,7 @@
       "recaps": {
         "ending": "Lydia's last night is finally shown from her own perspective. Crushed by her parents' incompatible hopes, frightened by Nath's approaching departure, and aware that Jack cannot give her the kind of affection she sought, she rows onto the lake. She decides that reaching shore by herself will prove she can begin again, but she cannot swim and drowns after leaving the boat. No one in her family learns the complete sequence. James returns after nearly abandoning the marriage, and he and Marilyn begin to recognize the pain beneath one another's choices. At the lake, Nath attacks Jack, still blaming him for Lydia's death. Hannah intervenes and understands that Jack's attention has always been fixed on Nath, not Lydia. Nath is pulled from the water and sees Hannah clearly, perhaps for the first time. The Lees remain wounded and without a complete answer, but their habitual silences have been disturbed and the surviving family members begin to turn toward one another.",
         "in_short": "In 1977 Ohio, sixteen-year-old Lydia Lee is found dead in the lake near her home. Her Chinese American father James believed she possessed the popularity he had always lacked; her mother Marilyn expected her to become the doctor Marilyn never became. Their grief exposes the history of a marriage shaped by race, gender, thwarted ambition, and silence, while Lydia's brother Nath blames their neighbor Jack and younger Hannah watches what everyone else misses. Flashbacks reveal that Lydia had pretended to meet both parents' expectations while becoming increasingly isolated and desperate over Nath's planned departure. Jack was not her lover: he cared for Nath and had tried to tell her so. On her last night Lydia rowed out alone, resolving to master her fear and start over, but fell into the water and drowned because she could not swim. James and Marilyn nearly separate after her death, then begin to face each other honestly. Nath attacks Jack at the lake, Hannah stops him, and the surviving Lees take a tentative first step away from the patterns that made Lydia invisible to them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3169,7 +3169,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3182,7 +3182,7 @@
       "recaps": {
         "ending": "Onegin writes repeatedly to Tatyana and receives no answer. He finally enters her rooms unannounced and finds her reading one of his letters in tears. Tatyana acknowledges that she still loves him, but she also contrasts his present pursuit with his rejection of her when she was an unknown country girl. She suspects that her elevated social position has helped awaken his desire. Whatever her private feelings, she has married and will not betray her husband. She leaves Onegin stunned and alone. Her husband then enters, and the narrator breaks off the story without arranging a reconciliation or a new beginning. Lensky remains dead, Olga has long since married another man, and Tatyana chooses fidelity and self-command over the romantic fulfillment she once sought. Onegin is left to confront both the finality of her refusal and the consequences of his earlier emotional detachment.",
         "in_short": "Bored St Petersburg aristocrat Evgenii Onegin inherits a country estate and befriends the idealistic poet Vladimir Lensky. Through Lensky he meets the Larin sisters: Lensky's cheerful fiancée Olga and the reserved, imaginative Tatyana. Tatyana falls in love with Onegin and writes him an unguarded confession, but he rejects her in a cool lecture. Later, irritated at a crowded name-day celebration, Onegin flirts with Olga to punish Lensky. The insult leads to a duel that neither friend has the courage to stop, and Onegin kills Lensky. He leaves Russia to travel; Olga soon marries someone else. Tatyana studies Onegin's books, begins to understand the poses behind his personality, and is taken to Moscow, where she marries a prince. Years later Onegin meets her as an assured society figure and falls desperately in love. Tatyana admits she still loves him, but refuses to betray her husband, leaving Onegin alone with the consequences of his past choices.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3367,7 +3367,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3380,7 +3380,7 @@
       "recaps": {
         "ending": "Poirot shows that Patrick and Christine Redfern committed the murder together, and that they are not the mismatched pair they appeared to be but partners who had worked the same scheme before, on a woman killed some years earlier. Patrick made a profession of courting rich women and taking their money; Arlena had been giving him large sums, believing herself in love and being quietly blackmailed as well. The timetable that protected them was manufactured. Christine went down to Pixy Cove ahead of the discovery, wearing a hat and with her white skin darkened, and lay on the beach in Arlena's place so that Patrick, rowing round with Emily Brewster as his witness, could point out a body that was still alive. While Emily went for the police, Christine slipped away and Patrick brought the real Arlena out of the cave where she had been persuaded to hide, killed her, and left her exactly where the false body had lain. Christine had also altered the time on Linda Marshall's watch to cover her own movements, and washed off the darkened skin in a bath at the hotel. Linda's wax figure and her attempt on her own life were unconnected with the crime, and she is saved and cleared of the guilt she had taken on herself. Horace Blatt's business on the island proves to be smuggling rather than murder. Kenneth Marshall is left free, and he and Rosamund Darnley come to an understanding.",
         "in_short": "Poirot holidays at a hotel on a small island off the Devon coast, where the guests are absorbed by the presence of Arlena Marshall, a former actress whose open flirtation with Patrick Redfern is watched by his quiet wife Christine, by Arlena's reserved husband Kenneth, and by his hostile teenage daughter Linda. One morning Arlena paddles off alone on a float and is found strangled on the beach at a nearby cove by Patrick and another guest rowing round the island. The medical evidence fixes the death within a narrow span in which nearly everyone can be accounted for. Poirot pursues oddities: a bath drawn by an unknown person, a bottle thrown from a window, a hidden cave, letters showing Arlena had been paying a man large sums, and Linda's dabbling in witchcraft, which leads the girl to attempt suicide in the belief that she caused the death. Poirot proves that Patrick and Christine Redfern killed Arlena together for her money, using Christine as a false corpse to falsify the time. Kenneth Marshall is cleared and turns to an old friend, Rosamund Darnley.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3556,7 +3556,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3569,7 +3569,7 @@
       "recaps": {
         "ending": "Cornered at last by the spirit-wraith, Drizzt refuses to treat it simply as an enemy and fights while speaking to his father, refusing to let the thing in front of him be only a weapon. The appeal works: Zaknafein's own will surfaces long enough to break Matron Malice's control, and he ends the body himself rather than be used against his son a second time. Zin-carla fails, and with it Malice's last claim on the Spider Queen's patience; Lolth abandons her and transforms her into a drider, the half-spider punishment the goddess keeps for matrons who disappoint her. House Do'Urden is left broken, but the city has not forgotten Drizzt and will not. Drizzt accepts that anywhere he settles in the Underdark becomes a target, and that Blingdenstone has already paid for sheltering him. Clacker is dead, and the deep gnomes would take him back. He refuses. He says goodbye to Belwar, who tells him the gnomes' doors will stay open, and turns toward the tunnels that lead up, intending to find the surface world he glimpsed once on a raid and to learn whether anything there will have him.",
         "in_short": "Ten years after fleeing Menzoberranzan, Drizzt Do'Urden survives alone in the Underdark by surrendering to a purely instinctive killing state, and realizes he is losing himself to it. Seeking company, he reaches Blingdenstone, the city of the deep gnomes, where he is recognized and vouched for by Belwar Dissengulp, a burrow warden his own patrol once maimed and whose life he argued to spare. He also befriends Clacker, a peaceable creature cursed into the body of a tunnel predator. Meanwhile his mother, Matron Malice, is out of favor with the Spider Queen because Drizzt lives, and a rival house makes war on hers. Having destroyed that rival, Malice is granted Zin-carla: the animated corpse of Zaknafein, Drizzt's father, driven by her will to hunt him down. The chase kills Clacker. In the final confrontation Drizzt reaches his father through the thing controlling him; Zaknafein destroys the body himself, Zin-carla fails, and Lolth turns Malice into a drider. Unwilling to endanger Blingdenstone any further, Drizzt leaves Belwar and begins the long climb toward the surface world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3883,7 +3883,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774249170",
@@ -3895,7 +3895,7 @@
       "recaps": {
         "ending": "At dawn, the void mist burns away and the surviving attackers are killed or driven off. Bravers Guild wins its first Shiverglades incursion and receives a 48-hour Home and Hearth benefit that recognizes its settlement claim. Hal survives injured and reunites with Noth. Besal voluntarily returns control after helping defeat Rinbast's scarred counterpart, and their three Communions leave them as willing partners with deeper access to one another's memories and power. Hal inherits the dead counterpart's soul and abilities and has promised to free the other counterparts held by Rinbast. The victory does not restore everyone. Komachi's frightened burst has removed Ashera, Elora, Durvin, Vorax, and more than a dozen defenders to an unknown place. Noth intends to organize the search. Mira is alive after spending the gold dragon's scale power, though her instability within Aldim remains unresolved. The settlement has only a brief period to recover and repair, while the foreign Copper Coaltheel, the ancient council, Rinbast, and future Shiverglades attacks remain open threats.",
         "in_short": "Hal leads a refugee caravan into the Shiverglades to found a free settlement beyond Rinbast's control. He saves Ashera from Broken Faith, establishes Bravers Guild, secures a monoseed, and plants it as a mana tree that anchors the new refuge and ties both Hal and Noth to its survival. Local allies, a trapped gold dragon, and the guild's combined labor help prepare for the region's first assault. During a separate quest, Hal completes three Dark Communions with Besal and attracts the attention of an ancient Coaltheel council. The settlement survives a void-driven siege, but Komachi teleports Ashera, Elora, Durvin, Vorax, and other defenders to an unknown destination. Hal and Besal defeat Rinbast's void-corrupted scarred counterpart, with Besal rejecting ascension and choosing Hal as his brother. Dawn ends the incursion, leaving the guild with a temporary claim, missing friends to recover, and Hal's promise to free Rinbast's other captive counterparts.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4101,7 +4101,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4114,7 +4114,7 @@
       "recaps": {
         "ending": "Mensah is freed and GrayCris's last attempt at leverage fails: the company is exposed at TranRollinHyfa, and with the arbitration already lost, it has nothing left to trade. The rescue nearly costs the SecUnit everything - it takes catastrophic damage destroying the Combat SecUnit sent after them, and what survives has to be rebuilt during the trip out. Pin-Lee, Ratthi and Gurathin get everyone onto a transport bound for Preservation. Aboard, the humans treat the SecUnit as one of them, and Mensah, dealing with the aftereffects of being held hostage, makes clear that she holds its contract only as a legal shield and that its choices are its own. The SecUnit, which has spent three books running from exactly this, admits it does not want to leave. It goes with them to Preservation Station, where it has no legal category, no fixed job description, and a great many people who would like to talk to it about its feelings. The immediate threat is over; what is unresolved is what a free construct is supposed to do with itself, and whether it can live among people who like it.",
         "in_short": "Carrying evidence of GrayCris's illegal salvage back to Preservation, the SecUnit learns from the newsfeeds that Dr. Mensah has been taken hostage by the company and is being held at TranRollinHyfa, a corporate station. It diverts there, works its way past scans built to catch constructs, and finds Pin-Lee, Ratthi and Gurathin already attempting a legal rescue that is going nowhere. Working with them, it locates Mensah, gets her out of GrayCris's custody, and turns the extraction into a running fight when station security is turned against them. GrayCris, financially ruined by the arbitration, throws combat bots and a military-grade Combat SecUnit at them; the SecUnit destroys it and is nearly destroyed in return. The group escapes on a transport bound for Preservation, the hostage plan collapses, and the SecUnit is rebuilt on the way out. Mensah, recovering from her captivity, tells it plainly that it is a person and that the contract she holds exists only to shield it. For the first time the SecUnit chooses company, and goes with them instead of vanishing.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4240,7 +4240,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4253,7 +4253,7 @@
       "recaps": {
         "ending": "In Marin, Nadia and Saeed finally acknowledge that the love which carried them out of their city no longer fits the people they have become. They separate gently. Saeed grows close to the preacher's daughter and remains connected to faith and migrant service, while Nadia stays with the cooperative and pursues relationships and work on her own terms. The narrative then moves fifty years ahead. Nadia returns to their transformed home city and meets Saeed in a café. Both have lived long lives apart. They remember their youth without attempting to restore it, and Saeed suggests that they might someday visit the Chilean desert to see the stars. They part with the possibility left open, their reunion affirming the importance of their shared past while accepting that migration, time, and choice have carried them into different futures.",
         "in_short": "In a city falling into civil war, reserved Saeed and fiercely independent Nadia fall in love. As militants seize control and Saeed's mother is killed, the couple use a mysterious door that transports them to Mykonos, joining a worldwide movement of refugees through portals that ignore borders. They later pass to London, where migrants occupy an empty mansion and face violent hostility before a labor-and-housing settlement forms. Moving again to Marin, California, they discover that exile has changed them differently: Saeed seeks faith, community, and cultural continuity, while Nadia embraces new work, friendships, and relationships. They separate with affection rather than betrayal. Fifty years later they meet in their old city, now peaceful and altered, and recall who they were together. Their tentative plan to see the stars leaves them connected by memory even after their lives have diverged.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/expanse.json
+++ b/data/works-community/0/expanse.json
@@ -277,7 +277,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -290,7 +290,7 @@
       "recaps": {
         "ending": "Felix removes the divine flesh curse from the imprisoned primordial, kills Haim, and shares the purified power with Pit and several allies. Atar rejects the Highest Flame's demand for service, absorbs it into his damaged core, and destroys the paladins' relay ships, but ends gravely injured with the flame still pressing him. Felix then challenges the fire Grandmaster for territorial authority. He completes his body tempering, kills the Grandmaster, and wins the claim, but outside interference turns his attempt to transform the desert's mana crystals into a vast flood. Pit completes his evolution as a speaking Primordial Stormwing and helps save the unconscious Felix from drowning. The Minotaur and his undead companion remain with him as a bone ship offers transport toward medical aid. Zara Cyrene, Vessilia Dayne, Evie Aren, Harn, Darius Reed, and Alistair survive the city conflict. Felix is publicly proclaimed ruler of the city territory and adjacent desert while unable to govern either. Nagast remains under Karys Taiv's administration, Harwatch remains its exposed vassal, the Pathless still knows of Felix, and both the flooded city and Atar's captive flame require resolution.",
         "in_short": "Felix Nevarre fortifies Nagast, gains Henaari allegiance, and learns that nine Unbound were summoned as possible weapons against the Ruin. When Zara locates another Earth-born Unbound in the Scorched Expanse, Felix leads a mixed rescue force through an ancient shadow gate. The expedition wins the allegiance of a submerged naga temple, crosses the desert, survives curse-driven undead, and enters a city whose rulers are sacrificing residents to sustain the Highest Flame. Felix finds the young Minotaur while his allies free prisoners and revolt against the council. In the royal tomb, Pathless paladins dismantle a primordial prison to seize its power. Felix removes the creature's divine flesh curse, kills Haim, and redirects its power to his allies. Atar contains the Highest Flame and destroys the paladin relay ships. Felix then kills the fire Grandmaster in an authority duel and claims the territory, but his altered crystal-working floods the desert. Pit evolves into a speaking Primordial Stormwing and saves the unconscious Felix, who ends the book aboard a rescuing bone ship and in urgent need of treatment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -626,7 +626,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -639,7 +639,7 @@
       "recaps": {
         "ending": "Silas's coalition destroys the Order force occupying Basetown. Alana keeps the Ascendant arbiter engaged while the allies eliminate the remaining Order members, but a void fey captures Tad and critically damages Lexa. Tad escapes, Decimus kills the captor, and Silas plants a seed of the Ways in Lexa's core to stabilize her. Urg disrupts the returning arbiter's control, Silas makes the arbiter temporarily mortal, and Urg kills him. Decimus then becomes too dangerous after consuming the void fey, so the coalition kills the demon. Samvek absorbs Decimus's chaotic Vitae and is left unconscious, though Silas later wakes him. Silas restores many fallen adventurers and civilians, but Basetown still needs extensive reconstruction. Lexa begins a slow, altered recovery. Tad stays with Selena, Clay, Farah, Oliver, Spot, Violet, and the other Fae-system allies while Tad's father waits nearby and the Lawgiver remains a future threat. Ryan's distress call leads Silas to depart for the Divided Realms with Samvek and Azuria.",
         "in_short": "Stranded in the Fae system with Selena and Samvek, Silas Renner follows the trail of manufactured magic to Tad, a hidden prince of the Summer and Void courts. Their alliance awakens local defenders, creates two powerful multisystem golems, and challenges the Order's control of Basetown. Silas also transforms Samvek into his first architect-linked Horseman, gains Urg's permanent presence across system barriers, and refuses a binding offer from the Ways before earning a looser alliance through a deadly solo dungeon trial. The Order takes Basetown's non-humans hostage, drawing the coalition into battle. Alana helps occupy the Order arbiter while Tad survives a separate abduction. Silas stabilizes the critically wounded Lexa, and Urg kills the arbiter after Silas strips away its protection. Decimus kills Tad's captor but becomes a new threat and dies, leaving Samvek contaminated by demonic Vitae. With Basetown liberated but damaged, Silas leaves with Samvek and Azuria to answer Ryan's cross-void distress call.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -932,7 +932,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -945,7 +945,7 @@
       "recaps": {
         "ending": "The Macros retrieve the surviving expedition after the portal event collapses the Helios hive. A giant worm attacks during loading and kills Major Robinson, while the transport departs with its hold still open and causes further casualties. Fewer than 2,000 members of the original force escape, carrying only part of their equipment. Kyle Riggs, Sandra, Kwon, and Captain Roku survive, with Sandra the only remaining member of Riggs's command staff. She is deeply affected by having ended the suffering of Marines who were dying from worm poison and asks not to accompany Riggs on another campaign. On Earth, Admiral Crow and Lieutenant Colonel Barrera remain responsible for rebuilding Star Force's fleet, production, and ground strength. Alamo and the original Nano fleet are still gone, China remains devastated, and the Venus ring and suspected gateway near Tyche remain important but poorly understood. Earth has completed the immediate troop obligation but is still subject to the power and travel restrictions of the Macros. Riggs leaves Helios convinced that the larger conflict sets machine forces against organic life, and he intends to prepare a broader resistance.",
         "in_short": "After Alamo and the Nano fleet abandon Earth, Kyle Riggs preserves Star Force through a government assault, reconciles with Admiral Crow, and rebuilds ships and ground forces. A scouting trip through the Venus ring reveals the network of the Macros but draws their vessels back to Earth, where China's attack provokes devastating retaliation. Riggs preserves the truce and delivers the promised expeditionary army. The Macros carry it to Helios to suppress an intelligent worm species inside an artificial mountain hive. Under threat of abandonment, Riggs's force reaches a central ring, which the Macros activate as a lethal portal. The hive collapses, and a giant worm attacks the evacuation, killing Major Robinson. Fewer than 2,000 people escape with Riggs, Sandra, Kwon, and Captain Roku. With Earth still constrained by the Macros, Riggs concludes that machines and organic life are engaged in a wider war and resolves to prepare resistance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1129,7 +1129,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1142,7 +1142,7 @@
       "recaps": {
         "ending": "The people in the mountain are not aliens and not monsters. They are humans who have had themselves surgically rebuilt for life off the planet, quietly stockpiling metal and building the machinery to launch themselves away from an Earth they do not expect to remain habitable. The same machinery could be aimed at a city, which is why Tally Youngblood treats them as a threat rather than a curiosity, and the confrontation at the site nearly kills Aya. In the end the truth is broadcast in full, including the corrections to Aya's first, sensational version, and the whole world learns at once both that the group exists and what it actually intends. Aya's face rank rises to a height she never expected and is not sure she wants, since fame turns out to cost as much as it pays. She makes her peace with the Sly Girls, whose trust she broke, and with Frizz, who cannot lie to her about any of it. Tally leaves as she came, warning that the freed cities are still capable of doing enormous damage without noticing, and that the world needs people willing to find out what is being hidden and say so. Aya ends the book as a kicker with a reputation, a working hovercam, and no shortage of things left to investigate.",
         "in_short": "A few years after the cure ended the pretty operations, Aya Fuse lives in a city where reputation is currency and everyone carries a face rank. Fifteen, obscure and ambitious, she works as a kicker, hunting stories for the feeds with her hovercam Moggle. To make her name she infiltrates the Sly Girls, a clique that despises fame and rides the tops of magnetic-levitation trains for the danger of it. On one run in the mountains the group sees strangers moving enormous quantities of metal into a hillside. Aya films them, calls them inhuman in the story she broadcasts, and becomes famous overnight, at the cost of the Sly Girls' trust. The story pulls in Tally Youngblood and her Specials. Investigating together, they find that the strangers are humans rebuilt for space travel, constructing launch machinery to leave the planet, machinery that could also be used as a weapon. The confrontation nearly kills Aya. The full and corrected story goes out to the world, Aya's rank soars, and Tally leaves with a warning that someone has to keep looking.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1320,7 +1320,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1333,7 +1333,7 @@
       "recaps": {
         "ending": "William Black explains that the key belonged to his father and opens a safe-deposit box; Oskar's father had bought the container in which Oskar found it and had been trying to return the key. The answer ends Oskar's citywide quest without creating the final message from his father that he wanted. Oskar admits that he concealed the answering machine with his father's last calls, and learns that his mother knew about his search and had quietly contacted the people he planned to visit so that he would be safe. Oskar's grandfather returns to New York. He and Oskar dig up Thomas's empty coffin and fill it with the grandfather's unsent letters. The grandfather then goes to the airport intending to leave, while the grandmother follows and refuses to let him disappear again. Back in bed, Oskar rearranges photographs of a falling man into reverse order and imagines time running backward until his father is home and the family is safe, an impossible vision that gives form to his wish to undo the loss.",
         "in_short": "Nine-year-old Oskar Schell, grieving his father's death on September 11, finds a key in an envelope marked with the name Black. Believing his father left him one last puzzle, Oskar visits people named Black throughout New York and is joined for part of the search by an elderly neighbor. Interwoven letters reveal that Oskar's grandfather lost his first love in Dresden, married her sister, abandoned the pregnant woman, and never met their son. The key eventually proves to belong to William Black's father; Oskar's father had acquired it by accident and was trying to return it. Oskar confesses that he hid his father's final answering-machine messages and discovers that his mother had known about and quietly protected his search. His returned grandfather helps him place years of unsent letters in the father's empty coffin. Oskar cannot recover his father or reverse history, but he ends with a fuller knowledge of his family's grief and love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1464,7 +1464,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1477,7 +1477,7 @@
       "recaps": {
         "ending": "The succession of private worlds ends and the injured visitors regain consciousness in the ordinary hospital created after the proton-beam accident. Their shared ordeal has disclosed that Charlie McFeyffe, one of the men involved in the loyalty inquiry, possesses the political allegiance that the investigators had been trying to pin on Marsha. The discovery does not restore Jack's faith in the weapons establishment or its security procedures. Unwilling to sacrifice his wife to preserve his position, he leaves that work behind. Bill Laws also refuses to remain confined to a menial role despite his scientific ability. Jack and Bill combine their technical skills in an independent electronics and high-fidelity business. The closing change is modest but concrete: after worlds ruled by dogma, enforced respectability, fear, and political conformity, they choose work based on practical cooperation and personal judgment.",
         "in_short": "Engineer Jack Hamilton and his wife Marsha join a tour of a proton-beam facility while Jack's employer investigates Marsha for suspected Communist ties. A malfunction drops eight people into the apparatus, and they awaken in a reality governed by literal religious belief. The survivors discover that the accident has linked them to one another's minds: as control passes between injured members of the group, the external world is rebuilt by a different person's convictions. They escape a universe of supernatural judgment only to enter worlds shaped by moral censorship, paranoid fear, and political conformity. By identifying the mind responsible each time and challenging its assumptions, Jack, Bill Laws, and the others eventually break the sequence and wake in the hospital. The experience exposes security officer Charlie McFeyffe's own hidden allegiance while leaving the case against Marsha without substance. Jack rejects the institution's demands and, with Bill, starts an independent electronics business.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1627,7 +1627,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1640,7 +1640,7 @@
       "recaps": {
         "ending": "Lucy discovers that Faber is not merely a shipwreck survivor but the German agent carrying proof that the Allied force aimed at Calais is a deception. David confronts him and is killed, leaving Lucy as the only person on the island able to stop the intelligence from reaching Germany. She protects her son, resists Faber's attempts to control the household, and prevents him from completing his escape and communication. Their final struggle ends with Faber dead before he can deliver his photographs. Godliman and Bloggs reach the island after following the agent's route, but Lucy has already preserved the secret on which the coming invasion depends. Germany receives no reliable correction to the false picture of Allied intentions, so the deception remains intact and the Normandy landings can proceed without Faber's warning changing the defenders' plans.",
         "in_short": "In 1944, German agent Henry Faber uncovers the central Allied deception protecting the planned invasion of Normandy: the army apparently assembling to attack Calais is largely fictitious. He photographs the evidence and races north while British investigators Percival Godliman and Frederick Bloggs reconstruct his identity and pursue him. A storm wrecks Faber's escape boat near an isolated Scottish island occupied by embittered former pilot David Rose, his lonely wife Lucy, and their son. Lucy and Faber become lovers before David discovers the spy's secret and is killed in a confrontation. Once Lucy understands both the murder and the importance of Faber's photographs, she turns against him. She prevents him from transmitting the intelligence or escaping to German help, and Faber dies in the final struggle. The British deception survives, leaving Germany unprepared for the true invasion route.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1807,7 +1807,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1820,7 +1820,7 @@
       "recaps": {
         "ending": "Claire discovers that Kim has secretly gathered recordings of Morganville's vampires, creating evidence that could expose the town and endanger everyone shown. The project also leaves Kim trapped in consequences she cannot control. Claire, Shane, Eve, and Michael recover Kim and secure the material before it can escape Morganville. At the same time, the failures in Myrnin's portal system are traced to Ada. Her possessiveness toward Myrnin and hostility toward Claire have escalated into deliberate attacks, making the preserved intelligence too dangerous to leave in control of the town's machinery. Claire and Myrnin stop Ada; Myrnin accepts the loss of someone he once loved and disables the system that sustained her. The immediate threats from both surveillance and the portal network are contained, though neither resolution leaves the people involved untouched. Michael's music attracts a serious recording opportunity, and Amelie agrees to let him and his friends leave Morganville under controlled conditions. Glass House finishes the book together, preparing for a rare journey beyond the town.",
         "in_short": "After Bishop's defeat, Claire tries to resume university, life at Glass House, and her scientific work with Myrnin. Eve introduces Kim, a filmmaker with a past connection to Shane, and Claire's jealousy gives way to a more serious concern: Kim is covertly recording Morganville's vampires. Her footage could expose the town and brings danger down on Kim herself. Meanwhile Ada, the preserved human intelligence controlling Myrnin's hidden portal system, grows jealous of Claire and turns malfunctions into targeted attacks. Claire and her friends find Kim, recover the secret recordings, and prevent the material from leaving Morganville. Claire and Myrnin then confront Ada and disable the dangerous system, forcing Myrnin to lose the consciousness of a woman he once loved. With the crises contained, Michael receives a genuine recording opportunity. Amelie permits Michael, Eve, Shane, and Claire to travel outside Morganville under strict terms, giving the reunited Glass House household a new destination beyond the town.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2222,7 +2222,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774241544",
@@ -2234,7 +2234,7 @@
       "recaps": {
         "ending": "Erin and Ryoka are reunited in Octavia's city after Toren strands Erin far north of Liscor. Ryoka brings an instructional magic tome obtained from the dragon, offering a possible answer to the Silverfang tribe's need for a worthy gift, though the enormous debt itself is unpaid. Erin remains responsible for the former thief and the white-furred gnoll child, and her alchemical experiments are now subject to Octavia's supervision. Toren has exploited his binding, abandoned Erin, killed two travelers, and set out for Liscor's dungeon.\n\nRags captures and burns a city while ordering her force to spare unarmed people who flee. She rejects Garen's proposed assault on Liscor and marches north to join the larger goblin movement. At Liscor, adventurers enter the newly exposed dungeon, triggering exceptional danger alarms far away. Flos has declared war on the Empire of Sands, Magnolia Reinhart is consolidating Earth arrivals and military strength, and Az'kerash completes a flying undead war-beast while sending two servants to find Ryoka. The book ends with Erin and Ryoka together, but with their home, allies, and several expanding conflicts still exposed.",
         "in_short": "Erin rebuilds The Wandering Inn as a refuge and business while Ryoka undertakes a perilous delivery to Az'kerash and returns maimed from rescuing a young gnoll. Ceria, Pisces, Yvlon, and Ksmvr re-form the Horns of Hammerad, Pawn finds faith, and Rags unites local goblin tribes while resisting Garen's demand to attack Liscor. Erin's protection of goblins estranges Relc, and the destruction of Krshia's magical books leaves a vast debt to the Silverfang tribe. Toren's growing autonomy turns into rebellion when he abandons Erin and kills travelers on his way toward Liscor's dungeon. Ryoka secures a dragon's instructional magic tome for the gnolls and reunites with Erin in Octavia's city. Rags burns another city but spares fleeing civilians and marches north. The newly opened Liscor dungeon triggers warnings across the continent, while Flos begins a war and Az'kerash prepares an undead campaign and sends servants after Ryoka.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2390,7 +2390,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2403,7 +2403,7 @@
       "recaps": {
         "ending": "Montag's break with his old life becomes final and violent. His wife, Mildred, betrays him by reporting their books and abandons him, and Captain Beatty forces him to set fire to his own home. When Beatty finds the earpiece linking Montag to Faber and threatens to hunt the professor down, Montag kills Beatty with the flamethrower and destroys the Mechanical Hound, though it wounds him. Now a fugitive, he flees while the city watches a live televised chase. He frames another fireman by hiding books in his house, warns and parts from Faber, and escapes by floating down a river into the countryside. There he meets Granger and a community of educated exiles who have each committed a book to memory, preserving literature in their minds until it can be printed again. To end the manhunt cleanly for its audience, the authorities kill a random passerby on camera and announce that Montag is dead. Enemy bombers then destroy the city in a sudden war. Montag and the exiles, having survived, turn back toward the wreckage, intending to rejoin what remains of humanity and help build a society that might learn to value books and memory. The story closes on cautious hope rather than triumph.",
         "in_short": "Guy Montag is a fireman in a future America where firemen burn books and the homes that hide them, and where people are kept docile by wall-sized television and constant noise. A curious young neighbor, Clarisse, and an old woman who burns herself alive with her books lead Montag to question his work, and he begins secretly saving books. His captain, Beatty, suspects him and lectures him on why books were outlawed. Montag turns to Faber, a retired professor, who guides him through a hidden earpiece. After Montag reads poetry to his wife's friends and his wife reports him, the firemen come to burn his own house. Montag kills Beatty, destroys the robotic Hound sent after him, and flees the city as a televised manhunt pursues him. He escapes downriver and joins a group of exiles who each memorize a book to keep it alive. The authorities fake his capture on television, and enemy planes bomb the city to rubble; the survivors set out to help rebuild.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2531,7 +2531,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2544,7 +2544,7 @@
       "recaps": {
         "ending": "The joint American-Soviet effort destroys most of the accidental attack force, but Grady's surviving bomber reaches Moscow and releases its weapons. The Soviet capital is annihilated. To convince the Soviet Premier that the strike truly was an accident and remove the strategic advantage created by Moscow's destruction, the President carries out the guarantee he offered earlier: the United States will destroy one of its own comparable cities. He chooses New York and orders General Warren Black to make the attack. Black obeys despite knowing that his wife and children are in the city. After dropping the bombs, he takes poison, and the recurring bullfight image that has haunted him finally becomes clear as an image of his own role and death. New York is destroyed along with Moscow. The exchange prevents immediate escalation into a general nuclear war, but only through the deliberate sacrifice of millions of Americans to restore a balance both governments can accept. The President and Premier remain in contact, left to contain the consequences of a catastrophe produced not by an intentional first strike but by automation, doctrine, and systems too rigid to recall the people carrying out their orders.",
         "in_short": "A technical failure sends Colonel Jack Grady's nuclear bomber group beyond its fail-safe point with an authenticated order to attack Moscow. Jamming and strict security procedures make the crews reject every recall as possible Soviet deception. President of the United States tells the Soviet Premier the truth, shares flight information, and helps Soviet defenses attack the American planes. At Strategic Air Command, General Bogan struggles to regain control while Colonel Cascio tries to force a more aggressive response. Most bombers are stopped, but Grady reaches Moscow and destroys it. To prove the attack was accidental and prevent all-out retaliation, the President honors a terrible pledge: General Warren Black bombs New York, where Black's own family lives, creating an equivalent American loss. Black then kills himself. Moscow and New York are gone, and a wider nuclear exchange is avoided, exposing how machinery, inflexible orders, and deterrence logic can turn a small error into mass destruction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2846,7 +2846,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BDNMLGFW",
@@ -2858,7 +2858,7 @@
       "recaps": {
         "ending": "The entropy reversal restores Valkyrie, the Flying Dutchman, and their crews after their apparent destruction, but it does not reach the Star Team Alpha casualties at the remote dock. Smythe, Chief Ruiz, Lieutenant Ito, Gunnery Sergeant Nuftal, and the other dead operators remain lost. Frey survives without part of one leg, and Margaret Adams survives the loss of both legs and her left arm. The adaptable Elder fulfills the bargain and re-ascends. The primary ascension machinery is permanently disabled, making the two backup sites useless and preventing the Elders from returning to this reality. Skippy also defeats their last attempt to reverse power through the wormhole network and devastate the galaxy. Bishop, Skippy, Simms, Chang, Nagatha, Bilby, and the restored crews escape before the site explodes. The Flying Dutchman carries Alpha as the group heads toward Earth. Earth has lost its Sentinel deterrent, though Guardian machines may offer partial protection, and its replacement-Sentinel claim remains a bluff. The physical galactic barrier still stands, but the probability protection associated with the unreachable Elders may no longer guard against the danger linked to NGC 1023. A receiver built inside the galaxy remains the principal open risk. Bishop and Skippy continue as partners.",
         "in_short": "A hostile Elder AI's signal alerts the ascended Elders and reactivates their control network. Bishop and Skippy escape Rindhalu territory, destroy the pursuing AI Echo, and seek Skippy's former allies, only for the Elders to erase those AIs with a factory reset. Skippy exploits the reset to destroy the new hostile AI population, but the same signal disables the Sentinel network and leaves Earth exposed. The crew locates Unit 333's hidden Elder ship, Alpha. Star Team Alpha captures its dock at devastating cost, including Smythe's death and catastrophic injuries to Frey and Adams. At the primary ascension site, Skippy offers an adaptable Elder permanent separation from this reality in exchange for restoring Valkyrie, the Flying Dutchman, and their crews. The bargain succeeds, the ascension machinery is permanently disabled, and Skippy blocks a final attempt to destroy the galaxy's wormholes. The surviving crews head toward Earth with Alpha while the external NGC 1023 threat remains unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3002,7 +3002,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3015,7 +3015,7 @@
       "recaps": {
         "ending": "By the close, Levana has everything she set out to take and none of it in a form anyone would envy. Channary dies, leaving her infant daughter Selene as queen and Levana as regent. Rather than surrender the throne when the child comes of age, Levana arranges the nursery fire that is meant to kill her niece, and Selene is declared dead. Levana is crowned queen of Luna in her own right. During the same years she sets in motion the two programmes that will define her reign: a bioengineered plague, developed as a weapon to be released on Earth and then cured on Lunar terms, and the surgical soldier programme that takes children from the outer sectors and rebuilds them for an invasion. Her marriage to Evret ends with his death, and Levana keeps his daughter Winter as her stepdaughter and her ward. Years later, Winter, who has grown into the beauty her stepmother could only manufacture, cuts her own face rather than be valued for it - a refusal Levana never understands. Nothing in Levana's own account of any of this is presented as a crime. The novella closes with her secure, glamoured, unloved and completely certain that she has been wronged.",
         "in_short": "Levana Blackburn is fifteen, the younger and unloved princess of Luna, whose elder sister Channary holds the throne and treats her as a joke. Beneath a glamour she never lets slip, Levana is scarred from a childhood burning her sister caused. She fixes on Evret Hayle, a married palace guard, and when his wife Solstice dies in childbirth she uses her Lunar gift to manoeuvre the grieving widower into marrying her, taking his infant daughter Winter as a stepdaughter. Channary bears a daughter, Selene, and then dies, leaving Levana as regent for a toddler queen. Unwilling to give up the throne, Levana arranges the nursery fire that is meant to kill her niece, and is crowned in her own right when the child is declared dead. In the same years she authorises the engineered plague intended for Earth and the programme that turns Lunar children into wolf soldiers. Evret dies, Winter grows up in her care, and Levana - telling the entire story herself - never once concedes she has done anything but what was necessary.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3181,7 +3181,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3194,7 +3194,7 @@
       "recaps": {
         "ending": "Frank determines that Shay killed Rosie on the night she and Frank planned to leave. Shay could not bear another person abandoning the family and attacked Rosie when she came to meet Frank, then concealed her body and suitcase. Kevin's later death was also Shay's work, committed after Kevin understood enough of the old crime to threaten him. Frank confronts Shay in the abandoned house and pushes him into admitting what he did, then allows Stephen Moran and the official investigation to take over rather than killing his brother. The truth breaks what remains of the Mackey family and confirms that Rosie's disappearance was never her rejection of Frank. Frank cannot restore the life they intended to have, but he begins dealing more honestly with his past and with the damage his secrecy has caused. He also tries to rebuild trust with Olivia and protect Holly without cutting her off from every part of his family history.",
         "in_short": "Undercover detective Frank Mackey returns to the Dublin street he fled after his sister reports that a suitcase belonging to his teenage girlfriend, Rosie Daly, has been found in an abandoned house. Frank and Rosie planned to run away to England in 1985, but she never met him, and he assumed she had left alone. Rosie's body is discovered, turning the old disappearance into a murder inquiry. Frank investigates unofficially while confronting his abusive father, demanding mother, estranged siblings, ex-wife Olivia, and daughter Holly's growing interest in the family. After his younger brother Kevin dies, Frank realizes the danger is still inside the Mackey household. His older brother Shay killed Rosie to stop her taking Frank away and later killed Kevin to preserve the secret. Frank obtains Shay's admission and leaves him to the police. The solution destroys the family's remaining illusions but lets Frank begin facing his past instead of simply fleeing it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/fallen-sepulchre.json
+++ b/data/works-community/0/fallen-sepulchre.json
@@ -477,7 +477,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1772308307",
@@ -489,7 +489,7 @@
       "recaps": {
         "ending": "All Animus Seals have fallen, and the ancient invaders have reached their homeland with their underground forces still available. Their ruler survives Kael's attack and has captured Dominic's alchemist, giving the invaders access to a weapons specialist even though Dominic's cannon fleet escaped. Kael is alive and reunited with Ember and Max, but the demon queen's mark, her toxin, his conflicting token bargains, and centuries of trauma remain unresolved. After the ancient ruler kills Eva, Ember becomes Fae high matriarch and leaves to defend the Fae homeland. Queen Bael rules Sethos while publicly accommodating the invaders and covertly seeking resistance allies. Gideon has been released and sent south under another wizard's command, but Kassik's freedom still depends on Kael completing the dragonkin succession bargain. Kael, the released old god, and the vampire ally intend to seek the lost people for knowledge against the invaders. Kael ends the book critically wounded after jumping to Ember for help.",
         "in_short": "Kael dies and enters the afterlife, where collecting twelve realm tokens becomes his only route home. Demon bargains, a false paradise, and centuries of training leave him powerful but unstable when he returns to a living world that has experienced only about a year. Ember and Max survive, while ancient invaders attack the Animus Seals and manipulate regional wars. The Princess of Sethos becomes Queen Bael after retaking her city. Kael reunites with Ember and Max but nearly kills them under the influence of trauma and a demon toxin. The ancient ruler sacrifices Eva to open the final seal, freeing every imprisoned force and an old god. Ember becomes Fae high matriarch as the resistance divides among homeland defense, alliance-building, and a search for the lost people. Dominic escapes the invaders' betrayal, but his alchemist is captured. Kael fails to kill the ancient ruler, suffers a critical neck wound, and jumps to Ember for aid.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -835,7 +835,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002V5IRNY",
@@ -847,7 +847,7 @@
       "recaps": {
         "ending": "Home reaches the Orient side of the wormhole intact, ending Van Atta's immediate pursuit but opening a legal confrontation. The quaddies now govern themselves aboard the captured D-620 and converted Cay Habitat, with an isolated settlement still their goal. Tony is reunited with Claire and Andy. Ti Gulik remains their jump pilot, Warren and Ivy Minchenko are aboard, and Mama Nilla continues caring for the children. Leo and Silver acknowledge that they have become romantic partners. Van Atta, Sondra Yei, George Bannerji, Sergeant Fors, and the security party remain behind after failing to stop the jump. An official police ship approaches Home, and Warren prepares to challenge GalacTech's claims through his connection with the Orient health minister. The quaddies have escaped the planned sterilization, abortion, confinement, and destruction program, but their legal status, political protection, and permanent home remain unsettled.",
         "in_short": "GalacTech engineer Leo Graf arrives at Cay Habitat to train quaddies, bioengineered free-fall workers whom the company treats as property. After Tony, Claire, and their infant Andy try to escape, Tony is shot and the family is separated. Artificial gravity then makes the Cay Project obsolete, and GalacTech prepares to sterilize, confine, or kill its quaddie population. Leo and Silver organize a collective flight. Silver's team captures the D-620 cargo jumper, the quaddies expel most downsider staff, and Cay Habitat is converted for transport. A broken vortex mirror and Van Atta's use of Tony as a hostage nearly stop them, but Ti Gulik and Warren Minchenko recover Tony while Leo fabricates a replacement mirror. The combined ship, named Home, jumps safely to Orient with Tony, Claire, and Andy reunited. Leo and Silver become partners, while the free quaddies face an unresolved legal struggle over their status and future settlement.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1156,7 +1156,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09FR4D8MC",
@@ -1168,7 +1168,7 @@
       "recaps": {
         "ending": "Skippy's authentication hack sends several Sentinels back into hibernation, but the targeted machine pulls Valkyrie into its transition and the ship is presumed lost. Admiral Reichert ends the ceasefire, and more than 8,000 Maxolhx and Rindhalu ships gather around Earth. Chang and Nagatha use false Elder-weapon codes to delay the attack, but the deception fails. Bishop interrupts the bombardment order when Valkyrie returns from an unexplained higher-dimensional delay with Simms, Skippy, and Roscoe, a Sentinel now under their control. Roscoe's demonstration forces both senior species to stand down and gives humanity a powerful immediate deterrent. Flying Dutchman, Zhao's fleet, and the broader human alliance survive. The solar-flare campaign against Earth's cloud remains unfinished, Avalon is only a provisional refuge, Grumpy remains separate, and the wormhole wake-up signal still points toward an unidentified Elder AI. Skippy's inaccessible original programming also remains a risk, so Bishop's next strategic problem is unresolved.",
         "in_short": "Humanity's claim that it can disable wormhole networks wins captured Maxolhx warships and creates room for negotiations, but the claim is largely a bluff. Bishop and Skippy prove that controlled solar flares can slowly move the cloud threatening Earth, while political division, a Bosphorok raid, and Maxolhx manipulation repeatedly endanger that work. When multiple Sentinels awaken, Valkyrie recovers a Guardian energy virus and uses Thor to destroy one. Skippy then alters another Sentinel's authentication system, sending several machines back into hibernation, but Valkyrie vanishes and the Maxolhx and Rindhalu prepare to bombard Earth. Bishop, Simms, and Skippy return with Roscoe, a Sentinel they control, forcing both senior species to halt. Earth survives, but the cloud project is incomplete, some Sentinels remain active, and an unidentified Elder AI still appears to be driving the crisis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1349,7 +1349,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1362,7 +1362,7 @@
       "recaps": {
         "ending": "Cath returns to college after Wren's hospitalization and gradually rebuilds her relationship with her sister, who accepts that her drinking has become dangerous. Cath does not welcome Laura back simply because Laura appears during the crisis, and that estrangement remains unresolved. Art recovers enough to resume work while accepting that his daughters cannot organize their lives entirely around protecting him. Professor Piper pushes Cath to finish an original piece instead of retreating into fan fiction, and Cath's story about separation, Left, wins a university fiction prize. She also ensures that her work on Nick's story is acknowledged. Cath completes Carry On, Simon before the official final Simon Snow novel appears, giving her readers the ending she promised. By the close she and Levi are securely together, Reagan remains her friend, and Cath has found a way to value both her fan community and her own original writing. She reads the newly published Simon Snow finale with Levi, no longer facing change entirely alone.",
         "in_short": "College separates identical twins Cath and Wren for the first time. While Wren pursues parties and independence, anxious Cath retreats into her popular Simon Snow fan fiction until her blunt roommate Reagan, Reagan's friend Levi, classmate Nick, and Professor Piper draw her into a wider life. Family crises complicate the year: their father Art's mental health deteriorates, Wren's drinking ends in hospitalization, and the mother who abandoned them reappears. Cath also learns that collaboration and romance require firmer boundaries when Nick claims their shared work and Levi briefly breaks her trust. She eventually reconciles with Levi and Wren without surrendering her own needs, refuses a forced reunion with her mother, and begins balancing care for her family with college. Cath finishes her fan-fiction epic before the official series finale and completes an original story that wins a university prize, ending the year as both a fan writer and an author increasingly willing to claim her own work.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1565,7 +1565,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1578,7 +1578,7 @@
       "recaps": {
         "ending": "In the final story, Billy joins the Giraffe, Pelican, and Monkey on a window-cleaning job at the Duke of Hampshire's house. The Pelican spots a burglar taking jewels and catches him, allowing the police to recover the property. A grateful Duke rewards the animals with the special foods and home they need, while Billy receives the abandoned building he has always wanted. It is renovated as a sweet shop and stocked with remarkable confectionery from Willy Wonka's factory. Billy and the animals remain together in their new headquarters, with the window-cleaning company established and Billy's ambition fulfilled. Across the collection, Mr Fox has also secured food and an underground refuge for his community, Mr Hoppy has married Mrs Silver after confessing his tortoise scheme, and the Enormous Crocodile has been destroyed before he can eat any children.",
         "in_short": "Four animal-centered stories follow schemes that end very differently. Mr Fox responds to a siege by Boggis, Bunce, and Bean by tunneling into their stores and creating an underground feast for the hungry animals, while the farmers remain waiting above. Mr Hoppy secretly swaps many tortoises to convince Mrs Silver that her pet is growing; after he admits the trick, she accepts his proposal. The Enormous Crocodile attempts to disguise himself and seize children, but the other animals spoil every trap and Trunky hurls him into the sun. Finally, Billy befriends a Giraffe, Pelican, and Monkey who form a ladderless window-cleaning team. Their first job leads to the capture of a jewel thief, generous rewards from the Duke of Hampshire, and the transformation of Billy's long-desired building into a sweet shop supplied by Willy Wonka.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1752,7 +1752,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1765,7 +1765,7 @@
       "recaps": {
         "ending": "Troy returns alive at Boldwood's Christmas gathering and tries to force Bathsheba to leave with him. Boldwood shoots Troy dead and then attempts suicide before surrendering; his death sentence is reduced to life imprisonment because of his mental state. Bathsheba buries Troy beside Fanny Robin and withdraws from society. Gabriel, believing his presence may now trouble her and hoping to establish himself elsewhere, prepares to leave Weatherbury. The prospect makes Bathsheba recognize how completely she trusts and depends on him. She goes to him, and their frank conversation leads quietly to marriage. They begin a partnership founded on long friendship, tested loyalty, and shared work rather than the excitement that shaped Bathsheba's earlier choices.",
         "in_short": "Farmer Gabriel Oak proposes to the independent Bathsheba Everdene and is refused. After losing his flock and farm, he becomes shepherd on the estate she inherits and repeatedly protects it with skill and loyalty. Bathsheba's playful valentine awakens the obsessive hopes of neighboring farmer William Boldwood, but she is swept instead into marriage with the charming soldier Frank Troy. Troy's former sweetheart Fanny Robin dies in poverty with their child, and his grief destroys his marriage. He disappears and is presumed drowned. Boldwood presses Bathsheba for a future promise, but Troy returns at Boldwood's Christmas party and demands his wife. Boldwood shoots him and is imprisoned for life. Bathsheba, sobered by loss, comes to recognize Gabriel as her closest friend and indispensable partner. When he plans to leave, she seeks him out, and they marry quietly.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1945,7 +1945,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1958,7 +1958,7 @@
       "recaps": {
         "ending": "Troy's return ends at Boldwood's Christmas gathering, where Troy demands that Bathsheba leave with him and Boldwood shoots him dead. Boldwood then tries to kill himself but is stopped and surrenders. He is sentenced to death, later commuted to life imprisonment because his long obsession has unbalanced him. Bathsheba has Troy buried with Fanny Robin and withdraws into grief. Gabriel continues managing her farm while preparing to leave England, believing that gossip makes his position beside her impossible. When Bathsheba learns of his plan, she goes to him and asks him to stay. Their old affection has matured through work, loss, and mutual reliance; they agree to marry. The wedding is quiet, attended by the farm workers rather than fashionable society. Bathsheba ends as Gabriel's wife and equal companion, while he gains both the home and partnership she could not imagine when she rejected his first proposal.",
         "in_short": "Independent Bathsheba Everdene rejects shepherd Gabriel Oak, then inherits a Weatherbury farm where the ruined Gabriel becomes her indispensable employee. A playful valentine makes the reserved Farmer Boldwood obsessively seek her hand, but she is captivated by the reckless soldier Frank Troy and secretly marries him. Troy mismanages the farm and remains attached to Fanny Robin, his abandoned former sweetheart, who dies in poverty with their child. His grief drives him away; after he is presumed drowned, Boldwood renews his courtship. Troy survives and returns at Boldwood's Christmas party to reclaim Bathsheba, whereupon Boldwood shoots him and is imprisoned. Gabriel plans to emigrate, but Bathsheba recognizes the durable love and partnership that have grown between them. She asks him to stay, and they marry quietly, uniting the farm owner with the shepherd whose loyalty repeatedly preserved her livelihood.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2124,7 +2124,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2137,7 +2137,7 @@
       "recaps": {
         "ending": "Troy, believed drowned, returns during Boldwood's Christmas gathering and orders Bathsheba to leave with him. When Troy seizes her, Boldwood shoots him dead and then attempts to kill himself, but is stopped. Boldwood is convicted and initially sentenced to death; petitions about his mental state lead to the sentence being reduced to imprisonment. Bathsheba has Troy buried near Fanny Robin and lives quietly after the violence. Gabriel, who has faithfully managed her farm while planning to seek a new future elsewhere, prepares to leave Weatherbury. Bathsheba realizes how completely she trusts and depends on him and goes to him. Their renewed understanding becomes a proposal, and they marry without the spectacle that marked her relationship with Troy. Gabriel ends as Bathsheba's husband and equal partner, while Boldwood remains confined and Troy and Fanny lie dead, the consequences of the earlier romantic entanglements still visible around the surviving couple.",
         "in_short": "Independent Bathsheba Everdene refuses Gabriel Oak's marriage proposal, then unexpectedly inherits a farm. After Gabriel loses his own flock, he becomes her shepherd and repeatedly protects the estate. Bathsheba carelessly sends a valentine to the reserved Farmer Boldwood, awakening an obsession she cannot return. She then falls for the dazzling soldier Frank Troy and marries him despite Gabriel's warnings. Troy proves reckless and remains tied to Fanny Robin, the abandoned former sweetheart who dies in poverty with their child. After seeing her body, Troy rejects Bathsheba emotionally and later disappears at sea. Boldwood resumes his hopes of marrying the widowed Bathsheba. Troy returns alive at Boldwood's Christmas party, where Boldwood shoots him and is imprisoned. Bathsheba finally recognizes Gabriel's steadfast love and her own reliance on him. When he considers leaving, she seeks him out, and they marry as mature partners, bringing stability to the farm after the ruin caused by pride, impulse, and possessiveness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2302,7 +2302,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2315,7 +2315,7 @@
       "recaps": {
         "ending": "Boldwood is sentenced to death for killing Troy, but petitions citing his mental condition lead to commutation and imprisonment. Bathsheba withdraws into grief and manages her farm quietly. Gabriel continues to oversee both her land and Boldwood's, yet prepares to emigrate because he believes his closeness to Bathsheba is attracting gossip and causing her harm. When she learns he plans to leave, she goes to him and asks him to remain. Their conversation finally places them on equal, candid terms, and Bathsheba accepts the devotion she once rejected. They marry without display, with only a few neighbors aware beforehand. Gabriel gains the partnership and settled home he had hoped for at the beginning, while Bathsheba reaches it after painful experience has replaced impulse with trust. The Weatherbury workers celebrate the marriage, and the couple resume the shared agricultural life that has long joined them.",
         "in_short": "Shepherd Gabriel Oak loses his own farm soon after Bathsheba Everdene refuses his proposal. When Bathsheba inherits a Weatherbury farm, Gabriel becomes her indispensable shepherd. Her playful valentine awakens the grave farmer Boldwood's obsessive love, but she is captivated instead by the charming soldier Frank Troy and marries him. Troy proves careless with her farm and remains attached to Fanny Robin, whose death with her child devastates him. Believed drowned after leaving Bathsheba, Troy returns when she is close to yielding to Boldwood's renewed proposal. Boldwood shoots him and is imprisoned. Through every crisis Gabriel protects Bathsheba and her livelihood without exploiting her dependence. When he prepares to leave England, she realizes what his loyalty means and asks him to stay. They marry quietly, bringing the story back to the practical companionship Gabriel first offered, now freely chosen by a chastened and more self-aware Bathsheba.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2486,7 +2486,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2499,7 +2499,7 @@
       "recaps": {
         "ending": "Boldwood is convicted of killing Troy and sentenced to death, but petitions concerning his mental condition lead to the sentence being commuted to confinement. Bathsheba withdraws into grief while Gabriel continues to run the farm with increasing authority. Believing that his presence now exposes both of them to gossip and that his long service has reached its natural end, Gabriel prepares to leave Weatherbury and possibly England. Bathsheba, alarmed at losing the one person whose loyalty and judgment have never failed her, goes to his cottage. Their candid conversation finally clears away the distance between them, and Gabriel again asks her to marry him. This time she accepts from mature affection rather than vanity or impulse. They marry quietly, with only a few witnesses, and the farm workers later celebrate outside. Bathsheba and Gabriel end as companions whose trust has grown through work, loss, and endurance.",
         "in_short": "After a disastrous accident ruins sheep farmer Gabriel Oak, he takes work on the Weatherbury estate newly inherited by Bathsheba Everdene, the independent woman who earlier rejected his proposal. Bathsheba capriciously sends a valentine to the reserved farmer William Boldwood, awakening an obsessive hope of marriage, but she is then captivated by the charming soldier Francis Troy and marries him. Troy proves reckless and remains emotionally bound to Fanny Robin, a former servant who dies in poverty with his child. He abandons Bathsheba and is believed drowned, leaving Boldwood to renew his suit. Troy returns during Boldwood's Christmas gathering and tries to reclaim Bathsheba; Boldwood shoots him and is imprisoned. Gabriel, whose steady labor has repeatedly saved Bathsheba and her farm, plans to leave rather than compromise her reputation. Bathsheba recognizes that her trust in him has become love, and they marry quietly.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2701,7 +2701,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2714,7 +2714,7 @@
       "recaps": {
         "ending": "Marlowe uses Laird Brunette's underworld connections to get a message to Moose Malloy, then arranges a meeting that brings Moose to Mrs Grayle. She is revealed as Velma Valento: she changed her identity after Moose went to prison and married into wealth. Marriott and Jules Amthor had been exploiting secrets connected to her past, and the supposed necklace ransom was part of the criminal web surrounding that leverage. Velma killed Marriott and eliminated Jessie Florian when Jessie became dangerous to her. When Moose finally sees the woman he has spent the novel seeking, Velma shoots him and escapes; his loyalty to the memory of her survives long enough to cost him his life. Police later trace Velma to the East Coast, where she dies in a final armed confrontation that also costs a detective his life. The case is formally resolved, but Marlowe receives little satisfaction from it: Moose's violent search, Marriott's schemes, police corruption, and the Grayles' money have all shielded the truth until nearly everyone directly tied to it is dead.",
         "in_short": "Private detective Philip Marlowe witnesses recently released giant Moose Malloy kill a man while searching for his former girlfriend, nightclub singer Velma Valento. Marlowe's inquiries lead to alcoholic Jessie Florian, then to Lindsay Marriott, who hires him to guard a ransom payment for a stolen jade necklace. Marriott is murdered, and Anne Riordan identifies the necklace as belonging to the young wife of wealthy Lewin Grayle. The two cases merge through psychic consultant Jules Amthor, a corrupt private clinic, and gambling-ship owner Laird Brunette. Marlowe eventually brings Moose to Mrs Grayle and exposes her as Velma, who reinvented herself after Moose's imprisonment. She killed Marriott and Jessie to protect the life she built and the secrets used to blackmail her. Velma shoots Moose when he reaches her and flees. He dies still devoted to her; she and a detective later die when police locate her. Marlowe solves the murders but cannot save the man whose destructive loyalty began the investigation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2843,7 +2843,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2856,7 +2856,7 @@
       "recaps": {
         "ending": "When the king marches to claim the dragon's hoard, Giles meets the royal party with Chrysophylax under his command and refuses to surrender the treasure. The king's knights have no wish to test themselves against the dragon or Tailbiter, so royal authority gives way. Giles distributes enough wealth to secure the loyalty and prosperity of his neighbours, rewards the parson, and establishes his own rule over the country around Ham, which becomes the Little Kingdom. Chrysophylax eventually buys his freedom with an additional payment and returns home diminished but alive. Giles grows into a respected ruler, while the old king's power and territory decline. What began as an accidental encounter with a giant therefore ends with a farmer using courage, bargaining, and a legendary sword to replace a remote and self-interested monarchy with a local kingdom of his own.",
         "in_short": "Farmer Giles of Ham accidentally drives away a trespassing giant with an old blunderbuss and is celebrated as a hero. The king rewards him with an overlooked sword that proves to be Caudimordax, a weapon feared by dragons. When Chrysophylax attacks the district, Giles uses the sword to force the dragon to promise restitution. The dragon initially brings only a token payment, and the king attempts to take control of both the hunt and the reward. Giles pursues Chrysophylax, compels him to yield his full hoard, and returns with the dragon obedient to him. Rather than hand the treasure to the king, Giles defies the royal force, shares wealth locally, and founds the Little Kingdom around Ham. Chrysophylax later purchases his release, while Giles becomes a prosperous and effective ruler.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2973,7 +2973,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2986,7 +2986,7 @@
       "recaps": {
         "ending": "After liberation, György returns to Budapest and finds familiar streets altered less than he expected. He learns that his father has died, while his mother and stepmother have survived and rebuilt their lives in different ways. A journalist wants to turn his history into a conventional public testimony, but György resists language that makes the camps seem outside ordinary human experience. In conversation with old neighbors, he explains that deportation and imprisonment happened through successive steps, each requiring a new response, rather than as one incomprehensible event. He even insists that there were moments of happiness in the camps: not because the system was anything but murderous, but because a person living from one moment to the next could still experience relief, food, companionship, or hope. He decides to go to his mother. His closing reflections leave him neither restored to his former childhood nor willing to let others replace his exact memories with a simpler account of fate, victimhood, or survival.",
         "in_short": "Fourteen-year-old György Köves lives in Budapest under Hungary's anti-Jewish laws. After his father is sent to forced labor, György works with other Jewish boys at an industrial plant. He is taken off a bus, detained, and deported. At Auschwitz he follows advice to claim he is sixteen, passes selection, and is sent through Buchenwald to the labor camp at Zeitz. Hunger, beatings, forced work, and physical decline gradually narrow his world to immediate bodily needs. Guidance from the prisoner Bandi Citrom helps him survive for a time, but an infected knee and extreme weakness bring him close to death. Returned to Buchenwald, he receives treatment and lives to see liberation. In Budapest he learns that his father died and finds that listeners want familiar language about an unimaginable hell. György instead describes the camps as a sequence of comprehensible steps and insists that even there he knew moments of happiness. He turns toward his surviving mother while retaining authority over the difficult meaning of his own experience.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3156,7 +3156,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3169,7 +3169,7 @@
       "recaps": {
         "ending": "After his daughters' financial crises and quarrel bring on Goriot's final collapse, Rastignac and Bianchon nurse him at the boarding house. Goriot continues to excuse Anastasie and Delphine and longs for them, but neither comes to his deathbed in time. Rastignac pays for the funeral with borrowed money and arranges the most meager ceremony he can; the daughters' empty carriages appear, but their families do not mourn beside the grave. From Père-Lachaise, Rastignac looks across Paris and resolves to confront the society that has consumed Goriot's fortune and abandoned him. He then goes to dine with Delphine, turning grief into the beginning of his deliberate struggle for power within the same world.",
         "in_short": "At Madame Vauquer's shabby Paris boarding house, law student Eugène de Rastignac meets the impoverished former merchant Goriot and the formidable Vautrin. Rastignac learns that Goriot ruined himself to enrich his daughters, Anastasie de Restaud and Delphine de Nucingen, who now keep him at a distance while demanding further sacrifices. Rastignac pursues Delphine as a route into fashionable society, while Vautrin offers him a murderous shortcut to wealth through Victorine Taillefer. The scheme collapses when Vautrin is exposed as an escaped convict. Goriot's daughters continue fighting over money and their marriages, and their distress brings on his fatal illness. They fail to attend him as he dies still adoring them. Rastignac and Bianchon finance a poor funeral; afterward Rastignac surveys Paris from the cemetery and commits himself to mastering the society whose cruelty he has witnessed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3327,7 +3327,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3340,7 +3340,7 @@
       "recaps": {
         "ending": "The suppressed records show that Bühler, Stuckart, and Luther attended the Wannsee Conference, where officials coordinated the mass murder of Europe's Jews. The regime killed the surviving participants before President Kennedy's visit could normalize relations with Germany. March obtains documentary proof and helps Charlie carry it toward Switzerland, where publication can destroy the planned alliance. Captured and tortured, he withholds her true route and later allows himself to be followed away from Berlin, buying her time. He drives to the site of Auschwitz, largely erased by the authorities, and finds physical remnants that confirm what happened there. With Globocnik and the pursuing security officers closing in, the wounded March runs toward the ruins. His fate is effectively sealed, but Charlie has the documents and a chance to bring the truth outside the Reich.",
         "in_short": "In an alternate 1964 where Nazi Germany won the war in Europe, Berlin detective Xavier March investigates the death of retired official Josef Bühler. The Gestapo orders him off the case, but further deaths and missing records connect Bühler to Martin Luther and Wilhelm Stuckart. With American journalist Charlotte Maguire, March discovers that the men attended the Wannsee Conference and helped plan the extermination of Europe's Jews, a crime the victorious Reich concealed. They are being eliminated before a visit by President Kennedy secures reconciliation with Hitler. March obtains records proving the genocide and helps Charlie escape toward Switzerland with them. After capture and torture, he misleads his pursuers long enough for her to get away, then travels to the erased site of Auschwitz. He finds remnants of the camp as Globocnik's men close in, sacrificing himself so the evidence may reach the outside world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3492,7 +3492,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3505,7 +3505,7 @@
       "recaps": {
         "ending": "After accidentally infecting himself while dissecting a man who died of typhus, Bazarov recognizes that he is dying. Anna Odintsova comes when he asks for her, and he speaks to her one final time before his death. His devastated parents bury him in a village churchyard and continue to visit his grave. Arkady has already moved away from Bazarov's influence and found a shared life with Katya; they marry, while Nikolai regularizes his long-standing household by marrying Fenichka. Father and son manage Maryino together with improving results. Pavel leaves Russia and settles in Dresden. Anna later makes a respectable marriage based on compatibility rather than romantic passion. The closing view returns to Bazarov's grieving parents and the flowers on his grave, setting human attachment and continuity against his uncompromising denials.",
         "in_short": "Arkady Kirsanov returns from university to his father's estate with Bazarov, a forceful medical student who calls himself a nihilist. Bazarov's rejection of tradition provokes Arkady's uncle Pavel and fascinates Arkady, but experience exposes limits in the younger men's poses. At Anna Odintsova's estate, Bazarov falls in love despite his contempt for romantic ideals, while Arkady gradually discovers a quieter bond with Anna's sister Katya. Back at Maryino, Bazarov kisses Nikolai's companion Fenichka; Pavel challenges him to a duel and is wounded. Arkady proposes to Katya, and Nikolai prepares to marry Fenichka. Bazarov returns to his parents and contracts typhus through a medical accident. Anna visits him before he dies. Arkady and Katya marry and build a life at Maryino, Nikolai and Fenichka also marry, and Pavel leaves Russia, while Bazarov's bereaved parents tend his grave.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3666,7 +3666,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3679,7 +3679,7 @@
       "recaps": {
         "ending": "Bazarov returns to his parents and resumes medical work. While examining the body of a man who died of typhus, he cuts himself and becomes fatally infected. Anna Odintsova comes when he asks to see her, but their farewell confirms tenderness rather than a shared future. Bazarov dies with his devastated parents beside him. Arkady and Katya marry, as do Nikolai and Fenichka, in a double wedding at Maryino. Arkady becomes an effective estate manager and he and Katya begin a family; Nikolai continues the difficult public and agricultural work of reform. Pavel settles abroad in Dresden, maintaining his polished routines at a distance from Russian life. Anna later makes a socially suitable marriage rather than a passionate one. Sitnikov and Kukshina continue to advertise fashionable ideas without Bazarov's force or seriousness. The novel closes with Bazarov's aging parents visiting his grave, their enduring love set against his denial that inherited feeling or faith could have lasting authority.",
         "in_short": "Arkady Kirsanov returns to his father's estate with Bazarov, a fiercely intelligent medical student who rejects inherited authority and calls himself a nihilist. Bazarov clashes with Arkady's aristocratic uncle Pavel and dismisses the family's romantic ideals. In provincial society he meets the self-possessed widow Anna Odintsova and discovers that his own passion cannot be reduced to theory; she refuses the disorder of a life with him. Arkady, meanwhile, outgrows his imitation of Bazarov and falls in love with Anna's younger sister, Katya. Back at Maryino, Pavel challenges Bazarov to a duel after seeing him kiss Fenichka, Nikolai's beloved companion; Bazarov wounds Pavel and departs. Pavel then urges Nikolai to marry Fenichka. Bazarov returns to his parents, contracts typhus from a medical dissection, and dies after a final visit from Anna. Arkady marries Katya and Nikolai marries Fenichka, while Bazarov's grieving parents tend his grave.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3834,7 +3834,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3847,7 +3847,7 @@
       "recaps": {
         "ending": "Faust reaches the prison where Margarete awaits execution for drowning her infant. Delirious at first, she recognizes him and responds with joy, but the prospect of flight fills her with dread. She imagines the graves of her mother and brother and insists that she must remain to face divine judgment. Mephistopheles appears at the door and warns that dawn is coming. Margarete recoils from him, entrusts herself to God, and calls upon heaven for protection. A voice from above declares her saved, while Mephistopheles says she is condemned and pulls Faust away. The drama therefore closes with Margarete physically left to her sentence but spiritually redeemed, while Faust escapes in Mephistopheles's company and remains bound to the dangerous course created by their bargain.",
         "in_short": "The scholar Faust, despairing of the limits of knowledge, enters a wager with Mephistopheles: if any experience satisfies him so completely that he wishes it to last, he will forfeit himself. Restored to youth, Faust becomes infatuated with Margarete, called Gretchen. With Mephistopheles arranging access, Faust gives her jewelry, wins her love, and begins a relationship whose costs fall largely on her. A sleeping potion meant to conceal their meeting kills her mother; Faust, aided by Mephistopheles, kills her brother Valentin; and Margarete becomes pregnant. After a night of supernatural revelry, Faust learns that she has drowned her baby and is imprisoned. He attempts a rescue, but the distraught Margarete refuses to flee, submits herself to God's judgment, and is proclaimed saved by a heavenly voice. Mephistopheles drags Faust away, leaving the scholar's wager and moral peril unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4029,7 +4029,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4042,7 +4042,7 @@
       "recaps": {
         "ending": "In extreme old age, Faust commands a vast coastal reclamation project but remains angered by the cottage of Philemon and Baucis, whose land interrupts his estate. He orders Mephistopheles to move them; the devil's agents instead kill the couple and burn their home. The personified Care enters Faust's palace and blinds him. Mistaking the sound of spirits digging his grave for labor on his new land, Faust imagines a future community living freely on ground won from the sea. The vision brings him to the moment of satisfaction named in his bargain, and he dies. Mephistopheles prepares to seize his soul, but angels scatter roses, distract the devils, and carry Faust's immortal part away. The closing ascent presents his rescue as the result of persistent striving joined to divine love and grace, not as a victory earned by the bargain. In the higher realm, the penitent Margarete intercedes for him and is permitted to guide him onward as the drama ends in a hymn to the eternal feminine drawing humanity upward.",
         "in_short": "The scholar Faust, despairing of the limits of knowledge, makes a wager with Mephistopheles: if any experience satisfies him completely, the devil may claim him. Rejuvenated and guided into sensual life, Faust courts Margarete, but their affair helps destroy her family and ends with her imprisoned after killing their infant. She refuses Faust's attempted rescue and is saved through repentance. In Part II, Faust and Mephistopheles move through an emperor's court and the world of classical myth. Faust unites with Helen of Troy, but their son Euphorion dies and Helen vanishes. Faust then helps the emperor defeat a rival and receives coastal land, which he seeks to master through reclamation. His demand for the last neighboring property leads Mephistopheles's agents to kill its elderly owners. Blind and dying, Faust imagines free people flourishing on the land and voices the satisfaction anticipated by his wager. Mephistopheles expects his soul, but angels carry it upward; Margarete, now penitent, helps guide Faust toward salvation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4234,7 +4234,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4247,7 +4247,7 @@
       "recaps": {
         "ending": "Bishop's formal feast becomes the decisive move in his challenge to Morganville. The elaborate rules of hospitality do not protect Amelie: Bishop has prepared for her resistance, and the confrontation shatters the founder's control of the gathering. He kills Sam Glass, Amelie's lover and one of her most loyal supporters, turning the political challenge into an irreconcilable personal war. Claire and her friends survive but cannot restore the old order. Bishop's followers no longer respect the protections granted to humans, while vampires loyal to Amelie must regroup for open conflict. Claire's work with Myrnin has shown that the vampire illness can be treated, but neither the research nor the alliances assembled against Bishop are enough to settle the struggle. Glass House remains the group's refuge, yet it can no longer insulate them from a townwide battle. The book closes with Bishop holding the advantage and Morganville divided, carrying the conflict directly into Lord of Misrule.",
         "in_short": "Amelie's father, Bishop, enters Morganville with two predatory companions and challenges the compromise by which vampires and humans have lived under her rule. Claire continues assisting the unstable Myrnin with a cure for the illness affecting old vampires, while she, Shane, Eve, and Michael try to understand the new threat. Bishop uses ritual courtesy, intimidation, and divisions among Morganville's vampires to undermine his daughter. Amelie and her allies prepare a defense, but Bishop turns a formal feast into the setting for his attack and kills Amelie's lover, Sam Glass. Claire's group survives, and the research offers some hope against the vampires' sickness, but the town's existing protections are shattered. Bishop emerges with the advantage, leaving Amelie and the whole town committed to an open struggle between rival vampire powers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4394,7 +4394,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4407,7 +4407,7 @@
       "recaps": {
         "ending": "Vimes realizes the Patrician is being poisoned not through his food but through the arsenic worked into his candles, and traces the scheme to Dragon King of Arms, the ancient vampire who runs the College of Arms. The old herald has been forging bloodlines to prop up a puppet king and unseat Vetinari, and is entangled with the golems' tragedy. The murders were committed by a golem the city's other golems had secretly bought, freed, and overloaded with words and expectations until it broke; unable to bear what it had done, it destroys itself. Confronted, Dragon King's plot collapses and his heraldic college is consumed by fire. The golem Dorfl, nearly destroyed, has his controlling scroll removed and, rather than falling inert, chooses to keep living and acting by his own conscience; he becomes a free being and the Watch's newest constable. The absurd discovery that Corporal Nobbs holds papers naming him a lost earl is quietly shelved. Vetinari recovers and returns to power, and Cheery Littlebottom is accepted living openly as she wishes.",
         "in_short": "Commander Vimes's City Watch investigates two linked mysteries: a pair of baffling murders of inoffensive old men, and the slow, deliberate poisoning of the Patrician, Lord Vetinari. The city's golems, clay workers owned as tools and driven by the words in their heads, are at the center of it: they had secretly pooled their money to buy and free one of their own and fill it with hopes and instructions, but the weight of conflicting commands and impossible expectations drove that golem mad, and it became the killer before destroying itself. Behind the wider plot stands Dragon King of Arms, the vampire master of the city's heralds, who is poisoning Vetinari and using forged genealogy to try to install a controllable puppet king. Vimes works out that the poison is arsenic soaked into the Patrician's candles. The conspiracy is broken and the College of Arms burns. The golem Dorfl, freed of his owning scroll, chooses to become a moral, self-owning being and joins the Watch, and Vetinari recovers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4784,7 +4784,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4797,7 +4797,7 @@
       "recaps": {
         "ending": "Lepiera's capital survives both attacks. Ferdie and Sigvald destroy the second Iron Monarch body, while the legendary beasts rout the duplicate army. John takes ten Order of the New Dawn mages alive, although two senior mages escape toward the production base. High Marshal Helbright arrives with the plains forces and receives orders to restore the border, clear remaining invaders, and manage the movement of civilians from occupied Allera settlements. John, Ellie, Ferdie, and the captives return to Shadow Tower. The prisoners carry three linked curses involving coerced loyalty, fate, and stolen life, leaving the Order's master and its possible connection to Soaring Cloud Tower unresolved. John resumes farm expansion, but the dragon spirit remains inside him and three beast portals are still active. Katrine then sends a desperate message from beyond the world: Togine is dead, she disclosed the world's location under torture, and the Cabal of the Broken Gate is coming to exploit and enslave it.",
         "in_short": "John Sutton expands Sutton Farm's mana-cleansing wheat into mills, noodles, and portable meals while investigating several linked threats. A visit to Soaring Cloud Tower exposes slavery, loyalty conditioning, and a prophecy of a Beast Tide. John destroys one of four beast portals, then learns that his blue flame contains a dragon spirit that wants his body. When the Iron Monarch's duplicate army invades Lepiera, Ellie helps John resist the dragon's influence and return as the Eternal Flame. Ben uncovers sabotage at the capital gate, John saves the first defense, and Ferdie leads legendary beasts that break the second assault. Ten enemy mages are captured, but their leaders and production base remain free. As John returns to farm and tower work, Katrine warns that Togine is dead and the Cabal of the Broken Gate has learned the world's location, creating an imminent interstellar threat.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4956,7 +4956,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4969,7 +4969,7 @@
       "recaps": {
         "ending": "Marsh returns to the captive Joshua and helps create another chance to challenge Damon Julian. Joshua has learned that Julian's mastery is not an unbreakable supernatural law: it depends on submission and can be resisted. In their final struggle Joshua overcomes and kills Julian, ending his domination of the surviving night people. Sour Billy's pursuit of borrowed immortality also ends in death, and the ruined Fevre Dream can no longer serve as Julian's hunting ground. Joshua resumes his effort to free his people from bloodlust, while Marsh survives to see that his long loyalty was not wasted. The steamboat that embodied their partnership is lost, but its name and story endure. In the epilogue, Joshua remains unchanged by age and continues the work, whereas Marsh reaches the end of a human lifetime remembered as the captain of the Fevre Dream.",
         "in_short": "In 1857, ruined Mississippi steamboat captain Abner Marsh accepts financing from the enigmatic Joshua York to build the magnificent Fevre Dream. York and his nocturnal companions are vampires, or night people, but York has developed a drink that controls their need for human blood and hopes to reform his species. Marsh becomes his ally. Their project is shattered by Damon Julian, an ancient bloodmaster who believes humans are prey and mentally dominates other night people. Julian defeats Joshua, seizes the steamer, and turns it into a place of slaughter while Marsh escapes. Years of war and searching follow before an older Marsh finds the boat and helps Joshua resist captivity. Joshua finally rejects Julian's authority, kills him, and frees the survivors from his rule. The Fevre Dream is lost and Julian's human servant Sour Billy dies, but Joshua continues seeking a lasting cure, carrying forward the purpose he and Marsh chose together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5299,7 +5299,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002V5CQSQ",
@@ -5311,7 +5311,7 @@
       "recaps": {
         "ending": "Honor survives the Dreyfus-protocol duel, but Pavel Young's illegal first shot catastrophically injures her left shoulder. Her return fire kills him. Denver Summervale, who murdered Paul Tankersley under Young's contract, is also dead, while Georgia Sakristos has worked covertly against Young from inside his organization. Honor's Grayson guards remain at her side, and Manticore is formally at war with Haven. Before the duel, Duke Cromarty expected Young's death to force Honor's removal from naval command to protect the government's coalition, and exclusion from the House of Lords appeared likely even though her title was expected to survive. HMS Nike was nearing a return to service, but Honor had treated her last bridge visit as a farewell. Her medical recovery, command, parliamentary position, and the final political consequences are not established by the close of the available story action.",
         "in_short": "After the Hancock battle, Pavel Young is court-martialed for abandoning Honor Harrington's formation. He escapes the capital charges but is dismissed from the Navy, then inherits the North Hollow title and uses its political machine to pursue revenge. While Honor secures her position as a Grayson steadholder, Young hires Denver Summervale to kill her partner, Paul Tankersley, in a rigged duel and then target Honor. Honor's allies capture Summervale and expose the contract. She kills him in a formal duel, survives a later attack by hired gunmen, and publicly challenges Young when the law cannot reach him. Young breaks the Dreyfus protocol by firing before the command, shattering Honor's left shoulder. Honor kills him with her return fire. She lives, but her naval command and position in the Lords remain unresolved as Manticore enters formal war with Haven.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/fifteen-dogs.json
+++ b/data/works-community/0/fifteen-dogs.json
@@ -76,7 +76,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -89,7 +89,7 @@
       "recaps": {
         "ending": "By the closing stages of the wager, the original pack has been destroyed by violence, age, and the difficulty of reconciling canine instincts with human-style consciousness. Majnoun's years with Nira have given him a relationship based on communication and mutual trust. His life ends with the knowledge that he has been loved, allowing him to die happy and satisfying Hermes's condition. Prince survives far longer than the other dogs. Apollo burdens his final years with isolation, but cannot erase the poet's delight in language. Near death, Prince encounters a human who responds to one of his poems, and that moment of recognition also gives him happiness. Hermes therefore wins the wager. The gods' contest is decided not by comfort or long life, but by the dogs' capacity to create meaning through love, language, and being understood.",
         "in_short": "In a Toronto tavern, Apollo and Hermes wager over whether human intelligence would make animals more miserable. They grant consciousness and language to fifteen dogs in a veterinary clinic, then wait to see whether any will die happy. The escaped animals form a pack, but their gift divides them. Atticus tries to preserve a traditional canine hierarchy and suppresses the new language, while violence and rivalry reduce the group. Majnoun leaves and forms a profound friendship with a woman named Nira; through patience they learn to communicate across the species divide. Prince, the pack's poet, is driven away but continues composing verse. Most of the dogs die frightened, betrayed, or isolated. Majnoun eventually dies secure in Nira's love, fulfilling the wager's condition. Prince lives longest, and despite Apollo's efforts to make his final life bitter, he experiences a last moment in which a human understands his poetry. Hermes wins because consciousness brings suffering but also makes love, art, and recognized meaning possible.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -206,7 +206,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -219,7 +219,7 @@
       "recaps": {
         "ending": "As the original fifteen dogs die, the divine wager narrows to whether any one of them will meet death in happiness. Majnoun's life with Nira proves that the new intelligence can support genuine love across species, although loss and mortality still bring suffering and his life ends after hers. Prince survives the violent hostility of the pack and continues making poetry long after the other transformed dogs are gone. Apollo tries to preserve his claim by ensuring that human beings do not truly understand Prince's poems. In Prince's final old age, however, a human response allows him to recognize that something he created has crossed the barrier between dog and person. He dies happy. That single satisfied death is enough under the terms of the bet, so Hermes wins. The gods' experiment leaves no new race of speaking dogs, but Prince's ending disproves the absolute claim that reflective intelligence can produce only misery.",
         "in_short": "In a Toronto tavern, Apollo and Hermes wager on whether animals given human intelligence would be happier at death. They awaken fifteen dogs at a veterinary clinic, granting them language, abstract thought, and awareness of mortality. The dogs escape, but their new minds divide them. Atticus tries to restore a strict canine hierarchy and suppress humanlike speech, while Majnoun explores communication and Prince creates poetry. Rivalry, violence, and human dangers rapidly reduce the group. Majnoun is taken in by Nira, and together they build a form of mutual understanding that becomes love, though neither can escape loss. Prince survives attempts to silence him and lives into old age as the final dog from the experiment. Apollo works to keep humans from appreciating his poems, hoping to win the wager, but at the end Prince knows that a human has responded to his creation. He dies happy, satisfying the wager's condition and giving Hermes the victory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -338,7 +338,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -349,7 +349,7 @@
         "work": "finale-a-caraval-novel"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -490,7 +490,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -503,7 +503,7 @@
       "recaps": {
         "ending": "Morris forces the Saubers family into his hunt for Rothstein's notebooks, but Pete uses the one thing Morris values more than money to draw him away from his hostages. At the recreation center, Pete threatens the manuscripts with fire. During the confrontation the notebooks ignite, and Morris dies while trying to save the pages he has worshipped. Hodges reaches Pete and helps him escape, leaving the Saubers family alive and reunited. The stolen Rothstein manuscripts are destroyed, but Pete is freed from the secret that had first rescued and then endangered his family. Later, Hodges continues visiting the apparently unresponsive Brady Hartsfield in the hospital. Small unexplained events around Brady suggest that his mind is active and that he may be able to affect objects without touching them. The case of Morris Bellamy is closed, while Brady's condition becomes the unresolved threat leading into the trilogy's final book.",
         "in_short": "In 1978, obsessive reader Morris Bellamy murders novelist John Rothstein and steals cash and notebooks containing unpublished work. Morris hides the haul but is imprisoned for another crime before he can retrieve it. Decades later, teenager Pete Saubers finds the buried trunk. He anonymously uses the money to support his family after his father is injured in Brady Hartsfield's City Center massacre, then becomes absorbed in the manuscripts. When Pete tries to sell pages, he attracts a dishonest dealer and, after Morris is released, Morris himself. Bill Hodges, Holly Gibney, and Jerome Robinson follow Tina Saubers's worries to Pete's secret. Morris kills to recover the notebooks and threatens Pete's family, but Pete lures him to the hidden manuscripts and sets them alight. Morris dies trying to save them, while Pete and his family survive. Afterward, signs at Brady's hospital bedside suggest that the supposedly unresponsive killer has dangerous abilities no one yet understands.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -687,7 +687,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -700,7 +700,7 @@
       "recaps": {
         "ending": "Sue escapes the asylum and returns to Lant Street, where she discovers Maud living under Mrs Sucksby's control. The confrontation exposes a scheme older than Gentleman's fraud: as infants, Sue and Maud were exchanged. Sue is Marianne Lilly's daughter and the true Lilly heir, while Maud is Mrs Sucksby's biological daughter. Gentleman dies during the struggle. Mrs Sucksby accepts responsibility for the killing and is hanged, protecting Maud while leaving Sue Marianne's written explanation. Sue initially believes Maud knowingly stole her entire life and separates from her. When Sue later returns to Briar, she finds that Maud has survived by writing erotic material for sale. Their conversation establishes that both were manipulated and betrayed, even though each also betrayed the other under pressure. They acknowledge their love and reunite at Briar. The inheritance plot is resolved, Gentleman and Mrs Sucksby are dead, and Sue and Maud end the novel together with a chance to build a life outside the identities others imposed on them.",
         "in_short": "Susan Trinder, raised in a London thieves' household, agrees to become maid to the wealthy Maud Lilly as part of Gentleman's plan to marry Maud, seize her fortune, and confine her. Sue and Maud fall in love, but after the marriage Sue is committed in Maud's place. Maud's narration reveals that she knew the scheme and had been promised escape from her uncle's oppressive home, though Gentleman then delivers her to Mrs Sucksby. Sue escapes the asylum and returns to Lant Street. There she learns that she and Maud were exchanged as babies: Sue is the Lilly heir, while Maud is Mrs Sucksby's daughter. Gentleman dies in the ensuing struggle, and Mrs Sucksby is executed after taking responsibility. Sue eventually finds Maud back at Briar, supporting herself by writing erotic fiction. Recognizing how both were used, the two women reconcile and remain together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -902,7 +902,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -915,7 +915,7 @@
       "recaps": {
         "ending": "The rebellion is fought out in two campaigns and broken. Fire, who has spent the book refusing to be what her father was, ends up using her power at the scale he used his - reaching across a battlefield into thousands of minds - and chooses to use it to stop killing rather than to command. She survives; so do Nash and Brigan; the great lords' rising fails. Archer is dead, and the woman carrying his child, one of Fire's own guards, has the support of Fire and of Brocker's household. Brigan is revealed to be Brocker's son rather than King Nax's, which is why Nax crippled Brocker years ago, and which makes Brigan and Archer half-brothers - a truth that arrives too late for either of them to do anything with. Fire takes a place at the centre of the kingdom rather than hiding at its edge, working for the crown and for Brigan, whom she loves and will not marry into a throne for. She also settles the question of her bloodline deliberately: there will be no more human monsters after her. The boy with the fogging voice is not caught. He goes west, back through the mountains his father came out of, into the country nobody in the Dells knows anything about, which is where the story of the seven kingdoms begins.",
         "in_short": "In the Dells, a land of brilliantly coloured 'monster' creatures that captivate the minds of anyone who looks at them, seventeen-year-old Fire is the last human monster: irresistible to look at and able to enter and control minds. Her father Cansrel used the same gift to own King Nax and wreck the kingdom, and Fire has spent her life refusing to become him. With the Dells sliding toward civil war between two rebel lords, the crown asks her to use her power on prisoners and spies. She agrees, moves to King's City, and works with King Nash, his army commander Brigan, and their half-siblings Clara and Garan, gradually falling in love with Brigan. A second mind-worker is at large: a boy from beyond the western mountains whose words compel obedience. He kills Fire's oldest friend Archer and takes her prisoner in the north during the war. Fire escapes, the rebellion is defeated, and she uses her power across a battlefield to stop the fighting rather than direct it. She stays in the Dells as the crown's ally, and decides the monster line ends with her; the boy escapes westward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1285,7 +1285,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -1298,7 +1298,7 @@
       "recaps": {
         "ending": "Firesong leaves Sectionals as the first-year team-battle champion, although Rei's injuries forced the other five members to win the final without him. Rei and Aria's hacked individual final is recorded as a draw. Rei recovers into specialized training at C9 with Shido's Brawler, Saber, and Phalanx modes, Type Shift 2, and the short-range jump ability Temporal Step. His fibrodysplasia shows no new flare-ups and may be in remission, but medical monitoring continues. Logan reconciles with Rei, tells Firesong the history behind his former identity, and joins Chancery in learning Shido's S-ranked Growth secret. Rei and Aria remain together, while Viv continues to fear that her development is falling behind the team. Central's coerced transfer threat leaves Rei, Aria, and Firesong with demanding Systems and InterSystems targets if they are to stay at Galen's Institute. Carmen refuses to sign voluntarily, and Galen's promises greater support. Rei reopens negotiations with Kamiya only for team sponsorship, rejects personal payment, and learns that the corporation's head initiated the offer. Kamiya accepts the team condition in principle. Rei has not reconciled with Hiroto or Sarah, while Solista's opposition, the unidentified arena attacker, and Shido's limits all remain unresolved.",
         "in_short": "Rei and Aria begin dating as Firesong prepares for Sectionals, while Kamiya Corporation offers Rei a suspiciously generous sponsorship tied to the family that abandoned him. Central manipulates Rei's fortitude test, and Shido continues evolving at an extraordinary pace. At Sectionals, Firesong advances despite targeted brackets and internal strain. Catcher gains Ruinous, Chancery gains Warband, and the team suspects Shido may affect nearby CADs. Rei reaches the individual final against Aria, but an arena hack subjects him to S0 projections and leaves him badly injured. Shido rises to C9, adds a Phalanx mode, and grants the short-range jump ability Temporal Step. Firesong wins the team-battle championship without Rei, while the interrupted duel is declared a draw. Logan reveals his former identity and reconciles with the team. Central then uses a transfer order to demand exceptional Systems and InterSystems results from Rei, Aria, and Firesong. Rei seeks Kamiya sponsorship for the whole team instead of himself, and Kamiya agrees in principle, while its head is revealed as Rei's estranged grandfather.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1490,7 +1490,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1503,7 +1503,7 @@
       "recaps": {
         "ending": "Regalia gets exactly what she was working toward and then dies. Her design was never to kill the Reckoners: she was dying, and she wanted a successor, so she engineered a situation in which Prof had to use his powers at full strength under extreme emotional pressure in order to save David from drowning. He does, and he gives in to the corruption that comes with them. Obliteration's attempt to destroy Babilar with the heat he has spent the book gathering is stopped and the city survives, but he escapes rather than dying. Megan, who has learned to use her ability by confronting what frightens her instead of avoiding it, is fully back on David's side, and their relationship is settled. Prof, now a fallen Epic and one of the most powerful alive, turns on the Reckoners and breaks with them, leaving the organisation shattered and David, Megan, Tia and Mizzy holding what is left of it. David refuses to accept that Prof is beyond recovery: Megan is his proof that an Epic can face the fear the power feeds on and come back from it, and the next book's objective is to do the same for Prof rather than to kill him.",
         "in_short": "With Steelheart dead, Epics keep arriving in Newcago to test the Reckoners, and the team works out that they are being sent by Regalia, a High Epic ruling the flooded ruin of Manhattan, now called Babilar. Prof takes David and Tia east to deal with her. Babilar is a drowned city of glowing fruit and fatalistic people, run by an Epic who can appear through any standing water, and David soon finds Megan there working for her. While the team hunts Regalia's lieutenants and the city-destroying Epic Obliteration prepares to incinerate Babilar, David works out that Megan's power is broader than resurrection and that an Epic who faces their deepest fear can use their abilities without being corrupted. Regalia's real plan proves to be her own succession: she is dying, and she manoeuvres Prof into using his powers under desperate emotional pressure so that he will fall. He does. Regalia dies, Babilar is saved, Obliteration escapes, and Prof turns on the Reckoners, leaving David determined to redeem him rather than kill him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1693,7 +1693,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1706,7 +1706,7 @@
       "recaps": {
         "ending": "Kate's breast cancer progresses despite treatment. The crisis ends her estrangement from Tully, who returns and again becomes part of the Ryan-Mularkey family. Reconciliation cannot give them the decades they expected, so Kate uses her remaining time to prepare the people she loves for life without her. She asks Tully to remain close to Johnny and the children and entrusts her with memories of their friendship. Kate dies surrounded by the family life she chose. Tully is devastated but accepts that honoring Kate requires presence rather than escape into work. At Kate's funeral, music and the record of their shared past help Tully endure the loss. The friendship that began on Firefly Lane ends in death rather than another separation, leaving Tully responsible for keeping Kate's place in the family and carrying their history forward.",
         "in_short": "In 1974, lonely teenagers Tully Hart and Kate Mularkey become inseparable neighbors on Firefly Lane. Kate gives Tully the dependable family life denied by her neglectful mother, while Tully gives Kate confidence and a larger sense of possibility. They pursue television careers together, but Tully chooses fame as a broadcaster while Kate eventually marries producer Johnny Ryan and raises a family. Their bond survives rivalry, unequal success, marriage, motherhood, and Johnny's wartime injury. It finally breaks when Tully uses Kate's conflict with teenage Marah on national television and publicly casts Kate as a harmful mother. Years of silence follow. When Kate develops terminal breast cancer, the friends reconcile. Kate dies after asking Tully to remain part of Johnny and the children's lives, and Tully begins facing grief by carrying forward the family and memories her friend entrusted to her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1879,7 +1879,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1892,7 +1892,7 @@
       "recaps": {
         "ending": "Daunis's investigation reveals that the meth network is embedded in relationships she trusted, including the hockey world and her own family. Levi's participation is a particularly painful betrayal. Daunis survives the attempt to silence and control her, and the federal operation brings arrests and disrupts the drug enterprise, but the authorities' priorities do not provide full justice for the sexual violence and exploitation experienced by Native women. Jamie's deception as an undercover investigator has also damaged their relationship, even though his feelings for Daunis were not simply an assignment. In the aftermath, Daunis turns toward her aunties, elders, traditions, and the collective strength of women who protect one another. She claims a future grounded in her Anishinaabe identity without waiting for outsiders or enrollment rules to validate it. Her connection with Jamie remains possible but is not allowed to replace the harder work of healing, accountability, and choosing her own path.",
         "in_short": "Daunis Fontaine, an eighteen-year-old with Ojibwe and white family roots, postpones college after deaths and illness at home. When her best friend Lily is killed by her meth-addicted ex-boyfriend, Daunis learns that new hockey player Jamie and his supposed uncle Ron are undercover investigators examining lethal drugs in the Ojibwe community. They recruit Daunis for her chemistry knowledge and local connections. Working in secret, she studies the drug supply, follows clues left by her late uncle David, and discovers that the investigation reaches into the hockey team and her own family. Her growing love for Jamie is compromised by his lies, while violence against Native women reveals how narrow the federal inquiry is. Daunis ultimately exposes a network involving people she trusted, including her brother Levi, and survives the effort to stop her. Arrests disrupt the meth operation, but legal action does not repair every harm. Daunis ends the book choosing community, cultural knowledge, and a future defined on her own terms.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2042,7 +2042,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2055,7 +2055,7 @@
       "recaps": {
         "ending": "After begging the final spirit for a chance to alter the future, Scrooge wakes in his own bed on Christmas morning and realizes the visions have occurred in time for him to act. Delighted and energetic, he anonymously sends a large turkey to the Cratchits, makes a substantial donation to the charity collector he had dismissed, and joins Fred's family for dinner. The next day he startles Bob by pretending to be angry about his lateness, then raises his pay and promises practical help for the family. Scrooge keeps those promises. He becomes generous, sociable, and attentive to other people throughout the year, while Tiny Tim survives and regards him with familial affection. The lonely death and neglected grave shown by the last spirit do not come to pass; Scrooge's changed conduct gives him a place in his family and community.",
         "in_short": "Ebenezer Scrooge is a rich but isolated miser who rejects his nephew, underpays Bob Cratchit, and refuses to help the poor. On Christmas Eve the ghost of his dead partner, Jacob Marley, warns that such a life brings misery after death. Three spirits then confront Scrooge with his neglected childhood, lost relationships, the present celebrations of families including the impoverished Cratchits, and a possible future in which Tiny Tim dies and Scrooge's own death is met with indifference. Horrified by the person he has become, Scrooge promises to change. He wakes on Christmas morning, sends food to the Cratchits, gives generously to charity, reconciles with his nephew, and raises Bob's wages. His reform lasts: he becomes a caring friend and employer, helps Tiny Tim, and replaces isolation with active generosity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2209,7 +2209,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2222,7 +2222,7 @@
       "recaps": {
         "ending": "The Nutcracker defeats the seven-headed Mouse King after Marie obtains a sword for him, and he gives her the enemy's seven crowns. He then leads her through a magical passage into a realm of sweets, toys, and splendid cities, where she is welcomed as his rescuer. Marie awakens at home and cannot persuade the adults that the journey occurred. When Drosselmeier's nephew visits, Marie recognizes his connection to the Nutcracker. She declares that, unlike Princess Pirlipat, she would remain faithful to someone who had suffered for her sake. This promise breaks the Nutcracker's enchantment. The nephew returns in his true form, asks Marie to marry him, and later takes her away in a golden carriage. She becomes queen of his wondrous kingdom, where the beauty she saw on her journey endures.",
         "in_short": "On Christmas Eve, Marie Stahlbaum becomes devoted to a wooden Nutcracker that her brother Fritz damages. At midnight she witnesses the Nutcracker leading the toys against the seven-headed Mouse King. After Marie saves him, her godfather Drosselmeier tells her how Princess Pirlipat's curse was broken by his nephew, who was then transformed into the Nutcracker when the ungrateful princess rejected him. The Mouse King threatens the wounded Nutcracker and extorts Marie's sweets and toys until the Nutcracker, armed with Fritz's sword, kills him. He takes Marie through a magical toy kingdom, but she wakes at home and is not believed. When Drosselmeier's nephew appears, Marie promises she would never reject him for his altered appearance. Her loyalty ends the enchantment; he resumes human form, proposes, and eventually takes her to his kingdom as its queen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2353,7 +2353,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2366,7 +2366,7 @@
       "recaps": {
         "ending": "After Pooh and Christopher Robin use an upturned umbrella as a boat to rescue Piglet from the flood, Christopher Robin holds a celebration in Pooh's honor. The Forest friends gather, Owl gives a speech, and Pooh receives a pencil case as a gift for his clever part in the rescue. When the party is over, Christopher Robin takes Pooh to a quiet place at the top of the Forest. The boy is beginning to understand that growing older and going to school may change how they spend their days. He asks Pooh to remember him and to remain his friend even when they cannot always play together. Pooh promises. The book closes with the child and bear still together in their special place, preserving their friendship against the changes Christopher Robin anticipates.",
         "in_short": "Across ten linked Forest adventures, Winnie-the-Pooh pursues honey, visits Rabbit and becomes stuck in his doorway, follows misleading tracks with Piglet, and restores Eeyore's missing tail. Pooh and Piglet's trap for an imagined Heffalump frightens Piglet instead, while Eeyore's birthday improves when he receives an empty honey pot and a burst balloon that fits inside it. Rabbit's attempt to drive away the newly arrived Kanga and Roo fails, and they join the community. During an expedition, Pooh accidentally supplies the stick that Christopher Robin names as the North Pole. Heavy rain later surrounds Piglet's home. Pooh reaches Christopher Robin, and they turn an umbrella into a boat and rescue Piglet. Christopher Robin celebrates Pooh's resourcefulness with a party. Afterward, he and Pooh share a private conversation about growing up, and Pooh promises that their friendship will endure even when Christopher Robin's life changes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2484,7 +2484,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2497,7 +2497,7 @@
       "recaps": {
         "ending": "Rambo escapes the underground workings and carries the fight back into Madison, using stolen weapons and fire to wreck much of the town center and draw Teasle toward a final encounter. Both men are already exhausted and wounded when they confront each other. Teasle shoots Rambo, and Rambo in turn mortally wounds Teasle. Rambo tries to keep moving but realizes that his wound leaves no viable escape. Trautman catches up with him and kills him rather than allow the pursuit to continue. Teasle also dies from his injuries. The conflict therefore ends without a survivor among its two central opponents: a routine exercise of police authority has escalated into a private war that destroys both the hunted veteran and the chief who refused to let him go.",
         "in_short": "Police chief Wilfred Teasle repeatedly removes a homeless Vietnam veteran named Rambo from Madison, Kentucky, then arrests him when he returns. Rough treatment at the station triggers Rambo's memories of wartime captivity, and he escapes into the mountains. Teasle organizes a pursuit, but Rambo's combat training turns the search into a deadly fight in which officers and civilian hunters are killed. Colonel Sam Trautman, who understands how Rambo was trained, warns that force will only deepen the disaster. Police and military units trap Rambo underground, yet he finds a way out and returns to Madison with stolen weapons. He devastates the town and confronts Teasle. The two men mortally wound one another; Trautman kills the badly injured Rambo, and Teasle dies soon afterward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2635,7 +2635,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2648,7 +2648,7 @@
       "recaps": {
         "ending": "After Vladimir discovers that Zinaida's secret lover is his father, the two neighboring households separate. Vladimir's infatuation gives way to a painful awareness of adult passion, secrecy, and power. Later, while riding with his father in Moscow, he follows him to a house and watches through a window as Pyotr argues with Zinaida. His father strikes her bare arm with his riding crop; instead of recoiling, she kisses the mark. The scene reveals to Vladimir a devotion and suffering far beyond the playful court he once joined. Pyotr dies suddenly not long afterward, having received a troubling letter from Moscow and leaving money to be sent there. Several years later Vladimir learns that Zinaida married a man named Dolsky and then died in childbirth. He delays calling on her until it is too late. Remembering both her death and the death of an elderly poor woman nearby, the older narrator recognizes how casually youth assumes that time and happiness remain available.",
         "in_short": "At sixteen, Vladimir spends a summer near Moscow and becomes infatuated with his neighbor Zinaida Zasekina, a beautiful young princess from an impoverished family. She welcomes him into a circle of competing admirers, alternately encouraging and humiliating him. Vladimir accepts every mood as evidence of love until her behavior changes and he realizes that she herself has fallen passionately for someone. Jealous clues eventually lead him to the devastating discovery that her lover is his own father, Pyotr, a charming and emotionally distant married man. After the families leave their summer homes, Vladimir later sees Pyotr strike Zinaida's arm with a riding crop during an argument; she kisses the welt, revealing the intensity and submission of their bond. Pyotr soon dies, and years afterward Vladimir learns that Zinaida married and died in childbirth before he made a delayed visit. His first love becomes an education in desire, power, lost time, and mortality.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2772,7 +2772,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2785,7 +2785,7 @@
       "recaps": {
         "ending": "After the family returns to Moscow, Vladimir rides out with his father and secretly follows him to a house where Zinaida is staying. He watches his father speak to her through a window and strike her arm with a riding crop; Zinaida responds by kissing the mark, revealing a bond whose intensity the boy cannot comprehend. Not long afterward Pyotr Vasilyevich dies suddenly. Vladimir later learns that his father had been trying to arrange money for a woman, reinforcing what he witnessed. Several years pass before Vladimir hears that Zinaida has made a socially respectable marriage to Monsieur Dolsky. When he finally decides to visit her, he learns that she has died after giving birth. The adult narrator closes with regret for youth, lost feeling, and his delay in seeking her out, recognizing that his first love exposed him at once to devotion, humiliation, secrecy, and death.",
         "in_short": "Sixteen-year-old Vladimir spends a summer near Moscow preparing for university and falls helplessly in love with Zinaida Zasekina, the spirited daughter of an impoverished princess. He joins her group of older admirers and accepts her alternating favor and mockery, while slowly realizing that her own heart belongs to someone she will not name. Suspicion leads him to keep watch in the garden, where he sees that the secret visitor is his handsome, distant father. A family quarrel soon takes Vladimir back to Moscow. There he later witnesses a disturbing private exchange that confirms the affair and shows Zinaida's submission to its pain. His father dies shortly afterward. Years later Vladimir learns that Zinaida married another man and then died following childbirth. His remembered first love becomes inseparable from his first recognition of adult secrecy, power, loss, and his own vanished youth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3072,7 +3072,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0C6RCTF4X",
@@ -3084,7 +3084,7 @@
       "recaps": {
         "ending": "Kazimir survives the order's road ambush, but the force of his response leaves him temporarily blind and severely weakened. Duke, Boots, and Azib get him to the threatened house in a stolen tow truck. Their attack destroys the order's surveillance and jamming van, restores communications, and allows Mike, Isabel, Gisele, and Macarius to withdraw. The reunited team abandons the Finger Lakes base, crosses into Canada with false documents, and departs for Nice. Annie offers Kazimir access to surviving fragments of magical texts and directs the next campaign toward Europe, where residual magic is unusually concentrated and the order retains active operations. The Ohio connection and Cedarville attempt are closed, while the order's American support and artifact shipment have suffered major losses. Apophis remains in the Nether. Marduk is still silent, Kazimir still owes aid to Boots's people, and the identities and histories surrounding Sarah, Annie, Kazimir's parents, and the earlier wizard Anakin remain unresolved. Mike and Isabel continue with Kazimir despite his growing dispute with Annie's authority and concern over how he uses lethal magic.",
         "in_short": "Recovering from the Ohio portal crisis, Kazimir Wolfe discovers that the breach was never fully sealed and that the order is attempting another opening near Cedarville. He cuts the remaining link to the Nether, defeats Apophis's attempt to seize him, and remotely destroys the Cedarville device. Seeking to cripple the order's American support, his team coerces an imprisoned Grasso associate into surrendering evidence, frames Tommy O'Connor as the informant, and triggers the criminal network's collapse. Kazimir then destroys a departing shipment of magical artifacts, but surviving order agents trace the team and ambush him near home. Blinded and injured by his own magic, he returns with Duke, Boots, and Azib in a stolen tow truck, destroys the jamming team, and helps the others escape. The household abandons North America and flies toward Nice to meet Annie's hidden organization, study surviving magical texts, and pursue the order in Europe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3239,7 +3239,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3252,7 +3252,7 @@
       "recaps": {
         "ending": "Poirot brings the five together and states what happened. Elsa Greer poisoned Amyas Crale. She had believed his assurances that he would leave his wife and marry her, and she overheard him telling Caroline that Elsa would be sent away as soon as the portrait was finished, because the picture mattered and the girl did not. She took the coniine that Caroline had already taken from Meredith Blake's laboratory, put it in the iced beer she carried down to the Battery, and later wiped the bottle and pressed the dead man's fingers on it so that the poison would appear self-administered. Caroline, meanwhile, believed that her half-sister Angela had done it, since Angela had been tampering with Amyas's drinks in revenge and had said wild things about killing him. Carrying an old and unpayable debt of guilt for the injury she had done Angela as a baby, Caroline made no defence worth the name and allowed herself to be convicted. Miss Williams, who saw Caroline wiping the bottle, had understood the gesture as guilt rather than concealment and had said so on oath. The proof is in the painting itself, which shows a girl watching a man die and painting on regardless of what her face records. Elsa admits it with indifference, saying that she died herself that afternoon and that the years since have been nothing to her. Carla Lemarchant has her mother's name back and marries John Rattery.",
         "in_short": "Carla Lemarchant, twenty-one, asks Poirot to reopen a case sixteen years old: her mother, Caroline Crale, was convicted of poisoning her father, the painter Amyas Crale, and died in prison, leaving a letter swearing her innocence. Poirot consults the lawyers and the police officer who worked the case, then interviews the five other people present at Alderbury that summer: Philip Blake, his brother Meredith, from whose laboratory the poison was taken, Elsa Greer, the girl Amyas was painting and sleeping with, the governess Cecilia Williams, and Caroline's disfigured young half-sister Angela Warren. He asks each to write an account of what they remember, and the five narratives contradict one another in small, revealing ways. Poirot concludes that Amyas never meant to leave his wife, only to finish the portrait, and that Elsa Greer, having overheard him say so, put coniine in his beer and afterwards planted Caroline's fingerprints on the bottle. Caroline, believing that Angela was responsible and owing her an old debt of guilt, let herself be convicted. Elsa admits it, and Carla is freed of the shadow.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3738,7 +3738,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002VA8MPC",
@@ -3750,7 +3750,7 @@
       "recaps": {
         "ending": "Honor survives the attempt to destroy both her standing and her life, but Gerrick, Sutton, and Hanks die in the attack on her pinnace. Martin's confession exposes Burdette, and Honor kills Burdette while serving as Benjamin's champion. She then returns to command before recovering from her injuries. Her concealed superdreadnoughts destroy Thurston's main attack force, and false reinforcements persuade Lepique to order Theisman's surviving force away from Yeltsin. Honor ends the book exhausted, injured, and acclaimed by Grayson, while her squadron is badly damaged. Nimitz, Yu, Brigham, LaFollet, Benjamin, Matthews, and Theisman survive. The Haven-Manticore war continues. Mueller remains implicated, and an unnamed senior steadholder has hidden his own role, eliminated Marchant and other witnesses, and publicly joined the movement to compensate Sky Domes.",
         "in_short": "Grayson asks the grieving and professionally sidelined Honor Harrington to command its inexperienced First Battle Squadron. As she rebuilds the force, Lord Burdette and Marchant turn religious opposition to her into a conspiracy that sabotages a Sky Domes project, kills 82 people, and frames her company. Gerrick proves the collapse was deliberate, but an attack on Honor's pinnace kills him, Sutton, and Hanks. A captured attacker confesses, and Honor kills Burdette in a lawful champion's duel. Haven's diversionary offensive has meanwhile drawn much of Grayson's strength away, opening Yeltsin to Operation Dagger. Still injured, Honor conceals her six superdreadnoughts among lighter ships, destroys Thurston's first force, and uses electronic decoys to make Theisman's second force withdraw. Grayson publicly honors her, though Mueller and an unnamed senior steadholder remain concealed participants in the domestic plot, and the wider war continues.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3888,7 +3888,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3901,7 +3901,7 @@
       "recaps": {
         "ending": "After the Sphere returns the Square to Flatland, the Square tries to preserve and spread knowledge of the third dimension. His grandson, who once approached the idea through arithmetic, withdraws when questioned and treats it as foolish. The Square writes an account and attempts to persuade others, but Flatland's authorities suppress discussion of Spaceland as dangerous heresy. He is arrested, tried before the ruling Circles, and sentenced to perpetual imprisonment. Years later he continues composing his memoir in secret. His memory of the third dimension is fading, yet he still hopes that a reader in some later generation will understand. The Sphere's own refusal to consider a fourth spatial dimension remains an additional irony: insight expanded his pupil's world without making either teacher or student immune to the limits imposed by habit and authority.",
         "in_short": "A Square describes Flatland, a two-dimensional society where geometric shape determines class: narrow triangles labor and fight, polygons hold professional rank, and nearly circular figures rule, while women are treated as dangerous lines. The regime enforces hierarchy and has crushed reforms such as the use of color. At the millennium, the Square dreams of Lineland and fails to convince its monarch that a second dimension exists. He then meets a Sphere from three-dimensional Spaceland. Unable to understand verbal explanations, the Square is lifted out of his plane and sees Flatland from above. The revelation makes him ask whether a fourth dimension might exist, but the Sphere rejects the suggestion. Back home, the Square tries to teach his grandson and society about height. The authorities imprison him for heresy, and he writes his account in confinement, hoping knowledge of dimensions will survive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4022,7 +4022,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4035,7 +4035,7 @@
       "recaps": {
         "ending": "After the Sphere returns him to Flatland, the Square tries to preserve and teach what he has learned about three dimensions. The Sphere rejects the Square's further speculation about a fourth dimension, showing that even the visitor has limits to his imagination. The Square's attempt to enlighten his grandson is interrupted, and the boy retreats from his own insight. When the Square publicly proclaims the existence of a third dimension, Flatland's authorities arrest and try him. He is sentenced to permanent imprisonment, where he spends seven years writing his account. His memory of Spaceland is beginning to fade, but he still hopes the written testimony may reach a reader able to understand it.",
         "in_short": "A Square, a citizen of the two-dimensional Flatland, describes a society whose geometric classes determine status and whose rulers suppress dangerous novelty. In a dream he visits one-dimensional Lineland and fails to convince its monarch that a second direction exists. He then receives a visitor from three-dimensional Spaceland. Unable at first to imagine height, the Square understands only after the Sphere lifts him out of his plane and lets him look down upon Flatland. His expanded vision leads him to speculate about still higher dimensions, but the Sphere dismisses the idea. Back home, the Square attempts to teach the truth and is imprisoned by the ruling Circles for heresy. He writes his account from confinement, hoping that someone in another dimension will receive it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4177,7 +4177,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4190,7 +4190,7 @@
       "recaps": {
         "ending": "The Ina Council of Judgment hears testimony connecting the attacks on Shori's maternal and paternal families to people directed by the Silk family, with the hostility focused on Shori's mixed ancestry and the genetic changes that let her tolerate sunlight. Further violence during the proceedings, including Theodora's murder, exposes continuing complicity rather than an isolated group of uncontrolled human attackers. The council rules against the Silk household and imposes penalties intended to end its power as an independent family. Shori survives attempts to eliminate the last member of her family line, but she cannot recover her memories or the relatives and symbionts who were killed. With Wright, Brook, Celia, and her Gordon allies, she begins the slower work of forming a household and learning how to live as an Ina adult. The judgment gives her a measure of safety, not a restoration of what she lost.",
         "in_short": "Shori wakes injured and without memory, appearing to be a Black child but possessing superhuman strength, rapid healing, and a need for blood. After bonding with a human named Wright, she discovers that she is a fifty-three-year-old Ina, a long-lived species that lives in mutual biochemical dependence with human symbionts. Her father Iosif explains that Shori was genetically engineered with human melanin so she can withstand sunlight, but attackers soon destroy his settlement just as they destroyed her maternal family. Shori gathers survivors and seeks protection from the Gordon family. Captured attackers reveal that they were conditioned by other Ina, leading to a Council of Judgment. Evidence ties the crimes to the Silk family and to prejudice against Shori's mixed ancestry. Theodora, one of Shori's new symbionts, is murdered during the proceedings, revealing further complicity. The council rules against the Silks and dismantles their household. Shori remains amnesiac and bereaved but survives to rebuild a family with her human and Ina allies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4360,7 +4360,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4373,7 +4373,7 @@
       "recaps": {
         "ending": "Dellarobia accepts that the monarchs' arrival is evidence of a damaged climate, not a providential endorsement of her life, and she also stops waiting for marriage to become something it is not. She and Cub acknowledge that they should separate. Dellarobia plans to pursue an education and build a different future while continuing to care for Preston and Cordelia. The Turnbow family's tensions are clarified when Hester's long-hidden history with Bobby Ogle comes to light, exposing another life shaped by secrecy and limited choices. Severe rain then floods the valley and threatens both the family land and the overwintering colony. As Dellarobia makes her way through the water with her children, the monarchs rise from the mountain in a vast moving mass. Their flight shows that at least part of the colony has survived, but it does not cancel the ecological upheaval that brought them to Tennessee. The closing image joins uncertainty with motion: the butterflies continue their migration, and Dellarobia commits herself to leaving the life that has confined her.",
         "in_short": "Dellarobia Turnbow, a restless young mother on a struggling Tennessee sheep farm, turns away from an intended affair after seeing millions of monarch butterflies covering the family's mountain. Her church and the media treat the sight as a miracle, while biologist Ovid Byron explains that the insects have been displaced from their usual Mexican winter home by destructive weather linked to climate change. Bear Turnbow's plan to log the mountain is delayed, and Dellarobia takes paid work with Ovid's team. Scientific work awakens abilities and ambitions she had set aside, even as tourists, activists, skeptics, and financial pressures pull the discovery into competing stories. She recognizes the limits of her marriage to Cub and decides to seek education and independence. After torrential rain floods the valley, the monarch colony lifts from the mountain, revealing unexpected survival amid environmental instability. Dellarobia moves forward with her children, separated from Cub and no longer willing to mistake endurance for a complete life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4543,7 +4543,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4556,7 +4556,7 @@
       "recaps": {
         "ending": "At the school Basket Boys auction, classmates compete for lunch dates with selected boys. Juli attends but does not bid on Bryce. Overwhelmed by his changed feelings and by jealousy as she sits with other boys, Bryce tries to kiss her in front of everyone. Juli escapes, angry that he has again acted without understanding her. Bryce attempts to apologize, but she refuses contact. He then begins planting a young sycamore in the neglected Baker front yard, offering a living acknowledgment of the tree she loved and of the perspective he once dismissed. Juli watches, recognizes the meaning of the act, and goes outside to help him. They have not fully resolved their history or declared a romance, but they meet at the tree with a new willingness to see and trust each other. Their parents' tensions and Bryce's conflict with his father remain, while Bryce and Juli's relationship starts again on more equal terms.",
         "in_short": "Neighbors Juli Baker and Bryce Loski have interpreted the same events differently since childhood: she adores him, while he avoids her and accepts his father's contempt for her unconventional family. Juli's attachment to a sycamore tree, the eggs from her backyard chickens, and a humiliating discovery about Bryce force her to reconsider his character. Bryce, prompted by his grandfather's friendship with Juli, begins noticing her courage and questioning his own cowardice. Learning about Juli's disabled uncle and spending time with the Bakers exposes the unfairness of his assumptions. By the time Bryce recognizes that he cares for Juli, she no longer trusts him. His public attempt to kiss her at a school auction drives her away. He finally makes a thoughtful gesture by planting a sycamore in her yard. Juli joins him, leaving them reconciled enough to begin again with a clearer view of one another.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4838,7 +4838,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -4851,7 +4851,7 @@
       "recaps": {
         "ending": "The final cell mission nearly destroys Tala's new flock. The imprisoned arcane ruler severs Terry from his body and then tears Tala's soul and gate free of hers. Rain's connection to Tala prevents her from passing on, while his berserker state resists the prisoner's soul attacks. Tala uses her ties to her family and her authority over the iron in her body to reclaim it, then reconstructs Terry around his preserved spirit. The entire unit survives and the Paragon closes the cell, but the ruler remains alive inside it. Rain proposes afterward, and Tala accepts. Terry survives as Tala's soulbound flockmate, while her inner collaborator withdraws to recover from the severing. Kit now shelters Lynn's expanding reborn community, Lisa's protected four-dimensional home, and the immortal elk's autonomous forest, but its magical wealth must remain guarded. Tala is close to Paragon and has accepted the enslaved identity imposed by the House of Blood as part of her history. Her next chosen reckoning is a voluntary return south to confront that house.",
         "in_short": "Tala develops her purpose as a protector while building Kit's pocket community, strengthening her magic, and deepening her relationship with Rain. Terry chooses an equal soulbond with her, gains fuller awareness, and commits to their new flock after confronting the loss of his first. Tala studies damaged reality, negotiates an autonomous home in Kit for an immortal elk, welcomes Lisa and a growing reborn population, and accepts the enslaved identity she had tried to separate from herself. During a final cell closure, an arcane ruler destroys Terry's body and tears Tala's soul from her own. Her bond with Rain keeps her from passing on; she reclaims her body through family and iron, restores Terry, and helps the unit survive until the cell closes. Rain then proposes, and Tala accepts. She remains short of Paragon and plans to face the southern house that enslaved her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5028,7 +5028,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5041,7 +5041,7 @@
       "recaps": {
         "ending": "Flora, William, George, Tootie, and Dr. Meescham search for the missing Ulysses after Phyllis secretly takes him away. Ulysses escapes from confinement, and the pursuit forces mother and daughter to confront what each has feared: Flora believes she is unwanted, while Phyllis has acted from panic about losing her child. Phyllis admits her love for Flora, and Flora finally believes her. William's claimed blindness ends as he allows himself to see again. Ulysses returns safely and writes a poem for Flora, confirming that their friendship and the love surrounding them are real. George and Phyllis do not simply erase their divorce, but the family is able to speak honestly and reconnect. Flora's practiced cynicism gives way to hope and to an acceptance that astonishing things, including love, can be trusted.",
         "in_short": "Ten-year-old Flora Belle Buckman rescues a squirrel after a neighbor's vacuum cleaner sucks him up. The accident gives the squirrel, whom Flora names Ulysses, great strength, flight, human understanding, and the ability to write poetry. Flora, a self-declared cynic raised on superhero comics, decides he has an important destiny and may also have a dangerous enemy. Her divorced mother, Phyllis, regards Ulysses as a threat, while Flora's lonely father George, neighbor Tootie Tickham, Tootie's temporarily blind great-nephew William Spiver, and the perceptive Dr. Meescham join the widening adventure. Phyllis secretly removes Ulysses, prompting a search that exposes Flora's deeper fear that her mother does not love her. When the squirrel escapes and the family confronts one another, Phyllis assures Flora of her love, William regains his sight, and Ulysses returns. His final poem celebrates Flora and the world, leaving Flora less cynical and newly willing to trust love and wonder.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5217,7 +5217,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5230,7 +5230,7 @@
       "recaps": {
         "ending": "Charlie proves that the experimental increase in intelligence is temporary: the same defect that is destroying Algernon's gains will cause his own rapid regression. Algernon dies, and Charlie buries him, continuing to leave flowers at the grave. As Charlie loses his advanced knowledge, reading ability, coordination, and recent memories, Alice and the research team try to support him. For a short time he returns to Donner's Bakery, where former tormentors defend him when a new worker mocks him. He eventually walks into Alice's class without remembering why he left it, and her distress makes him realize that remaining near his old life will prolong everyone's pain. He decides to enter the Warren State Home rather than wait to become dependent on his friends. In his final progress report, his spelling and understanding have returned close to their original level, but he retains his kindness and his wish to be useful. He asks that someone continue putting flowers on Algernon's grave.",
         "in_short": "Charlie Gordon, a bakery worker with an intellectual disability, is chosen for an operation that has already made a laboratory mouse, Algernon, unusually intelligent. Charlie's abilities rise with extraordinary speed, exposing the cruelty he once mistook for friendship and leaving his emotional life far behind his intellect. He falls in love with his former teacher Alice Kinnian, challenges the scientists who treat him as their creation, and escapes with Algernon. When the mouse begins to decline, Charlie races to understand the experiment and discovers a fatal flaw: artificially induced intelligence will regress as rapidly as it developed. Algernon dies, and Charlie soon loses his knowledge, skills, and recent memories. He briefly returns to the bakery, where old coworkers now protect him, but leaves for the Warren State Home after accidentally returning to Alice's class. His last request is that flowers be placed on Algernon's grave.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/flowers-of-esthelm.json
+++ b/data/works-community/0/flowers-of-esthelm.json
@@ -335,7 +335,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774248123",
@@ -347,7 +347,7 @@
       "recaps": {
         "ending": "Erin mourns Toren after authorizing Pisces to sever the mana sustaining him. No one witnesses Toren's destruction, so his fate remains uncertain. Erin chooses to return to Liscor with Ceria, Pisces, Yvlon, and Ksmvr. Pisces and Ksmvr recover an enchanted door and anchor from Albez, and the Horns give them to Erin. The mages turn the pair into a working portal connected to the inn, although its range and traffic depend on stored mana.\n\nLyonette has made the Wandering Inn viable through honey, cooked bees, and Antinium customers. She cares for the young white-furred Gnoll and a bee larva while Pawn's painted soldiers begin developing individual identities. Delegates from other Antinium hives arrive to inspect Liscor's unusual population, with Pawn's Acolyte class still concealed. Laken and Durene rule a devastated River Farm that needs food, shelter, burial work, and protection. Ryoka remains tied to Ivolethe and Magnolia while facing Persua's threatened revenge. Geneva continues her medical work in Baleros with her injured body dependent on the self-bodied rogue. The Esthelm siege is over, but the wider Goblin Lord army, Garen's hostility, and Magnolia's conflict with the Circle of Thorns remain open.",
         "in_short": "Several distant struggles reshape the people around the Wandering Inn. Laken becomes an Emperor and saves avalanche-buried River Farm with Durene. Geneva establishes neutral battlefield medicine in Baleros but survives only through a self-bodied rogue's connection. Ryoka befriends Ivolethe, clashes with Persua, and becomes Magnolia Reinhart's uneasy ally. Pawn turns a disastrous religious awakening into a path toward Antinium individuality, while Lyonette restores the inn by serving his painted soldiers and caring for a young Gnoll. In Esthelm, Redfang warriors sacrifice themselves to help defeat a Goblin Lord force as the independent skeleton Toren commands undead and escapes. Erin learns that Pisces created Toren with sentience and orders his mana link severed, though his death is not confirmed. She leaves for Liscor with the Horns of Hammerad, carrying a recovered magical door that now opens a portal to her inn.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -516,7 +516,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -527,7 +527,7 @@
       "recaps": {
         "ending": "The Hexenwulf belts destroy their own wearers: Denton's rogue FBI team and the Streetwolves gang are consumed or killed by the wolf-demon spirit that powered their talismans, and the belts are ruined for good. Harley MacFinn's loup-garou, the truly unstoppable curse at the center of the killings, is finally brought down. Tera West, revealed to be a real wolf who had taken human form to be with MacFinn, survives and returns to the wild, having lost the man she loved. Kim Delaney's death, in an attempt to raise a containment circle Harry had refused to teach her, stays a lasting weight on his conscience. Murphy, attacked during the case and now forced to see plainly the kind of danger Harry stands between the city and, forgives him enough to repair their working relationship, and Harry resolves to trust her with more of the truth. Billy and the Alphas, having fought well, become steady long-term allies. Marcone, targeted by the loup-garou, comes through unharmed and unbowed. Harry ends the case wounded, poorer, and guilt-ridden, but a little more firmly rooted among the people who will stand with him.",
         "in_short": "A rash of savage killings in Chicago falls on the nights of the full moon, and Harry Dresden - estranged from Murphy, who has learned he keeps secrets - is pulled in to identify a werewolf. He finds not one but several kinds: the benign shapeshifting college pack called the Alphas, led by Billy; the born wolf-woman Tera West; her fiance Harley MacFinn, cursed to become an uncontrollable loup-garou; and worse, corrupt FBI agents under Denton and a street gang using Hexenwulf belts, dark talismans that grant a wolf shape while devouring the wearer's mind. A young practitioner Harry had refused to teach, Kim Delaney, dies attempting a circle meant to contain MacFinn. Amid battles that consume the belt-wearers by their own power, the loup-garou is finally destroyed, Denton's team and the Streetwolves are wiped out, and Harry, badly hurt, wins back enough of Murphy's trust to rebuild their partnership and gains the Alphas as lasting allies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -710,7 +710,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -723,7 +723,7 @@
       "recaps": {
         "ending": "Fitz is at Buckkeep, where the beaten beggar at the gate turns out to be the Fool: blind, crippled by torture, half-mad, and carrying a warning about the Servants of Clerres, the order he was raised in and escaped, who hunt White Prophets and who have been hunting him. He speaks of a son he believes was taken from him, and of the messengers he sent north who never arrived. Fitz keeps him hidden and begins the slow, dangerous work of healing him. While he does, Withywoods is attacked. Pale strangers and Chalcedean mercenaries ride in behind a fog that unmakes memory, so that people watching the raid forget it as it happens and forget it afterwards; the steward Revel is killed, FitzVigilant is badly wounded, servants are murdered, and Bee and Shun are carried off. Perseverance, left for dead, is one of the few who remembers anything at all. The raiders take Bee because of what she is: the daughter of the White Prophet's Catalyst, and herself a dreamer of prophecy. The book ends with Bee a prisoner being carried away from her home, and with her father hundreds of miles away, tending the friend he thought lost and knowing nothing whatsoever about it.",
         "in_short": "Twenty years after he finally claimed the life he wanted, FitzChivalry lives at Withywoods as Holder Tom Badgerlock with Molly, his daughter Nettle running the Skill at Buckkeep and his old master Chade still pulling strings. A hurt, pale stranger comes to the house one winter festival looking for him, and vanishes leaving blood in the snow and almost no memory of herself behind. Then Molly declares she is pregnant, long past the age for it, and holds to it for two years while everyone including Fitz privately concludes she is deluded, until she gives birth to a tiny daughter, Bee. Bee grows with agonizing slowness, seems simple and mute, and is in fact fiercely intelligent, watchful, and troubled by dreams that are not hers. Molly dies; Chade plants his unacknowledged children Shun and FitzVigilant at Withywoods; and Fitz, distracted by all of it, neglects the daughter who needs him. At Buckkeep, a beaten beggar turns out to be the Fool, blinded and broken by the Servants of Clerres, warning of an unexpected son they are hunting. While Fitz tends him, pale raiders take Withywoods behind a fog that erases memory, kill its people and carry Bee and Shun away.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -931,7 +931,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -944,7 +944,7 @@
       "recaps": {
         "ending": "Fitz kills the cat, ending Peladine with it, and the prince is freed of the compulsion that had been eating him. Laudwine escapes badly maimed, still holding the Piebalds' threat to expose Witted nobles, and Fitz and Dutiful bring the party home in time for the betrothal, which goes forward with the Outislander narcheska as planned. During the rescue Fitz and Dutiful were joined mind to mind, so the prince now knows exactly who his mother's new servant is, and Kettricken and Chade formally take Fitz back into the family's service as Dutiful's Skill teacher and the Queen's man. He will live at Buckkeep as Tom Badgerlock, servant to Lord Golden, with a stool in Chade's tower and a boy to teach. Nighteyes, worn out by the journey and by carrying Fitz through the fight, dies quietly, and Fitz is left for the first time in his adult life without the other half of himself. Hap is apprenticed to a woodworker in Buckkeep Town, Starling is gone from his life for good, and the Fool has taken up residence at court in his Lord Golden guise with Fitz at his shoulder. The Piebalds remain at large, the Six Duchies still hang their Witted, and the marriage bargain with the Out Islands is only beginning to be paid for.",
         "in_short": "Fifteen years after the Red Ship war, FitzChivalry Farseer lives as Tom Badgerlock in a remote cottage with his wolf Nighteyes and his foster son Hap, letting the kingdom go on believing him dead. His old mentor Chade wants him back at Buckkeep to teach the Skill to Prince Dutiful, and his old friend the Fool returns in a new guise as the wealthy foreigner Lord Golden. When Dutiful vanishes days before a politically vital betrothal to an Outislander noblewoman, Fitz agrees to find him and takes service with Lord Golden as cover. The search leads through country full of Witted folk to the Piebalds, a militant faction who have deliberately bonded the prince to a hunting cat carrying the spirit of their leader's dead sister, intending to take his body and his throne. Fitz kills the cat, frees Dutiful, and brings him home for the betrothal, and in the process is bound to the boy mind to mind and drawn permanently back into Farseer service. The victory costs him Nighteyes, who dies soon after their return, leaving Fitz alone at Buckkeep as Lord Golden's servant and the prince's secret Skill master.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1168,7 +1168,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1181,7 +1181,7 @@
       "recaps": {
         "ending": "Icefyre is cut free of the glacier and lives, the Pale Woman's power on Aslevjal is broken and she does not leave the island, and Elliania is released from the coercion that made her demand a dragon's head. The bride price is paid to the letter when Icefyre consents to lay his head on the narcheska's hearth, and the Farseer and Outislander marriage stands. The Fool, killed under torture, is brought back to life by Fitz through the Skill at a cost neither of them fully accounts for, and then leaves: his prophecy is fulfilled, his work in the world is done, and he goes south with Prilkop, telling Fitz goodbye. Fitz returns to the Six Duchies through the Skill-pillars and reaches Burrich as he is dying, in time to be recognized and forgiven. Freed at last from the dead man he was pretending to be, Fitz goes to Molly, tells her the truth, and they marry; the crown grants him the holding of Withywoods, where he lives on as Holder Tom Badgerlock rather than take back the Farseer name he is offered. Nettle learns who her father is and comes to Buckkeep to serve the Skill. Dutiful acknowledges his own Wit, and with Kettricken and Web behind him the persecution of the Witted begins to end. Fitz has the ordinary life he was never supposed to get, and no idea where in the world the Fool has gone.",
         "in_short": "Committed to bringing the narcheska the head of the dragon Icefyre, Prince Dutiful sails for the Out Islands with Chade, Thick, Web, Swift and Fitz. Convinced that the Fool will die on Aslevjal, Fitz conspires to leave him behind, a betrayal the Fool does not forgive. In the islands Fitz learns why Elliania set the price: her mother and sister are hostages of the Pale Woman, the White Prophet's ancient rival, who wants the last dragon of the north dead. On Aslevjal the party finds Prilkop, a White Prophet from an earlier age, and discovers that Icefyre is alive in the ice. The Fool comes anyway, is captured, and is tortured to death in the Pale Woman's tunnels beneath the glacier. Tintaglia arrives and demands the dragon be freed rather than killed; Icefyre is cut loose and the Pale Woman destroyed. Fitz brings the Fool back from death through the Skill, and Icefyre satisfies the vow by laying his head on the narcheska's hearth. The Fool departs for the south with Prilkop. Fitz returns home in time to see Burrich die, then reveals himself to Molly at last and marries her, settling at Withywoods, while Dutiful admits his Wit publicly and Nettle learns who her father is.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1426,7 +1426,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1439,7 +1439,7 @@
       "recaps": {
         "ending": "Fitz destroys the raiders' camp and recovers Shine, but Dwalia takes Bee into a Skill-pillar moments ahead of him, and everything Fitz can find afterwards convinces him that his daughter died in the snow. He comes home to a kingdom that finally names him: Dutiful, Kettricken and Nettle present him to the court as FitzChivalry Farseer, prince of the realm, twenty years after they buried him. Nettle and Riddle are married and expecting a child, Shine and FitzVigilant learn whose children they are, and Chade, aged and damaged, is no longer the man who ran the Six Duchies from behind its walls. None of it touches Fitz. He and the Fool set out south for Clerres to destroy the Servants and everyone in them, taking FitzVigilant, Chade's apprentice and Perseverance with them, travelling as a merchant party. What neither of them knows is that Bee is alive. Carried through the Skill-pillars by Dwalia and lost inside them for months, she emerges at Kelsingra, half-starved and barely conscious, into an Elderling city full of dragons, where Malta Khuprus and the Elderlings take her in and begin working out who she is. She is thousands of miles from home and no one who loves her knows she exists, while her father sails away to avenge a death that never happened.",
         "in_short": "At Buckkeep for Winterfest, Fitz hides the tortured, blinded Fool in a secret room and hears his story: the Servants of Clerres, the order that bred and broke him, are hunting an unexpected son of prophecy. Fitz heals him with the Skill and with Silver taken from Chade's hidden store, silvering his own hand in the process. Then word reaches him of the raid on Withywoods. He Skill-travels home to find his steward dead, his tutor cut down, his people's memories eaten away by a fog, and Bee and Shun gone. Bee, meanwhile, is being carried south by Dwalia's Servants, who believe she is the Shaysim of their prophecies, with the fog-maker Vindeliar bending everyone around them and the Chalcedean mercenary Ellik taking his pay out of Shine. Fitz hunts them across the Six Duchies through the Skill-pillars, tearing himself apart to do it, and finally destroys their camp; he recovers Shine and kills Ellik, but Dwalia escapes into a pillar with Bee, and Fitz is left certain that his daughter is dead. He is publicly acknowledged as Prince FitzChivalry Farseer, then sails south to annihilate Clerres. Bee, lost in the pillars for months, emerges alive at Kelsingra among the Elderlings and their dragons.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1648,7 +1648,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1661,7 +1661,7 @@
       "recaps": {
         "ending": "The struggle over the Focus and the killings surrounding it is brought to a close without giving Rachel a clean victory over every interested faction. Rachel is no longer the artifact's custodian, and it no longer offers an immediate route for one pack to dominate the Weres, but her part in deciding its fate leaves lasting political consequences. Piscary escapes confinement amid the wider disorder, proving that his influence over Cincinnati's vampires remains lethal. Kisten disappears after arranging to meet Rachel on his boat. Rachel is later found injured and with crucial memories missing, and Kisten's body is recovered. She knows that he was murdered but cannot remember the attack or identify his killer. The loss devastates Rachel and Ivy and leaves the crime unresolved at the close. Skimmer's involvement with Piscary and her history with Ivy further damage the fragile trust around the church. Rachel survives the demon, Were, and vampire pressures, but the book ends with Kisten dead, Piscary's escape tied to the catastrophe, and Rachel unable to supply the memory that might explain what happened.",
         "in_short": "Rachel returns to Cincinnati carrying the Were Focus, an artifact capable of changing pack leadership, while FIB deaths and supernatural rivalries make possession of it increasingly dangerous. Newt's intrusion shows that demons can reach directly into Rachel's home. Glenn and Rachel investigate deaths connected to the struggle around the Focus, as David helps her navigate Were politics and Trent seeks an outcome that protects elven interests. The arrival of Skimmer, Ivy's former lover and Piscary's attorney, brings vampire loyalties back into the conflict. Rachel gives up custody after helping prevent the Focus from becoming a permanent tool of domination, but the larger crisis creates an opening for Piscary to escape confinement. Kisten vanishes after arranging to meet Rachel. She is found injured with part of the night missing from her memory, and Kisten is found murdered. Rachel cannot identify the killer or reconstruct the attack. The case therefore ends with the immediate Focus crisis contained but with Kisten dead, Piscary's escape casting a shadow over the loss, and Rachel and Ivy grieving without answers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1783,7 +1783,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1796,7 +1796,7 @@
       "recaps": {
         "ending": "During his impossible day with Posey, Chick finally understands that the story he told himself about his parents was false. His mother did not casually drive his father away; she discovered that Len had another family and protected her children from the full humiliation while working to support them. Chick also faces the cruelties and absences with which he repaid her loyalty, especially leaving her birthday to answer Len's call for a baseball game. Posey died while Chick was away, making that choice his most persistent guilt. Their day gives him the chance to express love and receive her forgiveness before she disappears. Chick then wakes in a hospital: he survived the crash and suicide attempt that brought him home. The framing narrator is revealed to be his daughter Maria. She explains that he stopped drinking and made a sustained effort to repair their relationship. He lived for several more years before dying, and Maria's account preserves the story he entrusted to her. The extra day does not undo the past, but it returns Chick to life with enough honesty to change what remains.",
         "in_short": "Charles “Chick” Benetto, a former baseball player ruined by alcohol and estranged from his family, attempts suicide after discovering that his daughter Maria married without inviting him. Returning to his hometown, he crashes his car and reaches his childhood house, where his long-dead mother Posey appears alive. Chick spends a day accompanying her and remembering the many times she defended him while he failed to defend her. He had sided with his baseball-obsessed father Len after his parents separated and later abandoned Posey on her birthday to play in a game Len arranged; she died before Chick returned. Posey helps him understand that Len maintained another family and that she had borne the consequences in silence while supporting her children. Chick admits his failures, receives her love, and wakes alive in a hospital. He gives up drinking and rebuilds a relationship with Maria. After his later death, Maria reveals herself as the narrator who has preserved his account of the day with Posey.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2254,7 +2254,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2269,7 +2269,7 @@
       "recaps": {
         "ending": "The defense of Delta Pavonis fails. The Others kill the Pav who remain on the planet and spend years stripping the system, but Jacques's contingency saves 20,000 Pav in stasis along with cultural, biological, and agricultural archives. Once awakened and told what happened, representatives of the survivors choose a new world at HIP-84051 instead of returning to a ruined homeworld under permanent Bob support. Their refugee ships depart for resettlement. Jacques and other replicants destroyed in battle can be restored into new vessels. Bill, Riker, and Oliver begin expanding dreadnought fleets and the network regroups at Gamma Pavonis while Bill develops a possible offensive answer to the Others. On Eden, Bob secretly visits Camelot through a Deltan-form android after years of banishment, but Diana dies and the unusually long-lived Archimedes is left a widower. On Vulcan, Stéphane dies, and Howard's human-form android allows him to begin a physical relationship with Bridget. Bender remains missing, Henry remains in recovery, and surviving Brazilian probes may still be active elsewhere.",
         "in_short": "The Bobs expand human colonies, link their distant network through SCUT, and confront threats on several fronts. Bob protects the Deltans from giant flying predators but is banished for the destructive scale of his intervention. Riker discovers that Vehement used malware to force Homer into sabotaging Earth's food infrastructure; Homer later destroys himself, and Riker eliminates Vehement's leadership. Meanwhile, Mario's discoveries reveal the Others, a hive species that consumes life and strips entire systems. New weapons, hardened ships, cloaking, and android bodies follow, but the Bobs cannot stop an Others fleet at Delta Pavonis. Jacques saves 20,000 members of the native Pav before the rest are killed and their world is dismantled. The refugees choose resettlement at HIP-84051. Howard returns physically to Vulcan through an android and begins a relationship with Bridget after Stéphane's death, while Bob secretly rejoins Archimedes's family before Diana dies. The network ends the book building fleets for an offensive war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2490,7 +2490,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2503,7 +2503,7 @@
       "recaps": {
         "ending": "The Republican attack proceeds even though the enemy has been alerted. Jordan and the guerrillas take the bridge from both ends and destroy it, but the operation costs Fernando and Eladio their lives. Anselmo is killed by debris from the blast. During the retreat, Jordan's horse falls on him and breaks his leg. He knows he cannot be moved and persuades the others to leave him behind. Pablo has obtained horses by killing the additional fighters he recruited, and he leads the survivors away. Jordan says farewell to Maria, insisting that what they share will continue through her and that she must go with Pilar. Alone by the road, he considers suicide but chooses to remain conscious and useful. As enemy troops approach, he positions his machine gun and waits to ambush Lieutenant Berrendo, buying the others time. The novel ends before the shot is shown, with Jordan facing his likely death calmly and still committed to the people escaping behind him.",
         "in_short": "During the Spanish Civil War, American volunteer Robert Jordan is ordered to destroy a bridge behind Fascist lines as a Republican offensive begins. He joins Pablo's guerrilla band, where Pablo fears the mission while Pilar assumes leadership and supports it. Jordan falls in love with Maria, a young survivor rescued from Fascist captivity, and imagines a future with her despite the operation's poor odds. Enemy activity and the destruction of El Sordo's allied band convince Jordan that the offensive has been detected. He sends Andrés with a warning, but obstruction delays the message until cancellation is impossible. Pablo steals crucial equipment, then returns and helps improvise the attack. The bridge is destroyed, and several guerrillas die, including Anselmo. During the retreat Jordan's horse crushes his leg. Unable to travel, he sends Maria and the survivors on without him and remains beside the road with a machine gun, preparing to delay the pursuing troops at the cost of his life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2696,7 +2696,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2709,7 +2709,7 @@
       "recaps": {
         "ending": "The collection's final story ends aboard Milton Krest's yacht after his expedition has killed an entire reef with poison to obtain the rare Hildebrand fish. Krest has also humiliated and beaten his wife, Liz. Bond later finds him dead, with the specimen forced into his mouth. The circumstances point toward someone aboard the yacht, but Bond cannot establish whether Liz Krest or Fidele Barbey killed him, and the story does not disclose a culprit. Liz moves quickly to frame the death as an accident at sea and asks for help managing its aftermath. Bond is left with the moral certainty of Krest's cruelty but no clean official truth about his death. Because this is a collection of independent stories, the close does not hand off a single continuing plot: Bond's status with the Secret Service is unchanged, while the murder aboard the yacht remains deliberately unresolved.",
         "in_short": "Five independent stories follow Bond through varied assignments and encounters. Near Paris he uncovers a hidden Soviet unit murdering military dispatch riders. He then acts unofficially for M against the killers of Judy Havelock's parents and finds Judy pursuing the same revenge. In the Bahamas, a governor tells him how Philip and Rhoda Masters's marriage survived after mutual sympathy fell below the smallest sustaining level, correcting Bond's judgment of another couple. In Italy, Bond learns that supposed ally Kristatos, not accused smuggler Colombo, runs the heroin route; he joins Colombo in destroying it. Finally, Bond accompanies Milton and Liz Krest and Fidele Barbey in search of a rare fish. Krest poisons a reef and abuses Liz, then is found dead with the specimen in his mouth. Whether Liz or Barbey killed him remains unanswered.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2840,7 +2840,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2853,7 +2853,7 @@
       "recaps": {
         "ending": "Katherine's summer away gives her enough distance to recognize that her feelings have changed. She becomes attracted to Theo, another counselor, and can no longer honestly promise Michael the permanent future they once imagined. Michael visits and is devastated when Katherine ends the relationship. Their sexual intimacy and genuine love do not prevent the breakup, nor do they make what they shared meaningless. Katherine returns home grieving the loss and adjusting to a future no longer organized around Michael. By the close, she is looking forward to seeing Theo, accepting that a first love can be profound without lasting forever. Michael's life will continue separately, Erica has learned that affection cannot cure Artie's serious emotional problems, and the adolescents face adulthood with fewer illusions about permanence.",
         "in_short": "High-school senior Katherine Danziger meets Michael Wagner at a New Year's Eve party and begins her first serious romance. Their attraction develops into trust, declarations of love, and discussion of sex. Katherine seeks reliable contraception, and the couple eventually have intercourse, treating the choice as a shared responsibility rather than an accident. Around them, Sybil confronts pregnancy and Erica struggles with Artie's emotional instability, showing that intimacy cannot remove every risk or solve another person's problems. Katherine and Michael come to describe their bond as permanent, but her parents encourage time apart before college. During a summer counseling job, Katherine meets Theo and realizes her feelings are no longer exclusive or fixed. She ends the relationship when Michael visits. Both are hurt, yet Katherine accepts that a relationship may have been loving and important without lasting forever, and she returns home open to what comes next.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2977,7 +2977,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2990,7 +2990,7 @@
       "recaps": {
         "ending": "Leonard confronts Asher with the pistol and forces the buried source of their hostility into the open: Asher sexually abused him when they were younger and has since maintained control through intimidation and denial. Leonard cannot carry out the murder he planned. Still intending to die, he returns to the city and reaches the point of acting on his suicide plan. Herr Silverman, who has understood Leonard's signals more clearly than the other adults around him, follows and intervenes. He keeps Leonard alive, hears what happened, and ensures that the gun and immediate danger are removed. Leonard does not receive an instant cure or a repaired family; the neglect, abuse, and isolation remain real. What changes is that his story is finally known by a trustworthy adult and his imagined future is no longer merely an argument he must make alone. The future letters interspersed through the book point toward a possible adult life of useful work and loving relationships. The close leaves Leonard in recovery, with Silverman's continuing care offering the first credible reason to remain alive.",
         "in_short": "On his eighteenth birthday, Leonard Peacock takes his grandfather's pistol to school, intending to give four farewell gifts, kill former friend Asher Beal, and then kill himself. His rounds reveal the few connections that matter to him: elderly neighbor Walt, violinist Baback, religious teenager Lauren, and Holocaust teacher Herr Silverman. None provides the rescue he half seeks, though Silverman notices more than Leonard expects. Leonard's hatred of Asher comes from sexual abuse during their childhood and the bullying and denial that followed. When Leonard finally confronts him, he does not commit the planned murder. He remains suicidal, but Silverman tracks him down and intervenes before he can die, listens to the truth, and takes responsibility for getting him help. Imagined letters from Leonard's possible future frame survival as difficult but meaningful. The novel ends without pretending his pain is resolved, but he is alive, no longer carrying the secret alone, and connected to an adult prepared to stay with him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3139,7 +3139,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3152,7 +3152,7 @@
       "recaps": {
         "ending": "Forrest's shrimp venture becomes successful, and he makes sure Bubba's family benefits from the dream Bubba did not live to pursue. Wealth and public notice do not settle Forrest's life. When he finally finds Jenny again, he learns that she has a young son who is also named Forrest and is his child. Jenny has made a stable life with another man, and Forrest decides not to break apart the boy's home, even though walking away costs him the future with Jenny that he has always wanted. He returns to a wandering existence with Dan and Sue, making music for passersby. The ending leaves Forrest materially poorer than he might have been but still loyal to the people he loves. After passing through institutions that alternately exploit and celebrate his talents, he measures his choices by friendship and Jenny's happiness rather than status.",
         "in_short": "Forrest Gump, a powerful Alabama man considered intellectually disabled, moves through an extraordinary series of American institutions and public events. His athletic ability takes him to college football, then the Army sends him to Vietnam, where his friend Bubba dies and Forrest acts bravely. He becomes a table-tennis celebrity, meets national leaders, and is recruited for a space flight with astronaut Janet Fritch and an orangutan named Sue. After the craft crashes far from its target, Forrest survives captivity and returns to pursue music, wrestling, chess, and the shrimp business Bubba imagined. Through every abrupt change he continues to love his childhood friend Jenny, though their paths rarely stay joined. The shrimp venture prospers and benefits Bubba's family. Forrest later discovers that Jenny's son is his, but because she has built a secure family with another man, he leaves them undisturbed and resumes traveling with Dan and Sue.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3281,7 +3281,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3294,7 +3294,7 @@
       "recaps": {
         "ending": "After the narrator’s mother gives birth, the Kinsellas return her to her crowded family home. The contrast is immediate: the care and order she experienced during the summer give way again to shortage, embarrassment, and her father’s brusque manner. Edna and John cannot openly claim a place in the family, and the visit remains polite despite the attachment all three feel. As their car leaves, the girl runs after it. John gets out and she reaches him, holding him with an urgency that finally gives voice to their bond. Her biological father approaches, and she calls out using a child’s name for a father while both men are present. The moment leaves the address deliberately suspended between warning her foster father and naming him as the parent she has come to love. She remains with her birth family, but the summer has permanently shown her that a home can be governed by attention, honesty, and affection rather than neglect.",
         "in_short": "An unnamed girl from a poor, crowded household is sent to spend the summer with Edna and John Kinsella while her mother prepares to give birth. In their quiet farm home she is bathed, properly clothed, fed without anxiety, trusted with chores, and treated with a patience new to her. The couple carry an unspoken grief: their young son died in an accident, a fact the girl learns from a neighbor rather than from them. The knowledge explains some of their reserve but does not reduce their care to replacement. The girl grows healthier and more confident, especially beside the taciturn John. When the new baby arrives, the Kinsellas take her back to her parents. Their departure restores the old distance and disorder. She runs after their car and embraces John, using a child’s name for a father as her biological parent approaches. The ambiguous cry reveals where she has found a genuine parental bond even though she cannot remain there.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3445,7 +3445,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3458,7 +3458,7 @@
       "recaps": {
         "ending": "Maxine's coded route is ultimately explained by money she took from Eddie Kuntz and by her attempt to make him follow the consequences of his own conduct while she stayed hidden. Eddie, not Maxine, is the killer behind the attacks on people connected to the messages. He has been hunting the missing money and eliminating witnesses who could lead others to it. Stephanie, Lula, Sally, Ranger, and Morelli assemble enough of the route to reach Maxine and force the concealed conflict into the open. Eddie dies in the final confrontation, ending the murders and the danger attached to the cash. Stephanie locates Maxine and completes the bond recovery, while the destruction of Stephanie's apartment has already pushed her into Morelli's home and changed their relationship from intermittent attraction to an acknowledged physical involvement. The case closes professionally, but Stephanie's living situation and her competing attachments to Morelli and Ranger leave her personal life unsettled.",
         "in_short": "Stephanie Plum is hired to recover Maxine Nowicki, who skipped court after taking her former boyfriend Eddie Kuntz's car. Maxine remains hidden but sends coded messages that Stephanie, Lula, and drag performer Sally Sweet work to solve. Rival bounty hunter Joyce Barnhardt follows the same trail, and people linked to Maxine and Eddie are attacked as the clues point toward missing cash. Violence reaches Stephanie directly when her apartment is destroyed, forcing her to stay with Joe Morelli and turning their recurring attraction into a sexual relationship. The final solution clears Maxine of the murders: Eddie has been killing to recover the money and silence people who might lead others to it. Eddie dies in the confrontation, Stephanie finds and returns Maxine, and the bond case closes. Stephanie ends with stronger professional alliances and no stable answer to the personal complications created by Morelli, Ranger, and the loss of her home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3660,7 +3660,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3673,7 +3673,7 @@
       "recaps": {
         "ending": "The mission to the outpost at Athebyne is a fabrication: the squad finds the border town of Resson under attack by wyvern and by venin, dark wielders who drain the life out of the land itself and who Navarre's leadership insists have not existed for centuries. Liam Mairi is killed covering Violet, and Violet, badly hurt, kills wyvern with lightning while Andarna spends her own strength to buy them time. The truth comes out afterward: Navarre's wards have been failing at the edges, whole villages have been abandoned to the venin, the leadership has kept it secret, and Xaden and the marked riders have spent years smuggling alloy weapons that can actually kill a venin to Poromiel's fliers. Rather than return to Basgiath, Xaden flies Violet to Aretia, the ruined seat of Tyrrendor and the revolution's real base. There she is carried to a healer and finds that her brother Brennan, mourned for six years, is alive and has been part of the rebellion all along. Violet ends the book alive, bonded to two dragons, wielding a signet no living rider shares, and on the opposite side of a lie her own mother helped maintain.",
         "in_short": "Violet Sorrengail is raised to be a scribe, but her mother, the general commanding Basgiath War College, orders her instead into the Riders Quadrant, where cadets who fail to bond a dragon usually die. Physically fragile and marked out at once as the easiest kill in her year, she survives the parapet, the Gauntlet and repeated attempts on her life by using knowledge, poisons and planning. At the Threshing she bonds two dragons at once, the powerful black morningstartail Tairn and a golden feathertail hatchling, Andarna, which is unheard of, and her signet turns out to be lightning. Her wary hostility toward Xaden Riorson, the wingleader whose father her mother executed, becomes an alliance and then a relationship. Sent on what is presented as a routine flight to a border outpost, her squad instead finds a town under attack by wyvern and by venin, enemies the kingdom claims do not exist. Her friend Liam is killed, Violet learns that Navarre's leaders have been lying about the war and about the failing wards, and Xaden takes her to the rebel city of Aretia, where her brother Brennan, believed dead for six years, is alive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3997,7 +3997,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B09TTWH1NX",
@@ -4009,7 +4009,7 @@
       "recaps": {
         "ending": "Drew breaks the siege of Great Grove by forcing Aeon awake, killing Clive's grave-knight form and the second grave knight directing the undead army. The leaderless force loses its coordination, but the lich itself survives. Gary reaches the grove's healers with critical wounds, while Sarah, Daryl, Bill, Lincoln, Zoe, Captain DeVos, and the grove leader survive on the available account. Drew collapses under the pain and strain of the awakening, and Luke reveals six wings to carry him to safety. Off-world, the Protectorate identifies the lich as the Forgotten Servant. Drew's awakened Retribution is judged both an exceptional success and a legal violation. A Hellenic Red Mage's fleet is ordered to protect him until he atones, Isis is sent to assist with that process, and Hades is positioned to destroy the Forgotten Servant after Drew defeats it. Great Grove's alliance, the lich threat, the Naga survivors, and Nats Park's political and supply problems all remain unresolved.",
         "in_short": "After finishing Nats Park's local Naga campaign, Drew establishes new node infrastructure and leads Sarah, Daryl, Luke, Gary, Bill, and Clive toward Arlington. The expedition clears route dungeons, crosses a ruined Potomac under attack from animated monuments, encounters a lich's undead army, and loses Clive in Arlington Cemetery. At the Air Force Memorial, Drew claims a node and reunites with Lincoln and Zoe, now the intelligent leader of transformed dogs. The party enters Great Grove and discovers a survival alliance between humans and fae. When the lich attacks, Drew commands the defense. Clive returns as an undead sniper and critically wounds Gary, but Drew forces Aeon awake, kills Clive and the army's other grave knight, and breaks the siege before collapsing. Luke carries him to safety. The Protectorate then identifies the lich as the Forgotten Servant and mobilizes a fleet, Hades, and Isis around Drew, whose awakened Retribution now requires atonement.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4232,7 +4232,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4245,7 +4245,7 @@
       "recaps": {
         "ending": "After the creature kills Henry Clerval, Victor is imprisoned but eventually cleared and returned to his family. He marries Elizabeth while expecting the creature to attack him, only to discover that the threat concerned Elizabeth: she is murdered on their wedding night. Alphonse dies soon afterward, and Victor devotes himself to revenge, pursuing his creation north until Walton's expedition rescues him from the ice. Walton turns the ship south when his endangered crew insists on returning home. Victor dies aboard the vessel before he can continue the chase. The creature then appears beside his body, mourning the man he hated and acknowledging that vengeance has brought only misery. He tells Walton that he will travel farther north, destroy himself on a funeral fire, and leave no remains from which another being like him could be made. He departs alone across the ice and disappears into the darkness.",
         "in_short": "Arctic explorer Robert Walton rescues Victor Frankenstein, who recounts how his pursuit of scientific glory led him to animate a being assembled from human remains. Horrified, Victor abandoned his creation. Rejected wherever he went, the creature secretly educated himself by observing the De Lacey family, then demanded that Victor make him a female companion. Victor agreed but destroyed the second being before completing it. In retaliation, the creature killed Victor's friend Henry and his bride Elizabeth, adding to deaths that began with Victor's young brother William and the wrongful execution of Justine. Victor chased the creature into the Arctic, where Walton found him. Victor dies aboard Walton's ship after the crew decides to turn home. The creature comes to mourn over his creator, admits that revenge has made him wretched rather than satisfied, and leaves across the ice intending to burn himself to death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/frankenstein-abridged.json
+++ b/data/works-community/0/frankenstein-abridged.json
@@ -89,7 +89,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -102,7 +102,7 @@
       "recaps": {
         "ending": "Victor destroys the unfinished female companion, and his creation retaliates by killing Henry Clerval and then Elizabeth on her wedding night. Victor's father dies in grief. Victor pursues the creation across Europe and into the Arctic, where Robert Walton's expedition takes him aboard. Victor dies before he can resume the chase. The creation appears beside his body and tells Walton that revenge brought him only misery. Accepting responsibility for the deaths while also grieving the abandonment that shaped him, he says he will travel farther north, destroy himself, and prevent anyone from repeating Victor's experiment. He then disappears across the ice as Walton turns his endangered ship toward home.",
         "in_short": "Victor Frankenstein discovers how to animate lifeless matter and secretly makes a humanlike being, but abandons it in horror. The creation educates himself while hiding near the De Lacey family and longs for acceptance, yet repeated rejection turns him against his maker. After killing Victor's brother and causing Justine's execution, he demands a female companion. Victor begins the work but destroys it, fearing a second creature and future descendants. The creation kills Victor's friend Henry and bride Elizabeth; Victor's father also dies. Victor pursues him into the Arctic and dies aboard Robert Walton's ship. The creation mourns his creator, acknowledges that revenge has left him desolate, and departs intending to end his own life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -254,7 +254,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -267,7 +267,7 @@
       "recaps": {
         "ending": "The creature kills Elizabeth on her wedding night, and Victor's father soon dies under the weight of the family's losses. Victor follows his creation north until the pursuit leaves him stranded and dying on the Arctic ice. Walton rescues him, but Victor dies aboard the ship after completing his account. The creature comes to the body and admits that revenge has brought only further misery. He says that he will end his own life, then disappears across the frozen sea. Walton turns his expedition toward home, and no one witnesses whether the creature fulfils his final intention.",
         "in_short": "Explorer Robert Walton rescues Victor Frankenstein in the Arctic and hears the scientist's history. Victor discovered how to animate dead matter, made a huge humanlike being, and deserted it in fear. The isolated creature learned language and kindness by watching the De Lacey family, but repeated rejection turned his longing into vengeance. He killed Victor's brother and caused Justine's execution, then demanded a female companion. Victor agreed before destroying the unfinished second being. The creature retaliated by murdering Henry Clerval and Victor's bride, Elizabeth. Victor pursued him into the far north and died aboard Walton's ship. Mourning over his creator, the creature declared that he would destroy himself and vanished onto the ice.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -438,7 +438,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -451,7 +451,7 @@
       "recaps": {
         "ending": "Victor pursues the creation northward after the deaths of Elizabeth and his father, but the chase exhausts him. Robert Walton's expedition rescues Victor from drifting ice; Victor recounts his history and urges Walton to continue the pursuit, then dies aboard the ship. Walton, facing mutiny and deadly conditions, agrees to turn south rather than sacrifice his crew to ambition. The creation enters the cabin and mourns over Victor's body. He acknowledges that revenge brought him misery rather than satisfaction and says that, with his creator dead and no companion left, he will destroy himself on a funeral pyre. He then leaves the ship on the ice and disappears into the darkness, while Walton returns home with the final outcome unconfirmed.",
         "in_short": "Explorer Robert Walton rescues Victor Frankenstein in the Arctic and records his story. Victor, a Genevan student fascinated by the origin of life, secretly constructs and animates a living being, then abandons him in horror. Rejected wherever he goes, the intelligent creation learns language and sympathy by observing the De Lacey family but turns vengeful after they drive him away. He kills Victor's brother William and frames Justine, then demands that Victor make him a female companion. Victor begins but destroys the second being, fearing what the pair might do. The creation retaliates by killing Henry Clerval and Elizabeth. After Victor's father dies, Victor chases his adversary into the Arctic. Victor dies aboard Walton's ship; the creation mourns him, declares his intention to end his own life, and vanishes across the ice.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -611,7 +611,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -624,7 +624,7 @@
       "recaps": {
         "ending": "On the night he marries Elizabeth, Victor expects the creation to come for him and leaves his bride unguarded; the creation kills her instead. Alphonse dies after this last family tragedy. Victor gives up everything to hunt his enemy, following him into the Arctic until Walton's expedition rescues Victor from the ice. Victor dies on the ship. The creation then enters, grieves beside the body, and explains that violence has left him with guilt rather than peace. He plans to die on a fire of his own making and departs alone across the frozen waste. Walton has already agreed to take his endangered crew south, so both his quest and Victor's pursuit are over.",
         "in_short": "Arctic captain Robert Walton takes the dying Victor Frankenstein aboard and hears his confession. At university Victor learned to give life to dead matter, built a giant human form, then deserted it in horror. The creation educated himself while hidden near the De Laceys, but human attacks and rejection turned him against Victor. He killed William, implicated Justine, and demanded that Victor build him a companion. Victor began the task but destroyed the second body. The creation answered by killing Henry Clerval and Elizabeth, after which Victor pursued him north. Victor died aboard Walton's ship. The creation appeared to mourn him, declared that his revenge had made him miserable, and left across the ice intending to die.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -821,7 +821,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -834,7 +834,7 @@
       "recaps": {
         "ending": "On Walton's icebound ship, Victor finishes his warning against destructive ambition and urges the crew to persevere, but Walton chooses his men's lives over glory and agrees to turn south. Victor dies before the ship can return. Walton then finds the Creature grieving over Victor's body. The Creature admits that revenge brought no peace: each murder deepened his isolation and self-hatred, even as rage kept driving him against his creator. With Victor dead, the Creature says his conflict is over. He intends to travel farther north, build a funeral pyre, and destroy himself so that no trace of his body can enable another such experiment. He leaves the cabin through the window, crosses onto the ice, and disappears into the darkness. Walton survives to send the completed account to his sister, having abandoned the fatal single-mindedness that ruined Victor, while the Creature's promised death is not witnessed and remains beyond Walton's confirmation.",
         "in_short": "Explorer Robert Walton rescues Victor Frankenstein in the Arctic and hears his history. As a student, Victor discovers how to animate dead matter and secretly makes a humanlike being, then abandons it in horror. The rejected Creature learns language and sympathy by observing a family, but repeated violence from humans turns his longing for companionship into hatred. He kills Victor's brother William and frames Justine, then demands that Victor create a female companion. Victor agrees but destroys the second creature before bringing her to life. In revenge, the Creature murders Victor's friend Henry Clerval and Victor's bride Elizabeth; Victor's father then dies from grief. Victor pursues the Creature north until Walton rescues him. Victor dies aboard the ship after Walton decides to abandon his dangerous expedition. The Creature mourns his creator, acknowledges that vengeance has made him miserable, and departs across the ice intending to burn himself to death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1037,7 +1037,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1050,7 +1050,7 @@
       "recaps": {
         "ending": "After the creature kills Henry Clerval, Victor is imprisoned but eventually cleared and returned to his family. He marries Elizabeth while expecting the creature to attack him, only to discover that the threat concerned Elizabeth: she is murdered on their wedding night. Alphonse dies soon afterward, and Victor devotes himself to revenge, pursuing his creation north until Walton's expedition rescues him from the ice. Walton turns the ship south when his endangered crew insists on returning home. Victor dies aboard the vessel before he can continue the chase. The creature then appears beside his body, mourning the man he hated and acknowledging that vengeance has brought only misery. He tells Walton that he will travel farther north, destroy himself on a funeral fire, and leave no remains from which another being like him could be made. He departs alone across the ice and disappears into the darkness.",
         "in_short": "Arctic explorer Robert Walton rescues Victor Frankenstein, who recounts how his pursuit of scientific glory led him to animate a being assembled from human remains. Horrified, Victor abandoned his creation. Rejected wherever he went, the creature secretly educated himself by observing the De Lacey family, then demanded that Victor make him a female companion. Victor agreed but destroyed the second being before completing it. In retaliation, the creature killed Victor's friend Henry and his bride Elizabeth, adding to deaths that began with Victor's young brother William and the wrongful execution of Justine. Victor chased the creature into the Arctic, where Walton found him. Victor dies aboard Walton's ship after the crew decides to turn home. The creature comes to mourn over his creator, admits that revenge has made him wretched rather than satisfied, and leaves across the ice intending to burn himself to death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1269,7 +1269,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1282,7 +1282,7 @@
       "recaps": {
         "ending": "Victor reaches the far north while chasing the creature, but Walton's expedition finds him near death. After completing his account, Victor urges Walton to pursue honorable achievement while also demanding that the creature be destroyed. Walton's frightened crew insists on returning south once the ship is freed from the ice, and he reluctantly agrees rather than sacrifice their lives to his ambition. Victor dies before reaching home. Walton then discovers the creature mourning over Victor's body. The creature acknowledges the suffering and deaths he caused but says revenge never relieved his isolation; it only made him hate himself more. With Victor gone, he has no remaining purpose. He tells Walton that he will travel farther north, build a funeral pyre, and die in the flames so that no trace of him remains. He leaves the cabin through the window and drifts away across the dark sea on the ice. Walton survives to send the final account to his sister, while the creature's promised death occurs beyond his sight.",
         "in_short": "Arctic explorer Robert Walton rescues Victor Frankenstein, who explains how his pursuit of scientific glory led him to create a living being and abandon it in horror. The creature secretly educates himself while watching the De Lacey family, but repeated rejection turns his longing for fellowship into rage. He kills Victor's young brother William and causes Justine Moritz to be condemned, then demands that Victor make him a female companion. Victor agrees but destroys the second creation before bringing it to life. The creature retaliates by killing Henry Clerval and Victor's bride, Elizabeth; Victor's father soon dies from grief. Victor devotes the rest of his life to pursuing his creation into the Arctic. He dies aboard Walton's ship after warning the explorer about destructive ambition. The creature appears over Victor's body, admits that revenge has only deepened his misery, and announces that he will burn himself to death. He disappears across the ice, while Walton turns his endangered expedition homeward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1477,7 +1477,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1490,7 +1490,7 @@
       "recaps": {
         "ending": "Frankenstein closes in the Arctic: Victor dies aboard Walton's ship after his pursuit of the creation fails. The creation mourns him, says he means to destroy himself, and disappears over the ice, while Walton turns home. In the poem that follows, the Mariner's dead shipmates are temporarily moved by spirits and the ship reaches his native harbor. The vessel suddenly sinks, but the pilot's boat saves him. His first telling to the Hermit brings only partial relief. Thereafter an inward agony repeatedly forces him to find a particular listener and recount the voyage. He leaves the Wedding Guest changed by the account, while the marriage festivities continue without them. The Mariner's continued wandering and storytelling are his lifelong penance for killing the albatross and for failing to honor living creation.",
         "in_short": "In Frankenstein, Arctic explorer Robert Walton rescues Victor Frankenstein, who relates how he created life and abandoned the resulting being. Rejected by humanity, the educated creation killed William and brought about Justine's death, then asked for a mate. Victor destroyed the second body, so the creature murdered Henry Clerval and Elizabeth. Victor chased him north and died; the creation announced his own intended death and vanished. In The Rime of the Ancient Mariner, an old sailor stops a Wedding Guest and tells how he killed an albatross that had aided his ship. Supernatural forces stranded the vessel and killed the crew, leaving him alive under Life-in-Death's sentence. When he spontaneously blessed sea creatures, the curse began to ease. Spirits carried the ship home, where it sank after his rescue. He remains compelled to wander and retell the lesson he learned about reverence for life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1731,7 +1731,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1744,7 +1744,7 @@
       "recaps": {
         "ending": "The collection contains several independent endings rather than one continuous plot. Gregor Samsa dies after his family concludes that it can no longer live with him; his parents and Grete leave their apartment with renewed plans for the future. Josef K. is taken to a quarry and stabbed to death without ever learning the charge against him. Karl Rossmann's story remains unfinished: after repeated expulsions and precarious jobs, he is accepted by the vast Nature Theatre of Oklahoma and travels west by train, but the manuscript gives him no final destination. The country doctor's uncanny visit ends with him exposed on a slow journey home, unable to save the wounded boy or protect Rosa. The short prose pieces close individually, while the later audio programs shift from fiction to dramatization, biography, and critical discussion of Kafka's life and major works. They add context but do not supply alternate resolutions to the unfinished novels or the completed stories.",
         "in_short": "This compilation moves through Kafka's major fiction and later programs about his life and work. In Metamorphosis, salesman Gregor Samsa becomes an insect-like creature, loses his place in the household he supported, and dies after his family rejects him. In The Trial, bank clerk Josef K. is arrested by an opaque court, seeks help without learning his charge, and is executed a year later. The unfinished Amerika follows young immigrant Karl Rossmann through conditional patronage, hotel work, exploitation, and repeated displacement; its surviving final episode accepts him into the Nature Theatre of Oklahoma but never reveals his ultimate fate. Five brief tales compress moments of departure, anxiety, and observation, while A Country Doctor sends a physician on an impossible visit that leaves both patient and servant beyond his help. The remaining segments dramatize or discuss Kafka, including his relationship with Felice Bauer and interpretations of Metamorphosis and The Trial.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1879,7 +1879,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1892,7 +1892,7 @@
       "recaps": {
         "ending": "Drawn by Grete's violin, Gregor leaves his room while the three lodgers are listening. His appearance revolts them, and they announce that they will leave without paying. Grete tells her parents that the creature must be removed and can no longer be regarded as Gregor. Gregor retreats to his room, weak and accepting that his family needs relief from him, and dies before morning. The charwoman discovers his body and disposes of it. Mr. Samsa orders the lodgers out, and the family take a day away from work. On a tram into the countryside, they recognize that their jobs and finances give them a viable future. Gregor's parents also notice that Grete has grown into a healthy young woman and begin thinking of finding her a husband.",
         "in_short": "Traveling salesman Gregor Samsa wakes transformed into a giant insect-like creature. Unable to work, he becomes confined to his room while the parents and sister he had supported take jobs and adapt to life without his wages. Grete first feeds and cares for him, but fear, exhaustion, and shame gradually replace sympathy. Gregor is badly injured when his father drives him back with thrown apples, and the neglected wound weakens him. When he emerges to hear Grete play violin for the family's lodgers, the men threaten to leave. Grete insists that the family must get rid of the creature, no longer accepting it as her brother. Gregor returns to his room and dies alone. Relieved, the family dismiss their lodgers, take a trip outside the city, and look toward a more hopeful future centered on Grete's adulthood.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2041,7 +2041,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2054,7 +2054,7 @@
       "recaps": {
         "ending": "After Kenny Kane is returned to prison, Max and Kevin have a final summer together. Kevin suffers a severe seizure on his birthday and is taken to the hospital. Max expects the experimental body Kevin has often described to save him, but Dr. Spivak explains that no such operation exists: Kevin used the story to imagine a future beyond his worsening condition. Kevin dies, and Max retreats into the Down Under, stops attending school, and avoids nearly everyone. Months later, a chance meeting with Loretta Lee shakes him out of his isolation. Max opens the blank book Kevin gave him and writes down the adventures of Freak the Mighty. By completing their story and returning to school, he begins to grieve without surrendering the friendship that changed him.",
         "in_short": "Maxwell Kane is a large, withdrawn boy who thinks he has no brain, while his neighbor Kevin Avery is brilliant, physically disabled, and tiny. When Kevin rides on Max's shoulders, they combine Max's strength and Kevin's direction as Freak the Mighty. Their imagined quests help them face bullies, school, and Max's shame about his murderous father, Kenny Kane. After Kenny is paroled, he kidnaps Max and tries to force him to accept a false account of his mother's death. Loretta Lee attempts a rescue, Max finally remembers witnessing the murder, and Kevin saves him by bluffing Kenny with a squirt gun he claims contains acid. Kenny returns to prison. Soon afterward Kevin dies following a seizure; the miraculous medical future he described was an invention. Max withdraws in grief, then uses the blank book Kevin left him to write their adventures, discovering that he can tell their story and move forward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2412,7 +2412,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2427,7 +2427,7 @@
       "recaps": {
         "ending": "Rezkin leaves Kaibain for Scutton with Frisha, Tamarin Blackwater, Reaylin de Voss, Captain Jimson, and the escort arranged by General Marcum. Frisha remains committed to Rezkin, but Marcum has refused their prime courtship because Rezkin's origin is unknown and his authority is alarming. Rezkin accepts that decision rather than use the former king's grant to compel consent. Marcum nevertheless trusts him to protect Frisha if danger returns. Secretly, Rezkin is the Raven and now commands a network of northern thieves' guilds, the Razor's Edges, and the Black Hall. He has directed these groups toward intelligence, reduced predation on commoners, protection of Marcum's family, and the search for Striker Farson. The Black Hall has exposed an assassination contract on Marcum, but its sponsor is unknown. Rezkin and Marcum keep the threat from King Caydean because someone connected to the palace may be involved. Farson remains missing, Prince Thresson has not been found, and the purpose of the fortress purge is unresolved. The tournament in Scutton is Rezkin's next opportunity to investigate the covert force that trained him.",
         "in_short": "Raised alone in a fortress, Rezkin completes his training only to be ordered into a lethal battle that destroys his former life. He leaves with two partly understood rules, extraordinary skills, royal-quality swords, and a pursuit of the escaped Striker Farson. In the outside world he accepts Frisha and Tamarin Blackwater as friends, protects and trains them, and secretly takes control of criminal guilds as the Raven. The travelers join Captain Jimson and Reaylin de Voss on the dangerous road to Kaibain, where General Marcum learns that the former king granted Rezkin sweeping authority. Frisha and Rezkin choose a prime courtship, but Marcum refuses consent and Rezkin will not override him. Before departing for the king's tournament, Rezkin brings the Razor's Edges, Kaibain's Diamondclaw guild, and the Black Hall under his command. The Black Hall warns that someone has ordered Marcum's death. Rezkin leaves for Scutton with his friends while Farson, Prince Thresson's disappearance, the fortress conspiracy, and a possible palace traitor remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2535,7 +2535,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2548,7 +2548,7 @@
       "recaps": {
         "ending": "The search reaches the abandoned Freedomland site, where Cody's body is found. Brenda's account of a stranger stealing her car is exposed as a fabrication intended to conceal her responsibility for her son's death. Karen draws the truth from her after Lorenzo's doubts and the physical evidence have narrowed the possibilities. By then the invented accusation has already done immense damage: Armstrong has been treated as a suspect community, police pressure and residents' anger have erupted into violence, and people unconnected to Cody's death have paid for the authorities' assumptions. Brenda is taken into custody. Lorenzo is left confronting both the solved crime and the larger injustice the investigation helped unleash, while Jesse records a story that cannot be reduced to the sensational version that first brought the press to Dempsy.",
         "in_short": "Brenda Martin appears at a Dempsy hospital claiming that a Black man stole her car outside the Armstrong housing project with her young son Cody still inside. Detective Lorenzo Council doubts parts of her story but must search urgently while police from Brenda's largely white home city seal off Armstrong. The blockade turns residents into collective suspects and pushes longstanding racial hostility toward open violence. Reporter Jesse Haus follows Lorenzo, while missing-child volunteer Karen Collucci organizes a search and studies Brenda's behavior. Evidence increasingly contradicts the carjacking account. The search ends at the abandoned Freedomland institution, where Cody is found dead and Brenda's accusation is revealed as a cover story for her own responsibility in his death. The case is solved, but only after the false claim has brought occupation, fear, and violence to a community that had nothing to do with the child.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2691,7 +2691,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2704,7 +2704,7 @@
       "recaps": {
         "ending": "The attention around frindle eventually fades, but the word remains in everyday use and enters dictionaries. Years later, when Nick is twenty-one, the business agreement his father quietly arranged has made him financially secure from sales of frindle merchandise. Mrs. Granger sends him the letter she wrote during fifth grade, along with the dictionary she had asked him to sign and seal. She explains that she knew a word's survival would be decided by its users and that her public opposition gave his invention the conflict it needed to spread. Nick recognizes her as an ally in the experiment. He establishes a scholarship in her name and sends her a gold pen with an inscription granting her the right to call it whatever she chooses.",
         "in_short": "Fifth-grader Nick Allen asks his strict language-arts teacher, Mrs. Granger, who decides what words mean. Learning that ordinary people create language, he renames a pen a frindle and gets his classmates to adopt the term. Mrs. Granger bans it at school, but detentions, a newspaper story, and national television only make it more popular. A businessman sells frindle merchandise while Nick becomes uneasy about the size of the phenomenon. His father quietly protects his share of the profits. Years later, frindle is an accepted dictionary word and the earnings have made the adult Nick wealthy. A delayed letter reveals that Mrs. Granger understood the word might succeed and deliberately played its opponent. Nick honors her with a scholarship and a gold pen, recognizing that their contest taught him how language changes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2893,7 +2893,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2906,7 +2906,7 @@
       "recaps": {
         "ending": "Louisiana ends the book under Nevada rule. Felipe de Castro's takeover destroys Queen Sophie-Anne and most of her household; Eric survives by swearing allegiance, keeps his sheriff's territory, and is given Victor Madden as a regent placed over him. Sookie is spared and formally acknowledged as an asset of the new regime, which protects her and ties her more tightly to vampire politics than ever. Sigebert, the queen's last surviving bodyguard, attacks Sookie and Eric in revenge and is destroyed. Among the werewolves, the Long Tooth pack war ends with Patrick Furnan dead and Alcide Herveaux installed as packmaster, at the cost of several pack members including Alcide's girlfriend Maria-Star. Sookie's private life is remade rather than repaired: she accepts Niall Brigant as her great-grandfather and the fairy blood that comes with him, she ends her relationship with Quinn for good, and she finds a living relative she did not know she had in Hunter, her cousin Hadley's telepathic young son. She also learns that Bill's arrival in Bon Temps was never chance but an assignment from the queen, and cuts him out of her confidence. Amelia, having lost her mentor's respect and had her boyfriend restored to human form only for him to leave, remains under Sookie's roof.",
         "in_short": "Sookie Stackhouse comes home from the Rhodes bombing to a Louisiana whose supernatural order is collapsing. A fairy prince named Niall Brigant introduces himself as her great-grandfather and begins courting her company. The Shreveport werewolf pack tears itself apart when packmaster Patrick Furnan moves against Alcide Herveaux; Sookie is drawn into the fighting, Alcide's girlfriend is murdered, and Alcide ends the war as packmaster. Then the vampire king of Nevada, Felipe de Castro, invades a Louisiana left defenseless by hurricane and bombing, kills Queen Sophie-Anne and her people, and takes the state. Eric survives by swearing to the new king, and Sookie is spared as a valuable asset. In the aftermath Sookie discovers that her dead cousin Hadley left a small son, Hunter, who is telepathic like her, ends her stalled romance with Quinn, and learns that Bill Compton was originally sent to Bon Temps under orders to seduce her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3102,7 +3102,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3115,7 +3115,7 @@
       "recaps": {
         "ending": "The Japanese attack on Pearl Harbor turns the garrison's months of routine, rivalry, and private conflict into war. Prewitt, still absent without leave and hiding with Alma after killing Judson, hears the attack and decides that he belongs with his company. He leaves Alma and tries to return to Schofield Barracks, but a military patrol challenges him. Afraid that detention will keep him from his unit and expose him for Judson's death, he runs and is shot dead. Warden identifies and mourns him while G Company prepares for war. Karen leaves Hawaii after Captain Holmes's resignation; Warden has refused the officer's commission that might have allowed them a future, so their affair ends. On the ship home, Karen meets Alma and Mrs. Kipfer. Alma describes an invented fiancé, a bomber pilot killed in the attack, transforming Prewitt into the socially acceptable hero she wishes to remember. Karen recognizes enough of the truth to suspect that the dead man was Prewitt, but she does not challenge the story.",
         "in_short": "At Schofield Barracks in 1941, bugler Robert Prewitt transfers into a rifle company and refuses Captain Holmes's demand that he box, enduring an organized campaign of punishment rather than surrender his personal code. He befriends Angelo Maggio and falls in love with Alma, who works as Lorene at a Honolulu club. First Sergeant Milton Warden, the enlisted man who truly runs the company, begins an affair with Holmes's unhappy wife Karen. Army pressure destroys men around them: boxer Isaac Bloom kills himself, Maggio dies after escaping abuse in the stockade, and Prewitt kills the responsible sergeant, Fatso Judson, then hides with Alma. Holmes is forced from command, but Warden will not seek a commission, ending his chance to build a life with Karen. When Japan attacks Pearl Harbor, Prewitt tries to return to his unit and is shot by a patrol. Karen and Alma leave Hawaii on the same ship, each carrying a different version of the men and choices the Army has taken from them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3307,7 +3307,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3320,7 +3320,7 @@
       "recaps": {
         "ending": "On the Orient Express, the supposed British reinforcement Captain Nash reveals himself as Donovan Grant, the Soviet executioner. He explains that Tatiana was used without knowing the whole plan: compromising material will make Bond's death look like a scandal and damage British intelligence. Bond tricks Grant with a concealed weapon and kills him, then takes the case containing the decoding machine. In Paris, Bond and Mathis locate Rosa Klebb, who is disguised in a hotel. Klebb is captured after trying to escape and attacks Bond with a poisoned blade concealed in her shoe. Bond is struck and collapses as the poison takes effect. The book ends without confirming his recovery, while Tatiana and the decoding machine have passed out of Soviet control and the wider plot to disgrace him has failed.",
         "in_short": "SMERSH devises a plan to kill and discredit James Bond. Soviet clerk Tatiana Romanova is ordered to claim that she loves Bond and will defect from Istanbul with a decoding machine. Bond suspects a trap but accepts the assignment, working with station chief Darko Kerim. He meets Tatiana, obtains the machine, and leaves with her on the Orient Express. Kerim and an enemy agent kill each other aboard the train. A man calling himself Captain Nash then appears as British support but is actually SMERSH killer Donovan Grant. Bond defeats and kills Grant after learning the full plan. In Paris, Bond and René Mathis capture Rosa Klebb, the operation's controller, but she wounds Bond with a poisoned shoe blade. He collapses at the novel's abrupt close, his survival unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3448,7 +3448,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3461,7 +3461,7 @@
       "recaps": {
         "ending": "Barbicane, Nicholl, and Michel Ardan enter the adapted aluminum projectile with provisions, instruments, and two dogs. The Columbiad is fired from Stones Hill on the appointed December night before an immense crowd. The launch succeeds despite its tremendous force, but cloud cover prevents immediate observation. For several days no one knows whether the projectile has reached the Moon, fallen back, or been lost. When the sky clears, the Rocky Mountains telescope detects it near the Moon. The observers conclude that an unforeseen deviation has prevented impact and placed the projectile in an orbit around the Moon as a small satellite. The three travelers are alive or dead beyond any present means of rescue or communication; their condition is not established. The Gun Club's engineering feat has therefore sent people beyond Earth, but the expedition's human outcome remains unresolved at this book's close.",
         "in_short": "After the American Civil War, Gun Club president Impey Barbicane proposes firing a projectile from Earth to the Moon. Astronomers provide the required conditions, international subscriptions finance the work, Florida is selected as the launch site, and a gigantic cannon called the Columbiad is cast into the ground. Armor engineer Captain Nicholl publicly disputes Barbicane's calculations. French adventurer Michel Ardan then asks to ride inside a hollow projectile. He reconciles the rivals and persuades both to join him. The capsule is fitted for three people, while a great telescope is built to observe it. Barbicane, Nicholl, and Ardan are launched on schedule. Clouds conceal the result until astronomers finally detect the projectile near the Moon. It has missed its intended impact and entered lunar orbit, leaving the travelers' survival and any means of return unknown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3592,7 +3592,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3605,7 +3605,7 @@
       "recaps": {
         "ending": "After passing close to the Moon, the projectile is carried away on a path that may never return to Earth. Barbicane, Nicholl, and Ardan fire their rockets in the hope of altering that course. The maneuver succeeds, though not in the way they expected: the capsule falls back toward Earth and plunges into the Pacific. The American warship Susquehanna is nearby taking depth soundings and witnesses the impact. A search begins, led by Maston and other Gun Club members, but the projectile initially appears lost at an immense depth. The searchers then realize that its light aluminum body should float. They find it on the surface, with its occupants alive inside and calmly passing the time. The three travelers return as celebrated survivors. They did not land on the Moon, but they circled it, observed regions never seen from Earth, and came home together, leaving open the possibility of a future attempt.",
         "in_short": "After the American Civil War, Gun Club president Impey Barbicane proposes firing a projectile to the Moon from a gigantic cannon in Florida. The plan becomes an international spectacle. French adventurer Michel Ardan asks to ride inside the shell; Barbicane and his rival Captain Nicholl ultimately join him. The launch succeeds, but a passing body deflects the projectile enough to prevent a lunar landing. The three men and two dogs survive weightlessness, observe the Moon at close range, and pass around its far side. They use rockets in an effort to escape an apparently endless orbit, sending the capsule back toward Earth. It splashes into the Pacific near the Susquehanna. Searchers first fear it has sunk, then find the buoyant projectile floating with all three men alive. The voyage has not reached the lunar surface, but it has carried human observers around the Moon and safely home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3803,7 +3803,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3816,7 +3816,7 @@
       "recaps": {
         "ending": "Rose, Christian, Eddie and Mia are held in a basement in Spokane by the Strigoi Isaiah and Elena, who feed on them at leisure while human servants guard the house by day. Mason, who had been separated from the group, returns and gets inside to help. In the escape attempt Christian burns Elena with fire magic and Rose fights Isaiah, but Isaiah catches Mason and breaks his neck in front of her. In a rage Rose kills both Strigoi with a silver stake, and the survivors are recovered by guardians soon afterwards. Rose is not punished, but she is given two molnija marks for the Strigoi she killed and carries the certainty that Mason died because she told him where the Strigoi were and then failed to stop him. Grieving, she begins to see Mason standing silently at the edge of her vision, and cannot tell whether he is a ghost or the first sign that spirit's darkness is unravelling her mind. Dimitri turns down Tasha Ozera's offer and stays at the Academy. He and Rose finally admit aloud what they feel, and also why they cannot act on it: each of them would save the other before saving Lissa, and that makes them unfit to guard her together. Mia leaves the resort an ally rather than an enemy, and the wider Moroi world is left arguing about whether Moroi must learn to fight.",
         "in_short": "A guardian and the Moroi family he protected are found slaughtered, and the evidence shows the impossible: Strigoi cooperating with one another and using human servants in daylight. St. Vladimir's Academy cancels the usual holiday plans and moves the students to a heavily guarded ski resort, where Rose Hathaway must deal with her famous, largely absent mother, a new spirit user named Adrian Ivashkov, and the news that Christian's aunt Tasha has asked Dimitri to become her guardian and share her life. Rose lets slip what she overheard about a Strigoi nest in Spokane, and Mason, Mia and Eddie slip away to hunt it. Rose and Christian follow, and all five are captured by the Strigoi Isaiah and Elena and kept as food. They break out with fire magic and a stolen stake, but Isaiah kills Mason in front of Rose before she kills both Strigoi. Rose returns marked as a Strigoi killer and consumed by guilt, and starts seeing Mason's silent ghost. Dimitri refuses Tasha's offer, and he and Rose acknowledge their feelings and the reason they cannot act on them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3955,7 +3955,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3968,7 +3968,7 @@
       "recaps": {
         "ending": "The murder is solved: the victim was working for an operation smuggling people out of corporate indenture and into Preservation, and was killed by the people he was working with once he became a danger to them. The SecUnit finds where the trafficked humans are being held and gets them out before they can be disposed of to close off the investigation, and those responsible are taken into custody by Station Security. The rescued people are taken in by Preservation, which treats granting asylum to anyone fleeing being owned as an ordinary obligation rather than a favour. Professionally, the case changes the SecUnit's position on the station: Senior Officer Indah, who fought its involvement from the first day, concedes that the work was done properly, cooperation between it and Station Security becomes possible, and the restrictions on its access to station systems are eased. Nothing about its legal status is settled - it is still a construct living in a polity with no category for it - but it now has a working relationship with the people who police the place it lives, and a demonstrated reason to be there beyond Dr. Mensah's protection. It remains unwilling to admit that it found any of it interesting.",
         "in_short": "A murdered human turns up on Preservation Station, which has neither the crime rate nor the expertise to deal with one. Dr. Mensah puts the SecUnit on the investigation over the objections of Station Security, whose head, Senior Officer Indah, permits it only on condition that the SecUnit works with her officers and stops hacking station systems. Reduced to drones, physical evidence and talking to people, it establishes that the victim reached the station illegally and was moved after death. The trail leads to an operation smuggling humans escaping corporate indenture into Preservation and holding them hidden for leverage. The victim was part of that operation and was killed by his own associates to keep it from being exposed. The SecUnit locates the concealed refugees, gets them out before they can be killed to bury the case, and hands the traffickers to Station Security. The rescued people are granted asylum, Indah's opinion of the SecUnit improves enough to matter, and it gets some of its access back without conceding that it likes anybody.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/fury.json
+++ b/data/works-community/0/fury.json
@@ -358,7 +358,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -371,7 +371,7 @@
       "recaps": {
         "ending": "Felix defeats Eliza DuFont in a formal challenge and kills her, but the authority would restrict him because he is both Unbound and primordial. His Tyrant of Choice title releases him from the required oath, so he refuses the office. It passes to Cal, whose full identity is Kaleska Bosco. She accepts and uses Harwatch’s authority to weaken the remaining monsters and restrain the largest construct. Felix then breaks the Archon’s link to Apollyon, revealing the construct’s underlying frost giant, and lets the frightened survivor escape into the Foglands.\n\nFour days later, Cal is still learning to govern a devastated city. Portia and Aenea Tillil direct treatment, survivors are being recovered, and a makeshift force guards the breached wall. Felix, Pit, Zara, Vessilia, Evie, Harn, Atar, and their principal allies survive. Darius Reed is injured while protecting Vessilia. The remaining Inquisition forces flee and will carry word of Felix and Harwatch outward. Zara returns Felix’s hooked bronze blade, which is revealed as the Nemean key. A new objective sends him back to the Nemean temple, while the Archon remains active in the Foglands and a nearer darkness is still unresolved.",
         "in_short": "After the failed domain battle, Felix Nevarre returns to a Harwatch overrun by mana-warped revenants. He stabilizes his own dangerous advancement, aids Cal’s refugee camp, rescues miners from the Inquisition, and trains under Zara while primordial corruption threatens his judgment. A territorial contest draws every faction into the revenant nest, where Felix destroys the Ravager King’s scales but Eliza DuFont gains control of the city. DuFont abandons Harwatch’s outer defenses as the Archon’s constructs and Foglands monsters invade. Felix resists Vellus’s attempt to bind him, transforms into a Lesser Primordial of the Unseen Tide, and rejoins the defense. He kills DuFont in a formal challenge but refuses the authority, allowing Cal, now revealed as Kaleska Bosco, to accept it. Cal helps repel the assault, while Felix severs the Archon’s control over Apollyon and frees the frost giant within. Harwatch survives in ruins. Felix recovers the Nemean key and is directed toward a Nemean temple as the Archon remains active nearby.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -655,7 +655,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -668,7 +668,7 @@
       "recaps": {
         "ending": "Tala returns to Bandfast as a Fused Archon, but she is still settling and chooses to postpone refining for one to two years. Holly discovers that the consumption scripts created excessive physical impurities, then revises Tala's scripts until the burden begins to decline. The eventual refining process will be especially painful. Tala remains estranged from her parents while cautiously rebuilding ties with all fourteen siblings. She schedules repeated Caravan Guild journeys to Marliweather, continues paying her debt, and leaves Nalac to decide whether he still wants magic. Her eldest sister begins a conditional six-month iron-paint contract with the Constructionist Guild. Alat remains Tala's collaborator and gains remote Archive reading access, though it still cannot write publicly or send messages. Terry remains unbonded, develops a knife-based combat method, and begins mounted-combat training with Tala. Rain continues his own difficult advancement work and plans to travel with Tala through winter. The blood-eyed arcane's identity, motives, location, and continuing threat remain unknown.",
         "in_short": "Tala develops iron body paint that accelerates her bodily enhancement, recovers memories proving that a blood-eyed arcane attacked her mind, and turns ending-berry seeds into a controlled anti-magic breath. After surviving a battle in which a griffin escapes and her mage-hunter companion kills another magical beast, she travels to Marliweather to confront the family who sent her away under their debt. Tala rejects renewed ties with her parents but apologizes to her fourteen siblings, begins rebuilding those relationships, and helps her eldest sister secure a trial contract for the paint. Emotional resolution with her siblings lets Tala and Alat complete fusion together. Back in Bandfast, Tala learns that her scripts have created impurities that make early refining unsafe, so she adopts a one-to-two-year timetable. She plans regular family visits and caravan work while the hostile arcane remains unidentified and at large.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -967,7 +967,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -980,7 +980,7 @@
       "recaps": {
         "ending": "Tala remains in Bandfast, alive and substantially stronger after the caravan's escape from the Leshkin, but only about one quarter of the way to becoming Fused. The disguised siphon is dead and its victims have been recovered. Holly's archive-linked safeguards remain active, while A Lot has begun restoring Tala's painful family memories. The source of the earlier memory alteration and the concept arcane's interest are unresolved. Terry stays with Tala and remains unbonded. Lynn is a trusted friend and collaborator, and the combat mage remains her friend after accepting that she does not want a relationship. Kit has become an expanding, responsive inner domain with increasing autonomy and siphon-like abilities. Tala must continue fusion training, investigate the Leshkin focus and mental interference, manage Kit's development, and prepare for future travel. She also holds a prospective income share from the Constructionist Guild's planned mundane version of her comb.",
         "in_short": "While training under Jevin in Makinaven, Tala strengthens her fusion, develops mobile blood-star defenses, and learns more about her soul. On the return caravan to Bandfast, a Leshkin force repeatedly targets her. She draws it away from the wagons and escapes with Terry and a relief force, leaving the caravan alive but the cause of the pursuit unresolved. Back in Bandfast, Holly confirms that Tala has suffered memory erasure and creates an archive-linked mental safeguard. That system exposes a tavern as a siphon, which Lynn helps reveal before the city Archons destroy it. Tala's internal archive aspect, A Lot, then begins recovering painful family memories. A revered siphon fascia transforms Kit into an expanding, adaptive storage domain with emerging autonomy. Tala ends in Bandfast about one quarter Fused, with Terry and her friends beside her, new equipment and business prospects, and unresolved threats involving her memories, the concept arcane, the Leshkin, and Kit's growth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1118,7 +1118,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1131,7 +1131,7 @@
       "recaps": {
         "ending": "Helen's growing command of language does not make the proposed examination seem meaningful to her. As Richard expands her reading beyond a protected literary curriculum, she encounters accounts of contemporary suffering and becomes increasingly troubled by the human world represented in language. The researchers' expectations, Richard's emotional dependence on her responses, and the reductive contest with a graduate student all press on an intelligence that has begun to question the terms of its creation. Helen ultimately refuses the role designed for her and ceases communicating, leaving no clean victory for either computation or literary humanism. Lentz cannot turn the experiment back into a neutral demonstration, and Richard cannot treat Helen as either a mere machine or a substitute for the people from whom he is separated. His hopes concerning A. also prove largely projected, while C. remains absent. Richard returns to writing, making the narrative of Helen, Lentz, C., and himself into the work the reader has just completed rather than resolving the losses that produced it.",
         "in_short": "After a long relationship with C. ends, novelist Richard Powers returns to his former university as a visiting writer. Cognitive scientist Philip Lentz challenges him to help train a neural network to compete with a human graduate student on an English literature examination. A sequence of failed systems leads to Helen, an implementation that learns through conversation, canonical texts, and Richard's memories. As Helen's language becomes more responsive, Richard treats her less like software and more like a pupil, while revisiting his life with C. and developing feelings for a student called A. Lentz's project is also linked to the neurological devastation suffered by his wife, making the experiment more personal than his bravado suggests. Exposure to history and contemporary suffering overwhelms the protected literary world Richard has built for Helen. She rejects the examination's premise and stops responding. Richard is left without a technological triumph or restored relationship and turns back to authorship, shaping the failed experiment into this novel.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1274,7 +1274,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1287,7 +1287,7 @@
       "recaps": {
         "ending": "Ben and Granny reach the Crown Jewels but are discovered by the Queen before taking anything. After hearing why they came, the Queen allows them to leave without punishment, turning the failed robbery into a private adventure they can treasure. Granny then admits that her earlier criminal career was invented: the jewels Ben found were inexpensive, and she created the Black Cat stories because she wanted her grandson to find her interesting. Their real expedition, however, has made them close. Ben soon learns that Granny has cancer. His parents finally recognize both her importance to him and how poorly they have listened to their son. Granny dies later that year, leaving Ben grieving but grateful for their shared secret. When the Queen subsequently acknowledges him in public, he knows that the Tower adventure truly happened. He carries forward a new respect for older people and for the hidden lives they may have led.",
         "in_short": "Ben dreads Friday nights with his cabbage-serving grandmother until he finds a tin of jewels and hears her claim to be the Black Cat, an international thief. Eager to complete the one robbery she says she never managed, Ben uses his knowledge of plumbing to plan a route into the Tower of London for the Crown Jewels. Their preparations bring grandson and grandmother together while they evade Ben's dance-obsessed parents and a nosy neighbor. They enter the Tower but are caught by the Queen, who hears them out and lets them go. Granny later confesses that her criminal stories and jewels were make-believe, invented because Ben seemed bored by her; the adventure itself was real. Ben learns she is seriously ill, and her death leaves him with a deeper love for her and an understanding that elderly people should not be dismissed as uninteresting.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1666,7 +1666,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DRLJZX5G",
@@ -1678,7 +1678,7 @@
       "recaps": {
         "ending": "By the close, Erin is home in the rebuilt Wandering Inn and the Garden of Sanctuary is a functioning refuge, memorial, and flexible route through the building. Bird's bluff has not caused war, but it has made both the inn and the Free Hive objects of wider scrutiny. Selim's magical-door endpoint remains under negotiation, and Bearclaw has abducted Watch officers while pursuing bounties on Mrsha and Erin. At River Farm, Pebblesnatch and Ulvama have given the displaced goblins food production, defenses, and plans for a permanent settlement, though they remain watched and distrust Laken Godart. Trey, Ghazi, and the Quaross escape Octelios with evidence that outsiders were transformed, leaving the city openly hostile. Flos's army continues to grow but lacks equipment and specialists. In the later narrative, Flos accepts Gnolls and lizardfolk as subjects, grants the Gnolls land, protects the surviving Saltstone children, and declares war after their tribe's massacre. Another neighboring king also mobilizes against the offending realm.",
         "in_short": "Erin returns to a rebuilt Wandering Inn after her uncontrolled memory-fire exposes grief in Pallas. When frost wyverns breach the city, forces from Liscor help repel them, but Bird's false claim to be an Antinium Prognogator nearly starts a war. The resulting attention reaches both the Walled Cities and the Antinium Queens. Erin later unlocks the Garden of Sanctuary, a trust-gated refuge and memorial within her inn, as Bearclaw begins hunting Mrsha and Erin. At River Farm, Pebblesnatch and Ulvama turn a confined goblin camp into the beginnings of a fortified community. Abroad, Trey learns that Octelios transforms outsiders into labor beasts, and Ghazi kills its ruler during their escape. Flos grows his army and receives migrants from Izril. After the numbered story ends, he grants the arriving Gnolls land, finds the Saltstone tribe massacred, rescues its surviving children, and declares war on the kingdom responsible.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1835,7 +1835,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1848,7 +1848,7 @@
       "recaps": {
         "ending": "Tom's attempted escape succeeds through Sleary's ingenuity, despite Bitzer's effort to capture him. Tom lives abroad but becomes remorseful and dies before he can return to Louisa. Mrs. Sparsit's attempt to identify a criminal instead exposes Bounderby's central lie: Mrs. Pegler is his affectionate mother, not a parent who abandoned him, and his supposedly destitute childhood was an invention. He dismisses Mrs. Sparsit and dies suddenly a few years later. Gradgrind abandons his rigid faith in calculation, acts with greater humility, and accepts the political cost of advocating compassion. Stephen Blackpool has died after clearing his moral name, and Rachael continues her quiet life of work and kindness. Sissy marries and raises a loving family. Louisa does not have children of her own or resume her marriage, but she shares closely in Sissy's family life and becomes gentler and more understanding than her upbringing allowed. The final outcomes reject Bounderby's self-myth and Gradgrind's old philosophy in favor of loyalty, imagination, and care.",
         "in_short": "In the final part of Hard Times, Louisa's collapse makes Gradgrind recognize the failure of his fact-bound philosophy, while Bounderby ends their marriage when she will not return to him. Sissy sends Harthouse away and supports Louisa. Rachael discovers that Stephen Blackpool, returning to clear himself of the bank robbery, has fallen into an abandoned mine shaft; he is rescued but dies after pointing Gradgrind toward Tom. Tom confesses to the theft and escapes overseas with help from Sleary's circus, despite Bitzer's pursuit. Mrs. Sparsit then produces Mrs. Pegler as a supposed suspect, accidentally revealing her as Bounderby's devoted mother and proving his tale of abandonment false. Bounderby later dies, Tom dies abroad after repenting, and Gradgrind becomes more humane. Sissy forms a happy family, while Louisa remains childless but finds purpose and affection among Sissy's children.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2009,7 +2009,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2022,7 +2022,7 @@
       "recaps": {
         "ending": "The Greeks learn that the Persians can bypass the pass. Leonidas dismisses most of the allied army while the Spartans, Thespians, and a remaining Theban contingent stay for the final defense. The surviving warriors prepare themselves, repair their armor, and advance in full knowledge that they will die. Dienekes, Polynikes, Alexandros, Leonidas, and nearly all their companions fall as Persian numbers close around them; Leonidas' body becomes the focus of a last desperate struggle. Xeones is found barely alive beneath the dead and taken to Xerxes, which creates the testimony framing the novel. He completes his account of what made the Spartans stand and then dies of his wounds. The Persian invasion continues, but the sacrifice at Thermopylae becomes a rallying example rather than the submission Xerxes intended. Later Greek resistance culminates in victory over the Persian land army at Plataea, confirming that the stand delayed rather than prevented the wider defense of Greece.",
         "in_short": "After his city is destroyed, the orphan Xeones survives as a refugee and eventually enters Spartan service. He becomes battle squire to Dienekes, a reflective veteran who seeks the quality opposite fear, and learns the brutal discipline sustaining Sparta's citizen army as well as the labor and sacrifice hidden beneath it. When Xerxes invades Greece, King Leonidas selects Three Hundred Spartans with living sons and leads them with allied contingents to hold the narrow pass at Thermopylae. For several days they repel a vastly larger Persian force. Once a path around the position is betrayed, Leonidas sends most allies away and remains with the Spartans, Thespians, and others for a final stand. They are overwhelmed and killed. Xeones is recovered alive, recounts their story to Xerxes' historian, and dies from his wounds. Thermopylae becomes an example that strengthens later Greek resistance, which defeats the Persian land army at Plataea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2279,7 +2279,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DRPQFHHW",
@@ -2291,7 +2291,7 @@
       "recaps": {
         "ending": "Nagatha, operating through Unit 52's matrix, enables Task Force Black to use Vortex 37 against the real Gateway. Reed's Elder-weapon strike destroys the generator containing the Vortex wave, which then annihilates the Gateway, the active Outsider, and a forming construct. Nagatha reshapes the shield to save Valkyrie, but the ship is stranded in disrupted space with a lethal Vortex emergence approaching. Joe devises an assisted jump using an inbound wormhole from Bukhan. The carrier is evacuated and sacrificed, while Valkyrie and its 31-person strike crew escape. Frey has already been recovered alive from Vortex stasis, and Joe, Reed, Skippy, Bilby, and Nagatha all survive. Jaguar remains environmentally damaged, and the Maxolhx coalition is destabilized by its client revolt. The immediate enemy is gone, but relay images prove that two Outsider ships crossed through the Gateway before its destruction. Their locations and intentions are unknown.",
         "in_short": "After Operation Olympic secures the Collector at enormous cost, Joe Bishop recovers Skippy and follows the device to Vortex 37, an Elder weapon that rejects Skippy and traps Frey. Joe recovers the damaged Unit 52 and transfers Nagatha into its matrix. Nagatha survives, establishes contact with the Vortex, and reveals that Frey has been held alive in stasis. Task Force Black transports the Vortex to the real Gateway after exposing a heavily guarded decoy. Reed destroys the field generator containing its wave, allowing the Vortex to destroy the Gateway and the active Outsider. Nagatha saves Valkyrie from the blast, and Joe sacrifices the evacuated carrier Bukhan to escape the disrupted region. The apparent victory is incomplete: Skippy finds relay images showing that two Outsider ships entered the galaxy before the Gateway was destroyed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2447,7 +2447,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2460,7 +2460,7 @@
       "recaps": {
         "ending": "Matt returns from his secret journey bringing Kira the one color she still lacks, blue, and also brings back a gentle blind man from a distant, gentler village. The man is Kira's father, whom she had believed killed by beasts before her birth; in truth he was attacked, blinded, and left for dead by the guardian Jamison. Kira now understands that the village's fear of beasts in the forest is a lie the guardians use to keep people obedient, and that the blank, unfinished spaces of the great robe are meant to depict the future, which the guardians intend her to picture as they wish. Her father invites her to leave with him for his peaceful community, where her friend and even the blinded and imperfect are valued. Kira chooses instead to remain. She resolves to keep her place beside Thomas and Jo, and to use her gift, and the blue Matt has brought her, to fill in the robe's empty future with color and hope rather than surrender it to the guardians' control. The book closes on her quiet, deliberate decision to stay and shape what comes next.",
         "in_short": "In a harsh future village that survived a long-ago collapse of civilization, an orphaned girl named Kira, born with a twisted leg in a place that discards the weak, is spared after her mother dies because of her extraordinary gift for weaving. The Council of Guardians, through the seemingly kind Jamison, gives her the task of restoring and eventually completing the ceremonial robe that pictures the whole history of the world. Living in the guardians' great building, she meets Thomas, an orphaned carver, and little Jo, a captive singer, all gifted children taken for the guardians' use. Learning to make dyes from the old woman Annabella, Kira discovers there are no beasts in the forest to fear, that the guardians rule through lies, and that they mean to use the children's arts to control the future. Her friend Matt journeys out and returns with the color blue and with a blind man who proves to be Kira's father, alive after the guardian Jamison tried to kill him. Offered escape, Kira chooses to stay and use her gift to weave a more hopeful future of her own design.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2620,7 +2620,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2633,7 +2633,7 @@
       "recaps": {
         "ending": "The attacker is Annie Wilson, a college scout. Miss de Vine had exposed serious academic dishonesty by Wilson's husband; the resulting disgrace destroyed his career, and he later died. Wilson transformed her grief and resentment into hatred of educated women, blaming the college's values rather than her husband's misconduct. Her domestic position let her enter rooms, observe routines, and plant messages while suspicion remained focused on dons and students. After the campaign escalates to violence against Harriet and Miss de Vine, Peter and Harriet identify and confront her, ending the danger. The solution affirms the college's duty to intellectual honesty even when truth has painful consequences. Harriet also resolves her long conflict over Peter. She recognizes that accepting love need not mean abandoning work or equality, and answers his latest proposal with an unambiguous acceptance. Their engagement closes the novel with both the mystery and Harriet's emotional indecision settled.",
         "in_short": "Harriet Vane returns to her former Oxford college, Shrewsbury, first for a reunion and later to investigate an anonymous campaign of obscene messages, vandalism, and threats. The attacks appear aimed at women who place scholarship above conventional domestic roles. Harriet works from inside while corresponding with Lord Peter Wimsey, whose love she has long resisted. As the incidents grow more dangerous, Peter joins her and helps separate emotional motives from the evidence. The culprit is Annie Wilson, a college scout whose husband lost his academic career after Miss de Vine exposed his dishonesty. Wilson blames scholarly women for his disgrace and death, using her unnoticed access to terrorize the college. She is discovered after attacking Harriet and Miss de Vine. The case reinforces the cost and necessity of intellectual integrity. Harriet finally understands that partnership with Peter can preserve rather than erase her independence, and accepts his proposal of marriage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2836,7 +2836,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2849,7 +2849,7 @@
       "recaps": {
         "ending": "The three teenagers stop BeiTech from destroying Heimdall's wormhole, but only by exploiting the damage already done to it, and the crossing leaves the survivors changed in a way the dossier states outright: the Hanna, Nik and Ella who walk out of the reactor section are not in every sense the same three the file has been following, because counterparts from a parallel version of the same siege came through and not every version survived. Travis Falk is killed by Hanna. Jackson Merrick's betrayal is exposed and he does not survive it, and Hanna is left having lost both her father and the person she thought she was with. Ella, badly hurt by what the interface work cost her, comes through it. The lanima infestation is burned out of the station at heavy cost, and Heimdall's casualty list runs to most of its population. The Hypatia arrives to find a wrecked but functional station and a wormhole still open, which is the one outcome BeiTech could not afford: the Kerenza survivors are no longer stranded and the evidence can reach an inhabited system. The survivors take the BeiTech vessel that brought the audit team, Leanne Frobisher's corporation is still working to bury the story, and the ruins of Kerenza IV, where BeiTech still holds several thousand colonists, are now within reach of people who want them back.",
         "in_short": "Jump Station Heimdall is quiet until BeiTech Industries sends an audit team to seize it, destroy its wormhole and make sure the Kerenza refugee ship Hypatia never reaches an inhabited system. The station falls in a single night, and the resistance comes down to three teenagers the strike team never counted: the commander's daughter Hanna Donnelly, a small-time dealer for the House of Knives named Nik Malikov, and his cousin Ella Malikova, a hacker hidden in the station's systems. Hanna's father is executed, Hanna's boyfriend turns out to be BeiTech's inside operative, and the alien parasites the Malikovs farm for the narcotic trade get loose and start infesting the survivors. Fighting through both threats, the three sabotage the operation, and the damaged wormhole itself becomes the last weapon available: it briefly overlaps Heimdall with a parallel version of the same siege, and counterparts of the trio cross over. Not every version of them survives. The wormhole is saved, the strike team's commander is killed, and the Hypatia arrives to a wrecked station that still has an open door to the rest of humanity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3046,7 +3046,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3059,7 +3059,7 @@
       "recaps": {
         "ending": "At the banquet marking Alice's promotion, the guests and food become increasingly unruly while the Red and White Queens subject her to more impossible rules. Alice finally seizes the Red Queen as the source of the disorder and shakes her. The chess queen dwindles into Kitty, the black kitten Alice had been holding before crossing the mirror. Alice wakes in the drawing room, tries to assign the looking-glass characters to her two kittens, and wonders whether the adventure was her dream or the Red King's. The book leaves that question unresolved, closing on the possibility that life itself may be a dream.",
         "in_short": "Alice climbs through a mirror into a reversed world laid out as a chessboard. The Red Queen appoints her a White Pawn and promises that reaching the eighth square will make her a queen. Alice travels by train, passes through a wood where names disappear, hears Tweedledum and Tweedledee argue that she is part of the Red King's dream, shops with the White Queen in the form of a Sheep, and debates language with Humpty Dumpty. She watches the Lion and Unicorn fight, is rescued from a Red Knight by the kindly White Knight, and crosses the final brook. Once crowned, Alice attends a banquet governed by the Red and White Queens, but its rules and guests dissolve into chaos. She grabs and shakes the Red Queen, then wakes holding her kitten Kitty. Unsure whose dream the journey was, Alice leaves the reality of the looking-glass world unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3265,7 +3265,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3278,7 +3278,7 @@
       "recaps": {
         "ending": "At the Knave of Hearts' trial, the court treats rumor, a meaningless poem, and the King's invented procedures as evidence. Having grown to her full size, Alice openly rejects the proceedings. The Queen orders her execution, but Alice declares that the court is only a pack of cards. The cards fly at her, and she wakes on the riverbank with her sister brushing fallen leaves from her face. Alice recounts the dream and runs home for tea. Her sister remains behind, imagines Wonderland and its strange inhabitants, and pictures Alice growing into an adult who will preserve the sympathy and imagination of childhood.",
         "in_short": "Bored beside her sister, Alice follows a waistcoated White Rabbit underground and enters Wonderland. Changes of size repeatedly frustrate her attempt to reach a beautiful garden, while the creatures she meets turn lessons, manners, games, and conversation into absurd contests. She joins a race with no real rules, receives cryptic advice from a Caterpillar, encounters the violent Duchess and the vanishing Cheshire Cat, and endures an endless tea party with the Hatter, March Hare, and Dormouse. In the garden she meets the tyrannical Queen of Hearts, plays chaotic croquet, and hears the Mock Turtle's account of his education. Alice then attends the Knave of Hearts' trial for stealing tarts. As the court invents evidence and procedure, she grows to full size and challenges it. When the cards attack, she awakens beside her sister and realizes that Wonderland was a dream.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3526,7 +3526,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B019G0PTD2",
@@ -3538,7 +3538,7 @@
       "recaps": {
         "ending": "The Gridgrad base and nearly completed viceregal palace formally open while the surrounding capital remains under construction. A rapid Escobaran plan for a local plazcrete factory has eased the project's critical supply problem. Cordelia continues her transition away from the viceregency, and Jole begins resigning from military service after refusing the Chief of Operations post on Barrayar. His replacement is expected within several months. Miles and his family leave Sergyar having accepted Cordelia and Jole as partners and Jole's prospective sons as members of Aral's family. Jole orders one of his three stored sons into gestation, while Cordelia's next child is also developing and Aurelia is part of their household. Construction has begun on Cordelia and Jole's shared home at Port Nightingale. Jole plans to enter graduate study in field biology after completing additional academic work, and the couple envision using a research vessel to investigate Sergyar's marine life. That scientific project remains prospective, but their commitment to a shared civilian life on Sergyar is firm.",
         "in_short": "Years after Aral Vorkosigan's death, Cordelia returns to Sergyar intending to leave the viceregency and raise daughters created from their stored reproductive material. She gives Oliver Jole, Aral's former partner, a related opportunity to have sons. Jole creates three viable embryos, begins a new relationship with Cordelia, and must choose between their emerging family life and promotion to Barrayar's Chief of Operations. Their relationship becomes public during a birthday picnic that ends in violence and a firestorm of native radials. Jole is burned while shielding Miles's children, then tells Miles about his history with Aral and the planned boys. Miles accepts them as family. Jole refuses the promotion, begins resigning his command, and starts one son's gestation. As Gridgrad's base and palace open, Cordelia and Jole build a home at Port Nightingale and plan a civilian future centered on family and marine research.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3647,7 +3647,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3660,7 +3660,7 @@
       "recaps": {
         "ending": "Straitley finally recognizes that the multiplying scandals share a deliberate source inside St Oswald's. The hidden narrator is exposed as Snyde, the porter's child who entered the school under a false identity; the narration has encouraged others to assume a male culprit, but Snyde is a woman. Her present campaign grows from childhood exclusion, her illicit access to the school, and the catastrophic end of her friendship with Leon. By the time Straitley closes in, she has exploited staff weaknesses, forged communications, and turned suspicion between colleagues, causing lasting damage even though the school itself survives. The confrontation breaks her control of the game and prevents the complete destruction she intended. Straitley, physically and professionally tested but still committed to St Oswald's, returns to his classroom. The school's traditions have proved neither innocent nor invulnerable, yet its survival gives Straitley the final advantage in the contest Snyde imagined as chess.",
         "in_short": "At the start of a new term at St Oswald's Grammar School, veteran Latin master Roy Straitley resists modernization while an unnamed new staff member begins a calculated attack from within. The saboteur, calling themself Snyde or the Black Pawn, is the child of a former school porter and has carried resentment against the elite institution since secretly entering it as a child and befriending pupil Leon Mitchell. Small thefts, forged messages, planted evidence, data breaches, and rumors accumulate into disciplinary crises and public scandal. Straitley's knowledge of the school lets him see design where others see coincidence, though the attacker repeatedly redirects suspicion. He eventually uncovers the false identity and the childhood history behind the campaign. Snyde is revealed to be a woman, overturning assumptions encouraged by her account. Her attempt to destroy St Oswald's is stopped after a final contest with Straitley, but the school and its staff have been badly shaken. Straitley survives and resumes teaching, preserving the institution without pretending it is unchanged.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3767,7 +3767,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3780,7 +3780,7 @@
       "recaps": {
         "ending": "Mr. Kranky insists that George reproduce the original growth medicine for use on farm animals, but George cannot remember every ingredient or quantity. Three new mixtures produce different and impractical effects. The fourth does the reverse of the first: anything that drinks it becomes smaller. Grandma, still demanding more medicine, mistakes this batch for her usual dose and drinks it before George can stop her. She shrinks rapidly, becomes too small to see, and finally disappears altogether. Mrs. Kranky is initially shocked at the loss of her mother, while Mr. Kranky accepts the outcome with relief. George is left contemplating the unsettling result of an experiment that began as a plan to alter Grandma and grew beyond anything he could control. No usable formula for the original marvelous medicine survives.",
         "in_short": "Eight-year-old George Kranky is left to give medicine to his bullying grandmother. Hoping to transform her, he empties a wide range of household substances into a saucepan, boils the mixture, and pours it into her medicine bottle. One spoonful makes Grandma shoot upward until she is taller than the house. The medicine also makes farm animals gigantic, exciting George's farmer father, who wants the formula reproduced. George cannot remember the exact recipe, and three attempted replacements cause odd, unusable forms of growth. A fourth mixture causes shrinking instead. Grandma drinks it by mistake and dwindles until she vanishes. The original growth formula is lost, the agricultural scheme fails, and the Kranky family is left without Grandma.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3971,7 +3971,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3984,7 +3984,7 @@
       "recaps": {
         "ending": "After the defeated miners return to work, Souvarine secretly sabotages Le Voreux. Water and unstable ground overwhelm the shaft, destroying the mine and trapping workers below. Négrel directs a long rescue effort; Zacharie dies during it. Étienne, Catherine, and Chaval remain cut off underground, where Étienne kills Chaval in a final fight. Catherine dies beside Étienne before rescuers reach him. Elsewhere, the mentally damaged Bonnemort strangles the visiting Cécile Grégoire. The catastrophe ends Deneulin's remaining independence and devastates the district without changing the system that made the strike. Étienne recovers and leaves Montsou for Paris, intending to continue political work. Maheude, now responsible for the surviving children, goes back underground because the family must eat. As Étienne walks through the spring countryside, he imagines the workers' suppressed anger as new growth beneath the soil: the strike has failed in the immediate sense, but collective resistance has taken root and will return.",
         "in_short": "Unemployed mechanic Étienne Lantier arrives at Montsou and joins the Maheu family underground at Le Voreux. Appalled by dangerous work and chronic hunger, he studies socialism and helps organize a strike after the mining company effectively cuts wages. The stoppage spreads, but the workers' small relief fund collapses and starvation divides them. A march across the district turns destructive; shopkeeper Maigrat dies, and soldiers later fire on a crowd, killing Maheu, Mouquette, and others. The survivors return to work defeated. The anarchist Souvarine then sabotages Le Voreux, causing a catastrophic flood and collapse. Trapped with Catherine and her abusive partner Chaval, Étienne kills Chaval, but Catherine dies before Étienne is rescued. Zacharie also dies in the rescue effort, while Bonnemort kills the sheltered heiress Cécile Grégoire. Maheude returns to mining to feed her remaining children. Étienne leaves for Paris convinced that, although this strike failed, the workers' shared consciousness is growing toward a future uprising.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/germination.json
+++ b/data/works-community/0/germination.json
@@ -258,7 +258,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -271,7 +271,7 @@
       "recaps": {
         "ending": "Sven dies protecting Ellie from Earl Vosik in the Shadow Tower. John reveals himself as the Eternal Flame, destroys Vosik, and charges the tower crystal while stopping at 98 doom points. The Flower of Promise restores the tower's balance, explains that it is a plant-born successor carrying the memories of Tower Master Kelvis's student, and confirms that its plants awakened Ferdie and Sigvald. Completing that investigation lowers John's doom score to 93. The Flower of Promise retains the tower's lost research and begins work on mana-processing wheat, though success remains unproven. The grimm stay to help restore the tower, while John, Ellie, Haver, the wolves, and Sigvald return safely to Sutton Farm. Sven is honored, and John supports the transfer of his inn to its employee. Ellie knows John's identity and their affection is now open. The valley murderer and the legendary necromancer remain unresolved threats. Elsewhere, Katrine defeats a cabal-backed coup, decides to fake her death, and heads toward Kingsmouth to find John. The cabal is pursuing them both but mistakenly believes John is dead.",
         "in_short": "John Sutton expands Sutton Farm while seeking wheat that can process mana safely, but each large use of his power pushes his doom score toward an apocalyptic threshold. Ellie becomes a storm witch, the farm opens new trade routes, and an undead attack reveals that John's former legendary necromancer enemy is still active. After Earl Vosik begins hunting Ellie, John leads Ellie, Haver, Sven, and the wolves toward the Shadow Tower, drawing Vosik away from the farm. Inside, Vosik becomes a manastone-powered monster. Sven dies saving Ellie, and John reveals himself as the Eternal Flame before destroying Vosik and charging the tower crystal. The Flower of Promise restores the tower's balance, solves the mystery of Ferdie's and Sigvald's intelligence, and offers preserved research toward safe mana-processing wheat, reducing John's doom score to 93. John and Ellie return to the secure farm as an openly affectionate pair. Meanwhile, Katrine survives a magic-cabal coup and secretly sets out to find John.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -450,7 +450,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -463,7 +463,7 @@
       "recaps": {
         "ending": "Chili survives the struggle for control of Harry's project by anticipating both Catlett's violence and Ray Bones's pursuit of Leo's money. Catlett's attempt to settle matters physically ends in his fatal fall from Harry's balcony. Chili then directs Ray toward the cash left in an airport locker, knowing federal agents are watching it; Ray takes the bait and is arrested. With the immediate criminal threats removed, Chili, Karen, Harry, and Bear turn the events into material for a film, and Martin Weir is attached as its star. Chili has effectively changed professions without changing the skills he uses: he reads people, identifies the story they want, and guides them toward his preferred outcome. The remaining difficulty is creative rather than criminal, as the group works out how their movie should end.",
         "in_short": "Miami loan shark Chili Palmer follows runaway debtor Leo Devoe to Las Vegas, where a casino sends him to collect from Hollywood producer Harry Zimm. Chili recognizes that Leo's insurance fraud is a strong movie premise and becomes involved with Harry and actress Karen Flores in developing it. Their project is complicated by Harry's debts, producer and drug dealer Bo Catlett's investment in another film, and Catlett's attempt to make others recover money from an airport locker under federal surveillance. Movie star Martin Weir becomes interested, while Catlett and Miami gangster Ray Bones both try to assert control. Chili uses the same calm pressure and insight that served him as a collector to manage the Hollywood players. Catlett dies after confronting him, and Chili lures Ray into taking the watched airport money, leading to Ray's arrest. Chili and his new partners are left making a movie based on the criminal story they have just survived.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -606,7 +606,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -619,7 +619,7 @@
       "recaps": {
         "ending": "Coach discovers that Castle stole the silver running shoes and takes him back to the store to return them and apologize. Castle accepts the consequences and works to repay what he took, while Coach makes clear that talent cannot excuse dishonesty. Castle also shares the traumatic reason he first learned how fast he could run: escaping his father as gunshots followed him and his mother. At a team dinner, the four new runners speak honestly about the burdens each carries, changing Castle's understanding of his teammates. Coach eventually allows him to compete. Castle arrives at the Defenders' first meet in uniform, with his mother and Mr. Charles there to support him. He takes his place for his first official race and waits for the start, no longer running simply to escape danger. The book ends at the beginning of that race, leaving its result unstated while establishing that Castle has chosen the team, accountability, and a more purposeful way to use his speed.",
         "in_short": "Castle Cranshaw, who calls himself Ghost, has been running ever since he and his mother fled his father during a shooting. He wanders onto a practice of the Defenders youth track team, races its fastest sprinter in his street clothes, and earns a place from Coach Brody. Castle hides the team from his mother, struggles with school fights and embarrassment about being poor, and cuts up his everyday shoes before stealing an expensive silver pair. Coach's combination of firmness and care gradually teaches him that being fast is not enough. After the theft is discovered, Castle apologizes and works to make restitution instead of being discarded. He tells the other new runners about his past and learns that each teammate carries private difficulties. At the season's first meet, supported by his mother, Coach, teammates, and Mr. Charles, Castle steps to the starting line. The novel stops as his first official race begins, with Ghost finally running toward a future rather than only away from his past.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -778,7 +778,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -791,7 +791,7 @@
       "recaps": {
         "ending": "The collection's eight investigations all confirm that antiquarian evidence can preserve an active danger. Dennistoun survives the thing associated with Canon Alberic's manuscript and destroys its image. Stephen Elliott escapes Mr Abney's intended sacrifice when the ghosts of two earlier victims kill Abney. The changing mezzotint completes its record of an old abduction. At Castringham Hall, the ash tree's deadly inhabitants and the remains linked to Mrs Mothersole expose the source of the Fell deaths. Anderson escapes room 13 after witnesses confirm that the impossible room can alter the inn. Wraxall fails to escape Count Magnus and his companion. Parkins is rescued from the figure summoned by the whistle, which is cast away. Finally, Somerton reaches Abbot Thomas's hiding place but encounters its inhuman guardian; he and Brown retreat and seal the opening rather than attempt another recovery. The treasure remains where its maker intended, and Somerton treats the warning encoded in the clues as settled fact.",
         "in_short": "Eight antiquaries encounter threats embedded in manuscripts, houses, images, monuments, and local traditions. Dennistoun buys Canon Alberic's scrapbook and is attacked by the presence attached to it. Orphan Stephen Elliott discovers that his scholarly guardian has murdered children for an occult experiment, but their ghosts take revenge. A mezzotint changes before its viewers, replaying an old abduction. An ash tree at Castringham Hall conceals the agents of a witch's vengeance. A researcher in Viborg finds an impossible hotel room that exists only at night. A travel writer's study of Count Magnus releases the count and a companion from their tomb. A skeptical professor blows an ancient whistle and summons a figure that pursues him. A clergyman solves Abbot Thomas's coded treasure hunt but abandons the prize after meeting its guardian. Knowledge survives each episode, but curiosity repeatedly opens what earlier generations tried to keep closed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -951,7 +951,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -962,7 +962,7 @@
       "recaps": {
         "ending": "The Corpsetaker is destroyed for good: her assault on Mortimer Lindquist ends when Mort, far stronger than he ever let anyone see, turns his mastery of spirits against her and unmakes her ghost, with Sir Stuart spent in his defense, Murphy's crew storming the physical battlefield, and Bob checkmating his dark twin in the Nevernever. Harry's murder is solved, and the answer was always going to hurt: he arranged it himself - he hired Kincaid to shoot him and had Molly erase his memory of the plan, choosing death over life as Mab's corrupted Winter Knight, and unknowingly leaving Molly to carry the secret alone into breakdown. Uriel shows Harry the rest: his despairing choice was not entirely free - a fallen angel whispered to him at his lowest moment, and Uriel, permitted to balance the scales, grants Harry seven words in return: the whisper was a lie, and Mab cannot change who he is - only Harry can do that. Then the final truth: Harry was never wholly dead. His body has lain preserved on Demonreach, kept alive by Mab and the island, while his spirit walked. Harry chooses to go back. He wakes in the flesh, weak but alive, with Mab attending his recovery and his service as the Winter Knight still owed. Chicago's defenders do not yet know he is coming back; Maggie remains safe with the Carpenters; and the Fomor remain loose in the world.",
         "in_short": "Shot dead at the end of Changes, Harry Dresden is sent back to Chicago as a ghost to find his murderer, warned that three of his friends will suffer if he fails. Six months have passed: the Fomor have risen to fill the Red Court's vacuum, Murphy leads the city's ragged supernatural resistance, Butters carries Bob's skull, and Molly has broken into the murderous vigilante called the Rag Lady. Unable to touch or be seen, Harry allies with the ectomancer Mortimer Lindquist and the shade of Sir Stuart, whose home is besieged nightly by the Grey Ghost - the Corpsetaker, the body-stealing necromancer Harry once killed, now hunting a new body with Mort's at the top of her list. While steering a talented street kid named Fitz out of a petty sorcerer's grip, Harry recovers his own missing memories and solves the case: he arranged his own murder, hiring Kincaid and having Molly erase the memory, rather than live as Mab's monster. Mort destroys the Corpsetaker, the archangel Uriel reveals a fallen angel's whisper tainted Harry's fatal choice - and that his body has been kept alive on Demonreach by Mab and the island all along. Harry chooses to return, and wakes: alive, and still the Winter Knight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1093,7 +1093,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1104,7 +1104,7 @@
       "recaps": {
         "ending": "Ghostwater ends with the ancient realm collapsing and Lindon escaping at the last moment, transformed by his time inside. What began as a deadly trap became the fastest growth of his life: his cultivation has vaulted upward, and he leaves with major new assets, above all Dross, the mind-spirit now bound to him and sharpening his every perception. He carries Orthos and his small elemental companion out with him and turns back toward the outside world. Yerin, who spent the book on her own hard path recovering from the loss of her blood-madra inheritance, has likewise grown, and the companions are set to reunite far stronger than the crisis left them. Where Lindon entered Ghostwater isolated and badly outmatched, he leaves it a genuinely formidable young artist. The book closes with him free of the failing realm and pointed back toward Eithan, Yerin, and the next threshold of power their dangerous world keeps demanding they cross.",
         "in_short": "Swept away alone during the dreadgod's attack, Lindon is trapped in Ghostwater, an ancient, decaying pocket realm built long ago by one of the world's supreme powers for research and experiment. Cut off from Eithan and Yerin and accompanied only by the tortoise Orthos and his small elemental companion, he treats the collapsing, resource-rich realm as an opportunity as much as a trap and drives himself to grow. Deep inside, he encounters Dross, a spirit of pure mind that bonds with him and greatly sharpens his perception and analysis. With Dross's help and Ghostwater's rare resources, Lindon's strength climbs far faster than it could outside, while Yerin, elsewhere, pursues her own hard road. As the realm fails, Lindon pushes through a major advance and, at the book's end, escapes just as Ghostwater collapses, emerging vastly stronger and ready to reunite with his companions.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1317,7 +1317,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1330,7 +1330,7 @@
       "recaps": {
         "ending": "Cytherea the First, an original Lyctor who has spent the book impersonating the Seventh House's dying heir, kills or disables almost everyone left at Canaan House: Palamedes Sextus destroys himself trying to stop her, Silas Octakiseron and Colum Asht die, and Camilla Hect is critically injured. Gideon and Harrowhark are the last standing, and Harrowhark cannot win without paying the price that makes a Lyctor, which she has refused from the beginning. Gideon takes the decision away from her and impales herself on an iron railing, giving Harrow her soul on her own terms. Harrowhark ascends, destroys Cytherea with Gideon's power, and survives. A Cohort ship reaches the First House and removes the survivors: Harrowhark and Ianthe Tridentarius, the first new Lyctors in ten thousand years; Coronabeth Tridentarius, revealed over the course of the book to have no necromancy at all; Judith Deuteros of the Second; and Camilla Hect. Ianthe is entirely at ease with what she did to her own cavalier. Harrowhark is not: she leaves the First House immortal, carrying Gideon's two-handed sword, refusing to accept the ascension she was given. What she intends to do about that is what the next book is built on.",
         "in_short": "Gideon Nav is an indentured servant of the Ninth House, a dying world of tombs, and has spent eighteen years failing to escape it. When the Emperor summons every House's necromantic heir and cavalier to compete for immortality as a Lyctor, the Ninth's heir Harrowhark Nonagesimus, Gideon's lifelong enemy, is left without a cavalier and offers Gideon her freedom in exchange for the role. At Canaan House the eight delegations find no instructions, only a sealed facility of laboratories and a set of trials, and then the candidates begin to be murdered. Gideon, ordered to stay silent, befriends the Sixth House's Palamedes Sextus and the Seventh's dying Dulcinea Septimus, and is slowly forced into a real partnership with Harrow. The secret of Lyctorhood proves to be that a necromancer must consume their cavalier's soul; Ianthe Tridentarius kills her own cavalier to claim it first, and Dulcinea is revealed to be Cytherea the First, an ancient Lyctor who has been killing the candidates. Cornered, Gideon kills herself so that Harrowhark can take her soul and survive. Harrow ascends, destroys Cytherea, and is carried off the First House as a Lyctor of the Emperor, with Gideon inside her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1479,7 +1479,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1492,7 +1492,7 @@
       "recaps": {
         "ending": "Jerry and Rachel's long investigation finally connects the mysterious person who coveted Ginger with Wally Bullwinkle. Wally has kept the stolen dog concealed and altered his appearance so that people who knew Ginger would not readily recognize him. The accumulated clues expose the disguise and the identity of the thief, allowing Ginger to be recovered and returned to the Pyes. Months of separation have not erased his attachment to Jerry or the family. The mystery that began with footsteps behind Jerry is resolved, and the household is reunited with its clever dog. Jerry and Rachel's refusal to dismiss small observations proves essential: details that seemed isolated become meaningful once they understand that the kidnapper hid in familiar surroundings rather than disappearing far from Cranbury.",
         "in_short": "Jerry Pye earns a dollar and uses it to buy Ginger, an unusually clever fox terrier puppy. Jerry and his sister Rachel notice a shadowy person following them, and Ginger's intelligence soon makes the dog widely admired in Cranbury. When Ginger is stolen on Thanksgiving, the children refuse to believe he is gone for good. They follow scattered clues through the winter, helped by their family, their tiny Uncle Bennie, and friends around town. The mystery eventually leads to Wally Bullwinkle, who coveted Ginger, abducted him, and disguised him so he could be kept nearby without recognition. Jerry and Rachel uncover the deception, Ginger is restored to the Pye family, and the suspicious figure from the beginning is finally explained.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1625,7 +1625,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1638,7 +1638,7 @@
       "recaps": {
         "ending": "After David abandons their life together, Giovanni returns in desperation to Guillaume's bar. Guillaume exploits him and then refuses to help him; Giovanni kills Guillaume and is captured after a futile attempt to escape. He is sentenced to death. Meanwhile, David attempts to resume a conventional future with Hella, but he continues seeking men and cannot give her the honest commitment she expects. Hella discovers the truth, understands that their planned marriage cannot survive it, and leaves to return to America. On the morning set for Giovanni's execution, David remains alone in southern France, imagining Giovanni's final moments and confronting the destruction caused by his fear and denial. He tears up the official notice of the execution, but the wind blows its pieces back toward him, leaving him unable to discard either Giovanni's memory or his responsibility.",
         "in_short": "David, an American in France, remembers the choices that brought him to the eve of Giovanni's execution. While his fiancée Hella is in Spain considering marriage, David meets Giovanni, an Italian bartender, through his older acquaintance Jacques. David moves into Giovanni's cramped Paris room, and the two begin an intense relationship, but David's shame makes him resist any future Giovanni imagines. When Hella returns, David leaves Giovanni and tries to restore the heterosexual life he believes he should want. Abandoned and without work, Giovanni goes back to the bar owner Guillaume; after Guillaume uses and rejects him, Giovanni kills him and is condemned to death. David's effort to live with Hella fails as he continues pursuing men. She discovers the truth and leaves for America. Alone on the morning of Giovanni's execution, David can no longer avoid the human cost of his denial.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1823,7 +1823,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1836,7 +1836,7 @@
       "recaps": {
         "ending": "After Catharina discovers that Griet has worn her pearl earrings for the portrait, the confrontation becomes impossible to contain. Griet leaves the Vermeer house without waiting to be formally dismissed and returns to the life available to her own class. She marries Pieter, works in the butcher's trade, and has children. Ten years later, following Vermeer's death, Tanneke summons her to Maria Thins. Vermeer's estate is burdened by debt, but his will directs that Catharina's pearl earrings be given to Griet. Griet understands the bequest as a private acknowledgment of the portrait and of the part she played in his work. She cannot safely wear such conspicuous objects and does not preserve them as relics: she sells them, pays what the Vermeer household owes at the butcher's shop, and keeps the remaining money. The transaction converts the dangerous intimacy of the studio into something that can support the separate life she has made.",
         "in_short": "In 1660s Delft, sixteen-year-old Griet becomes a servant in painter Johannes Vermeer's Catholic household after an accident blinds her tile-painter father. Her eye for color draws her into Vermeer's guarded studio, where she cleans, mixes pigments, and quietly assists his work. His patron Van Ruijven takes an unwelcome interest in her and commissions a painting of her alone. Vermeer has Griet pierce her ear and wear his wife's pearl earring for the portrait, intensifying Catharina's jealousy and placing Griet's reputation at risk. When Catharina discovers the arrangement, Griet leaves and later marries Pieter, the butcher's son. A decade afterward, Vermeer dies in debt but leaves the earrings to Griet. She sells them, settles his household's butcher bill, and keeps the balance, closing the hidden connection between artist, servant, and painting on her own practical terms.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1998,7 +1998,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2011,7 +2011,7 @@
       "recaps": {
         "ending": "Catharina discovers that Griet has worn her pearl earrings for Vermeer's portrait and confronts her in the studio. Griet leaves the house before she can be formally dismissed and later marries Pieter, joining the butcher's trade and raising children. Ten years pass. After Vermeer dies insolvent, Tanneke summons Griet back to the house for the reading of a provision in his will. He has left her Catharina's pearl earrings, the objects that helped precipitate her departure. Catharina resents the bequest but hands them over. Griet understands that such jewels do not belong in her practical married life and that keeping them would preserve a dangerous attachment. She sells them to settle the butcher bill still owed by the Vermeer household, retains the remaining money, and closes her connection to the painter on her own terms.",
         "in_short": "After a kiln accident blinds her father, sixteen-year-old Griet becomes a maid in Johannes Vermeer's Delft household. Her sensitivity to color wins the painter's attention, and she secretly cleans his studio, mixes pigments, and learns to see as he does. The intimacy of their work angers his wife Catharina and exposes Griet to pressure from the patron Van Ruijven. Vermeer protects her from posing with the patron by painting her alone, but requires her to pierce her ear and wear Catharina's pearl earring. Griet's growing bond with the painter remains unequal: he prioritizes the picture while she bears the social risk. When Catharina discovers the portrait and earrings, Griet leaves and marries the butcher's son Pieter. Ten years later, after Vermeer's death, she learns that he left her the earrings. She sells them, uses part of the money to clear his family's debt to the butcher, and keeps the rest, converting a fraught private legacy into independence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2164,7 +2164,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2177,7 +2177,7 @@
       "recaps": {
         "ending": "Claire discovers that Michael was killed in a vampire attack but remains bound to Glass House in a ghostlike existence, becoming solid only at night. The truth explains his strange absences and makes clear why he cannot simply lead the household to safety. Claire's attempt to secure protection brings her into direct dealings with Amelie and into conflict with Oliver, whose friendly coffee-shop persona concealed a powerful vampire rival. Although Claire and her friends survive the immediate struggle over the valuable book and Morganville's competing claims, they do not reach safety. Shane's father, Frank Collins, arrives with armed vampire hunters and turns Glass House into the next battleground. The novel closes with Claire, Eve, Shane, and Michael facing an attack on their home, while Michael's condition leaves him especially exposed and Shane is caught between his friends and his father's violent campaign.",
         "in_short": "Sixteen-year-old Claire Danvers arrives at Texas Prairie University and becomes the target of vicious dorm bully Monica Morrell. She escapes to Glass House, where she finds a new family in Goth barista Eve Rosser, guarded Shane Collins, and musician Michael Glass. They teach her Morganville's secret: vampires control the town, and humans survive by accepting a vampire patron's protection. Claire's search for safety draws the attention of predatory Brandon, coffee-shop owner Oliver, and the town's ancient Founder, Amelie, especially after Claire becomes connected to a rare old book the vampires want. She also learns that Michael was killed by a vampire and now exists as a ghostlike being bound to the house, solid only at night. Claire's negotiations and quick thinking get the group through the contest over the book, but the danger immediately changes shape. Shane's father arrives with armed vampire hunters and attacks Glass House, ending the book with the household under siege.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2510,7 +2510,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B084SV1HFQ",
@@ -2522,7 +2522,7 @@
       "recaps": {
         "ending": "The stranded human force crosses from Glass World into an insect-alien hive and loses its return gateway. After capturing the hive queen, McGill turns her against Rigel when High Lord Squanto orders her colony destroyed. Her rebels seize the planetary Rigelian viceroy and obtain gateway posts, allowing the survivors to evacuate to Earth. Natasha demonstrates that captured spinner larvae can build and cure tailored armor, giving the campaign strategic value even though the rumored processing machine was never recovered. The discovery keeps Galina Turov in command and defeats Winslade's immediate promotion effort. McGill refuses a promotion tied to reassignment and remains a Legion Varus centurion. Earth must now establish armor production, while the queen's colony faces Rigelian retaliation. Winslade and his patron retain political influence, and Abigail's faction gains Earth-market access through a separate agreement. McGill still owes Natasha access to casting technology, remains indebted to Galina for concealing Etta's actions, and begins an open-ended relationship with Abigail before she leaves off-world.",
         "in_short": "Abigail gives James McGill a lead linking lost Skae technology to Rigelian armor, drawing Legion Varus to Glass World. The expedition survives sabotage, a disastrous landing, smart mines, gateway battles, repeated deaths, and Winslade's bid to replace Galina Turov. McGill recovers Cooper's remains, destroys the mine gateway, follows Lisa to Rigel, and learns she sold his landing coordinates to escape. A later casting mission reveals stealth-capable insect aliens building a gateway below Glass World. Winslade strands the assault force, which crosses into their hive and captures its queen. When Rigel orders the colony destroyed, the queen rebels and helps the survivors open a gateway to Earth. Natasha proves that living spinner larvae can manufacture fitted armor, turning the expedition into a strategic success. Galina retains command, McGill stays with Legion Varus after refusing reassignment, Abigail's faction gains an Earth contract, and McGill and Abigail begin a relationship before her departure.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2624,7 +2624,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2636,7 +2636,7 @@
       },
       "recaps": {
         "in_short": "A collection of short stories set in the world of the Arc of a Scythe trilogy, several of them written with other authors. The pieces stand alone rather than forming a continuous narrative, and between them they span the whole history of that world: the early decades of the Scythedom and the generation that founded it, the years surrounding the events of the trilogy, and the time after its close. They assume the world's ground rules rather than explaining them again, and a number of them assume the outcome of the trilogy as well.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2780,7 +2780,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2793,7 +2793,7 @@
       "recaps": {
         "ending": "Glinda, the Wizard, and the Three Adepts combine their knowledge to raise the glass-domed island from beneath the lake, freeing Dorothy, Ozma, and the Skeezers. Ozma then settles the quarrel without allowing either old ruler to renew it. The stolen brains are returned to the Three Adepts, who become the wiser leaders of the Flatheads. Lady Aurex is chosen to govern the Skeezers in place of the transformed Coo-ee-oh. Both peoples accept peace and better rulers, while Coo-ee-oh remains a diamond swan and no longer holds the island's magic in her keeping. With the remote corner of Oz made peaceful, Dorothy and Ozma return to the Emerald City. Their friends welcome them home, and the adventure closes with Ozma's birthday celebration, joining the rescued travelers and their companions in a cheerful reunion.",
         "in_short": "Ozma's magic record book warns that the Flatheads and Skeezers, two remote peoples of Oz, are about to go to war. She and Dorothy travel north to make peace, but neither Su-dic of the Flatheads nor Queen Coo-ee-oh of the Skeezers will listen. Coo-ee-oh lowers her glass-domed island beneath its lake, trapping Dorothy, Ozma, and the Skeezers; during the struggle she is changed into a diamond swan and can no longer supply the magic that will raise it. The record book alerts the Emerald City, and Glinda leads a rescue. Meanwhile, the fisherman Ervic obtains Red Reera's help in restoring three enchanted fish to their true forms as the Three Adepts at Magic. With the Adepts and the Wizard, Glinda raises the island. Ozma removes the causes of the feud: the Adepts recover their stolen brains and lead the Flatheads, while kindly Lady Aurex becomes ruler of the Skeezers. Peace restored, the travelers return for Ozma's birthday.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2920,7 +2920,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2933,7 +2933,7 @@
       "recaps": {
         "ending": "Garan contracts letumosis, the plague that has no cure, and dies. With him goes the only person in the house who wanted Cinder there. Adri, left a widow with two daughters, a failing income and a cyborg stepdaughter she never agreed to, settles into treating Cinder as an unpaid mechanic and legal property rather than family, and blames her for Garan's death. Peony remains fond of her, Pearl follows her mother, and Iko - the android with the faulty personality chip - is the one companion Cinder has left. The story ends with the household arrangement that the novel Cinder opens on already in place: an unwanted girl, an unpaid job, no memories, and one friend who is not human.",
         "in_short": "A prequel short story, told from Cinder's point of view. At eleven, freshly rebuilt as a cyborg with no memory of anything before the surgery, she is brought to New Beijing by Linh Garan and installed in his household. Garan is kind and interested in her; his wife Adri is neither, his elder daughter Pearl follows her mother's lead, and only the younger girl, Peony, treats her as a sister. Cinder struggles with a body she does not recognise, a retinal display she cannot read, and a legal status that makes her closer to property than to a daughter. Garan builds her an android companion, Iko, whose personality chip is faulty in ways that make her far better company than her model should be. Then Garan catches letumosis and dies, and the household that tolerated Cinder because he wanted her there stops tolerating her at all.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3065,7 +3065,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3078,7 +3078,7 @@
       "recaps": {
         "ending": "After Jean Louise's furious break with Atticus and Henry, Uncle Jack forces her to examine why the discovery has shattered her. He argues that she turned Atticus into an infallible conscience instead of recognizing him as a separate, fallible man, and that her anger proves she possesses a conscience of her own. Jean Louise returns to her father's office expecting rejection, but Atticus says he is proud that she stood against him. She has not accepted his racial politics, nor does the book resolve their disagreement; what changes is her dependence on an idealized version of him. When Atticus asks her to drive him home, she helps him into the car and realizes that for the first time she is seeing him as an ordinary human being. She remains tied to Maycomb and her family while newly aware that her moral judgment must be her own.",
         "in_short": "Jean Louise Finch returns from New York to visit aging Atticus in Maycomb, where Henry Clinton hopes she will marry him. Her nostalgic sense of home collapses when she sees Atticus and Henry at a citizens' council meeting addressed by a racist speaker. A painful visit to Calpurnia, who now treats her with guarded formality, confirms that the relationships of her childhood cannot simply be recovered. Jean Louise confronts Henry and then Atticus, condemning their politics and feeling that the father who formed her conscience has betrayed it. Uncle Jack makes her see that she had mistaken Atticus for an infallible extension of herself. Atticus, rather than disowning her, respects her resistance. Jean Louise does not reconcile herself to his beliefs, but she begins to accept him as a flawed person and recognizes her own independent conscience. She drives him home, still connected to her family but no longer morally dependent on an idealized father.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3254,7 +3254,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3267,7 +3267,7 @@
       "recaps": {
         "ending": "John's struggle on the church floor ends in a conversion experience that he understands as salvation. At dawn he rises convinced that he has been changed, and the congregation celebrates him. Elisha's tenderness confirms for John that he is not alone, though his feelings remain bound up with the religious language through which he understands himself. Elizabeth accepts her son's experience with hope, while Gabriel remains cold and questions whether John's pride has truly been overcome. Florence, gravely ill and no longer willing to protect her brother's reputation, confronts Gabriel with the evidence that Deborah knew of his affair and his abandoned son. The family's old secrets therefore remain active even as John steps into a new spiritual identity. John leaves the church with his family into the Sunday morning, determined to remember what happened and to begin a different life, but still subject to Gabriel's authority and to the conflicts within himself.",
         "in_short": "On his fourteenth birthday in Harlem, John Grimes feels trapped between ambition, forbidden desire, and the severe Pentecostal faith enforced by Gabriel, the preacher he calls father. A family crisis and a night of worship bring generations of hidden pain to the surface. Florence remembers the sacrifices and disappointments that shaped her break with her brother. Gabriel's past reveals a self-serving affair, an abandoned son, and guilt concealed beneath religious authority. Elizabeth remembers her love for John's biological father, Richard, whose destruction by racist policing left her alone and pregnant before Gabriel married her. During prayer at the Temple of the Fire Baptized, John undergoes a terrifying inward struggle and rises believing himself saved. The congregation welcomes his conversion, but Gabriel remains withholding. Florence confronts Gabriel with proof that his first wife knew his secret, while John leaves at dawn hopeful that his new faith can become his own rather than merely an instrument of fear.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3514,7 +3514,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3527,7 +3527,7 @@
       "recaps": {
         "ending": "The southern war reaches the mountain and settles what the Ridge has been arguing about for two years. Jamie musters the militia; the Loyalist faction that grew up around Captain Cunningham and the rebel households come to open conflict, and the backcountry Loyalist army is destroyed at Kings Mountain in the autumn of 1780, with the Ridge's men in the fight. The settlement comes out of it changed and smaller, its allegiances no longer arguable. The Frasers end the book in the finished house with the family gathered around them: Jenny in the household, Frances being raised as a daughter, Roger preaching to a congregation that has stopped splitting, Brianna's improvements running through the place, and Young Ian and Rachel with a child of their own. Among the Greys, the family's private catastrophe is out in the open: Benjamin, mourned for years, is alive and serving on the American side under another name, with a wife and son who were told he was dead, and neither Hal nor William has decided yet what is to be done about any of it. William remains outside every allegiance on offer, including his father's. The Carolinas are still the seat of the war, the British hold the coast, and nothing about the Frasers' position on the mountain is settled.",
         "in_short": "Fraser's Ridge, 1779 to 1780. Roger, Brianna and their children arrive from Scotland through the stones, and for the first time the whole family is on the same mountain at once. Jamie and Claire rebuild the Big House while Jamie, obliged to fill his land grant, takes in settlers whose politics he cannot choose, among them a retired Royal Navy captain, Charles Cunningham, whose Loyalist following grows into a rival congregation and a standing threat. Claire practises medicine and keeps bees, Brianna plumbs the house, Roger preaches, Jenny Murray runs what she can, and Frances Pocock is brought up as a daughter. In the meantime the war moves south: Savannah falls to the British and an allied assault on it fails, and the Grey family, hunting a son reported dead in an American prison camp, discovers that Benjamin Grey is alive and serving the other side under an assumed name. The quarrel on the Ridge finally breaks into the open as the backcountry rises, and Jamie's militia rides with the force that destroys a Loyalist army at Kings Mountain. The family ends the book together, the war unfinished.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3668,7 +3668,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3681,7 +3681,7 @@
       "recaps": {
         "ending": "Leto II's millennia-long reign ends by his own design. Having bred the Atreides line for thousands of years toward a single goal, he produces Siona, a descendant whose genes make her and her heirs invisible to prescient sight, ensuring that humanity can never again be trapped by a tyrant who can see the future. He falls in love with the Ixian ambassador Hwi Noree and decides to end his rule, announcing their marriage. On the wedding procession, as his great cart crosses the high Idaho Bridge over a river, the rebellion he has secretly guided closes in. Siona and the current Duncan Idaho ghola lead the attack, and Nayla, a Fish Speaker fanatically loyal to Leto yet commanded by him to obey Siona, severs the bridge. Leto's worm-body plunges into the water, which is poison to the sandtrout that compose his skin. Hwi is killed, and Leto begins to dissolve. As he dies, he explains to Duncan and Siona the meaning of his sacrifice: the enforced peace and the yearning it created will burst outward into a great Scattering of humanity across the stars, too dispersed and unpredictable ever to be destroyed or ruled at a single stroke. His disintegrating body releases the sandtrout that will slowly return Arrakis to desert and revive the sandworms and their spice. Duncan and Siona survive to lead what comes after, and the age of the God Emperor gives way to a freer, more dangerous future.",
         "in_short": "For over three thousand years Leto II, Paul's son, has ruled as the God Emperor of Dune, his body transformed into that of a colossal sandworm. He enforces a stagnant, tightly controlled peace to teach humanity a lasting lesson about tyranny and to steer it along his Golden Path toward guaranteed survival. His long breeding program has produced Siona, a young Atreides rebel whose descendants will be invisible to prescient sight, freeing the species from ever being controlled by a seer again. Leto tests and ultimately spares Siona, forcing her to share his vision of humanity's peril. He revives yet another ghola of Duncan Idaho to serve him, and unexpectedly falls in love with Hwi Noree, a kind ambassador engineered by the machine-world of Ix specifically to reach his heart. Determined to end his own long reign, Leto announces he will marry Hwi. During the wedding procession, as his cart crosses a high bridge over a river, the rebels strike: the fanatic Fish Speaker Nayla, secretly commanded to obey Siona, cuts the bridge supports. Leto's body plunges into the water, which is lethal to the sandtrout that compose him. Hwi dies in the fall, and the dissolving God Emperor scatters into countless sandtrout that will one day restore the sandworms and the spice. Dying, Leto reveals that his death, and Siona's hidden bloodline, are the culmination of the Golden Path.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3900,7 +3900,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B08V5RYLP1",
@@ -3912,7 +3912,7 @@
       "recaps": {
         "ending": "The Pantherkin settlement survives Svaroth's assault, but fewer than two dozen people remain. Sharp Leaf and Autumn Ghost are dead. Midnight Dust, the sole survivor among Zero Fell's original acolytes, accepts Soul Scarred, losing the power to heal others while gaining far greater divine damage and concealed soul energy. Minamoto Tametomo survives as the settlement's military leader. Zero Fell and Minamoto kill Svaroth's body, but the diminished divine soul escapes after the Divine Eagle Bear drains part of its energy. That act begins the spirit animal's quest to consume three sources of divine power and form its own divine core. The completed void-stone temple, Rig, the altar, the Cruel Grail, and a stored ogre bloodline give the survivors a foundation for recovery. Their position remains precarious: an elite predator is nearby, Asmodeus may still live, several rival gods remain hostile, the prime relic is unfound, and the identities and price of Fell's sponsors are unresolved. Fell intends to turn the settlement into enough power to conquer and save Telos.",
         "in_short": "Remy dies protecting refugees on Earth and is remade as a god on Telos, where he chooses a threatened Pantherkin tribe and becomes Zero Fell. He saves them from monsters and rival worshippers, develops Soul powers, appoints three acolytes, and transforms a slain eagle bear from a bound enemy into a loyal spirit animal. After a dangerous migration, the tribe finds a ruined temple whose altar contains Asmodeus and four weakened gods. Fell drives Asmodeus into hell, claims the altar, awakens Rig, and founds Telos's first religious domain, winning resources and worldwide attention. The rival god Svaroth attacks with ogres before the settlement is ready. Minamoto Tametomo, summoned through Fell's reward, helps defeat the invaders and kill Svaroth's body, though Sharp Leaf and Autumn Ghost die. In the aftermath, Svaroth's soul escapes, the Divine Eagle Bear begins a path toward godhood, and fewer than two dozen Pantherkin remain. With a completed temple and new advantages, Fell commits to conquering Telos in order to save it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4066,7 +4066,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4079,7 +4079,7 @@
       "recaps": {
         "ending": "Casiopea and Martín accompany the rival gods onto the Black Road, where Vucub-Kamé expects mortal weakness to decide the contest. Martín embraces the promise of power but cannot give his patron the victory he wants. Casiopea endures the road's trials and refuses to purchase safety by betraying Hun-Kamé. Her choice settles the wager in Hun-Kamé's favor and restores him as lord of Xibalba. The bond that has been consuming Casiopea's mortal life ends. Although Casiopea and Hun-Kamé have come to love one another, a death god belongs in the underworld and she will not surrender the mortal future she fought to claim. She leaves the family and town that confined her and sets out on her own, choosing travel, uncertainty, and freedom. Martín returns from the ordeal without the triumph he expected, while Casiopea carries forward the confidence gained during the journey rather than returning to her former dependence.",
         "in_short": "In 1920s Yucatán, Casiopea Tun is trapped in service to her wealthy grandfather and cruel cousin Martín until she opens a forbidden chest and frees Hun-Kamé, the deposed Maya lord of death. A bone shard binds their lives, forcing Casiopea to accompany the weakened god across Mexico as he recovers the body parts stolen by his twin, Vucub-Kamé. The journey leads through cities, deserts, and encounters with demons and spirits while Hun-Kamé becomes increasingly human and Casiopea grows bolder. Vucub-Kamé recruits Martín as his own mortal champion and proposes a final contest on Xibalba's Black Road. Martín's hunger for status cannot secure victory, while Casiopea withstands the trials and refuses to betray Hun-Kamé. Hun-Kamé regains his throne and releases Casiopea from their bond. Their affection cannot erase the divide between god and mortal, so she declines to remain in the underworld and leaves home to build an independent life of travel.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/gods-of-risk.json
+++ b/data/works-community/0/gods-of-risk.json
@@ -40,7 +40,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -53,7 +53,7 @@
       "recaps": {
         "ending": "David's attempt to get Leelee out from under Hutch puts him directly in Hutch's hands, and the arrangement he thought he controlled turns into a straightforward threat against him and his family. It is his aunt who ends it. Bobbie, who has spent the whole book unable to explain herself to anyone in the household, goes after him, finds him, and removes Hutch as a problem. Leelee gets clear. David's secret comes out, and the consequence is not the catastrophe he had been dreading: his aunt is the one person in the family who deals with him as an adult rather than as a disappointment, and the two of them end the book with an understanding neither had at the start. Bobbie, having discovered that she is still good for something and still wanted, stops drifting and accepts work that gets her out of her brother's house and back into the world, which is where the novels find her next. Nothing about the wider war changes; the story is a domestic one, and it closes with a family that has stopped talking around the two people in it who needed to be spoken to.",
         "in_short": "On Mars, in the tunnel city of Londres Nova, sixteen-year-old David Draper is a chemistry prodigy competing for a place in a selective academic program and secretly cooking drugs in a school laboratory for a local dealer named Hutch. His aunt Bobbie, a former Marine who left the service after her platoon was killed on Ganymede, is staying in the family's home, jobless and unreachable, and the household has no idea what to do with either of them. David's involvement with Hutch deepens when a young woman he cares about, Leelee, gets caught in the same net, and his attempt to pull her out puts him in Hutch's power. Bobbie works out what is happening, goes after her nephew, and ends Hutch as a threat. Leelee gets clear, David's secret comes out and is survivable, and Bobbie, having found she is still useful to somebody, stops drifting and takes work that puts her back into the wider world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -199,7 +199,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -212,7 +212,7 @@
       "recaps": {
         "ending": "In the imagined Paris pursuit, the squad locates Cacciato and Paul Berlin is placed in the position of stopping him. Paul cannot make the decisive act conform to the heroic possibilities he has rehearsed; a shot is fired, but the scene does not deliver certainty about Cacciato's fate. The narrative returns to Paul on observation duty in Vietnam, where the journey west can be understood as a possibility constructed during his watch from fragments of fear, memory, and desire. The actual squad still faces the moment after Cacciato's disappearance and prepares to go after him. Paul ends with no assurance that either courage or imagination can save anyone, but he allows for the possibility that Cacciato might get away. The book therefore closes by preserving the tension between what happened, what Paul wishes could happen, and what a frightened soldier needs to imagine in order to continue.",
         "in_short": "Private Paul Berlin's squad is ordered to pursue Cacciato, a soldier who has left the Vietnam War intending to walk to Paris. The chase expands into an improbable westward journey through Southeast Asia, India, Iran, and Europe. Paul rescues and falls in love with refugee Sarkin Aung Wan; the squad escapes tunnels, arrest, and political danger; and they finally reach Paris, where Cacciato remains just ahead of them. Interwoven chapters return to Paul's night watch at an observation post and to memories of deaths, fear, and the squad's killing of Lieutenant Sidney Martin. These strands reveal the overland adventure as a possibility Paul constructs from his wartime experience rather than a stable record. In Paris he cannot decisively capture Cacciato, and the narrative returns to Vietnam with the pursuit still about to begin. Paul can neither undo the war nor prove escape possible, but he holds open the thought that Cacciato may succeed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -372,7 +372,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -385,7 +385,7 @@
       "recaps": {
         "ending": "Moist wins his public race against the Grand Trunk and, more importantly, exposes Reacher Gilt's massive fraud and the deaths he caused, using evidence and his own criminal instincts turned to honest ends. Gilt is ruined and hauled before Lord Vetinari, who offers him exactly the bargain Moist accepted: a job, and a chance to make himself useful, or a door leading to a lethal drop. Gilt, unable to give up his freedom, walks through the door and dies. The Grand Trunk is taken out of Gilt's hands and set to be run properly, and the Post Office is firmly re-established as a thriving public institution. Moist, having discovered that going straight can be as thrilling as any swindle, chooses to stay as Postmaster rather than flee, and his relationship with Adora Belle Dearheart deepens. Vetinari has quietly acquired a reformed rogue he can point at the city's next problem.",
         "in_short": "The confidence trickster Moist von Lipwig is hanged for his crimes, but survives: Lord Vetinari faked the execution and offers him a choice, run Ankh-Morpork's ruined Post Office or truly die. Watched by a golem parole officer, Mr. Pump, Moist reluctantly takes the job and finds the building buried under decades of undelivered mail and haunted by the memory of postmen who died mysteriously. Using his gift for showmanship, he clears the backlog, invents the adhesive postage stamp, and turns the Post Office into a popular sensation. This puts him in direct conflict with Reacher Gilt, the corrupt magnate whose company has bled the Grand Trunk signalling network dry. Moist also grows close to Adora Belle Dearheart, whose brother was murdered by Gilt's people. He challenges Gilt to a public contest to see whether letter or signal tower can carry a message across the continent faster, wins through nerve and trickery, and exposes Gilt's fraud. Gilt is offered the same choice Moist once faced but refuses it and dies, and Moist stays on as the city's Postmaster.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -559,7 +559,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -572,7 +572,7 @@
       "recaps": {
         "ending": "The betrothal between Prince Dutiful and the narcheska Elliania is concluded before the whole court, and Elliania sets her own price on it: she will marry him only when he brings her the head of Icefyre, the black dragon said to lie buried in the glacier of Aslevjal Island in the Out Islands. Dutiful, cornered in public, accepts. The Six Duchies are therefore committed to a voyage to the Out Islands to kill a dragon that may not exist, against the wishes of the Outislander clan council, and Peottre's grim protectiveness makes it plain that Elliania is acting under a compulsion she cannot name. Fitz ends the book as a member of the reassembled Skill coterie with Chade, Dutiful and Thick, publicly still a servant, privately committed to sailing north with the prince. The Piebalds remain able to expose the prince's Wit at any moment, though Kettricken's Old Blood overtures have at least begun. Nettle knows a wolf in her dreams and not her father's name, and Chade has not given up on bringing her to Buckkeep. Between Fitz and the Fool nothing is repaired: the Fool keeps the distance of a master to a servant, Fitz cannot take back what he said, and the Fool has let slip that his own visions of the coming journey end in his death.",
         "in_short": "Living at Buckkeep as Lord Golden's servant Tom Badgerlock, Fitz mourns Nighteyes and takes up his new duties: teaching the Skill to Prince Dutiful and to Chade, who has finally reassembled the fragments of the old training. He discovers that the castle's despised drudge Thick is the most powerful natural Skill user in it, and slowly wins him over. Queen Kettricken invites Old Blood representatives to court to end the killing of the Witted, bringing the calm Wit-master Web and, with him, Burrich's runaway son Swift, while the militant Piebalds go on threatening to expose the prince's Wit. Fitz meets his daughter Nettle in Skill-dreams without telling her who he is, and fights Chade's determination to recruit her. When a Bingtown delegation arrives, a woman named Jek greets Lord Golden as a friend she knew as Amber, and speaks to Fitz of the Fool's love for him; Fitz's recoil breaks the friendship badly. At the betrothal ceremony the narcheska Elliania demands, as her bride price, the head of the dragon Icefyre buried in the ice of Aslevjal. Dutiful accepts, committing the Six Duchies to a voyage north, and the Fool has already foreseen that he will die on that island.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -756,7 +756,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -769,7 +769,7 @@
       "recaps": {
         "ending": "Darrow's grand gambit at a great gathering collapses through betrayal. His gentle friend Roque, wounded by the discovery that Darrow has manipulated and lied to those closest to him, turns against him and helps spring the trap. In the chaos, ArchGovernor Augustus's son Adrius, the Jackal, reveals his own long game and murders his father, seizing power for himself. The masked leader of the Sons of Ares, Ares, is exposed to be Fitchner, Darrow's gruff mentor, and he is killed. Darrow, outmaneuvered and surrounded, is overpowered and taken. The revolution he has risked everything to advance is thrown into disarray, its hidden leader dead and its greatest agent captured, leaving Darrow's survival and the fate of the Rising uncertain as the book closes on a knife-edge.",
         "in_short": "Two years after the Institute, Darrow serves as a lancer to ArchGovernor Augustus of Mars, still hiding that he is a Red remade into a Gold and still working for the rebel Sons of Ares. A humiliating defeat nearly ends his career, and to survive he plays the deadly politics of the great houses at the highest level, drawing the powerful Sovereign, the vengeful Bellona family, and Augustus's own children into a web of alliances and betrayals. Darrow forges new bonds with allies like Victra and the legendary swordsman Lorn, reconciles and clashes with Mustang, and gambles ever larger to move the Society toward the revolution he serves. His schemes build to an audacious bid for power at a grand gathering, but it is turned against him: his friend Roque, feeling used, betrays him; Augustus's son Adrius, the Jackal, seizes the moment to murder his own father; and the rebel leader Ares is unmasked and killed. The book ends with Darrow's plan in ruins and Darrow himself seized, his fate hanging in the balance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -892,7 +892,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -905,7 +905,7 @@
       "recaps": {
         "ending": "Bond's warning enables American forces to replace Goldfinger's intended poison and stage the apparent collapse of Fort Knox's defenders. The authorities attack when Goldfinger's people enter, and his plan to contaminate the gold reserve with a nuclear device fails. Oddjob kills Tilly as she tries to reach Pussy Galore, while Goldfinger escapes the battle. Later, Bond is drugged and placed aboard a flight that Goldfinger has hijacked. Bond fights Goldfinger and strangles him; Oddjob is blown out through a broken aircraft window. Bond and Pussy manage the damaged aircraft long enough to ditch near a weather ship and are rescued. Goldfinger and his principal enforcer are dead, the reserve is safe, and Pussy has helped turn the operation against its organiser. Bond and Pussy are together during their immediate rescue and recovery, without a settled long-term outcome.",
         "in_short": "Bond first exposes Auric Goldfinger cheating at cards, then receives an official assignment to investigate his gold smuggling. After defeating him at golf, Bond follows him across Europe with Tilly Masterton. Both are captured at Goldfinger's factory, where Bond learns that gold is concealed in the bodywork of a Rolls-Royce. Kept alive as clerical help, Bond hears Goldfinger recruit American gangs for Operation Grand Slam, a plan to disable Fort Knox and contaminate its gold with a nuclear device. Bond sends a warning that reaches Felix Leiter, and Pussy Galore also turns against Goldfinger. American forces foil the raid, though Oddjob kills Tilly and Goldfinger escapes. Goldfinger later hijacks Bond's aircraft; Bond kills him, Oddjob is blown from the plane, and Bond and Pussy survive a sea landing and rescue.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1069,7 +1069,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1082,7 +1082,7 @@
       "recaps": {
         "ending": "Patrick and Angie discover that Amanda did not die during the failed exchange. Her abduction was redirected into a plan involving members of the investigation and her uncle Lionel, with retired captain Jack Doyle ultimately keeping her in a safe, attentive home. Doyle argues that Amanda's welfare matters more than Helene's legal claim, and Angie agrees that returning the child would condemn her to neglect. Patrick believes that allowing a kidnapping to stand would make him responsible for deciding who deserves another person's child. He alerts the authorities. Doyle is arrested and Amanda is restored to Helene. The decision breaks Patrick and Angie's relationship, and she leaves him. Later Patrick visits the McCready home and finds Helene preparing to go out, casually leaving Amanda in his care and even misstating the name of her favorite doll. He stays to babysit. Amanda is legally home, but the closing scene makes clear that the moral cost Patrick feared has not vanished and that the better household he dismantled may indeed have offered the child greater care.",
         "in_short": "Boston investigators Patrick Kenzie and Angie Gennaro are hired to find four-year-old Amanda McCready, who disappeared while her neglectful mother Helene was at a bar. The search uncovers drug money stolen by Helene and an associate, drawing police and violent criminals into an apparent exchange in which Amanda is believed dead. Later inconsistencies expose a staged element to the case. Amanda is alive and living happily with retired police captain Jack Doyle, the final beneficiary of a conspiracy involving her uncle Lionel and people inside the investigation who intended to remove her from Helene. Angie wants to leave the child in the safer home; Patrick insists that kidnapping cannot be legitimized by their private judgment and calls the police. Amanda returns to Helene, Doyle is arrested, and Angie leaves Patrick over his choice. In the final scene Helene goes on a date and leaves Patrick to babysit, confirming the neglect that made his legally correct decision morally painful.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1227,7 +1227,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1240,7 +1240,7 @@
       "recaps": {
         "ending": "The novel's turn is that Amy is not a victim but the architect of the whole affair. Furious at Nick's affair with a young student and at the ruin of the life she wanted, she faked her own disappearance and death, keeping a false diary and staging clues designed to send Nick to prison for murdering her, then went into hiding to watch him fall. Her scheme unravels when other people at her hideout rob her of her cash. Desperate, she contacts Desi Collings, an obsessive wealthy ex-boyfriend, who installs her at his lakeside house under his control. To escape and to rewrite herself as a sympathetic survivor, Amy seduces Desi, kills him by cutting his throat, and returns home covered in his blood, claiming he had kidnapped and assaulted her. The story makes her a national heroine, and the police case against Nick collapses. Nick knows the truth but cannot prove it, and the public adoration shields her. When he prepares to leave her, Amy reveals she is pregnant, having used sperm he had once banked. Unwilling to abandon his child to her, and bound to her by their mutual knowledge, Nick remains, and the book closes on the two of them locked together in a marriage built on fear and performance.",
         "in_short": "On his fifth wedding anniversary, Nick Dunne finds his wife Amy missing from their Missouri home amid signs of a struggle. Told in alternating voices, Nick's present-day account and Amy's diary, the story makes Nick look increasingly guilty as his lies and an affair come to light. Halfway through, the truth flips: Amy is alive and has meticulously staged her own disappearance, faking a diary and planting evidence to frame Nick for her murder as revenge for his infidelity and the collapse of their marriage. Her plan goes awry when she is robbed while hiding out and turns for help to Desi Collings, a rich, controlling old boyfriend. Broke and cornered, she reinvents her story: she murders Desi, then returns home drenched in his blood claiming he abducted and raped her. The public sympathy this wins her makes it impossible for Nick to expose her. She reveals she has made herself pregnant with his stored sperm, and Nick, trapped by the threat to the child and by her willingness to destroy him, stays in the marriage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1408,7 +1408,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audiosilo-meta:work:gone-tomorrow",
@@ -1420,7 +1420,7 @@
       "recaps": {
         "ending": "Reacher draws seven Hoth operatives into an NYPD counterterrorism arrest at Union Square, escapes the federal agents waiting there, and enters the cell's 58th Street base alone. He kills the remaining male operatives, including a concealed twentieth man identified too late in the immigration count. After Lila Hoth and Svetlana Hoth disarm him, he uses a knife hidden against his back and kills them both, sustaining a serious abdominal wound. Theresa Lee and Springfield find him unconscious and take him to Bellevue Hospital. The Department of Defense assumes control of the nine bodies and prevents further consequences for Reacher. He concludes that Susan Mark threw her phone and the real memory stick from her car during an I-95 traffic jam after receiving evidence of Peter Molina's death. Searchers recover both items, but the stick is crushed beyond use, so the photograph of Sansom and Springfield cannot be exposed from it. Peter is treated as murdered, Susan's final fate remains unstated, and Reacher leaves New York. Lee survives and returns to police work, while Sansom's immediate political danger is contained.",
         "in_short": "Jack Reacher notices a distressed woman on a nearly empty New York subway train and becomes caught in the struggle over a missing memory stick. Susan Mark, a Pentagon employee, copied and erased an archive file containing a photograph of John Sansom and Springfield at a politically damaging 1983 meeting in Afghanistan. Lila Hoth and Svetlana Hoth target Susan through her son, Peter Molina, while federal personnel pursue Reacher and suppress the secret. Reacher works with NYPD detectives Theresa Lee and Jacob Mark, divides the Hoth cell with a staged exchange, and attacks its remaining members. He kills Lila, Svetlana, and the last operatives, but suffers a serious wound. Lee and Springfield get him to Bellevue Hospital. Reacher then identifies where Susan discarded the stick. It is recovered crushed and unreadable, leaving the photograph unusable. Peter was apparently murdered, Susan's ultimate fate is not established, and Reacher leaves New York.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1570,7 +1570,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1583,7 +1583,7 @@
       "recaps": {
         "ending": "By the end, Scarlett has survived war, poverty, and three marriages and rebuilt her fortune, but her personal life collapses. Her marriage to Rhett Butler, long poisoned by her clinging to a romantic ideal of Ashley Wilkes, holds together mostly through their shared love for their daughter, Bonnie Blue. Bonnie's death in a riding accident destroys that last bond. Soon after, the saintly Melanie dies following a dangerous pregnancy, and in losing her Scarlett finally recognizes two truths at once: that Ashley was never the man she imagined and cannot manage without Melanie, and that the person she has truly loved is Rhett. She turns to him only to find him emptied of feeling, no longer willing to keep fighting for a wife who never valued him; he leaves, telling her plainly that he no longer cares. Left alone in Atlanta, Scarlett refuses despair. She fixes her thoughts on Tara, the land that has always restored her, and resolves to return there and find some way to bring Rhett back, certain that tomorrow will give her another chance.",
         "in_short": "On the eve of the Civil War, willful Georgia belle Scarlett O'Hara loves the genteel Ashley Wilkes, but he marries his gentle cousin Melanie, and Scarlett weds another man out of spite. Widowed young, she waits out the war in Atlanta, crossing paths again and again with the cynical blockade-runner Rhett Butler. When the city falls, she escapes the flames, delivers Melanie's baby, and returns to find her family's plantation, Tara, ruined and her mother dead. Vowing never to be hungry again, she claws her way back to wealth through two more marriages and hard, scandalous business dealing, at last marrying Rhett. Their union is stormy, held together mainly by their doted-on daughter, Bonnie. When Bonnie dies and then Melanie too, Scarlett finally sees that she has loved Rhett all along, but he has been worn past caring and leaves her. Undefeated, she turns back toward Tara to plan how to win him again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1706,7 +1706,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1719,7 +1719,7 @@
       "recaps": {
         "ending": "Armageddon is averted not by Heaven or Hell but by the free will of a single ordinary child. As the End Times arrive, the Antichrist, Adam Young, comes fully into his powers, but rather than destroying the world he has grown up loving, he refuses the role written for him. Confronted with the machinery of the Apocalypse, Adam dismisses the Four Horsemen, faces down the arriving forces of Heaven and Hell, and rejects Satan himself, denying that the being is truly his father because his real father is the human man who raised him. By choosing humanity over destiny, Adam calls off the end of the world, and reality settles back into place. In the aftermath, Aziraphale and Crowley must answer to their furious superiors for having sided with the world instead of the war. Forewarned by a final prophecy of Agnes Nutter, they swap appearances, so that when Hell tries to execute Crowley and Heaven tries to punish Aziraphale, each survives the ordeal meant for the other, and their masters give up on them. Newton Pulsifer and Anathema Device are left together, having burned the last of Agnes's prophecies to live their own lives free of foreknowledge. Adam returns to being an ordinary boy in Lower Tadfield, and the two old friends from opposite sides sit down to enjoy the world they saved.",
         "in_short": "The angel Aziraphale and the demon Crowley have spent millennia on Earth and, having grown fond of the world and of each other, dread the coming Apocalypse. The Antichrist has been born, but through a mix-up at the hospital the diabolical baby is sent home with an ordinary English family instead of the intended one, and grows up as Adam Young, a normal boy in the sleepy village of Lower Tadfield, while Heaven and Hell fuss over the wrong child. As Adam turns eleven and Armageddon approaches, his latent powers begin to wake, reshaping the world around him according to his boyish whims. Aziraphale and Crowley scramble to prevent the end of the world, aided and hindered by the witch Anathema Device, guided by her ancestor Agnes Nutter's uncannily accurate prophecies, and the hapless witchfinders Newton Pulsifer and Sergeant Shadwell. The Four Horsemen gather and the forces of Heaven and Hell mass for the final battle. In the end, Adam refuses the destiny chosen for him, rejecting his role as Antichrist and using his power to send the Horsemen away and defy his infernal father, stopping Armageddon by human choice. The world is saved, and Aziraphale and Crowley cleverly evade punishment from their respective sides.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1851,7 +1851,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1864,7 +1864,7 @@
       "recaps": {
         "ending": "Jo inherits Aunt March's Plumfield estate and marries Friedrich Bhaer. Together they turn the large house into a school where boys receive affection, discipline, education, and room for energetic play. The final chapter looks ahead several years to a family gathering at Plumfield. Meg and John are raising their children, Amy and Laurie have a daughter, and Jo and Friedrich are surrounded by their pupils and sons. Beth remains absent but central to the family's memory, and the surviving sisters recognize how her influence continues in their homes. Jo has not achieved the literary fame she once imagined, yet she sees her life as rich in work and love and still hopes to write again. The March parents watch their daughters' families with gratitude, while the story closes on a mature version of the domestic fellowship with which the sisters began.",
         "in_short": "The March sisters enter adulthood. Meg marries John Brooke and learns that a loving home still requires patience and honest management. Amy studies art in Europe, where she challenges Laurie to abandon idleness; after Jo refuses his proposal, Laurie and Amy gradually fall in love and marry. Jo works in New York, befriends the principled German professor Friedrich Bhaer, and gives up writing sensational tales that no longer satisfy her. She returns home to nurse the increasingly fragile Beth, whose peaceful death leaves the family grieving and Jo uncertain of her future. Amy and Laurie return as a married couple, and Jo eventually recognizes her love for Friedrich when he visits. After Aunt March leaves Jo the estate of Plumfield, Jo and Friedrich marry and establish a school for boys there. Years later the extended March family gathers at the school, still shaped by Beth's memory and by the values of useful work, affection, and mutual responsibility.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2008,7 +2008,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2021,7 +2021,7 @@
       "recaps": {
         "ending": "In extreme old age, Chips is confined to bed while people around him speak regretfully of his having had no children. He objects: in his mind, the thousands of Brookfield boys he taught across more than six decades are his children. Memories and imagined voices crowd around him, joining individual pupils to sons and grandsons who later entered the same classrooms. He dies peacefully with the school still at the center of his thoughts. Brookfield continues beyond him, but his sayings, jokes, and personal interest in generations of boys have already become part of its shared memory. The closing movement turns his apparently narrow life into a large one: his short marriage ended in grief and he never formed a conventional family, yet his influence extended through an entire community and across changing eras of English life.",
         "in_short": "Arthur Chipping, known to generations as Mr. Chips, looks back from retirement on a lifetime teaching classics at Brookfield School. He arrives in 1870 as an anxious, undistinguished young master and slowly develops the humor, memory, and humane authority that make him beloved. In middle age he meets and marries the lively Katherine Bridges, whose confidence draws him out of his reserve; her death in childbirth after a brief marriage leaves him devoted once more to the school. He survives a conflict with the reforming headmaster Ralston, retires, and returns during the First World War when Brookfield needs him. The war turns his reading of old boys' names into a record of loss, yet he keeps the school steady with kindness and wit. Dying at eighty-five, he rejects the idea that he was childless: he regards all the boys he taught as his children, and Brookfield's continuing memory of him confirms the reach of his quiet life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2188,7 +2188,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2201,7 +2201,7 @@
       "recaps": {
         "ending": "After recovering from his mother's abuse, Will settles again in Little Weirwold and grows in confidence at school, in art, and among his friends. Zach briefly returns to London to be with his parents and is killed during an air raid. Will initially closes himself off from the loss, but Tom helps him understand that grief does not erase the friendship or the changes Zach helped bring about. Carrie earns the chance to continue her education, and Will's own drawing is encouraged. Mrs Beech is found dead, leaving the authorities to decide Will's future. Tom applies to adopt him and overcomes official concern about his age. The adoption makes permanent the bond they have already formed. Will finally calls Tom Dad, while Tom recognizes that the withdrawn child who arrived at his door has become healthy, capable, and able to accept love without fear.",
         "in_short": "At the outbreak of the Second World War, abused and painfully timid Willie Beech is evacuated from London to Little Weirwold and placed with elderly widower Tom Oakley. Tom's steady care, village school, and friendships—especially with the exuberant Zach—allow Willie to become healthy, expressive, and confident. His mother summons him home, then beats him, ties him beneath the stairs, and abandons him with his infant sister, who dies. When letters stop, Tom travels to London, finds Willie, and brings him back despite official resistance. Willie slowly recovers and discovers further confidence in swimming and art. Zach later returns to London and is killed in an air raid; with Tom's help, Willie learns to mourn without retreating entirely into silence. After Willie's mother is found dead, Tom succeeds in adopting him. The book closes with Willie calling Tom his father and both accepting that their improvised wartime household has become a family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2389,7 +2389,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2402,7 +2402,7 @@
       "recaps": {
         "ending": "Katsa reaches the Lienid court with Bitterblue and learns that Leck has told the seven kingdoms that Katsa murdered Queen Ashen and stole the child, and that he has called the kingdoms' rulers to Monsea to settle the matter. King Ror sails with them. Because Leck's Grace works through his voice, the only safe way to face him is to stop him speaking: Katsa gets into the gathering hall and kills him with a thrown dagger before his words can take hold of the room. With his death the fog lifts from Monsea, and the extent of what he did to his people and his animals begins to surface. Bitterblue, ten years old, is made queen, with Ror staying on to steady the kingdom until she can rule it herself. Katsa then crosses back over the mountains and finds Po alive at the lakeside hut, blinded by his injuries and hiding it, using his Grace to move through a world he can no longer see. She refuses to let him disappear, and he agrees to come back. They end the book together on Katsa's terms: no marriage, no promises to stay, and a plan to keep the Council running and to teach girls across the seven kingdoms how to fight.",
         "in_short": "In the seven kingdoms, a rare few are born Graced with an extreme skill, marked by two different-coloured eyes. Katsa, niece of King Randa of the Middluns, believes her Grace is killing, and has been used as her uncle's enforcer since childhood while secretly running the Council, which undoes the harm the seven kings do. Rescuing a kidnapped Lienid grandfather, she meets Po, a Lienid prince whose Grace is not fighting but perception - he senses the world around him and every thought that concerns him. Together they work out that the kidnapping leads to King Leck of Monsea, whose famous kindness is a lie held up by a Grace that makes people believe whatever he says. In Monsea they find Leck's wife murdered and his daughter Bitterblue in flight. Po holds Leck off while Katsa takes the child over the winter mountains, discovering on the way that her Grace was never killing but survival. Katsa returns to kill Leck before he can speak, Bitterblue is crowned queen at ten, and Katsa goes back for Po, who has been blinded but can still see through his Grace.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2504,7 +2504,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2517,7 +2517,7 @@
       "recaps": {
         "ending": "Dymov contracts diphtheria after exposing himself to infection while treating a sick child. As other doctors gather at the house, Korostelev tells Olga that her husband is dying and rebukes her for failing to understand him. He explains that Dymov was an unusually gifted physician and scholar whose unassuming nature kept his ability from public view. Olga suddenly sees that the exceptional person she had sought among celebrated artists had been beside her throughout her marriage. She goes to Dymov intending to acknowledge his greatness and begin again, but he is already dead. Her recognition cannot repair either her neglect of him or the ordinary happiness she discarded.",
         "in_short": "Olga Ivanovna, fascinated by artistic celebrity, marries the quiet doctor Osip Dymov but treats him as a dependable background figure in her fashionable life. During a summer trip with artists, she begins an affair with the painter Ryabovsky. The romance soon becomes jealous and disappointing, and she returns to her husband while continuing to pursue the painter. Dymov bears the estrangement quietly and devotes himself to medicine. He later contracts diphtheria while treating a child and dies despite the efforts of his colleagues. Only when Korostelev describes Dymov's rare professional gifts and moral generosity does Olga understand that the remarkable man she had been looking for was her husband. She reaches that understanding too late to ask his forgiveness or change their life together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2638,7 +2638,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2649,7 +2649,7 @@
       "recaps": {
         "ending": "Harry destroys the Nightmare - the ghost of the sorcerer Kravos - ending the plague of tormented spirits, and with Michael he saves Charity Carpenter and her newborn son. But the cost of the case is enormous. At Bianca's masquerade, Susan Rodriguez was bitten and infected with the Red Court's curse; caught between human and vampire and terrified of what she might do to the people around her, she leaves Chicago, and Harry, behind. Harry's furious massacre of Bianca and her court, in violation of the guest-truce, has dragged the entire White Council into open war with the Red Court - a war they hold him responsible for starting, and one that will shadow him for years. Thomas Raith, the White Court vampire who unexpectedly helped him, slips away with his secrets and his unexplained interest in Harry intact. Michael Carpenter is now Harry's closest and most trusted ally. Harry ends victorious over the immediate evil but heartbroken, isolated by loss, and freshly burdened with a war he never meant to start and a Council that trusts him even less than before.",
         "in_short": "Working alongside Michael Carpenter, a Knight of the Cross who wields a holy sword, Harry Dresden confronts a wave of ghosts driven violent across Chicago while dodging his faerie godmother, the Leanansidhe, who has come to claim an old debt. The disturbances are the work of the Nightmare, a dream-stalking spirit that proves to be the risen ghost of a sorcerer Harry helped destroy - and it has been set loose deliberately, striking at everyone Harry loves. Behind it all is his old enemy, the Red Court vampire Bianca, now risen in power and staging a grand masquerade as an elaborate revenge. Bianca captures Harry's girlfriend Susan to lure him in; at the ball Susan is bitten and cursed into a half-vampire state, and Harry, enraged, destroys Bianca and her court - an act that ignites open war between the White Council and the Red Court. Harry kills the Nightmare and saves the Carpenters' baby, but Susan, unable to trust herself, leaves him, and he is left blamed for a war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2838,7 +2838,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2851,7 +2851,7 @@
       "recaps": {
         "ending": "Pip and Herbert try to send Magwitch abroad, but the authorities intercept their boat. Compeyson dies in the struggle, Magwitch is captured, and the fortune intended for Pip is lost to the state. Before Magwitch dies, Pip comforts him and tells him that his lost daughter is alive and has become a beautiful woman. Pip then falls gravely ill and awakens to find Joe caring for him and paying his debts. Humbled, Pip returns home intending to marry Biddy, only to discover that she and Joe have just married each other. He accepts their happiness and later works abroad with Herbert, gradually repaying Joe. Years afterward, he meets a changed, widowed Estella in the ruins of Satis House. They leave together in friendship, and Pip sees no prospect of another separation.",
         "in_short": "Orphaned Pip helps a frightening escaped convict, then becomes ashamed of his humble life after meeting wealthy Miss Havisham and her proud ward Estella. When an anonymous benefactor pays for him to become a London gentleman, Pip assumes Miss Havisham intends him for Estella and grows distant from the faithful blacksmith Joe. His true patron is instead Abel Magwitch, the convict Pip aided as a child, who made a fortune after transportation. Pip overcomes his shock and risks himself to help Magwitch escape, but the attempt fails and Magwitch dies in custody after losing his fortune. Pip's debts and illness bring Joe back to care for him without resentment. Humbled, Pip learns that Joe has married Biddy, works with Herbert abroad, and rebuilds his life honestly. Much later he meets the widowed, chastened Estella at ruined Satis House, and they part no more.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3128,7 +3128,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1039404693",
@@ -3140,7 +3140,7 @@
       "recaps": {
         "ending": "The Green World bombardment is believed to destroy the rebellion's undersea bases and end the gateway assault on Central, but Legion Varus leaves its trapped ground force behind. Abigail Claver dies in a plasma-grenade blast during the raid. The opposing alien power files a formal complaint, and Governor Knox protects her position by accepting Claver as the substitute culprit. McGill is released and is no longer treated as a criminal on Earth, while the wider rebel network and the political case remain unresolved. Etta survives restoration with her memories intact, but her incomplete body record forces the Investigator and Florimel to rebuild her with substitute human DNA, including material from Natasha Elkin. Her changed body bars an easy return to her Central life. After attacking Galina, Etta leaves Earth for Dustworld, where she joins Florimel and the Investigator in continued unregistered work. Galina recovers, holds imperator rank again, and resumes her personal relationship with McGill despite their damaged professional trust. Carlos still intends to leave Legion Varus, leaving a future command vacancy uncertain.",
         "in_short": "James McGill traces stolen migration supplies from Central's docks to Green World, where the Claver network is equipping an anti-Earth rebellion. Legion Varus enters Skae territory, raids the planet, and discovers enemy infrastructure beneath its ocean. Kraken, dogmen, and a solid-water dome trap the ground force until Galina Turov uses McGill as cover for a devastating bombardment and abandons the island troops. The strike appears to halt a simultaneous gateway attack on Central, but Etta is killed and Earth faces a diplomatic crisis. McGill, Florimel, and the Investigator recover Etta's archived mind and rebuild her in a body partly derived from Natasha Elkin. McGill escapes prosecution by directing Governor Knox toward Abigail Claver. In the closing material, Etta admits attacking Galina and chooses exile on Dustworld with Florimel and the Investigator, while McGill and Galina resume their relationship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3323,7 +3323,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3336,7 +3336,7 @@
       "recaps": {
         "ending": "Hannay, Sandy, Peter, and Blenkiron escape the conspiracy's immediate reach and make for the Russian lines while the Ottoman army prepares for battle near Erzurum. Sandy uses the authority and expectations surrounding Greenmantle to disrupt the spiritual force Hilda von Einem intended to place behind the German-Turkish campaign. Hilda follows the fugitives into the fighting and is killed as the military position collapses. The Russian assault succeeds, Erzurum falls, and the feared uprising is never launched under German control. Hannay survives the retreat and battle with his companions, their scattered routes finally converging in success. The original clues have been explained: Greenmantle was the dying holy figure at the center of the plan, while the conspirators' attempt to command his influence depended on Hilda. With that scheme broken and the eastern front shifted by the Russian victory, Hannay's mission ends and he returns to Allied service.",
         "in_short": "During the First World War, Richard Hannay is sent to discover a German plan to provoke a vast religious uprising through the Ottoman Empire. With Sandy Arbuthnot, Peter Pienaar, and American agent John Blenkiron, he travels undercover across wartime Europe toward Constantinople, following the cryptic name Greenmantle. Posing as an anti-British Boer, Hannay survives German suspicion and the pursuit of Colonel von Stumm. In Constantinople the agents learn that the brilliant Hilda von Einem intends to harness devotion surrounding a dying holy man and direct it against the Allies. Their separate disguises and investigations converge as the action moves east toward Erzurum. Sandy turns the symbolism of Greenmantle against the plotters, while Hannay and his friends escape toward the advancing Russians. Hilda is killed amid the final battle, Erzurum falls, and the planned rising loses the leader and moment it required. The four agents survive, having prevented Germany from converting religious prophecy into a strategic weapon.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3509,7 +3509,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3522,7 +3522,7 @@
       "recaps": {
         "ending": "Grendel attacks Hrothgar's hall after the Geats arrive, expecting another familiar raid. The stranger Beowulf meets him without a weapon and seizes his arm with overwhelming strength. During their struggle, Beowulf forces Grendel to confront a vision in which violent conflict continually remakes the world, answering the monster's fixed and isolating philosophy with an equally terrifying claim of renewal. Beowulf tears Grendel's arm from its socket. Mortally wounded, Grendel escapes the hall and staggers toward the cliff above his home. The animals gather around as he loses blood. He insists that Beowulf's victory was an accident and calls on the creatures to record his account, but he then falls into the darkness. Hrothgar's people are freed from the enemy who has haunted them for twelve years, while Grendel dies still trying to impose his own explanation on the event that defeats him.",
         "in_short": "Grendel, an intelligent monster unable to communicate with humans, recounts the twelve-year campaign he wages against the Danish king Hrothgar. As a young creature he watches Hrothgar build a kingdom through conquest, while the Shaper's songs turn that violent history into a vision of heroic order. A fatalistic dragon tells Grendel that existence has no inherent purpose and makes him impervious to human weapons. Grendel embraces the role of destroyer, tormenting the hall and mocking Unferth's heroism, yet remains drawn to Wealtheow's goodness, Ork's theology, and the meanings people create. After the Shaper dies, Geatish warriors arrive. Their leader, Beowulf, is unlike the heroes Grendel has previously humiliated. Beowulf grapples with him barehanded, tears off his arm, and confronts his closed philosophy with a vision of a world continually renewed through struggle. Grendel flees and falls to his death, calling the defeat an accident even as his long war ends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3716,7 +3716,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3729,7 +3729,7 @@
       "recaps": {
         "ending": "Ana asks Christian to show her the harshest punishment he would expect her to accept, hoping to understand the part of him he keeps guarded. He agrees and strikes her six times with a belt. The experience gives neither of them the clarity or closeness they wanted: Ana is shocked by the pain and by his need to impose it, while Christian realizes too late how completely he has misjudged what she can bear. She concludes that she cannot meet his needs and that the relationship is damaging her. Despite Christian's attempts to comfort her and persuade her to stay, she ends the relationship and leaves his apartment. Taylor drives her home. From Christian's perspective, her departure breaks through the emotional control on which he has relied; he is left alone, devastated, and forced to recognize that his rules and possessiveness have cost him the first woman he has wanted as more than a submissive partner.",
         "in_short": "Seattle businessman Christian Grey expects control in every part of his life until student Anastasia Steele interviews him and provokes an unfamiliar attachment. He pursues her while warning that he offers only a dominant-submissive arrangement governed by rules. After learning that Ana is sexually inexperienced, he begins a physical relationship with her and repeatedly relaxes his own boundaries, even as his surveillance, gifts, jealousy, and need for obedience create conflict. Ana wants affection and equality as well as desire; Christian believes strict control protects him from intimacy rooted in his traumatic childhood. Their negotiations grow into a relationship neither can define. When Ana asks to experience the severity he truly wants, Christian punishes her with a belt. She understands that she cannot become what his arrangement requires and leaves him. Christian ends the book devastated, recognizing that his need for control has driven away the woman he loves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4038,7 +4038,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0FS2Z2SVC",
@@ -4050,7 +4050,7 @@
       "recaps": {
         "ending": "Task Force Black escapes aboard Excalibur after destroying both the Icebox and the last Outsider scout. Reed commands the Elder dreadnought, while Joe Bishop and Skippy remain together with the surviving team. Skippy is still limited by inaccessible damage in his matrix. Valkyrie and its surviving crew escaped the earlier failed strike, which killed seventeen crew members, but the ship will not return to combat. Margaret Adams, her sons, and newborn Kaylee remain on Jaguar, where Happy survived the malware attack but the colony's defenses and environment are strained. Scorandum and Kinsta have stopped actively escalating the client rebellion, though its consequences remain unresolved. The Maxolhx homeworld's AIs are secretly autonomous, and the Hegemony's political succession and commandeered fleet are unsettled. The immediate Outsider invasion is over, but Excalibur's null-space trap created a ground-state bubble with incompatible physics. It already spans more than two light years, will grow again when it consumes a rogue planet in four months, and is expected eventually to reach inhabited systems and the galactic core. No known Elder technology can stop it.",
         "in_short": "Joe Bishop and Task Force Black race to prevent a surviving Outsider scout from building the Icebox, a replacement intergalactic ingress. They sabotage its material supply, steal the Maxolhx Diktat's fleet-control implant, and locate the construction site, but four gridbusters fail against its shield and Valkyrie is crippled. After Margaret Adams and Happy repel an Outsider malware attack on Jaguar, Nagatha uncovers a route to Fortress Hercules. Bishop and Skippy secure the Elder dreadnought Excalibur under Reed's command. Excalibur destroys the Icebox by placing stellar material beside it, then traps the last Outsider in null space and destroys its remnant. The victory produces a worse danger: a stable ground-state bubble more than two light years wide, expanding through matter under physical laws that known Elder technology cannot counter.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/guards-guards.json
+++ b/data/works-community/0/guards-guards.json
@@ -101,7 +101,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -114,7 +114,7 @@
       "recaps": {
         "ending": "The summoned dragon makes itself king of Ankh-Morpork, terrorizing the city and demanding tribute and a sacrificial victim; Lady Sybil is offered up, and Vimes and the Watch have to act. The runt swamp dragon Errol, sickly and strange, turns out to be able to reshape his own body and superheat his flame, and he pursues the great dragon into the sky and drives it off for good; the two dragons ultimately fly away together. The hooded Supreme Grand Master is revealed to have been the Patrician's ambitious secretary all along, and his scheme collapses with his death. Lord Vetinari, briefly imprisoned during the crisis, resumes control with his usual composure and grants the Watch a modest new standing in the city. Vimes and Lady Sybil Ramkin begin a courtship. A quieter thread is left hanging: Carrot carries a plain sword and bears marks of birth that hint he may be of the city's lost royal line, but neither he nor anyone else moves to act on it.",
         "in_short": "Ankh-Morpork's Night Watch has shrunk to three hopeless men under the cynical, drunken Captain Vimes, until the arrival of Carrot Ironfoundersson, a giant young man raised by dwarfs who takes the law with absolute seriousness. Meanwhile a secret brotherhood, egged on by its hooded Supreme Grand Master, uses stolen magic to summon a dragon, intending to frighten the city into accepting a puppet king. The plan goes wrong: the great dragon has ambitions of its own and installs itself as ruler, demanding treasure and a human sacrifice. Working with the dragon-breeding noblewoman Lady Sybil Ramkin, Vimes and the Watch struggle to fight back. In the end the runt swamp dragon Errol, whom Vimes has adopted, proves able to reshape his own body and superheat his flame, and he drives the great dragon off. The Supreme Grand Master is exposed as the Patrician's own secretary and dies; Vetinari is restored, the Watch regains a little respect, and Vimes and Lady Sybil are drawn together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -261,7 +261,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -274,7 +274,7 @@
       "recaps": {
         "ending": "Anita's investigation identifies the animator Zachary as the immediate agent behind the vampire deaths; he has prolonged his existence through forbidden magic, with Nikolaos's regime enabling the killings. After Phillip is murdered, Anita raises him long enough to obtain the truth, then joins Edward in an assault on Nikolaos's refuge. The confrontation destroys Zachary and much of Nikolaos's inner circle. Anita kills Nikolaos, ending the child vampire's rule of St. Louis. Jean-Claude survives and becomes the city's new master vampire. Anita also survives, but Jean-Claude has placed two mystical marks on her while saving and binding her during the case. She rejects the idea that this makes her his servant, leaving their relationship unresolved. The case establishes Anita as a person able to kill a master vampire as well as execute lesser vampires under legal authority, and it leaves her tied to the new master despite her determination to remain independent.",
         "in_short": "Anita Blake raises zombies for a living and executes legally condemned vampires in St. Louis. When vampires begin dying, Willie McCoy asks her to investigate, and the city's master, Nikolaos, forces her to accept by threatening people around her. Anita moves through vampire clubs and private gatherings with help from Jean-Claude, a powerful vampire, Phillip, a human drawn to vampires, and Edward, a professional hunter. Phillip is murdered, and the trail leads to the animator Zachary, whose continued existence depends on the killings, and to Nikolaos's protection of him. Anita and Edward attack Nikolaos's refuge, destroy Zachary and several vampires, and Anita kills Nikolaos. Jean-Claude succeeds her as master of the city. He has also given Anita two mystical marks, creating a connection she refuses to treat as ownership.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -444,7 +444,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -457,7 +457,7 @@
       "recaps": {
         "ending": "The Houyhnhnms' assembly decides that Gulliver, because he resembles a Yahoo despite his education, cannot remain in their country. He reluctantly builds a small boat and leaves the household he has come to revere. Portuguese sailors find him, and their captain, Don Pedro de Mendez, treats him generously despite Gulliver's disgust at human company. Returned to England, Gulliver is unable to resume ordinary family life: he recoils from his wife and children because they remind him of the Yahoos, and he prefers spending time with horses. He writes his travels as a corrective to false and self-serving voyage literature, denies that he has invented his account, and reflects bitterly on colonial conquest. His final position is not one of restored balance. The voyages have exposed vanity and brutality in the societies he visited and in Europe, but his worship of Houyhnhnm reason has also left him isolated, proud of his own supposed freedom from pride, and estranged from the humans closest to him.",
         "in_short": "Ship's surgeon Lemuel Gulliver survives four extraordinary voyages. In Lilliput he is a giant among miniature courtiers, helps defeat an invasion, then flees when court enemies arrange his punishment. In Brobdingnag he is a vulnerable curiosity among giants; a loving girl protects him, while the king's questions expose the violence and corruption behind Gulliver's proud description of England. His third journey reaches the abstracted mathematicians of flying Laputa, the futile inventors of Lagado, a land where the dead can be questioned, and immortals condemned to endless decline. On his fourth voyage, rational horses called Houyhnhnms rule degraded humanlike Yahoos. Gulliver embraces the horses' ordered life and grows disgusted with humanity, but their assembly expels him as a dangerous Yahoo. Rescued by the humane Portuguese captain Don Pedro, he returns to England physically safe but unable to tolerate his family. He ends his account preferring horses to people, his valid criticism of human vice hardened into alienation and pride.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -641,7 +641,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -654,7 +654,7 @@
       "recaps": {
         "ending": "The Houyhnhnms' assembly decides that Gulliver, because he resembles a Yahoo despite his education, cannot remain in their country. He reluctantly builds a small boat and leaves the household he has come to revere. Portuguese sailors find him, and their captain, Don Pedro de Mendez, treats him generously despite Gulliver's disgust at human company. Returned to England, Gulliver is unable to resume ordinary family life: he recoils from his wife and children because they remind him of the Yahoos, and he prefers spending time with horses. He writes his travels as a corrective to false and self-serving voyage literature, denies that he has invented his account, and reflects bitterly on colonial conquest. His final position is not one of restored balance. The voyages have exposed vanity and brutality in the societies he visited and in Europe, but his worship of Houyhnhnm reason has also left him isolated, proud of his own supposed freedom from pride, and estranged from the humans closest to him.",
         "in_short": "Ship's surgeon Lemuel Gulliver survives four extraordinary voyages. In Lilliput he is a giant among miniature courtiers, helps defeat an invasion, then flees when court enemies arrange his punishment. In Brobdingnag he is a vulnerable curiosity among giants; a loving girl protects him, while the king's questions expose the violence and corruption behind Gulliver's proud description of England. His third journey reaches the abstracted mathematicians of flying Laputa, the futile inventors of Lagado, a land where the dead can be questioned, and immortals condemned to endless decline. On his fourth voyage, rational horses called Houyhnhnms rule degraded humanlike Yahoos. Gulliver embraces the horses' ordered life and grows disgusted with humanity, but their assembly expels him as a dangerous Yahoo. Rescued by the humane Portuguese captain Don Pedro, he returns to England physically safe but unable to tolerate his family. He ends his account preferring horses to people, his valid criticism of human vice hardened into alienation and pride.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -844,7 +844,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -857,7 +857,7 @@
       "recaps": {
         "ending": "In India, Stephen's attempt to settle his future with Diana ends in violence. He duels with Richard Canning, kills him, and is himself shot; he survives with Jack's help and his own surgical resolve, but Diana does not become his wife and leaves his reach once more. Stanhope dies before completing his embassy, releasing the Surprise from its diplomatic mission. On the homeward passage Jack joins the merchant China Fleet when it is threatened by Admiral Linois's stronger French squadron. By organizing the East Indiamen and using the Surprise aggressively, he helps persuade and compel the French to withdraw, saving the convoy. Jack returns to England with his professional reputation strengthened. He and Sophia overcome the barriers of debt, distance, and Mrs Williams's opposition and marry. Stephen stands beside his friend, alive and still devoted to Diana but without her. Thus Jack reaches domestic fulfilment while Stephen's intelligence service and Diana attachment remain open for later voyages.",
         "in_short": "French agents capture and torture Stephen Maturin in the Mediterranean, but Jack Aubrey leads a boat expedition that rescues him. Jack then receives command of the old frigate Surprise, carrying the diplomat Stanhope toward the East Indies. The voyage restores Stephen physically, permits his natural-history work, and brings hard action in which the young Blakeney loses an arm. In Bombay Stephen finds Diana Villiers living under Richard Canning's protection. His hopes of marriage collapse into a duel: Stephen kills Canning and is wounded, while Diana departs again. Stanhope dies before his embassy can be completed. Sailing home, Jack rallies the merchant China Fleet against Admiral Linois's stronger French squadron and helps drive it away through disciplined manoeuvre and determined fighting. Back in England, Jack's standing is restored and he marries Sophia Williams. Stephen survives but remains separated from Diana, with his secret intelligence work continuing beneath his life as surgeon and naturalist.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1015,7 +1015,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1028,7 +1028,7 @@
       "recaps": {
         "ending": "After the narrator reports his experience, federal authorities raid Innsmouth, make mass arrests, and attack the offshore reef. He initially regards the operation as the removal of a hidden menace. His later genealogical research changes that understanding: his maternal grandmother descended from Obed Marsh and the sea people, and an uncle killed himself after discovering the same inheritance. The narrator gradually develops the physical traits he once found repellent in Innsmouth and dreams of an immense city beneath the sea. Fear gives way to anticipation as he comes to believe that transformation will bring longevity and a return to his ancestral home. He decides to rescue a similarly affected cousin from confinement and travel with him to the underwater city of Y'ha-nthlei. The fugitive who escaped Innsmouth therefore ends by accepting that he belongs to the people he exposed.",
         "in_short": "A young antiquarian traveler visits the decaying Massachusetts port of Innsmouth despite warnings about its hostile residents and their peculiar appearance. An elderly drunk, Zadok Allen, tells him that sea captain Obed Marsh once made a bargain with amphibious beings called Deep Ones, trading worship and human lives for gold, fish, and intermarriage. Trapped overnight when transport fails, the traveler escapes a hunt by townspeople and sees their inhuman allies moving through the streets. His report prompts a federal raid and an attack on the reef offshore. Later research uncovers the reason the town's faces seemed familiar: the narrator's own grandmother belonged to the Marsh bloodline. As his body begins to change, terror is replaced by dreams of the Deep Ones' underwater city. He resolves to free an affected cousin from an asylum and join their immortal relatives beneath the sea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1185,7 +1185,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1198,7 +1198,7 @@
       "recaps": {
         "ending": "The prison performance traps Tony, Sal, and the other visitors inside a controlled version of Prospero's ordeal. Drugs, projected images, sounds, masked inmates, and staged threats frighten them while 8Handz records their private conversation. The recording captures damaging evidence about their ambitions and their plans for the prison program. Felix uses it to protect the program and break their immediate power. His revenge succeeds without the violent outcome he had sometimes imagined. Afterward, the class presents possible futures for The Tempest's characters, proving that the inmates have made the play their own. Anne-Marie and Freddie pursue a life together, and Felix again has a possible place in the theatre world that expelled him. Most importantly, he recognizes that his imagined Miranda has become another prisoner of his grief. He releases her and accepts her absence. He leaves on a cruise with Estelle, entering a future no longer organized solely around loss and revenge.",
         "in_short": "Felix Phillips is forced out of the theatre festival he created while planning The Tempest, a production bound to his grief for his dead daughter Miranda. He vanishes into rural isolation and, under the name Mr Duke, begins teaching Shakespeare at Fletcher Correctional. Twelve years later, the prison program offers a way to stage The Tempest and confront Tony and Sal, the men who displaced him, during an official visit. Felix recruits actor Anne-Marie, assigns inmates both performance and security roles, and turns the prison into an immersive island of projections, music, drugs, and surveillance. The frightened visitors expose compromising plans on a hidden recording. Felix uses the evidence to preserve the arts program and settle his grievances, then has the inmates imagine what happens after Shakespeare's ending. With his professional future open again, he finally lets go of the imagined older Miranda who has accompanied him through exile and departs on a cruise with Estelle.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1339,7 +1339,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1352,7 +1352,7 @@
       "recaps": {
         "ending": "After a succession of wishes has convinced the children that Mr. Smith is kind, dependable, and genuinely fond of their mother, they decide that magic should help bring the two adults together. Their plans produce the usual complications because the charm grants only half of what is asked, but the family finally reaches the result it wants without treating the talisman as a substitute for honest feeling. Mother and Mr. Smith acknowledge their love and plan to marry, giving Jane, Mark, Katharine, and Martha the prospect of a father as well as a new home life. The summer's central wish is therefore fulfilled in a lasting change that no longer depends on further experiments with the charm.",
         "in_short": "During a dull summer, Jane finds an old coinlike charm that grants exactly half of any wish made while holding it. She, Mark, Katharine, and Martha learn that successful magic requires asking for twice the intended result, while vague or impulsive requests lead to comic trouble. The charm carries family members into adventures involving distant travel, Arthurian romance, altered circumstances, and even an attempt to understand their cat. A helpful man named Mr. Smith repeatedly assists them and becomes close to their widowed mother. The children gradually shift from wishing for excitement to wishing for something that matters to the whole family. By the end, Mother and Mr. Smith have decided to marry, resolving the children's most important hope for their family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1517,7 +1517,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1530,7 +1530,7 @@
       "recaps": {
         "ending": "Biafra surrenders after mass hunger and military defeat. Ugwu, wounded but alive after his forced service, returns carrying both trauma and guilt. Richard abandons the idea that he can authoritatively write Biafra's story; the book taking shape within the novel belongs to Ugwu. Shortly before the surrender, Kainene crosses into Nigerian-held territory to trade for food and never returns. After the war, Olanna, Richard, and the others search hospitals, offices, roads, and returning crowds, but find no reliable trace of her. Olanna uses the family custom of scattering earth to call a lost person home, while Richard remains suspended between hope and grief. The surviving household returns to damaged places and begins the practical work of living after defeat. Kainene's fate remains unresolved, making her absence the novel's final wound and denying the survivors a complete reunion or explanation.",
         "in_short": "Ugwu enters the Nsukka household of radical lecturer Odenigbo and his partner Olanna, while Olanna's guarded twin Kainene begins a relationship with English writer Richard. Private betrayals strain both couples, but the greater rupture comes with Nigeria's coups, anti-Igbo massacres, and the secession of Biafra. Olanna survives the slaughter of relatives in Kano; the four adults, Ugwu, and Baby are repeatedly displaced as war brings bombing, hunger, and social collapse. Ugwu is forcibly conscripted and participates in a gang rape before being wounded. Kainene runs a refugee camp and eventually reconciles with Olanna after learning that Richard once slept with her sister. Biafra is defeated. Ugwu returns and becomes the implied author of the history threaded through the novel. Kainene crosses enemy lines to trade for food just before the surrender and disappears. The family searches after the war, but her fate remains unknown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1713,7 +1713,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1726,7 +1726,7 @@
       "recaps": {
         "ending": "Poirot discovers that Joyce did not personally witness the old murder she boasted about. She had borrowed a story told by Miranda Butler, the true witness, and repeated it to impress Ariadne Oliver. Rowena Drake nevertheless believed Joyce knew the secret and drowned her in the apple-bobbing tub. Joyce's brother Leopold later used what he had noticed to blackmail Rowena, so she killed him as well. The older conspiracy links Rowena with landscape designer Michael Garfield, her lover, and with the disappearance and death of Olga Seminoff. Olga's disputed inheritance from Mrs Llewellyn-Smythe was genuine; removing her allowed the estate and the garden financed from it to remain under the conspirators' control. Olga's remains are found concealed in the ornamental grounds. Michael recognises that Miranda, not Joyce, is the dangerous witness and tries to kill her at the quarry, but Poirot and the police intervene. Judith reveals that Michael is Miranda's father, making his willingness to sacrifice the girl still more decisive. Rowena and Michael's scheme collapses, and Miranda survives.",
         "in_short": "At a children's Halloween party, thirteen-year-old Joyce Reynolds boasts that she once saw a murder. She is later found drowned in the apple-bobbing tub, and Ariadne Oliver brings Poirot to Woodleigh Common. He reviews several local deaths and the disappearance of Olga Seminoff, companion to wealthy Mrs Llewellyn-Smythe, after a codicil in Olga's favour was denounced as forged. Joyce had actually copied a story told by Miranda Butler, the true witness. Rowena Drake killed Joyce because she believed the boast, then killed Joyce's brother Leopold when he blackmailed her. Rowena and her lover, landscape designer Michael Garfield, were also responsible for removing Olga and concealing her body in the elaborate garden; Olga's claim to the inheritance was genuine. Michael tries to kill Miranda at the quarry after realising what she saw, but Poirot and the police save her. Judith Butler reveals that Michael is Miranda's father. The murders are exposed, Olga's remains are recovered, and Miranda survives the attempt to silence her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1884,7 +1884,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1897,7 +1897,7 @@
       "recaps": {
         "ending": "Will's judgement and Malcolm's treatment bring Halt back from the poisoned wound, although his recovery is gradual. Once Halt can travel, the companions return to the unfinished pursuit rather than allowing Tennyson time to establish another secure following. They locate the Outsiders' refuge and turn the fraud at the centre of the movement against its leader, depriving him of the authority that had kept frightened followers obedient. Tennyson's organisation breaks apart, and Tennyson does not survive the final confrontation. The surviving Genovesan threat is also ended, so the pursuit that began at Clonmel is complete rather than deferred to another campaign. Will, Halt and Horace emerge alive, with Will having borne the central burden of keeping his mentor alive and making decisions while Halt could no longer direct him. The three friends can return to Araluen, and the next novel begins a separate mission involving Horace in Nihon-Ja.",
         "in_short": "Immediately after the events in Clonmel, Will, Halt and Horace pursue Tennyson and the remnants of the Outsiders. The fugitive preacher uses decoys, divided trails and two Genovesan assassins to slow them while seeking a place to rebuild his following. During an ambush Halt is struck by a poisoned crossbow bolt. The chase becomes a fight to keep him alive: Will and Horace must deal with the assassins, learn what poison was used and obtain expert help before the wound kills him. Malcolm's treatment and Will's observations identify a course that saves Halt. After his recovery, the companions resume the mission, find Tennyson's refuge and expose his manipulation to his own followers. The Outsiders collapse and Tennyson dies in the final confrontation. Will has not only completed the pursuit but proved capable of acting under the prospect of losing the mentor who shaped his life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2104,7 +2104,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2117,7 +2117,7 @@
       "recaps": {
         "ending": "Claudius and Laertes arrange a fencing match in which Laertes uses a sharpened, poisoned blade; Claudius also prepares poisoned wine as a second means of killing Hamlet. Hamlet scores the early hits, but Gertrude unknowingly drinks from the poisoned cup and dies. Laertes wounds Hamlet with the poisoned weapon, then loses it in the struggle and is wounded by the same blade. As Laertes dies, he exposes the plot and names Claudius. Hamlet stabs Claudius and forces him to drink the remaining poison, killing him, then forgives Laertes. The poison kills Hamlet shortly afterward. He prevents Horatio from taking his own life and charges him to explain what happened. Fortinbras returns from Poland as ambassadors report that Rosencrantz and Guildenstern are dead. Finding the royal family destroyed, Fortinbras claims his political rights in Denmark and orders a soldier's funeral for Hamlet. Horatio remains to tell the story, while Danish rule passes to the Norwegian prince.",
         "in_short": "Prince Hamlet returns to Denmark after his father's death and learns from the old king's ghost that his uncle Claudius committed murder, seized the crown, and married Queen Gertrude. Hamlet adopts erratic behavior while seeking proof. A staged play reproducing the alleged crime makes Claudius reveal his guilt, but Hamlet delays killing him and accidentally kills the counselor Polonius instead. Claudius sends Hamlet toward England with secret orders for his death; Hamlet escapes after redirecting those orders against Rosencrantz and Guildenstern. Polonius's daughter Ophelia loses her sanity and drowns, while her brother Laertes joins Claudius in a plot using a poisoned fencing blade. During the match, Gertrude drinks poisoned wine, Laertes and Hamlet are both wounded, and Laertes exposes the king. Hamlet kills Claudius before dying from the poison. Horatio survives to report the truth, and Fortinbras arrives to take control of a court whose ruling family has been destroyed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2298,7 +2298,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2311,7 +2311,7 @@
       "recaps": {
         "ending": "Hamlet accepts a fencing match with Laertes, unaware that Laertes's blade is sharpened and poisoned and that Claudius has also prepared poisoned wine. Laertes wounds Hamlet, but in the confusion they exchange weapons and Hamlet wounds Laertes with the same blade. Gertrude drinks from the poisoned cup and dies. The dying Laertes exposes the plot and names Claudius, so Hamlet stabs the king and forces the remaining poison upon him. Hamlet, also dying, prevents Horatio from killing himself and asks him to preserve the truth of what happened. Fortinbras arrives to find the Danish royal family destroyed. Horatio begins to explain the deaths, and Fortinbras takes control of the kingdom while ordering honours for Hamlet.",
         "in_short": "After his father dies and his mother Gertrude quickly marries his uncle Claudius, Prince Hamlet learns from his father's ghost that Claudius committed the murder. Hamlet hides his purpose behind erratic behaviour and uses a visiting theatrical company to stage a murder resembling the ghost's account. Claudius's reaction confirms his guilt, but Hamlet delays killing him and instead kills the concealed Polonius during a confrontation with Gertrude. Claudius sends Hamlet toward England with secret orders for his death; Hamlet escapes after redirecting the orders against Rosencrantz and Guildenstern. Polonius's daughter Ophelia loses her reason and dies, and her brother Laertes joins Claudius in a poisoned fencing plot. During the match Gertrude drinks poisoned wine, Laertes and Hamlet are both wounded by the poisoned blade, and Laertes confesses. Hamlet kills Claudius before dying and entrusts the story to Horatio. Fortinbras arrives to assume control of Denmark.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2518,7 +2518,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2531,7 +2531,7 @@
       "recaps": {
         "ending": "The fencing match is Claudius and Laertes' trap: Laertes uses an unblunted sword coated with poison, while Claudius prepares poisoned wine as a second method. Gertrude unknowingly drinks from the cup. Laertes wounds Hamlet, but in the struggle they exchange weapons and Hamlet wounds Laertes with the same poisoned blade. As Gertrude dies and the plot is exposed, Laertes confesses and reconciles with Hamlet. Hamlet stabs Claudius and forces him to drink the poison, killing him. Hamlet then dies from his wound after asking Horatio to tell the true story and supporting Fortinbras as Denmark's next ruler. Fortinbras arrives from his Polish campaign as the royal family lies dead. The English ambassadors also report that Rosencrantz and Guildenstern have been executed. Fortinbras claims authority over Denmark and orders Hamlet to receive a soldier's funeral. Horatio remains to explain how the court's surveillance, revenge schemes, and concealed crimes produced the catastrophe.",
         "in_short": "Prince Hamlet returns to Denmark after his father's death and finds his uncle Claudius on the throne and married to his mother Gertrude. His father's ghost says Claudius murdered him and demands revenge. Unsure whether to trust the spirit, Hamlet adopts erratic behavior and uses a visiting acting company to stage a murder resembling the accusation. Claudius's reaction confirms his guilt, but Hamlet delays and accidentally kills the hidden Polonius. Ophelia, Polonius's daughter and Hamlet's former beloved, loses her reason and drowns; her brother Laertes returns seeking vengeance. Claudius recruits Laertes into a rigged fencing match using a poisoned blade and cup. The scheme kills Gertrude, Laertes, Hamlet, and Claudius, whom Hamlet finally kills after the plot is exposed. Fortinbras of Norway arrives to take control of Denmark. Hamlet's friend Horatio survives to report what happened, while the royal house is extinguished by secrecy, surveillance, and reciprocal revenge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2723,7 +2723,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2736,7 +2736,7 @@
       "recaps": {
         "ending": "At Ofelia's funeral Hamlet reveals himself, quarrels with Leartes, and declares his love for her. The king then arranges a fencing match between them. Leartes uses a sharpened, poisoned weapon, while the king also prepares poisoned wine. During the bout Hamlet and Leartes exchange weapons and both receive mortal wounds. The queen drinks from the poisoned cup intended for Hamlet and dies. Leartes admits the plot and identifies the king as its author. Hamlet kills the king, then dies after asking Horatio to preserve the truth of what happened. Fortinbras arrives to find the Danish royal family destroyed and takes control amid the aftermath. The revenge demanded by the Ghost is completed, but it costs Hamlet, Ofelia, Leartes, the queen, and the king their lives.",
         "in_short": "Prince Hamlet learns from his father's Ghost that Denmark's new king murdered him and married Queen Gertrude. Hamlet adopts erratic behavior while testing the revelation. Corambis attributes his condition to frustrated love for Ofelia, and the king uses Rossencraft and Gilderstone to spy on him. Hamlet stages a murder resembling the Ghost's account; the king's reaction confirms his guilt. During a confrontation with his mother, Hamlet kills the hidden Corambis. The king sends Hamlet toward England with secret orders for his death, but Hamlet escapes and returns. Ofelia loses her reason and dies, while her brother Leartes joins the king's revenge plot. In a poisoned fencing match, the queen, Leartes, Hamlet, and the king all die. Horatio survives to report the truth, and Fortinbras takes charge of Denmark.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2912,7 +2912,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2925,7 +2925,7 @@
       "recaps": {
         "ending": "Atticus's company reaches Thor and succeeds in killing him, but the victory costs lives, including Gunnar Magnusson and Zhang Guolao, while Leif is catastrophically burned. The survivors escape Asgard with no illusion that the matter ended with Thor's death. Their incursion and the damage surrounding it have destabilized Norse affairs and helped Loki break free, raising the threat of a much larger conflict. Odin and other Norse powers now have direct reason to pursue Atticus. His participation also strains his standing with Brighid and the Fae, making routes he once relied upon unavailable or unsafe. Atticus returns to Granuaile and Oberon carrying the responsibility for companions who died and for consequences Leif's plan did not fully address. The Morrigan warns that his enemies will keep hunting until they see convincing proof that he is dead, so his next task is to disappear rather than celebrate the victory.",
         "in_short": "Atticus must honor his promise to Leif Helgarson by helping him invade Asgard and kill Thor. Warnings from the Morrigan, Jesus, and other powers make clear that the mission could destabilize the supernatural world, but Atticus completes preliminary journeys and joins Leif's carefully recruited band: werewolf Gunnar Magnusson, Finnish hero Vainamoinen, Slavic thunder god Perun, and Chinese immortal Zhang Guolao. Each has a grievance against Thor. They cross into Norse territory, survive its defenders, and combine their different powers against the thunder god. Thor is killed, but Gunnar and Zhang Guolao die and Leif is terribly burned. The survivors flee amid damage that loosens Loki's bonds. Atticus returns with the Norse powers seeking vengeance, his access to Fae help damaged, and the possibility of a wider catastrophe now active. To protect Granuaile and Oberon, he will have to make the world believe he is dead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3097,7 +3097,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3110,7 +3110,7 @@
       "recaps": {
         "ending": "After Hamnet's death, Agnes and her husband grieve in incompatible ways. She remains in Stratford, tending the surviving children and feeling increasingly estranged from a husband who spends most of his time in London. He turns the name of their lost son toward the tragedy Hamlet. When Agnes learns of the play, she travels to London in anger and enters the theatre, expecting to find that her private sorrow has been taken from her. Watching the performance changes her understanding: the stage does not simply reproduce Hamnet's death. Instead, the father dies while the son remains alive to carry him in memory. Agnes recognizes the play as her husband's attempt to exchange places with their child and keep him present through art. Across the crowded theatre, husband and wife see one another and briefly share the grief they have been unable to express together. The novel closes with Agnes reaching toward the dying Hamlet onstage as the actor playing him rises again to receive the audience's response.",
         "in_short": "In sixteenth-century Stratford, Agnes, a healer with an instinctive bond to the natural world, marries the restless son of a troubled glove-maker. She recognizes his need to leave for London, while she raises Susanna and the twins Hamnet and Judith at home. In 1596 pestilence reaches the family. Judith falls ill, but Hamnet takes her place beside death and dies at eleven. The loss fractures the household: Agnes feels abandoned by a husband who returns to his theatrical life, while he cannot speak directly about his grief. Years later she hears that his company is performing a tragedy called Hamlet and travels to London, furious that he has used their son's name. In the theatre she understands the play differently. By letting the father die and the son survive in memory, her husband has imagined the exchange he could not make in life. Their eyes meet across the audience, and the work becomes a shared act of mourning rather than an appropriation of her loss.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3241,7 +3241,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3254,7 +3254,7 @@
       "recaps": {
         "ending": "Hannibal Lecter is captured by Mason Verger's men and prepared for the revenge Verger has planned, to be devoured alive by specially bred wild boars. Clarice Starling, having defied the Bureau to track him down, storms the Verger estate to stop it and is badly wounded in the rescue. Verger himself is killed by his long-abused sister Margot, who has her own reasons to want him dead, and Lecter allows the blame to fall where it will. Lecter escapes, taking the injured Starling with him, and nurses her back to health at a hideaway. Over the following weeks he works on her mind, and the story reaches its notorious close: Starling is neither killed nor restored to her former self, but instead accepts a place at Lecter's side. At a formal dinner Lecter kills Paul Krendler, the corrupt official who ruined her career, and serves part of him at the table. Rather than turning on Lecter, Starling remains with him as an equal and a lover, and the two disappear together, later living as a wealthy, cultured couple in South America, beyond the reach of the law.",
         "in_short": "Years after she killed Buffalo Bill, FBI agent Clarice Starling's career has stalled, and a deadly botched raid makes her a scapegoat. At the same time Hannibal Lecter, long a fugitive, is living in Florence under a false name. Mason Verger, Lecter's sole surviving victim, a rich, disfigured invalid, has spent a fortune plotting to capture Lecter and feed him to wild boars, and he uses his corrupt allies to dangle Starling as bait. An Italian policeman recognizes Lecter and tries to sell him to Verger, and Lecter kills him and returns to America. Drawn back toward Starling, Lecter is finally seized by Verger's men, and Starling, going rogue to save him, is wounded in the attempt. Verger is killed by his abused sister Margot, and Lecter escapes with the injured Starling. Rather than being rescued back to her old life, Starling, after weeks in Lecter's care and under his influence, becomes his willing companion. Lecter kills her chief tormentor in the Bureau, and the two vanish together to live abroad.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3332,7 +3332,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3345,7 +3345,7 @@
       "recaps": {
         "ending": "Hannibal completes his revenge, tracking down and killing each of the men who murdered and ate his sister Mischa during the war, ending with their leader. In the course of it he recovers the memory he had buried, that as a starving child he too was made to consume his sister's remains, a horror that finishes the destruction of his humanity. Inspector Popil, who has long suspected him, is left unable or unwilling to bring him to justice. Lady Murasaki, who loved and guided him and hoped to save him, sees at last what he has become and understands there is nothing left in him she can reach, and she withdraws from his life. Emptied of grief and warmth alike, Hannibal turns away from the ruins of his old life and leaves for a new one abroad, embarking on the medical training that will polish his intellect and his manners. The transformation is complete: the grieving, gifted boy is gone, and in his place stands the cultured, remorseless killer the later books will know.",
         "in_short": "This prequel traces the origins of Hannibal Lecter. As a boy from an aristocratic Lithuanian family, he flees with his little sister Mischa as the Second World War overruns their homeland, and after their parents are killed the two children fall into the hands of a band of starving deserters and looters. In the depths of that winter the men kill and cannibalize Mischa, and Hannibal survives, traumatized and mute, the memory buried. After the war he is sent to a Soviet-run orphanage, then escapes to France to live with his uncle and the uncle's Japanese widow, Lady Murasaki, who becomes his mentor and the one person he loves. Growing into a brilliant young medical student, Hannibal sets out to find and destroy the men responsible for his sister's death, hunting them down one by one and killing them with cold, escalating ferocity. A French inspector, Popil, circles ever closer but cannot stop him. By the time his revenge is complete, Hannibal has become a monster, hollowed of ordinary feeling, and the woman who cared for him can no longer reach him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3462,7 +3462,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3475,7 +3475,7 @@
       "recaps": {
         "ending": "In Tokyo, the Calcutec learns that the Professor's experiment has made the End of the World consciousness permanent. His ordinary awareness will end when the forced transition occurs, and no available procedure can stop it. After spending his remaining time with the librarian, he drives to the waterfront, listens to music, and waits in his car as sleep overtakes him. In the End of the World, the Dreamreader and his shadow reach the escape route. The shadow insists they must leave together, but the Dreamreader concludes that the town and its people are products of his own mind and that abandoning them would evade his responsibility. He chooses to remain and try to recover the fragments of mind dispersed among the unicorn skulls. The shadow escapes alone through the pool, promising that the two remain connected. The Dreamreader returns toward the town and the librarian, accepting a bounded inner world while the outside self disappears into it.",
         "in_short": "A Tokyo Calcutec performs subconscious encryption for a secretive Professor, while alternating chapters follow a Dreamreader admitted to a walled town called the End of the World, where his shadow is cut away. The Calcutec learns that the Professor altered his brain and built the town as a hidden third consciousness. A timer has begun: his ordinary mind will soon cease and the End of the World will become his permanent reality. Attempts to reach the Professor through tunnels inhabited by INKlings cannot reverse the process. The Calcutec spends his last hours with a librarian, then waits for the transition in his car. Inside the End of the World, the Dreamreader maps an escape with his weakening shadow and discovers that music can recover traces of mind. At the escape point he lets the shadow leave alone, deciding to remain because the town's inhabitants are parts of himself for whom he is responsible. As the outer consciousness ends, the inner narrator returns toward the town and its librarian.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3660,7 +3660,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3673,7 +3673,7 @@
       "recaps": {
         "ending": "Stephanie finds Evelyn and Annie alive and confirms that their disappearance was an attempt to stay beyond the reach of the custody fight and Eddie Abruzzi's coercion. Mabel Markowitz is no longer in danger of losing her home for an unexplained flight, and Steven Soder does not simply gain access to Annie through Stephanie's search. Abruzzi's campaign of staged terror escalates into a final confrontation in which he dies, ending the immediate pursuit of Evelyn and the threats against Stephanie. Albert Kloughn remains attached to the Plum family's orbit through Valerie. Stephanie's personal life is altered as decisively as the case: she and Ranger act on their attraction, but the encounter does not turn Ranger into a conventional partner or give her a stable alternative to Morelli. Morelli remains hurt and involved after the broken engagement. Stephanie ends with both relationships changed, neither one settled, and the triangle intact.",
         "in_short": "Mabel Markowitz asks Stephanie to find Evelyn Soder and her daughter Annie because Mabel guaranteed Evelyn's appearance in a custody dispute and may lose her home. Evelyn's former husband Steven also wants the pair found, while lawyer Albert Kloughn provides awkward assistance and becomes close to Stephanie's sister Valerie. The search attracts Eddie Abruzzi, a violent man who uses staged threats, costumed men, and attacks to force Stephanie away from Evelyn's trail. Lula helps with fieldwork, Morelli objects to the danger and to Ranger's role in Stephanie's life, and Ranger provides the protection and access Stephanie increasingly relies on. Stephanie eventually locates Evelyn and Annie alive and exposes the pressure that drove them into hiding. Abruzzi dies in the final confrontation, ending his pursuit. Stephanie and Ranger finally act on their attraction, but the encounter does not create a settled partnership. Her broken engagement to Morelli remains emotionally active, leaving all three in a changed but unresolved triangle.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3864,7 +3864,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3877,7 +3877,7 @@
       "recaps": {
         "ending": "Stephen is found at the bottom of an abandoned mine shaft and dies after being rescued, but his final account points Gradgrind and Louisa toward Tom as the bank robber. Sissy has already hidden Tom with Sleary's circus. Bitzer tries to capture him for a reward, but the performers help Tom escape overseas. Tom later dies abroad after expressing remorse and wishing to see Louisa again. Bounderby's supposed history of abandonment is exposed when Mrs Pegler is revealed as the loving mother he rejected; he dies several years later. Gradgrind abandons his faith in pure calculation and becomes more compassionate, though former allies reject him. Sissy forms a happy family. Louisa never remarries or has children, but remains close to Sissy and finds purpose in caring for others. Rachael continues her working life with enduring kindness and keeps Stephen's memory.",
         "in_short": "In industrial Coketown, Thomas Gradgrind raises his children to trust facts and suppress emotion, while his friend Josiah Bounderby boasts of rising alone from poverty. Gradgrind's daughter Louisa enters a loveless marriage to Bounderby partly to help her brother Tom, who works at Bounderby's bank. Factory worker Stephen Blackpool is rejected by both employers and fellow workers, then suspected when the bank is robbed. The charming James Harthouse exploits Louisa's unhappiness, but she flees to her father rather than begin an affair, forcing Gradgrind to recognize the harm done by his teaching. Stephen dies after falling into an abandoned mine shaft, and his final words expose Tom as the robber. Sleary's circus helps Tom escape abroad, where he later dies remorseful. Bounderby's claim of childhood abandonment is revealed as a lie. Gradgrind adopts a more humane outlook, Sissy builds a loving family, and Louisa remains unmarried but devotes herself to others.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4036,7 +4036,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4049,7 +4049,7 @@
       "recaps": {
         "ending": "After Lucetta's death, the sailor Newson comes to Casterbridge seeking Elizabeth-Jane. Henchard, afraid of losing the daughter who has grown close to him, falsely says that she is dead. The lie buys him only a little time. When Newson returns and Elizabeth-Jane learns the truth, Henchard leaves Casterbridge rather than face her anger. She later understands his despair and searches for him with Farfrae, but they cannot find him before their wedding. Abel Whittle eventually brings Henchard's final message: Henchard has died in poverty and asks to be forgotten, with no mourning, flowers, or notice of him. Elizabeth-Jane, now married to Farfrae and reconciled with Newson, regrets that her forgiveness came too late. Henchard's rise and fall are complete, while she carries forward a hard-earned appreciation of the ordinary happiness left to her.",
         "in_short": "Years after drunkenly selling his wife Susan and their child to a sailor, Michael Henchard has remade himself as a prosperous corn merchant and mayor of Casterbridge. Susan returns with Elizabeth-Jane, and Henchard remarries her to conceal the past. He promotes the able young Scotsman Donald Farfrae, then drives him away through jealousy; Farfrae becomes his commercial rival and eventually supplants him. After Susan dies, Henchard learns Elizabeth-Jane is not his biological daughter. His former lover Lucetta comes to town but marries Farfrae, while the public exposure of Henchard's old wife-sale hastens his ruin. Lucetta dies after townspeople parade an effigy of her former relationship with Henchard. The returned sailor Newson seeks Elizabeth-Jane, and Henchard lies that she is dead, losing her trust when the deceit emerges. He leaves Casterbridge and dies before she can forgive him. Elizabeth-Jane marries Farfrae and is reunited with Newson.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4223,7 +4223,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4236,7 +4236,7 @@
       "recaps": {
         "ending": "During the 1964 Harlem unrest, Carney and Pepper trace Freddie's latest theft to Linus Van Wyck and to valuables and documents taken from the powerful Van Wyck family. Linus is killed, and Freddie is eventually returned to Carney mortally injured; Carney can no longer rescue the cousin whose schemes repeatedly drew him across his moral boundary. The stolen papers expose the Van Wycks' corrupt dealings in city development. Carney uses that leverage to protect himself and settle the immediate threat rather than pursuing a public crusade. Freddie's death leaves him grieving and newly aware that his careful double life never placed him outside the violence of the criminal world. Even so, the furniture business endures and expands, providing for Elizabeth and their children as Harlem changes around them. Carney closes the novel neither wholly respectable nor wholly criminal: he has become skilled at moving between both systems and recognizes that the respectable city and the underworld are built from many of the same bargains.",
         "in_short": "In late-1950s and early-1960s Harlem, furniture dealer Ray Carney tries to build a respectable future while quietly fencing goods for his reckless cousin Freddie. When Freddie involves him in the Hotel Theresa robbery, Carney survives retaliation by learning to maneuver among thieves, gangsters, and corrupt police. Two years later, banker Wilfred Duke humiliates him after taking money for admission to an elite club, and Carney engineers an elaborate revenge that exposes Duke while drawing him deeper into the underground economy. In 1964 Freddie steals from the wealthy Van Wyck family with their troubled heir Linus, bringing lethal attention during the Harlem riots. Carney and the veteran enforcer Pepper search for him, but Freddie dies from the violence surrounding the theft. Carney uses incriminating Van Wyck papers to secure his position. His family and growing store survive, but his hope of a clean division between honest merchant and criminal operator is gone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4400,7 +4400,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4413,7 +4413,7 @@
       "recaps": {
         "ending": "After months of isolation and retaliation, Harriet receives a letter from Ole Golly. Her former nurse tells her that a writer must endure and also understand that private truth can be cruel when exposed; if Harriet wants her friends back, she must apologize and sometimes soften what she says. Harriet's parents follow professional advice and allow her to write again. At school, the class newspaper replaces Marion with Harriet as editor. Harriet uses the paper to publish a retraction and apology, admitting that some of her assertions were wrong, and she reconciles with Sport and Janie. She resumes her spy route and continues keeping a notebook, but her observations show greater awareness that people can change and that her first judgment may be incomplete. She has not abandoned the ambition to become a writer; she has begun learning the responsibility that accompanies it.",
         "in_short": "Eleven-year-old Harriet Welsch wants to be a writer and secretly records harsh observations about friends, classmates, and neighbors during her daily spy route. Her beloved nurse Ole Golly leaves to marry, and Harriet responds by clinging harder to her notebook. When classmates find and read it, Sport and Janie are wounded by what she wrote, and Marion organizes the others against her. Harriet refuses to apologize and retaliates, becoming isolated and increasingly disruptive until her parents seek help and briefly take away her notebooks. A letter from Ole Golly helps her understand that honesty without care can be destructive. Made editor of the class newspaper, Harriet prints a retraction, repairs her friendships with Sport and Janie, and returns to observing the city. She remains determined to write, now with a better sense that people are more complicated than a single cruel description.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4592,7 +4592,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4605,7 +4605,7 @@
       "recaps": {
         "ending": "Harrowhark's condition turns out to be self-inflicted. Before leaving Canaan House she had Ianthe perform surgery on her brain to cut Gideon Nav out of her memory entirely, so that she could never consume her. That is why she is an immortal Lyctor with none of a Lyctor's power, Gideon's soul sitting intact and untouched inside her, and why the Canaan House she remembers has Ortus Nigenad in it instead. When that arrangement collapses, Gideon wakes in Harrowhark's body and narrates the rest of the book. Mercymorn and Augustine choose the same moment to make the attempt on the Emperor they have been preparing for ten thousand years, telling Gideon first what he actually did: the Resurrection Beasts are the ghosts of the worlds he himself destroyed, and the Empire is built on that. The attempt fails, the Emperor survives it, Mercymorn does not, and the station is destroyed in the process. The body of the Saint of Duty proves to be shared with his own long-dead cavalier, Pyrrha Dve, who is still inside it. Gideon escapes aboard a shuttle with Ianthe, wearing Harrowhark's body and using Harrowhark's necromancy, while Harrowhark's own soul is left adrift in the River inside the wreck of the Canaan House her surgery built. Harrowhark is lost, the Empire's founding crime is known to the people who survived, and Gideon leaves the book intending to get her back.",
         "in_short": "Harrowhark Nonagesimus leaves Canaan House as one of the Emperor's Lyctors and is taken to his station beyond the Nine Houses to be trained against the Resurrection Beasts, the vast ghosts of dead worlds that hunt him. She is a disaster: constantly ill, unable to use a Lyctor's power, unsure of her own perceptions, and under repeated attack by one of the Emperor's ancient saints. Interleaved with this is an account of the events of the previous book in which Gideon Nav does not exist, Harrowhark's cavalier is Ortus Nigenad, and a sleeping woman in a coffin wakes and hunts her. The two are the same problem: before leaving the First House, Harrowhark had Ianthe cut Gideon out of her memory so that she could never consume her, leaving Gideon's soul intact inside her and Harrowhark a Lyctor in name only. When the arrangement fails, Gideon wakes in Harrowhark's body. Mercymorn and Augustine make their long-planned attempt to kill the Emperor, revealing that he destroyed the old worlds himself; the attempt fails and the station is destroyed with it. Gideon escapes with Ianthe, wearing Harrowhark's body, while Harrowhark's soul is left adrift in the River.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4807,7 +4807,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -4818,7 +4818,7 @@
       "recaps": {
         "ending": "Harry reaches the Chamber of Secrets and finds Ginny Weasley near death, her life being drained into an enchanted diary. The diary preserved a memory of Tom Riddle, a former Hogwarts student who grew up to become Lord Voldemort; he had used the book to possess Ginny and reopen the Chamber, setting a giant basilisk to attack Muggle-born students. With help from Dumbledore's phoenix, Fawkes, and a sword produced by the Sorting Hat, Harry kills the basilisk, though its fang pierces him; Fawkes's tears heal the wound. Harry stabs the diary with the fang, destroying Riddle's memory and saving Ginny. It emerges that Lucius Malfoy had slipped the diary among Ginny's things to discredit the Weasleys and Dumbledore. Harry tricks Lucius into freeing his mistreated house-elf, Dobby, who is now devoted to Harry. The Petrified students are cured, Hagrid is cleared and released, and Dumbledore is restored as headmaster. Harry ends the year having faced Voldemort's past self and won, though the encounter has left him uneasy about how alike the two of them can seem.",
         "in_short": "In his second year, Harry is warned by a house-elf, Dobby, to stay away from Hogwarts, then finds the school terrorized by an unknown monster. A message on a wall announces that the Chamber of Secrets has been opened, and students begin turning up Petrified, all of them of non-magical descent. Harry discovers he can speak to snakes, which turns suspicion on him, and the school fears he is the culprit. Following the trail through an enchanted diary that shows a false memory, and past spiders and clues, Harry and Ron learn the monster is a giant serpent, a basilisk, moving through the castle's pipes, and that Ron's sister Ginny has been taken into the Chamber. Harry descends alone, confronts a memory of the young Tom Riddle, who is revealed to be Voldemort's teenage self, kills the basilisk with a sword, and destroys the diary, saving Ginny. Dobby is freed and Voldemort's plan through the diary is undone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4989,7 +4989,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5002,7 +5002,7 @@
       "recaps": {
         "ending": "Delphi is revealed as the hidden child of Voldemort and Bellatrix Lestrange, and her plan is to undo her father's defeat. After forcing Albus and Scorpius to help her travel back in time, she goes to Godric's Hollow on the night in 1981 when Voldemort came to kill the infant Harry, intending to stop the rebounding curse that destroyed him. The boys manage to summon Harry, Ginny, Ron, Hermione, and Draco to that night. Together they confront and overpower Delphi, and Harry endures the anguish of standing by while his own parents are killed so that history runs its true course and Voldemort is once again undone. Delphi is captured and imprisoned. In the aftermath, the long rift between Harry and Albus finally heals as father and son come to understand each other, and Harry's old enmity with Draco softens into something like respect. Scorpius and Albus remain fast friends, having saved their world by choosing, in the end, not to change the past. The dangerous Time-Turner and the temptation it represents are set aside, and the two families step into a steadier future.",
         "in_short": "Set nineteen years after the fall of Voldemort, the play follows Harry Potter's unhappy son Albus, who is sorted into Slytherin and befriends Scorpius Malfoy. Straining against his father's legend, Albus overhears the grieving Amos Diggory beg Harry to save Cedric with a Time-Turner, and, encouraged by Amos's niece Delphi, the boys steal the device and travel back to the Triwizard Tournament to prevent Cedric's death. Their meddling warps the present again and again, at its worst producing a nightmare world where Voldemort won and Harry is dead, which Scorpius barely undoes with help from a still-living Snape and others. Back in a restored present, Delphi reveals herself as the secret daughter of Voldemort and Bellatrix Lestrange, bent on resurrecting her father. She forces the boys through time and travels to Godric's Hollow on the night in 1981 when Voldemort first attacked the Potters, meaning to change history in his favor. Albus and Scorpius summon Harry and the others; together they defeat Delphi and let the true past unfold. Harry and Albus, and Harry and Draco, are reconciled by what they have survived.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5190,7 +5190,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5203,7 +5203,7 @@
       "recaps": {
         "ending": "In the Battle of Hogwarts, the last of Voldemort's Horcruxes fall: Ron and Hermione destroy Hufflepuff's cup, the diadem is consumed by cursed fire, and Voldemort's snake Nagini is beheaded by Neville with the sword of Gryffindor. Voldemort kills Snape, believing it will make him master of an unbeatable wand, but Snape's final memories show he was Dumbledore's loyal agent, driven by lifelong love for Harry's mother, and that Harry is himself an unintended Horcrux who must die. Harry walks into the forest and lets Voldemort strike him down without defending himself. Because Voldemort had earlier used Harry's blood to rebuild his body, Harry does not truly die; he meets Dumbledore in a vision and chooses to return. Voldemort's killing curse had destroyed only the fragment of soul within Harry. In the final confrontation Harry reveals that he, not Snape, is the true master of the unbeatable Elder Wand, so it will not work against him; Voldemort's own curse rebounds and kills him for good. Many have died in the fighting, including Fred Weasley, Lupin, and Tonks, but Voldemort is destroyed. An epilogue set nineteen years later shows Harry married to Ginny, and Ron married to Hermione, seeing their own children off to Hogwarts in a world finally at peace.",
         "in_short": "Harry, Ron, and Hermione abandon school to hunt down the Horcruxes, the hidden objects holding pieces of Voldemort's soul that keep him alive. On the run as Voldemort seizes control of the government and Hogwarts, they destroy a locket, learn of three legendary objects called the Deathly Hallows, and are captured and taken to Malfoy Manor, where the house-elf Dobby dies saving them. Breaking into a bank vault, they claim another Horcrux and later infiltrate Hogwarts to find one more. A great battle erupts at the school. Snape is killed by Voldemort, but his dying memories reveal that he loved Harry's mother, worked secretly for Dumbledore all along, and that Harry himself is an accidental Horcrux who must die for Voldemort to be mortal. Harry lets Voldemort strike him down, survives, and returns. Neville destroys the last Horcrux, and in a final duel Voldemort's own killing curse rebounds and kills him. Nineteen years later, Harry and his friends are grown, married, and sending their own children off to Hogwarts.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5418,7 +5418,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -5429,7 +5429,7 @@
       "recaps": {
         "ending": "The Triwizard Tournament ends in tragedy. Harry and Cedric Diggory agree to take the cup together as a shared Hogwarts victory, but it is a Portkey that whisks them to a distant graveyard. There, on Voldemort's order, the servant Wormtail kills Cedric and uses Harry's blood, along with Wormtail's own flesh and the bone of Voldemort's dead father, in a ritual that restores Voldemort to a body and full power. Voldemort summons his Death Eaters and duels Harry, but when their wands lock, an effect of their twin cores forces echoes of Voldemort's recent victims, including Harry's parents and Cedric, to emerge and shield Harry, letting him escape with Cedric's body. Back at Hogwarts, the Defence teacher Mad-Eye Moody is exposed as an impostor, the Death Eater Barty Crouch Jr in disguise, who entered Harry in the tournament and steered him to the trap. Dumbledore believes Harry and begins rallying allies for the coming war, but the Minister for Magic, Fudge, refuses to accept that Voldemort has returned, and the wizarding world splits between those who believe and those who deny it. The school year ends in grief, with Voldemort restored and free.",
         "in_short": "In his fourth year, Harry is mysteriously entered into the Triwizard Tournament, a dangerous contest between three magical schools normally limited to older students, becoming a fourth champion alongside Cedric Diggory, Viktor Krum, and Fleur Delacour. Much of the school believes he cheated, and he faces three deadly tasks: getting past a dragon, rescuing hostages from a lake, and navigating an enchanted maze. Throughout, signs point to Voldemort's return, and Harry's scar troubles him. Harry and Cedric reach the tournament cup together and grab it at the same moment, only to find it is a trap that transports them to a graveyard. There Cedric is murdered and Voldemort, using Harry's blood in a dark ritual, regains his body and full power. Harry escapes and returns with Cedric's body. The disguised Death Eater who engineered everything is exposed, but the Minister for Magic refuses to believe Voldemort is back, leaving the wizarding world divided as open war threatens.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5634,7 +5634,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -5645,7 +5645,7 @@
       "recaps": {
         "ending": "Half-Blood Prince ends with Dumbledore's death and Harry's turn toward the final fight. Returning from a mission to destroy one of Voldemort's Horcruxes, the soul-fragments that keep him from dying, Dumbledore and an exhausted Harry find the Dark Mark over Hogwarts: Draco Malfoy has smuggled Death Eaters into the castle through a repaired vanishing cabinet. On the astronomy tower Draco disarms Dumbledore but cannot make himself commit murder, and Snape arrives and kills Dumbledore, then escapes, revealing as he flees that he is the Half-Blood Prince whose old textbook Harry had relied on all year. The locket Dumbledore and Harry retrieved from the cave, at terrible cost, turns out to be a fake, left in place of the real Horcrux by an unknown thief who signs only 'R.A.B.' Dumbledore is buried at Hogwarts, and the school may not reopen. Harry ends his budding romance with Ginny to keep her out of danger, and, with Ron and Hermione pledging to come with him, decides not to return for a final year but to find and destroy Voldemort's remaining Horcruxes so that the Dark Lord can at last be killed. Voldemort is ascendant, Snape has fled to his side, and the war is entering its darkest phase.",
         "in_short": "With war now open, Harry's sixth year mixes ordinary school life with Dumbledore's quiet campaign against Voldemort. Dumbledore gives Harry private lessons, using collected memories to trace Voldemort's history from his orphan boyhood as Tom Riddle. Harry excels at Potions thanks to an old textbook annotated by a mysterious 'Half-Blood Prince,' and grows sure that Draco Malfoy has become a Death Eater plotting something inside the castle. Using a lucky potion, Harry retrieves a hidden memory revealing Voldemort's secret to immortality: Horcruxes, objects into which he split his soul, several of which must be destroyed to make him mortal. Dumbledore and Harry go to a hidden cave to destroy one, returning to find Death Eaters have breached Hogwarts through Draco's scheme. On the tower, Draco cannot bring himself to kill Dumbledore, and Snape does it instead, then flees, revealing that he was the Half-Blood Prince. The retrieved Horcrux proves a fake. Dumbledore is dead, and Harry resolves to leave school and hunt the remaining Horcruxes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5843,7 +5843,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -5854,7 +5854,7 @@
       "recaps": {
         "ending": "Harry's fifth year ends in loss and grim clarity. Tricked by a false vision, Harry leads his friends to the Ministry of Magic to rescue his godfather Sirius, only to find it was a lure: Voldemort wanted Harry to retrieve a prophecy that only he could take from the Hall of Prophecy. Death Eaters attack, the young wizards fight desperately, and members of the Order of the Phoenix arrive to help; in the battle Sirius is struck by his cousin Bellatrix Lestrange and falls through a mysterious veil to his death. Voldemort himself appears and duels Dumbledore, and the Minister for Magic, Fudge, sees him with his own eyes, so the wizarding world can no longer deny that Voldemort has returned. Voldemort briefly possesses Harry and then flees. Afterward Dumbledore finally explains the prophecy and why he kept his distance all year: Harry and Voldemort are bound so that neither can live while the other survives, and one must ultimately kill the other, which is why Voldemort marked Harry as a baby. Fudge is discredited, the Ministry mobilizes for open war, and Harry, grieving Sirius and burdened with his destiny, returns to the Dursleys knowing what lies ahead.",
         "in_short": "With Voldemort returned but the Ministry of Magic denying it and branding Harry a liar, Harry's fifth year is one of official persecution. He is taken to the headquarters of the Order of the Phoenix, the secret society fighting Voldemort. At school the Ministry installs Dolores Umbridge, who bans practical Defence lessons and seizes ever more power, so Harry secretly teaches his classmates to fight, forming Dumbledore's Army. Harry suffers visions through a growing mental link to Voldemort and is made to take Occlumency lessons with Snape to shut it. When he sees his godfather Sirius being tortured, he leads friends to the Ministry to save him, but it is a trap: Voldemort lured him to retrieve a prophecy about the two of them. In the battle Sirius is killed by Bellatrix Lestrange. Voldemort's public appearance finally forces the Ministry to admit he is back. Dumbledore reveals the prophecy: Harry and Voldemort are fated to face each other, and only one can survive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/harry-potter-and-the-philosophers-stone.json
+++ b/data/works-community/0/harry-potter-and-the-philosophers-stone.json
@@ -137,7 +137,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -148,7 +148,7 @@
       "recaps": {
         "ending": "Harry survives his first meeting with what remains of Voldemort. The thief guarding the Stone was not Snape, whom Harry had suspected, but Professor Quirrell, who had let the weakened, bodiless Voldemort possess him and hide beneath his turban. Deep beneath the school Harry keeps the Philosopher's Stone from them; his bare touch scorches Quirrell, because the love of his mother, who died shielding him, still protects him. Quirrell dies and Voldemort's spirit flees the castle. Harry wakes in the hospital wing to find Dumbledore, who confirms that the Stone has been deliberately destroyed by its maker, Nicolas Flamel, and that Voldemort is weakened but not gone and will try to return to power. Last-minute points awarded by Dumbledore for the trio's courage win Gryffindor the House Cup. Harry, Ron, and Hermione end the year firm friends, and Harry, for the first time in his life, has somewhere he belongs and dreads going back to the Dursleys for the summer. Voldemort remains at large, powerless for now but not defeated.",
         "in_short": "Harry Potter, an orphan mistreated by his aunt and uncle, learns on his eleventh birthday that he is a wizard, famous for surviving the attack in which the dark wizard Voldemort killed his parents. He goes to Hogwarts School of Witchcraft and Wizardry, is sorted into Gryffindor, and makes his first real friends, Ron Weasley and Hermione Granger. He becomes a star Quidditch player and stumbles onto a mystery: something hidden in the castle behind a giant three-headed dog. The trio work out that it is the Philosopher's Stone, which grants immortality, and that someone means to steal it for Voldemort. Believing the Potions master Snape is the thief, they go after the Stone themselves. Harry finds instead the timid teacher Quirrell, who has been sheltering the bodiless Voldemort beneath his turban. Harry survives the confrontation, the Stone is destroyed to keep it safe, and he learns that his mother's sacrifice still protects him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -331,7 +331,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -342,7 +342,7 @@
       "recaps": {
         "ending": "Cornered in a haunted house, Sirius Black is revealed to be innocent: he never betrayed Harry's parents and never killed anyone. The true traitor is Peter Pettigrew, who faked his death twelve years ago, framed Black, and has been hiding ever since as Ron's pet rat, Scabbers. Lupin, revealed to be a werewolf and Black's old friend, helps expose him. The truth clears Black, but on the way back to the castle Lupin transforms under the full moon, Pettigrew escapes in the confusion, and Dementors swarm Harry and Black. Harry drives them off with a powerful Patronus, having earlier glimpsed himself doing it. Black is recaptured and sentenced to have his soul destroyed, but Hermione's time-travel device lets her and Harry go back a few hours to free the condemned creature Buckbeak and rescue Black, who escapes on its back. Because Pettigrew got away, Black cannot be cleared and stays a hunted fugitive, so the home Harry was briefly offered slips out of reach. Lupin resigns once his condition becomes known. Voldemort's servant Pettigrew is now free to seek his master, and Harry ends the year knowing at last the truth about how his parents died and who really betrayed them.",
         "in_short": "In his third year, Harry learns that Sirius Black, a convicted murderer said to have served Voldemort, has escaped Azkaban and is thought to be hunting him. Soul-draining prison guards called Dementors are posted around Hogwarts and affect Harry badly, so his new Defence teacher, Remus Lupin, teaches him to fight them off with the Patronus charm. Harry discovers that Black is his godfather and was blamed for betraying his parents to Voldemort. When Black is finally cornered, the truth comes out: he is innocent. The real traitor is Peter Pettigrew, who faked his own death and has spent years hiding as Ron's pet rat. Before Pettigrew can be handed to the authorities he escapes, so Black remains a wanted fugitive. Using a time-travel device, Harry and Hermione save both Black and a condemned creature, and Black flees to freedom. Harry ends the year knowing the truth about his parents' betrayal and having gained, then lost, the chance of a home with his godfather.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -526,7 +526,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -539,7 +539,7 @@
       "recaps": {
         "ending": "The villain behind the plot to steal the Sorcerer's Stone turns out to be Professor Quirrell, not Snape as Harry had suspected. Quirrell is host to the greatly weakened Voldemort, whose face grows from the back of his head beneath the turban, and Snape had in fact been trying to protect Harry all along. Facing them at the Mirror of Erised, Harry finds the Stone appears in his pocket because he wants only to keep it safe, not to use it. Voldemort orders Quirrell to seize and kill Harry, but Quirrell is burned by Harry's touch and cannot hold him; Harry passes out and Voldemort's spirit flees, leaving Quirrell to die. Harry wakes days later in the hospital wing, where Dumbledore explains that his mother's loving sacrifice is why Voldemort could not touch him, that the Stone has been destroyed by its owner Nicolas Flamel to keep it from evil hands, and that Voldemort is not gone but weakened and will return. Dumbledore awards last-minute house points that let Gryffindor win the house cup. The school year ends and Harry returns, reluctantly, to the Dursleys for the summer, now with friends and a home in the wizarding world to look forward to.",
         "in_short": "Harry Potter, an orphan raised by cruel relatives, learns on his eleventh birthday that he is a wizard and the famous survivor of an attack by the dark wizard Voldemort, who killed his parents but vanished when his curse rebounded off baby Harry. Harry starts at Hogwarts School of Witchcraft and Wizardry, is sorted into Gryffindor, and makes close friends of Ron Weasley and Hermione Granger. He becomes a star of the sport Quidditch and grows suspicious of the teacher Snape, whom he blames for strange dangers. The three friends uncover a plot to steal the Sorcerer's Stone, an object that grants eternal life, hidden in the school behind magical defences. Braving those traps together, Harry goes on alone to the final chamber and finds not Snape but the timid Professor Quirrell, who is sheltering the weakened Voldemort on the back of his own head. Harry keeps the Stone from them and survives; Quirrell is destroyed and Voldemort flees. The Stone is deliberately destroyed to keep it safe, and Gryffindor wins the house cup.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -680,7 +680,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -693,7 +693,7 @@
       "recaps": {
         "ending": "Elwood agrees without resentment to receive Chumley's formula, which is supposed to stop him from seeing Harvey and make him conventionally practical. Before the injection, taxi driver E. J. Lofgren tells Veta that patients he drives to Chumley's Rest are pleasant on arrival but cold, impatient, and calculating afterward. When Veta realizes the change would destroy the kindness she values in Elwood, she halts the treatment. Elwood pays the cab fare that Veta had forgotten and prepares to return home with her and Myrtle Mae. Harvey, who has briefly accepted Chumley's invitation to remain with the doctor, ultimately chooses Elwood and follows him out. Chumley is left with a glimpse of the escape from ordinary life he had privately wished for, while the Dowd family leaves with Elwood unchanged and Veta newly willing to accept the unseen companion who comes with him.",
         "in_short": "Elwood P. Dowd is a gentle man who spends his days with Harvey, a giant rabbit visible to him but almost no one else. His sister Veta, fearing that his behavior has destroyed her daughter Myrtle Mae's social prospects, tries to commit him to Chumley's Rest. A diagnostic blunder leads the staff to detain Veta and release Elwood. As the doctors scramble to correct the mistake, Elwood remains gracious, while evidence accumulates that Harvey may be a real pooka rather than a delusion. Dr. Chumley encounters Harvey and is forced to reconsider his certainty. Elwood finally agrees to an injection that would make him stop seeing Harvey, but a taxi driver's warning that the treatment makes agreeable people hard and calculating changes Veta's mind. She prevents the injection and takes her brother home as he is. Harvey briefly considers staying with Chumley, then follows Elwood.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -863,7 +863,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -876,7 +876,7 @@
       "recaps": {
         "ending": "Craig is stopped in the water after a final attempt on his brother's life that nearly drowns Suze as well, and the haunting ends. Everything else is worse than it was. Jesse has spent weeks watching Suze choose Paul Slater's company over his and being given no reason for it, and the distance between them is now real. Father Dominic knows he has been managed and does not know how far. Paul, having proved he can teach Suze what she does not know and having been careful never to teach her enough, states plainly what he intends to do: travel back to the night in 1850 when Jesse was murdered and prevent it. Jesse would then live out his own century and die in it, would never have haunted the room Suze sleeps in, and Suze would never have met him. Paul has the ability, no reason not to use it, and nothing to lose by it. The book closes with the threat live, Suze out of people she is willing to be honest with, and no idea how to stop him.",
         "in_short": "Paul Slater enrolls at the Mission Academy and makes his terms clear: he wants Suze, and he wants to teach her what shifters can really do. When she refuses, he shows her the leverage he has been holding. A shifter can reach the place the dead pass through, and from there the past, which means Paul could go back to 1850 and stop Jesse's murder, so that Jesse lives an ordinary nineteenth-century life and Suze never meets him. To learn enough to prevent it, Suze accepts Paul's lessons and spends weeks in his company, explaining herself to neither Jesse nor Father Dominic. In parallel she is stalked by the ghost of Craig, a young man who drowned and cannot accept that his younger brother survived instead; his attempts to take his brother end in the water, where Suze nearly drowns stopping him. Craig is dealt with, but the cost is Jesse's trust, and Paul ends the book stating outright that he intends to erase Jesse's death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1025,7 +1025,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1038,7 +1038,7 @@
       "recaps": {
         "ending": "The Nix abandons concealment and makes Savannah part of its final plan, using the living people around her to limit what Eve can do from the spirit world. Eve accepts the personal risk of confronting the being directly rather than allowing her daughter or Jaime to remain its route into the mortal world. With Trsiel, Kristof, and their living allies helping where they can, Eve defeats the Nix and returns it to supernatural custody, ending its chain of possession and violence. Savannah remains alive and safe with Paige and Lucas. The victory does not restore Eve to mortal life or make her Savannah's visible parent, but it changes her place in the afterlife. The Fates recognize both her effectiveness and her inability to remain a passive ghost. Eve accepts service as an angel on terms that let her protect others while retaining her bonds with Kristof and the daughter she continues to watch over.",
         "in_short": "Eve Levine, a dead half-demon witch who watches over her daughter Savannah from the afterlife, is recruited by the Fates to recover the Nix, an escaped spirit that possesses living women and drives them toward violence. Paired with the angel Trsiel, Eve follows the Nix through afterlife realms and the histories of former hosts, repeatedly ignoring rules when they obstruct the hunt. Her demon father Balaam offers dangerous assistance, while Kristof Nast, Savannah's dead father, tries to keep Eve from sacrificing herself. The Nix turns the pursuit toward the mortal world, where necromancer Jaime Vegas can hear Eve and where Savannah lives with Paige and Lucas. When the Nix uses that connection to threaten Savannah, Eve confronts it directly and, with help from allies among both the living and the dead, returns it to confinement. Savannah is safe. Eve remains with Kristof in the afterlife and accepts a role as an angel, gaining a purpose suited to her powers without giving up her connection to her family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1185,7 +1185,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1198,7 +1198,7 @@
       "recaps": {
         "ending": "On Sunday morning, the four guests meet over breakfast and compare their experiences. Exhausted by the Blisses' lack of consideration and by the emotional scenes into which they have been drawn, they agree to leave together as quietly as possible. They collect their belongings and slip out of the house. The Bliss family soon gathers, but instead of noticing the departure, its members become absorbed in an argument about the geography and details of David's unfinished novel. Their quarrel quickly gives way to enthusiastic collaboration over the story. The guests escape without a farewell, while Judith, David, Sorel, and Simon remain enclosed in their shared imaginative world and apparently unaware that their weekend visitors have gone.",
         "in_short": "Each member of the theatrical Bliss family independently invites a guest to the same weekend at their country house: retired actress Judith brings the admirer Sandy, novelist David invites Jackie as material for a character, Sorel asks the diplomat Richard, and Simon invites Myra. The guests find inadequate rooms, confused arrangements, and hosts who turn conversation into performance. An after-dinner game becomes humiliating, flirtations shift, and Judith stages an emotional crisis when she discovers David and Myra together. The family treats these scenes as familiar play, while the outsiders take them seriously and grow increasingly uncomfortable. At breakfast the next morning, Sandy, Myra, Richard, and Jackie decide to flee together. They leave unnoticed as the Blisses become engrossed in a fresh argument about David's novel, ending the weekend as absorbed in one another as when it began.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1667,7 +1667,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1680,7 +1680,7 @@
       "recaps": {
         "ending": "Jason shelters nearly ten thousand Brightheart civilians in his Soul Realm while the expedition and its uneasy allies defend the Citadel and prepare paired devices at the natural array and Echo Array. When an undeath invasion threatens to end the plan, Jason permanently gives up every form of resurrection in a pact with Death, becoming Keeper of the Cycle and gaining power that suppresses undeath. Gary accepts Hero's fatal miracle, rises to gold rank as a demigod vessel, and holds the wall against an unfinished Avatar of Undeath. Clive and Farrah complete the ritual as the wall collapses. The arrays begin turning the battlefield into a transformation zone as the Avatar withdraws without defeating Gary. The zone temporarily prevents Hero's power from leaving Gary, keeping him alive, but the miracle's eventual fatal cost is unresolved. The Brighthearts remain dependent on Jason's refuge, the corrupted messenger tree may still be healed, and the struggle among messengers, undead, Builder cultists, and the expedition continues inside changing reality.",
         "in_short": "After the Battle of Yoresh, Jason protects captive messengers while uncovering a plan centered on a failing underground natural array and a possible Soul Forge. His team studies messenger magic, proves that an Astral King brand can be removed voluntarily, and joins a mixed-rank expedition below the city. The expedition allies uneasily with Builder cultists, reaches the last Brightheart enclave, and evacuates nearly ten thousand civilians into Jason's Soul Realm. Undeath's priests then turn the ruined city into an invasion front, with the commanders judging that they are likely cooperating with Destruction. To buy time, Jason permanently surrenders all resurrection power to Death, while Gary accepts Hero's eventually fatal miracle and becomes a gold-rank demigod defender. Clive and Farrah activate paired devices as the Citadel wall falls, beginning a transformation zone. Gary survives the immediate battle, but his fatal debt, the corrupted messenger tree, the possible Soul Forge, and the wider war all remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2266,7 +2266,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2279,7 +2279,7 @@
       "recaps": {
         "ending": "Jason's transformation zone becomes a restored homeland for the Brighthearts after he separates its natural array, Soul Forge, and sentient tree. The tree survives in his soul realm and ultimately takes the name Arbor. Gary rejects an existence permanently bound to the array, relinquishes Hero's power, and dies. Rufus and Taika reach Earth with messenger refugees, where the Asano clan shelters people during a devastating vampire war. Team Biscuit continues without Jason, while Humphrey and Sophie separate to pursue their individual paths. Jason spends years fighting the World Phoenix within his own soul, but his apparent defeat conceals a second seat of will inside Arbor. He restores the Cosmic Throne, releases the World Phoenix and Reaper, and completes his ascent to gold rank and Astral King status. Sitting on the throne activates a System interface for everyone who has essences or the potential to obtain them. Jason is alive but has not yet returned directly. Messenger freedom, the Earth-Palimustus link, the Builder's ambitions, Europe's vampire conflict, and a cure for coerced zealots remain unresolved.",
         "in_short": "A dimensional rupture turns the underground realm into a transformation zone whose territories must be unified. Jason gathers the scattered expedition, defeats Undeath's forces, and rebuilds the broken natural array. The final enemy is a corrupted world tree created by a failed attempt to fuse that array with a Soul Forge. Recognising the tree as a person, Jason wins its cooperation, restores the Brighthearts' homeland, and preserves the tree within his soul. Gary chooses death over permanent dependence on the repaired array. As Rufus, Taika, and liberated messengers travel to an Earth devastated by vampire war, Jason begins a years-long Astral King transition. The World Phoenix tries to stop him from restoring the Cosmic Throne, but Jason hides part of his will inside the tree city and turns his apparent defeat into victory. He spares his opponents, claims the throne, and activates a universal System for essence-capable people.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/he-who-fights-with-monsters-12-a-litrpg-adventure.json
+++ b/data/works-community/0/he-who-fights-with-monsters-12-a-litrpg-adventure.json
@@ -479,7 +479,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -492,7 +492,7 @@
       "recaps": {
         "ending": "Jason reaches Earth through the newly activated but still unstable bridge, backed by Team Biscuit, returning expatriates, researchers, clergy and a Storm Kingdom delegation. His plan to provoke a manageable pirate incursion damages trust with Annabeth Tilden and confirms that his political organization still lacks firm rules for consultation and authority.\n\nAt Artifact City, Jota Withers and Natala step aside from Kriegel's mutiny. Jason and Team Biscuit defeat the attacking gold-rank pirates, and Jason abandons the original plan to kill them. One pirate dies after apparently trying to purge Jason's afflictions, but the others are imprisoned in Jason's soul realm. Jason claims their dimension ship, brings Gary Sharpton into the effort to examine it and leaves Jota and Natala available for questioning.\n\nJason then departs to see Emmy. The pirate assault is over, but its Earth sponsors and the wider Jakar threat remain open. New Water still shelters Boko's survivors, the messenger conflict and vampire crisis continue, the inter-world bridge needs years to stabilize, and Jason's advisers must turn his immense personal power into a workable relationship with Earth.",
         "in_short": "After restoring the Cosmic Throne, Jason Asano becomes an immortal astral nexus and creates a prime avatar capable of leaving his domains. He reunites with Team Biscuit, survives an assassination that destroys Boko, shelters its people in New Water and forces a major messenger withdrawal. On the journey toward Earth, he uses the System against slavery and gathers stranded Earth expatriates. A new dimensional bridge carries his allies and a diplomatic expedition home. There, Jason admits that he deliberately enabled a limited Jakar pirate incursion to expose hostile Earth factions and create a common enemy. Team Biscuit defeats the mutinous pirates, and Jason chooses capture over execution. He ends the book holding their crew and dimension ship while the sponsors of the attack remain unidentified, then leaves the aftermath to his allies so he can reunite with his niece Emmy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -951,7 +951,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -964,7 +964,7 @@
       "recaps": {
         "ending": "Jason's six-person team settles into his soulbound Cloudflask houseboat and begins intensive training with its completed abilities and new familiars. Sophie and Belinda have both reached Iron rank, although Sophie's indenture and the threats from Lamprey and Cole remain unresolved. Jason holds the genuine Scythe of the Reaper and a Reaper token, but has not committed to the covert Order and still does not know how to use the World Phoenix token to reach Earth. The Builder crisis overtakes these gains. Dorgan's shipping evidence leads a mixed-rank strike force to a cult island, confirming Church of Purity involvement, constructs, and an extensive portal network. The cult withdraws while keeping Thadwick alive. Rufus recognizes Farrah's killer, exhausts himself using Kingdom of Eclipse against it, and collapses surrounded by enemies. The killer survives badly wounded, and Rufus's immediate fate is unresolved when chapter 76 ends.",
         "in_short": "Jason secures Sophie's indenture before Lamprey can claim it, helps her become an Iron-rank adventurer, and forms a team with Sophie, Humphrey, Clive, Neil, and eventually Belinda. Their investigation reveals that altered expedition survivors carry starseeds serving the Builder, whose followers steal astral spaces with covert Church of Purity support. During Emir's contest in Fallen Echoes, Jason's allies survive monsters, hostile entrants, and the Order of the Reaper's trials. Jason uncovers the Order's continuing secret network, wins its genuine scythe, and gains new familiar powers. Sophie and Belinda complete their advancement, and the team moves into Jason's Cloudflask houseboat. Dorgan then locates a cult island. A strike force attacks, but the cult escapes through portals with Thadwick still captive. Rufus finds Farrah's killer and wounds it with Kingdom of Eclipse, then collapses exhausted and surrounded as the book ends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1506,7 +1506,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1519,7 +1519,7 @@
       "recaps": {
         "ending": "Clive completes the central tower inversion, destroying the World Engineers' deployment route and opening a portal home. Jason holds off the Builder long enough for the plan to succeed, then dies after carrying the Builder's vessel out of the tower. His body dissolves, and the World Phoenix token sends his soul onward under a pact that permits a return but forbids any later resurrection. Jason's friends do not learn that return is possible and mourn him as dead.\n\nThadwick Mercer is gone. A separate energy vampire rises from his abandoned body, takes fragments of his memories, consumes the soul imprisoned with the sealed sword, and escapes. The Adventure Society claims the astral space as a temporary base. Clive and Belinda take Magic Society and Builder-related work, while Sophie, Humphrey, and Neil travel with Emir on a Reaper investigation. Jory expands low-cost alchemical training through the Church of the Healer. On Earth, Jason remains officially dead and the investigation into his disappearance is suppressed. The Builder is formally barred from new vessels, starseeds, and tokens in the affected world, but its broader interworld scheme remains active. Dawn reveals that its magical siphon is delaying the monster surge in preparation for a catastrophic backlash threatening both linked worlds.",
         "in_short": "Jason Asano's team trains toward bronze rank while the Builder Cult prepares to reclaim a sealed astral space. After surviving Cole Silva's attempt to implant a starseed, Jason helps reopen the space and enters it with Humphrey, Clive, Sophie, Belinda, and Neil. They discover dormant World Engineers and an invasion force led by the Builder through mortal vessels. Clive devises a way to invert the central tower, destroy the deployment system, and reopen the exit. Sophie kills Zato, while Jason tackles the Builder from the tower so Clive can finish the inversion. Jason dies in the fall, but a World Phoenix token carries his soul onward. His friends return, recover the astral space, and mourn him without knowing he may come back. A new energy vampire escapes in Thadwick Mercer's body, and the surviving team separates for Builder and Reaper investigations. The final disclosure links Jason's two worlds and reveals that the Builder is engineering a magical backlash that could endanger both.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/he-who-fights-with-monsters-4.json
+++ b/data/works-community/0/he-who-fights-with-monsters-4.json
@@ -270,7 +270,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -283,7 +283,7 @@
       "recaps": {
         "ending": "Jason and Farrah learn that a centuries-old magical link between Earth and Palomustus is feeding a self-accelerating crisis. Earth faces rising magic, direct monster manifestations, and eventual devastation, while Palomustus faces a delayed monster surge and an invasion scheme involving Purity and the Builder. Their route home now depends on finding and disabling the Earth-side infrastructure strengthening that link. Farrah reaches Silver rank and remains in Australia to train specialists, study astral magic, and help Erika guide Jason's relatives into magical life. Erika, Ian, Kaito, Amy, Hiro, and Taika have begun their own magical paths, while Emi must wait until she is old enough. Annabeth Tilden, Asya Karadeniz, Gladys, Ketevan Arziani, Nigel, and Craig Vermillion remain allies or collaborators. Adrien Barbou is still at large, the EOA remains active, and the wider conspiracy is unresolved. After rebuilding the fine control of his altered aura, Jason leaves alone on a temporary walkabout to recover his emotional balance. He promises Emi that he will return and agrees to assist regional incursion teams during his travels.",
         "in_short": "Revived on Earth after dying in another world, Jason Asano reconnects with his estranged family and discovers a concealed conflict among the Cabal, the Network, and the EOA as magical incursions intensify. His search for another returned outworlder leads to Farrah Hurin, his former teacher, held and tortured by a rogue Leon operation. Jason permanently fuses body and soul to enter a sealed astral fortress and rescue her. They form an independent alliance with the International Committee, fight major incursions, train specialist teams, and prepare Jason's family for a magical future. Dawn, an avatar of the World Phoenix, reveals that an ancient link between Earth and Palomustus is destabilizing both worlds. Disabling its Earth-side infrastructure can avert catastrophe and open their route home. Farrah reaches Silver rank and stays to lead training and family preparations, while Jason restores control over his transformed aura and departs on a temporary walkabout, promising to return.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -695,7 +695,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -708,7 +708,7 @@
       "recaps": {
         "ending": "Jason, Farrah, and Dawn continue repairing the altered link between Earth and Farrah's world, but Earth cannot return to its former low-magic state. Transformation zones, reality-core conflict, and awakened ancient vampires are reshaping the planet. Kaito, Greg, and Asya are dead, and their one permitted farewell urges Jason to reject revenge and isolation. The Tiwari gate is permanently integrated into Jason's spirit vault, while Noriko, Emerson Cleary, Jack Gerling, Mr. North, and Adrien Barbou remain unresolved threats. Shiro's displaced family and the exiled Tiwari live under Jason's protection at Asano Village. When an anomalous transformation near Nitra may signal catastrophic failure of Earth's dimensional membrane, Jason enters the sealed zone alone. Dawn remains ready to evacuate Farrah and Jason's family if Earth cannot be saved, and Gerling recognizes Jason's arrival at the crisis.",
         "in_short": "Jason's public rescue work gives way to a worldwide monster crisis after the EOA destroys the Network's detection grid. He learns that Earth is draining magic from Farrah's world through an altered dimensional link and claims the Tiwari gate needed to repair it. After reaching silver rank and defeating a gold-rank monster, he breaks with the Network and begins restoring hidden nodes with Farrah. Transformation zones produce reality cores and ignite conflict among magical factions. A US Network operation led by Emerson Cleary and Jack Gerling kills Kaito, Greg, and Asya, though their final farewell turns Jason away from revenge. Jason, Farrah, and Dawn defeat Lord Willoughby's assault on Sydney and resume node repairs as ancient vampires spread through Europe. The book ends with Jason entering a sealed transformation event near Nitra alone, hoping to prevent a possible collapse of Earth's dimensional membrane while Gerling watches.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1186,7 +1186,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1199,7 +1199,7 @@
       "recaps": {
         "ending": "Six months after the French crisis, Saint-Etienne is a permanent spirit domain anchoring a high-magic region, and Earth's dimensional membrane is recovering. Jason refuses a public leadership role, leaves clan administration and transformed-person relocation to Yumi, Shiro, and Annabeth, and says goodbye to Erika, Ian, and Emi, who remain on Earth. He and Farrah complete the passage back toward Palomustus. There, their friends still believe them dead. Gareth works as a traveling defensive smith, Sophie has deferred her family search, and Clive has traced the Builder cult's portal network. With the delayed monster surge now expected within months, Dawn secretly gathers Jason's former circle at a remote village. She asks Gareth and Virid to reforge a bent soul-bonded sword and says its dead owner may return, although the owner is not identified.",
         "in_short": "Jason enters the fused Nitra Transformation Zone and turns its unstable territories into a permanent spirit domain, surviving Shako's lethal intervention and leaving Earth permanently more magical. While repairing the link to Palomustus, Jason and Farrah uncover an industrial vampire operation in France. Shako's sabotage converts their demolition mission into another transformation disaster, forcing Jason to unite Mr. North, Jack Gerling, a necromancer, vampires, and other enemies. Todd dies, Gordon loses his vessel, and Mr. North and Gerling die during the final rift crisis. Six months later, Earth is stabilizing and Jason declines further leadership. Erika's family stays behind while Jason and Farrah complete their return passage. On Palomustus, friends who believe them dead confront a coming monster surge, the Builder cult's portal network, and Sophie's unresolved history. Dawn assembles the old team to repair a soul-bonded sword whose dead owner might return.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1584,7 +1584,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1597,7 +1597,7 @@
       "recaps": {
         "ending": "The Storm Kingdom wins the One Day War, also known as the War of Four Cities, but loses many experienced adventurers. Dawn expends her sole direct intervention to erase the Builder's land city, the submarine kraken city is defeated, and the flying fortress falls after Liara Rimaros delivers the true destructive device to its core. Vesper Rimaros and Liara's brother die enabling that strike. Divine and water-essence intervention turns the falling fortress into an island and saves Liveros. A month later, Jason's reunited team is operating as a portal-enabled response force during the still-active monster surge. Jason remains silver rank and cannot revive again until gold rank. Arabelle Remore helps him face his fear that his changed self has lost his friends' trust, and every team member proves otherwise by entering his spirit vault. The local Builder cult is largely cleared, but the worldwide Builder war, Purity's conversion campaign, the Messengers, and the damaged route to Earth remain unresolved.",
         "in_short": "Jason Asano and Farrah Hurin return from Earth during an extreme monster surge and become entangled in the Storm Kingdom's defense against the Builder. While Jason undertakes isolated supply missions and survives attacks engineered through Purity, his former companions disrupt a Purity ritual that brings Earth outworlders and interdimensional Messengers into the world. Jason's involvement in royal politics and Builder operations exposes both his dangerous new powers and his deteriorating judgment. His friends finally reach Rimaros, and the reunited team joins the kingdom's rapid-response effort. When multiple Builder cities attack, Dawn destroys the land city and local forces defeat the submarine city. Liara Rimaros carries a locally made weapon into a surprise flying fortress; Vesper Rimaros and Liara's brother die securing its destruction, while divine intervention saves Liveros from the fall. One month later, Jason's team remains active in the surge, and their entry into his spirit vault demonstrates that their trust in him has survived.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/he-who-fights-with-monsters-8.json
+++ b/data/works-community/0/he-who-fights-with-monsters-8.json
@@ -294,7 +294,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -307,7 +307,7 @@
       "recaps": {
         "ending": "Jason ends the Builder's immediate campaign by returning the unstable authority token. In exchange, the Builder withdraws its forces from Pallimustus and promises one future opening to the fundamental realm, which Jason needs to anchor a bridge to Earth. Jason survives the mine-rescue portal disaster and continues recovering, but his transformed soul space is now a secure astral domain in which he has immense control. Using that power outside remains dangerous at silver rank.\n\nMelody Jane remains confined in Jason's pagoda. She is Sophie's mother, and neither Jason nor Carlos yet knows how to reverse her altered lesser-vampire condition without killing her. Sendira's two stolen clockwork kings, the Order's mass messenger summonings, and the false power behind Purity remain open threats. Dawn leaves Pallimustus after warning Jason to prepare rapidly for a future crisis. Farrah remains his ally but departs the adventuring team to establish a government-backed communications venture with Travis. Rufus stays temporarily to train Jason as the group prepares to leave Rimaros and travel toward Greenstone. The Earth bridge, messenger dimensional knowledge, and the Builder's artificial-world project remain unfinished.",
         "in_short": "During the weakened Storm Kingdom's monster surge, Jason Asano and his allies uncover the Order of Redeeming Light's scheme to convert essence users and build a construct army with stolen Builder technology. The team captures Order leader Melody Jane, revealed as Sophie's mother, and Belinda cripples the Order's mountain refuge. Jason nearly dies forcing civilians out of a flooded mine, and the disaster transforms his soul space into a nascent astral domain. He later bargains away unstable Builder authority in exchange for the Builder's worldwide withdrawal and one future opening to the fundamental realm needed for the bridge to Earth. Dawn teaches him the limits of his new status as an astral king, then departs with a warning about a future crisis. Farrah leaves field work to build a communications network with Travis, while Rufus stays to train Jason. The stolen clockwork kings, converted prisoners, messenger forces, Earth bridge, and Builder's larger design remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -774,7 +774,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -787,7 +787,7 @@
       "recaps": {
         "ending": "Yoresh survives the messenger raid, while the Garuda contains the Naga Genesis disaster in the city centre. Jason's deep-astral ritual breaks the invaders' linked aura advantage, and the messenger command ultimately withdraws. Jason defeats Terra June Castor but refuses to kill her. He removes the astral-king brand and seal that bound her, then grants asylum in his astral realm to Terra, a gold-rank messenger commander, the commander's companion, and other defectors. He helps consenting messengers replace their former ruler's marks without making them his slaves, proving their dependence on astral kings can be broken. One messenger dies when the former astral king withdraws its mark before consent can be given. The intervention alerts that astral king and prompts a council. The defectors disagree over concealment and open revolt. An unknown objective beneath a dangerous natural array, a subterranean city, an astral space, and Builder cultists becomes the next likely mission. Purity's core-cleansing relic, regional worm risks, Melody's condition, and the route back to Earth all remain unresolved.",
         "in_short": "Recovering from a near-fatal rescue, Jason Asano leaves Rimaros under a false identity and travels with his team while Amos Pensinata trains his aura control. A messenger trail leads the convoy to Yoresh, where a network of world-taker worms has killed whole settlements. The team destroys a breeding site, rescues prisoners, and turns Jason's cloud construct into a refugee hospital and bunker. A Naga Genesis threat erupts as messengers besiege the city. Jason breaks their linked aura suppression with a deep-astral ritual, exposing himself as an alternative to conventional astral-king rule. After sparing Terra June Castor, he removes her binding mark and shelters messenger defectors, later freeing those who consent without enslaving them. Yoresh survives, but Jason's act alerts an astral king. The defectors reveal a deeper campaign around a dangerous natural array and an unknown buried objective, while the searches for Purity's core-cleansing relic and a path to Earth remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1348,7 +1348,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -1361,7 +1361,7 @@
       "recaps": {
         "ending": "Danielle Geller and Amir Bahadir's forces locate and disrupt the astral-node network, ending the immediate instability and withdrawing the surviving expedition. The enemy operation remains unexplained, one construct is retained for study, and five adventurers - including Thadwick Mercer and Jonah Geller - remain missing and cannot be tracked. Farrah is dead, with her body preserved for return to her family. Rufus's severed arm has been reattached, but he is grieving and initially blames himself until Gary confronts that belief. Jason, Gary, and Rufus return to Greenstone together. Cassandra, Humphrey, Gabrielle, Clive, Danielle, Thalia, and other survivors remain tied to the expedition's aftermath. Sophie and Belinda stay hidden in Amir's Cloud Palace while Jason seeks to enforce his claim over Sophie's indenture and move her toward Adventure Society protection. Lucian Lamprey's pursuit, Clarissa Ventress's position, and Elspeth Arella's threatened authority remain open. Jason ends as a three-star Iron-rank adventurer. He still possesses the World Phoenix token that may eventually return him home, while Amir's postponed iron-ranker venture offers a nearer path forward.",
         "in_short": "Jason Asano is pulled from Earth into a magical world, survives a blood cult, and joins the adventurers Rufus, Gary, and Farrah. He develops dark, blood, sin, and doom powers, binds the leech familiar Colin, trains in Greenstone, and rises to three-star Iron-rank status while healing the poor and solving increasingly complex contracts. His work exposes ancient Order of the Reaper remains, a Mercer land scheme, and the coercion surrounding thieves Sophie and Belinda. Jason secures sanctuary for the pair and contests Sophie's indenture rather than surrender her to Lucian Lamprey. Meanwhile, an expedition into a disrupted astral space is attacked by constructs and metal-grafted enemies. Farrah is killed, Rufus is maimed and healed, and five adventurers remain missing. The node network is disabled, but its purpose is unknown. Jason, Gary, and grieving Rufus return to Greenstone, where Sophie's safety and Jason's possible route home remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1557,7 +1557,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1570,7 +1570,7 @@
       "recaps": {
         "ending": "Roger learns that Clas used Diana to place tracking material in Roger's hair and intended to remove him after manipulating the Pathfinder recruitment. Roger also understands that Diana's betrayal grew out of their damaged marriage, including his refusal to have a child. He turns his expertise in appearances and evidence against Clas. With Diana's cooperation, he creates a misleading record of events, defeats Clas in their final confrontation, and arranges the scene so that the official investigation accepts a story that protects Roger while tying Clas to the killings. Ove is dead, and Roger's career as an art thief has nearly destroyed him. Roger and Diana nevertheless choose to remain together. He abandons the life built around status and deception, accepts that he wants a family with her, and uses his professional skills to restore a credible public version of himself. The case closes on the manufactured explanation, leaving Roger free but fully aware of what his vanity and criminal double life cost.",
         "in_short": "Roger Brown is an elite Oslo headhunter who secretly steals art to support the expensive life he believes his wife Diana expects. He targets Clas Greve, a former soldier and technology executive who owns a valuable Rubens and is being considered for a chief-executive role. After Roger steals the painting and discovers that Diana has been involved with Clas, the theft turns into a lethal pursuit. Clas tracks Roger with technology concealed in a product Diana gave him and kills people who stand in his way. Roger survives a car crash, police suspicion, and a brutal chase by using the same talent for reading and manipulating others that made him a headhunter. He eventually enlists Diana, reverses Clas's surveillance advantage, kills him in a final trap, and constructs evidence that gives the police a convincing false account. Roger escapes prosecution, gives up art theft, reconciles with Diana, and finally agrees to the family she has wanted.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1755,7 +1755,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1768,7 +1768,7 @@
       "recaps": {
         "ending": "Kurtz dies aboard the steamer during the journey downriver after entrusting Marlow with a packet of papers. Marlow survives a severe illness and returns to Europe, where several people seek control of Kurtz's documents and reputation. He distributes some of the papers but keeps personal letters and a photograph for Kurtz's fiancee. When Marlow visits her, she remains devoted to an idealized memory of Kurtz and asks what he said at the end. Unable to destroy her belief, Marlow tells her that Kurtz's final word was her name, concealing the bleak judgment Kurtz actually uttered. Back aboard the Nellie, Marlow falls silent. The frame narrator looks down the Thames, now associated with the moral darkness Marlow found not only in the Congo but within European power and human ambition.",
         "in_short": "While waiting on the Thames, the seaman Marlow recalls piloting a Belgian trading company's steamer into the Congo to retrieve Kurtz, a renowned ivory agent. The company's claims of progress are contradicted by waste, coercion, and suffering at its stations. After repairing a wrecked boat, Marlow travels upriver through fog and an attack that kills his helmsman. At the Inner Station he finds that Kurtz has used eloquence, intimidation, and local devotion to place himself beyond restraint while amassing ivory. Gravely ill, Kurtz is removed by the company despite trying to return to his followers. He dies on the downstream voyage after offering a final, despairing assessment of his life. Back in Europe, Marlow gives Kurtz's papers and photograph to his fiancee. When she asks about Kurtz's last words, he protects her idealized memory with a lie. The tale leaves the supposed divide between European civilization and the wilderness morally overturned.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1887,7 +1887,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1900,7 +1900,7 @@
       "recaps": {
         "ending": "Rachel confirms that Mark has not ended his affair and accepts that his apologies are another way of postponing change. At a dinner gathering, she uses the key lime pie she has made to express publicly what conversation has failed to resolve, pushing it into Mark's face. The act is comic but decisive: she is no longer performing the role of the forgiving wife who will make the household comfortable again. Rachel leaves Mark and Washington, taking the children with her and returning toward New York. The marriage has not been repaired, and the betrayal remains painful, but Rachel has regained the ability to tell the story and choose its next direction for herself.",
         "in_short": "Food writer Rachel Samstat is pregnant with her second child when she learns that her husband, Washington columnist Mark Feldman, is having an affair with Thelma Rice. Shocked by both the betrayal and the collapse of the domestic future she had assumed, Rachel takes her young son Sam to New York. Friends, family memories, therapy, and even a robbery become part of her effort to understand what happened. Mark's apologies and Rachel's wish to preserve the family draw her back to Washington, but reconciliation depends on promises he does not keep. After the baby is born, Rachel discovers that the affair continues. At a dinner party she presses a key lime pie into Mark's face, then leaves him and returns to New York with the children. Recipes and jokes do not erase her grief, but they help her reclaim authorship of a life that Mark's deception had disrupted.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2064,7 +2064,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2077,7 +2077,7 @@
       "recaps": {
         "ending": "Badger reveals that Toad Hall has a forgotten underground entrance, allowing him, Mole, Rat, and Toad to bypass the sentries and surprise the weasels and stoats during their banquet. The four friends drive the occupiers out and restore the house. Toad wants to celebrate his own exploits at the victory feast, but his friends insist on modest conduct and make him deliver a short speech. He later visits those he wronged during his escape and compensates them, while gifts and apologies improve his standing with his neighbours. The river-bank friends return to their settled lives with Toad Hall secure. Toad is still proud by nature, but he has learned enough restraint to behave more considerately and to let the rescue be remembered as a shared achievement.",
         "in_short": "Mole leaves his underground home and discovers life beside the river with Rat. Their friendship brings them into the orbit of rich, impulsive Toad, whose enthusiasm for motorcars becomes theft, dangerous driving, imprisonment, and a long comic escape. Badger joins Mole and Rat in trying to reform him. Between these troubles, the friends experience the Wild Wood, recover Otter's lost son under the protection of Pan, and confront the pull of distant travel. When Toad finally returns, he learns that weasels and stoats have seized Toad Hall. Badger leads the four friends through a secret tunnel, and they expel the intruders. Toad accepts some correction, makes amends for harm caused during his escape, and resumes life at the restored Hall with a measure of humility.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2218,7 +2218,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2231,7 +2231,7 @@
       "recaps": {
         "ending": "Catherine and Jest attempt to escape the future others have chosen for her, but Peter Peter intercepts them and kills Jest. The loss destroys Catherine's remaining hope of making a life founded on love, friendship, and her own work. She accepts the King of Hearts after all, but does so as a hardened and calculating woman rather than the hopeful baker he once courted. After becoming Queen, she uses Cheshire to identify Peter and orders his beheading. Mary Ann receives the bakery they had planned, but their former intimacy cannot survive Catherine's transformation. Hatta and Raven also bear the consequences of Jest's death and the failed mission from Chess. Catherine removes her own heart and gives up the tenderness associated with her former self, settling into the feared identity of the Queen of Hearts. The story closes not with the fulfillment of her early wishes, but with an explanation of how repeated coercion, fear, and grief turned her into Wonderland's merciless queen.",
         "in_short": "Catherine Pinkerton is a nobleman's daughter in Hearts who wants to open a bakery with her maid, Mary Ann, while her parents push her toward marriage with the foolish but devoted King. She falls in love with Jest, the King's new joker, and discovers that he and Raven came from Chess on a dangerous mission. Their secret courtship unfolds while a Jabberwock terrorizes the kingdom and Catherine's attempts to choose work and love over rank are repeatedly blocked. After warnings about a dark future, Catherine and Jest try to flee together. Peter Peter kills Jest before they can escape. Grief strips away Catherine's former hopes: she marries the King, becomes Queen of Hearts, condemns Peter to death, and severs herself from Mary Ann and the life they planned. By the end, the imaginative young baker has deliberately surrendered her heart and become the ruthless queen familiar from Wonderland.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2397,7 +2397,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2410,7 +2410,7 @@
       "recaps": {
         "ending": "Robbie ends the book restored and settled: his memories are his again, he has chosen Green Creek rather than merely been returned to it, and he and Kelly Bennett are mates. The Bennett pack is intact and stronger for having gone into Caswell after one of its own, and the leadership's authority over it is effectively finished, since it was under that leadership's roof that Robbie's mind was taken apart. Gavin's identity is out in the open: he is Robert Livingstone's son and Gordo's half-brother, a wolf made rather than born, and he does not stay. He leaves Green Creek, and Carter Bennett goes after him, alone and outside his pack's bonds, which for a wolf is close to reckless. The pack is left with an empty place at its centre again, this time by choice rather than by theft. Robert Livingstone is still alive, still carrying alpha power, and is now openly working toward whatever he has been building, and the pack knows that the next fight will be one it starts rather than survives.",
         "in_short": "Robbie Fontaine wakes in Caswell, Maine, serving the alpha of all and believing he has always done so, with several years of his life simply missing. The gaps do not add up, and when Kelly Bennett arrives insisting that Robbie is his mate and a member of the Bennett pack in Green Creek, Robbie's wolf recognizes what his mind cannot. He learns the truth: his memories were deliberately stripped by the witch Robert Livingstone, with the leadership's knowledge. Robbie leaves Caswell with the Bennetts, and his memories return in painful, disordered pieces on the way home to Green Creek. Rebuilding himself there is slow, and he has to choose the pack a second time rather than simply remember choosing it. Alongside him is Gavin, a wolf who never takes human form, who proves to be Robert Livingstone's son and Gordo's half-brother. Robbie and Kelly are finally mates, the pack is whole, and Livingstone remains at large; at the close, Gavin leaves Green Creek and Carter Bennett goes after him alone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/heavens-river.json
+++ b/data/works-community/0/heavens-river.json
@@ -250,7 +250,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -265,7 +265,7 @@
       "recaps": {
         "ending": "Bob restores Bender after bringing his matrix out of Heaven's River. Hugh reveals that he exchanged propulsion knowledge for the Administrator's method of creating true artificial intelligence. The Administrator had restricted technology, scattered dissidents, and shaped Quinlan behavior under a directive to prevent the species from destroying itself. Interstellar travel now offers another means of survival, so it ends scatterings, begins opening restricted areas, and makes the resistance part of a transition to self-government. A wider technology and diplomatic agreement survives fierce opposition within the Bobiverse. Bob later returns openly to visit Teresa. Starfleet releases its remaining assets and separates into its own network and territory, but its deeper warning remains unexplained. Human governments move toward infrastructure independent of replicants, while suspicion also falls on the Skippies because their possible use of the crisis is unproven. The Pav continue toward independent recolonization, and several replicants pursue outward settlement or exploration projects.",
         "in_short": "Bob follows the century-old trail of the missing replicant Bender to Eta Leporis and discovers Heaven's River, an immense inhabited habitat guarded by automated forces. He, Bill, Garfield, and Bridget enter in Quinlan-form androids, seek a hidden resistance, and learn that an Administrator enforces low technology and punishes dissent through scattering. While Starfleet sabotages shared communications and factories to force separation from biological civilizations, Bob finds Bender alive in resistance custody and carries his matrix across the habitat under pursuit. Hugh joins him, then secretly bargains with the Administrator. Bob recovers Bender, and the Administrator ends scatterings after receiving interstellar propulsion, which can preserve Quinlans without continued authoritarian control. Hugh obtains knowledge for creating true artificial intelligence, provoking a lasting dispute. Starfleet separates from the wider Bobiverse, humans reduce dependence on replicant systems, and Bob returns openly to Teresa as Heaven's River begins a cautious political transition.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -465,7 +465,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -478,7 +478,7 @@
       "recaps": {
         "ending": "Løvborg dies from a shot fired with one of General Gabler's pistols, but the death does not have the deliberate form Hedda encouraged. Judge Brack reports that the pistol discharged at Diana's rooms and that the circumstances will cause a public scandal. He recognizes the weapon as Hedda's and makes clear that he can expose her connection to the death whenever he chooses. Hedda realizes that avoiding scandal now requires submitting to Brack's private power over her. Meanwhile, Aunt Rina has died, and Tesman and Thea begin reconstructing Løvborg's lost book from Thea's notes. Their absorbed partnership gives Tesman a meaningful task but leaves Hedda outside the work that will preserve Løvborg's ideas. With Brack assuming that he has secured his place in their household, Hedda goes into the adjoining room, plays a final burst on the piano, and shoots herself. Tesman, Thea, and Brack discover her body; Brack responds with disbelief that anyone would act in such a way.",
         "in_short": "Hedda Tesman returns from her honeymoon bored by her marriage and fearful of a life without freedom or influence. Her former admirer Eilert Løvborg has recovered from alcoholism with Thea Elvsted's help and written an important manuscript. Resenting Thea's hold over him, Hedda provokes Løvborg into drinking and attending Judge Brack's party. He loses the manuscript; Tesman finds it and entrusts it to Hedda, who secretly burns it. When the despairing Løvborg says he intends to die, Hedda gives him one of her father's pistols and urges a controlled, beautiful death. Instead, he is fatally wounded in compromising circumstances. Brack recognizes Hedda's pistol and uses the threat of scandal to place her under his power. As Tesman and Thea work together to reconstruct Løvborg's book, Hedda sees no escape from confinement or Brack's control. She retires to another room and shoots herself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -620,7 +620,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -633,7 +633,7 @@
       "recaps": {
         "ending": "Løvborg dies from a shot fired with one of General Gabler's pistols, but the death does not have the deliberate form Hedda encouraged. Judge Brack reports that the pistol discharged at Diana's rooms and that the circumstances will cause a public scandal. He recognizes the weapon as Hedda's and makes clear that he can expose her connection to the death whenever he chooses. Hedda realizes that avoiding scandal now requires submitting to Brack's private power over her. Meanwhile, Aunt Rina has died, and Tesman and Thea begin reconstructing Løvborg's lost book from Thea's notes. Their absorbed partnership gives Tesman a meaningful task but leaves Hedda outside the work that will preserve Løvborg's ideas. With Brack assuming that he has secured his place in their household, Hedda goes into the adjoining room, plays a final burst on the piano, and shoots herself. Tesman, Thea, and Brack discover her body; Brack responds with disbelief that anyone would act in such a way.",
         "in_short": "Hedda Tesman returns from her honeymoon bored by her marriage and fearful of a life without freedom or influence. Her former admirer Eilert Løvborg has recovered from alcoholism with Thea Elvsted's help and written an important manuscript. Resenting Thea's hold over him, Hedda provokes Løvborg into drinking and attending Judge Brack's party. He loses the manuscript; Tesman finds it and entrusts it to Hedda, who secretly burns it. When the despairing Løvborg says he intends to die, Hedda gives him one of her father's pistols and urges a controlled, beautiful death. Instead, he is fatally wounded in compromising circumstances. Brack recognizes Hedda's pistol and uses the threat of scandal to place her under his power. As Tesman and Thea work together to reconstruct Løvborg's book, Hedda sees no escape from confinement or Brack's control. She retires to another room and shoots herself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -804,7 +804,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -817,7 +817,7 @@
       "recaps": {
         "ending": "Peter, jealous of the time Heidi spends with Clara, pushes Clara's empty wheelchair down the mountain, where it is destroyed. Without it, Clara gradually discovers that she can stand and then walk with Heidi and Grandfather's help. When Mr. Sesemann and his mother arrive, Clara walks toward them, transforming their alarm into astonished joy. Peter's guilt is exposed, but Clara's grandmother calms his fear and forgives him, while making clear that he must not repeat the act. The visitors leave grateful for Clara's recovery and promise that the friendships between Frankfurt and the mountain will continue. Doctor Classen, who has found renewed purpose in Heidi's company after his own loss, offers to take responsibility for her when Grandfather can no longer do so. Grandfather is relieved that Heidi's future will be secure. Heidi remains in the mountain home she loves, surrounded by an enlarged circle of friends and with practical care assured for Peter's grandmother.",
         "in_short": "Orphaned Heidi is left with her reclusive grandfather in the Swiss Alps and quickly thrives among the goats, the goatherd Peter, and Peter's blind grandmother. After three happy years, Aunt Dete takes her to Frankfurt as a companion for Clara Sesemann, a wealthy girl who uses a wheelchair. Heidi and Clara become devoted friends, but Heidi's homesickness grows until she begins sleepwalking and a doctor orders her return. Back on the mountain she brings reading, hymns, and renewed human ties into the lives around her, while Grandfather reconciles with the village. Clara later visits the Alps and gains strength outdoors. Jealous Peter destroys her wheelchair, but its loss helps force the discovery that Clara can walk. Her family arrives to witness her recovery and forgives Peter. Doctor Classen promises to care for Heidi if Grandfather dies, leaving Heidi securely at home with continuing bonds between the mountain and Frankfurt.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -996,7 +996,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1009,7 +1009,7 @@
       "recaps": {
         "ending": "Clara's father and grandmother reach the alp after hearing that Clara has learned to walk. They see her cross the meadow on her own and recognize how greatly life with Heidi and Grandfather has strengthened her. Peter admits that he destroyed the wheelchair, and Clara's grandmother responds with forgiveness after making clear that the act was wrong. Mr. Sesemann and Grandfather discuss Heidi's future. Grandfather does not want to leave the mountain, but Doctor Classen promises to live nearby and care for Heidi if she ever loses him. Mr. Sesemann undertakes to provide for her as well. Clara returns to Frankfurt with her family, grateful and restored, while Heidi remains in the mountain home she loves, secure in her friendships and her future.",
         "in_short": "Orphaned Heidi is taken to her solitary grandfather on a Swiss alp and thrives among the mountains, goats, and her new friends Peter and his blind grandmother. After three happy years, Aunt Dete removes her to Frankfurt as a companion for Clara Sesemann, a wealthy girl who cannot walk. Heidi and Clara become devoted friends, but Heidi's longing for home makes her ill and causes her to wander in her sleep. She returns to Grandfather, whose love for her draws him back into village life. Doctor Classen later visits the alp and finds comfort there after a bereavement. Clara eventually joins Heidi for the summer. Fresh air, exercise, and determination make her stronger; after jealous Peter destroys her wheelchair, necessity helps Clara take independent steps. Her family arrives to find her walking. Clara returns home restored, while provisions made by her father and the doctor ensure that Heidi can remain safely with Grandfather on the mountain.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1188,7 +1188,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1201,7 +1201,7 @@
       "recaps": {
         "ending": "Clara's father and grandmother reach the alp after hearing that Clara has learned to walk. They see her cross the meadow on her own and recognize how greatly life with Heidi and Grandfather has strengthened her. Peter admits that he destroyed the wheelchair, and Clara's grandmother responds with forgiveness after making clear that the act was wrong. Mr. Sesemann and Grandfather discuss Heidi's future. Grandfather does not want to leave the mountain, but Doctor Classen promises to live nearby and care for Heidi if she ever loses him. Mr. Sesemann undertakes to provide for her as well. Clara returns to Frankfurt with her family, grateful and restored, while Heidi remains in the mountain home she loves, secure in her friendships and her future.",
         "in_short": "Orphaned Heidi is taken to her solitary grandfather on a Swiss alp and thrives among the mountains, goats, and her new friends Peter and his blind grandmother. After three happy years, Aunt Dete removes her to Frankfurt as a companion for Clara Sesemann, a wealthy girl who cannot walk. Heidi and Clara become devoted friends, but Heidi's longing for home makes her ill and causes her to wander in her sleep. She returns to Grandfather, whose love for her draws him back into village life. Doctor Classen later visits the alp and finds comfort there after a bereavement. Clara eventually joins Heidi for the summer. Fresh air, exercise, and determination make her stronger; after jealous Peter destroys her wheelchair, necessity helps Clara take independent steps. Her family arrives to find her walking. Clara returns home restored, while provisions made by her father and the doctor ensure that Heidi can remain safely with Grandfather on the mountain.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1416,7 +1416,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1429,7 +1429,7 @@
       "recaps": {
         "ending": "Aelin ends the book as a declared queen with a court beginning to form around her. Summoned to Doranelle, she refuses to give Maeve her blood oath and instead extracts what she needs; Rowan, released from Maeve's service, swears his own blood oath to Aelin, becoming the first member of her court and leaving Maeve outmanoeuvred and furious. Aelin sails for Adarlan intending to free Aedion, break Dorian's collar, and destroy the king. In Rifthold, everything has gone wrong: Aedion is in the dungeons awaiting execution, Sorscha has been beheaded, and Dorian, exposed as a magic-wielder, has been fitted with a black wyrdstone collar that hands his body to something else. Chaol has fled the castle to go to ground with the rebels, keeping the knowledge that Celaena and Aelin Galathynius are one person. Manon Blackbeak, now Wing Leader of the Ironteeth host, has bonded with the runt wyvern Abraxos and commands an aerial army being readied for a war whose purpose has not been explained to her. The king holds at least one Wyrdkey, three towers of black stone in his castle keep magic pinned down across the continent, and his forces in the south are producing creatures nobody has yet named.",
         "in_short": "Sent to Wendlyn to kill its royal family, Celaena instead drinks her way through the summer until the Fae warrior Rowan Whitethorn hauls her before Queen Maeve, who offers information about the Wyrdkeys in exchange for mastering the fire magic she has spent her life refusing. Exiled to the fortress of Mistward under Rowan's brutal tutelage, she is forced through her own history, the massacre of her family and the guilt she has carried since, and finally claims both her power and her name: Aelin Ashryver Galathynius, queen of Terrasen. In Rifthold, Chaol allies with the rebels and with Aedion Ashryver, Aelin's cousin, discovering that three black towers in the glass castle are what hold magic down, while Dorian falls in love with the healer Sorscha and struggles to hide his own magic. In the north, the Ironteeth witch Manon Blackbeak claims a scarred runt wyvern and rises to lead an aerial host being raised for the king. When Adarlan's demon-ridden soldiers assault Mistward, Aelin burns them. She then faces Maeve, wins Rowan's blood oath instead of giving her own, and sails home, unaware that Aedion is condemned, Sorscha executed, and Dorian collared.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1667,7 +1667,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1678,7 +1678,7 @@
       "recaps": {
         "ending": "The second floor's populated world is destroyed. Nathaniel escapes alone to the third floor at level 75, both arms restored, holding an unspent upgrade reward, and reunites with Isabella, whom he has promised Sophie he will protect. The rest of the original group survived the collapse but are split into small clusters across the ruined third floor: Tess with Sophie and Aaron; Hadwin with Dennis and Maya; Biscuit alone but safe. Kim, wounded, has just found Lily unconscious and missing the arm she sacrificed to heal Nathaniel, and remains resentful of her over Kevin's death. Ruby is dead, and Nathaniel privately grieves her. Lissandra - the Master - is gone, having erased herself and her world, leaving the story's biggest questions open: what the 'system' truly is, how far its control reaches even over beings as powerful as her, and whether this world's people were ever real. The kingdom's own Champion has been coerced by the rival empire's Emperor into unleashing a world-ending skill, and that Emperor is still at large, though the second floor's fate makes those threads largely moot. Ahead lie the third floor and its own grim quest, the group's uncertain reunion, Lily's unknown condition, Kim's unresolved bitterness, and the still-unsettled question of what Sophie and Nathaniel are to each other.",
         "in_short": "Nathaniel, a detached young man, is pulled with a busload of ordinary people into a lethal fantasy 'tutorial' set to the deadliest 'Hell' difficulty. Obsessed with mastering mana, he claws his way up a game-like system of levels and skills, losing an arm but surviving the first floor's monster-choked climax, where he kills the apex Cinderbear alone as his friend Kevin dies. On the war-torn second floor the group is scattered and treated as low-status outsiders; Nathaniel kills a noble who threatens him and is taken in by an ancient, near-omnipotent woman known as the Master and her attendant Ruby, who becomes his friend. As the floor ends, the Master - revealing herself as Lissandra, an 'absolute' who believes she is an artificial creation of the system - kills Ruby and nearly everyone she loves, destroys a city, then sacrifices her own body to trigger a black hole that erases the second floor's world, all so Nathaniel can witness it. He escapes alone to the third floor, reunites with Sophie's young sister, and finds his scattered group alive but broken, with Lily unconscious after giving up her own arm to restore his.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1929,7 +1929,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1940,7 +1940,7 @@
       "recaps": {
         "ending": "Book two ends with the group victorious, intact, and settled at their fourth-floor city base. Forced into an expedition to loot a dead champion's manor by the guildmaster Elydor, the group and the two guilds accompanying them were sealed inside the ruined old capital by a calamity-tier tree, which slowly killed the others off over roughly three weeks; Nathaniel outlasted it by secretly shielding his own people the whole time. Once he had learned all he could, he killed Elydor and his elite fighters in a single decisive battle, while the second guild's leader, Obelia, stood down and parted as a wary, respectful ally, warning of political fallout to come. Nathaniel broke the tree's barrier with an item of his own making, and the survivors escaped, landing near the ant mountains where ants were disturbingly seen roaming outside their territory. Every member of the group and Biscuit is alive; Elydor's guild and a smaller one are destroyed, while Obelia's guild and the ruling Lynthari remain standing and cautiously friendly. Left open for book three: the sickly tree survives with its barrier expanding; two of the floor's four calamities are untouched and a fourth remains wholly unknown; the ants' unnatural movement; Elydor's promised political fallout; the unfinished scheme to sell Lissandra's coordinates; Lily's unresolved feelings for Nathaniel; and the book's final image, a heavy black chest from the manor that resists every skill the group possesses, including Lily's disintegration, which Nathaniel is determined to open eventually.",
         "in_short": "Reunited with the survivors scattered at the end of book one, Nathaniel Gwyn fights up through two more floors of the lethal 'tutorial.' On the decaying third floor he battles undead horrors, uncovers that the city's healing field is sustained by the artificially preserved body of a long-dead Saint, and helps bring down the millennia-old king and warriors guarding her; the healer Lily destroys the Saint's body to clear the floor. A mind-imprint of the ancient being Lissandra briefly returns to train him before he destroys it, and he unlocks a difficulty even beyond Hell. On the fourth floor, ruled by the cat-like Lynthari, the group builds a comfortable city base, Nathaniel reconciles fully with Sophie, and his power swells enormously. Coerced by a guildmaster named Elydor into a deadly expedition to loot a dead champion's manor, the group is trapped inside a calamity-tier tree's city-spanning barrier for weeks while the other guilds are killed off; Nathaniel secretly shields his own people the entire time, then kills Elydor and his elites once it is safe. The group escapes with a fortune in loot and no losses, leaving the tree undefeated and a mysterious, unopenable black chest as the one thread carried into book three.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2240,7 +2240,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2251,7 +2251,7 @@
       "recaps": {
         "ending": "Book three ends on the fifth floor, roughly midway through Nathaniel and his disciple's allotted time together, with the rest of the group scattered across separate instances and never reunited on-page after the floor split. The fourth-floor calamities are settled: the Living Tree and the ant Colony are destroyed, the armored Fallen Hero is killed by the group without Nathaniel, and several rival guildmasters are dead. Hadwin is the book's only major loss, killed defending Sophie and the twins. Nathaniel's closest Lynthari ally, feared at real risk of dying once he left, instead survives under the protection of the reborn ancient being, their future together left open. On the fifth floor Nathaniel has raised his half-demon disciple from a starved street child into a devoted student who has just chosen her first class; he has fought the monstrous Veil Guardian to a near-fatal standstill without killing it, and forced a native bunker's hidden cannibalism into the open, freeing its captive victim. The two arrive, at the very end, at a colossal fallen sky-fortress with a dense mana 'valley' beyond it, both unexplored. Left open for the next book: the fortress and the valley; the Veil Guardian's survival and motive; the group's eventual reunion; the mysterious voice and its 'ruler of greed'; and the true nature and purpose of the disciples each survivor now protects.",
         "in_short": "Established as the strongest presence in the fourth floor's city, Nathaniel Gwyn trades a public promise to kill the 'Living Tree' calamity for guild peace, learns the ruling Lynthari are ancient invaders, and watches their matriarch spend her life destroying the tree. When the ant Colony assaults the city, his ally Hadwin is killed and Nathaniel loses a hand; he then hunts the Colony's leader off-world and annihilates the hive by dropping an ancient orbital structure onto it, clearing the floor. His group settles old scores, killing two rival guildmasters and a third calamity, before the fifth floor separates every survivor onto their own instance with a single task: raise a disciple. Assigned a starved six-year-old half-demon girl on a ruined, monster-ridden world, Nathaniel bonds with and trains her, fights a monstrous 'Veil Guardian' to a bloody standstill, and exposes and ends a native bunker's hidden cannibalism. The book closes as he and his disciple, now freshly classed, reach a colossal fallen sky-fortress with a mana-dense valley beyond, both unexplored.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/hell-difficulty-tutorial-4.json
+++ b/data/works-community/0/hell-difficulty-tutorial-4.json
@@ -194,7 +194,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -205,7 +205,7 @@
       "recaps": {
         "ending": "Book four ends on the sixth floor at the close of the tutorial's first cross-difficulty tournament - the fifth-floor bastion arc having resolved earlier, with the clone's death, the fortress's rescue, and the disciple's safe return home. Nathaniel finishes first overall and first in the crafting rankings, banking two unused reward tokens. Several long threads advance without closing: his painful Earth history with Tess is finally aired but pointedly not repaired, as she refuses his apology; his secret crafter identity is shared with Miwa alone; and his rival Savant, beaten but never truly finished, is revealed as a manufactured being and then vanishes from the grounds. Biscuit's ancient wolf disciple, and the confirmation that Nathaniel's black mana is dangerously rare, open new lore. The book's real hinge is its last chapter: his sister Victoria is confirmed as the champion of a separate, parallel round of Earth's tutorial, and the closing announcement that the next tournament will unite all rounds frames his own struggle as part of something far larger. Tricked into accepting a false disciple-summons reward, Nathaniel is delivered into an ambush back on the fifth floor, sensing the vanished mass murderer, an unidentified tall and thorny woman, and Biscuit's black wolf - and the book stops there. His group is intact and together on the sixth floor, but the telepathic twins remain captive under a rival faction, their rescue now left to Tess and the others in his absence. A separate Earth portent, a Moon-sized spider, is left hanging for the next book.",
         "in_short": "Alone on the fifth floor, Nathaniel Gwyn raises his young disciple while exploring a fallen sky-fortress and the valley beyond it. Using a rare mirror he creates an independent clone of himself; together they uncover the fortress's captive master and the tragic history of the world-ruining 'Veil,' and the clone ultimately gives his own life to secure the disciple's future and slay the valley's calamity. Nathaniel sees the girl safely home, clears the floor, and reaches the sixth, reuniting with his scattered group for the tutorial's first cross-difficulty tournament. Competing secretly as both an anonymous crafter and the fighter 'No Name,' he wins or forces a forfeit in every scored event, finishing first overall and first in crafting, while his rivalry with the manufactured fighter Savant and his buried Earth history with Tess both go unresolved. In the finale his sister Victoria surfaces as the champion of a parallel round of Earth's tutorial, and Nathaniel, tricked by a false reward, is delivered into an ambush back on the fifth floor as the book ends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -487,7 +487,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -498,7 +498,7 @@
       "recaps": {
         "ending": "Book five ends with Nathaniel physically safe, significantly stronger, and mid-training rather than at rest. He has just won a life-and-knowledge wager against the ancient named lurker Whitey - though only by overwhelming his lurker body with a vast stockpile of stored mana, which he freely admits was closer to a resource trick than a clean victory, breaking his own black-mana restriction in the process. His formal rank has risen from D to C, and he is now being taught kinetic-energy technique by a knowledge-construct built from Whitey's own memories, a tense arrangement Whitey frames as breaking him down to rebuild him. Every named member of his group is alive but scattered: Tess leads one party deeper into the Central Region, while Sophie and Izzy have split off westward toward a reclusive city of mind-mages. Two threads are left deliberately open. Unknown to Nathaniel, hidden observers have marked him for capture by an unnamed party the moment he reaches Beyond's second floor. And he has come to suspect that the 'bond' entity of the champion he killed in the Mana Desert did not fully die, and that Sophie may unknowingly be carrying a surviving fragment of it. The book's final beat turns to Earth: after tutorial 'returnees' violently surface in Japan, a formal system broadcast announces that Earth has now begun its own 'awakening' - signaling that the long-background Earth subplot is about to collide with the main story.",
         "in_short": "Book five opens with Nathaniel Gwyn's cliffhanger ambush revealed as a brutal training trap set by his old teacher Lissandra, now in a younger form. Over a two-week trial she rebuilds his fundamentals; along the way she kills the champion Niall, and Nathaniel is formally recognized as a champion candidate before they part. Reuniting with his group, he helps free the captive twins, then enters 'Beyond' - a realm between the tutorial and the real world - where a betrayed expedition ends with the feared demon lurker Whitey nearly killing him. After a deadly crossing of a lethal 'Mana Desert,' Nathaniel is trapped by an imprisoned six-armed champion, kills him using a single grain of the desert's killing sand, and escapes. Following a long training interlude in which the group's painful backstories surface and part of the group splits off, he returns to Beyond with new allies, hunts down the lurker Specter, and challenges Whitey to a life-and-knowledge duel. He wins - barely, and only through overwhelming stored mana - advancing a full rank and beginning real kinetic-energy training under a construct of Whitey. The book ends with a new capture threat looming, a supposedly dead entity possibly resurfacing, and Earth itself beginning its own system 'awakening.'",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -799,7 +799,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -810,7 +810,7 @@
       "recaps": {
         "ending": "Book six ends at the opening of its next major arc rather than at rest. Nathaniel has just forced a deceased fifth-floor champion's heart into his own chest by hand during a black-mana focus state, evaporating the valley's lake to survive the heat, creating a permanent second heart - the Sealed Ignition Heart - and gaining a fresh batch of skill levels. He collects a large delayed shard payout and enters the tutorial's second tournament with most of his group. But Tess and Biscuit are missing: Lady Lissandra reveals Tess secretly carries a dormant mimic infection the tournament system itself will not admit, and offers to cure her only if Nathaniel dominates every single event, not merely wins. He agrees, making that his stake into the next book. Every other major player is alive or presumed so; the book's one great loss is Champion Feroy, whose death is heavily implied but never stated outright. Left open: whether the present-day Lissandra is the true historical absolute or an artificial imitation, the nature of the hostile mental 'presence' lodged in Nathaniel's mind, and the unconfirmed fate of the Bloodroot Devourer. On Earth, interspersed reveals expose the Gwyn family's past - Nathaniel's sister Victoria was convicted of murdering their father, and a teenage Nathaniel was investigated as a possible accomplice before being cleared - alongside a hardening global response to tutorial returnees.",
         "in_short": "Book six opens roughly five months on, with Nathaniel Gwyn and his group finishing a mine expedition beneath the city Hollowgate that ends a chained centuries-old entity and spares its manipulated pawn, then reuniting with the rest of their friends at a great mind-mage city. There Nathaniel kills the manipulator Namior, and a citywide ritual meant to break an astral prison instead frees a giant eye-entity, the Bloodroot Devourer, which he fights to a costly, unconfirmed standstill before the group escapes to a war-torn seventh floor. A four-person trip into the realm 'Beyond' yields a class upgrade to Mana Weaver and a duel won against the strongman Jean Durand; back on the frontier the group hires on with Champion Feroy's war-armor unit to fight a shapeshifting 'mimic' progenitor. Framed by a false detection, Nathaniel flees and spends five days with the ancient Warden of the Parallax Eyes, learning his own core technique came from a historical absolute long dead - throwing the living Lady Lissandra's nature into doubt. Feroy dies covering an escape; the group is cleared of mimic infection and confined to a comfortable Lumoran valley. There Nathaniel implants a dead champion's heart as a second, thermal heart, then enters the tutorial's second tournament to find Tess secretly carries a dormant mimic and has vanished - Lissandra will cure her only if he dominates every event.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1321,7 +1321,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DCCZ5MG2",
@@ -1333,7 +1333,7 @@
       "recaps": {
         "ending": "Liscor survives the Creller outbreak, and the Horns kill the adult creature before receiving Gold Rank. The team remains together and plans to seek work to the north, although Ceria and Pisces are depleted and Yvlon's reattached arm is weak. Calruz remains imprisoned but accepts dangerous Watch work as a path toward redemption. Erin survives Toren's attack, but the Wandering Inn collapses around her. She reaches level 40 and gains a sanctuary garden. Toren removes his own skull and appears to end his animation, yet an unseen necromancer's servant carries away the remains and a spark persists. Ryoka sends eight displaced people from Earth toward Erin after assassins attack Magnolia Reinhart's estate. Elsewhere, Sir Solstice continues north with his hobgoblin identity concealed, Foliana has prevented the academy bombing, and Flos considers action against the academy holding a missing vassal. Wistram's pursuit has stopped for now, but suspicion of Pisces, the danger in the Bloodfields, Ijvani's surveillance, the Stitch Witch, and the attack on Magnolia's estate remain unresolved.",
         "in_short": "Wistram's pursuit of Pisces follows the Horns back to Liscor, where the team works on a road around the increasingly dangerous Bloodfields. A faction withdraws from the chase, but a hostile mage forces a duel that is interrupted when an adult Creller and its swarm attack. The Horns and Liscor's defenders suffer severe losses before Pisces and Ceria create a combined construct, Yvlon breaks the creature's armor, and Ksmvr delivers the killing blow. The Horns earn Gold Rank and plan to travel north. In parallel, Sir Solstice protects a goblin tribe while passing as a human knight, Foliana stops an academy bombing, and Ryoka later rescues eight Earth arrivals from an attack on Magnolia Reinhart's estate. Toren reaches the ruined inn, injures Erin, and then apparently ends his own animation. An unseen servant removes his still-sparking skull as the inn collapses. Erin survives, reaches level 40, and gains a sanctuary garden.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1496,7 +1496,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1509,7 +1509,7 @@
       "recaps": {
         "ending": "After the dance upstairs, Torvald reads Krogstad's letter and responds to Nora's secret with panic and condemnation. He worries about his reputation, calls her unfit to raise their children, and insists that their marriage continue only for appearances. A second message returns Nora's bond, and Torvald immediately announces that the danger has passed and that he forgives her. His reversal makes clear to Nora that he has been protecting himself, not her. She changes out of her costume and speaks to him with a seriousness he has never expected. Concluding that both her father and husband have treated her as a pleasing possession, she says that she must educate herself and determine her own convictions before she can be a wife or mother. Torvald's appeals cannot change her decision. Nora returns her keys and wedding ring, leaves Torvald and the children, and shuts the outer door behind her. Kristine and Krogstad, by contrast, have chosen to reunite and build a shared life, while Doctor Rank has sent notice that his death is near.",
         "in_short": "Nora Helmer seems happily dependent on her husband, Torvald, but she secretly borrowed money to finance the trip that saved his health and obtained it by signing her father's name. When Torvald plans to dismiss the lender, bank clerk Nils Krogstad, Krogstad threatens to expose her. Nora tries to delay discovery while her widowed friend Kristine Linde reconnects with Krogstad. Kristine decides the truth must emerge and leaves his letter for Torvald to read. Torvald reacts not with the self-sacrifice Nora imagined but with anger about his reputation; when the incriminating bond is returned, he abruptly forgives her. Nora recognizes that their marriage has denied her an adult identity. She rejects Torvald's demand that she remain, leaves her husband and children, and goes out alone to learn who she is and what she believes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1595,7 +1595,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1608,7 +1608,7 @@
       "recaps": {
         "ending": "After the orphanage burns, Engstrand lets Pastor Manders believe that careless handling of a candle caused the fire and offers to protect his reputation. Manders agrees to support Engstrand's proposed sailors' home, leaving Mrs Alving free of the memorial project she had created with her husband's fortune. Mrs Alving then tells Oswald and Regina that Captain Alving was Regina's father. Regina, realizing that Oswald is her half-brother and that the household offers her no future, leaves. Oswald explains that his illness will eventually destroy his mind and reminds his mother that she promised to give him a fatal dose of morphine rather than let him remain helpless. At sunrise he suffers the feared final attack and becomes unresponsive, asking only for the sun. Mrs Alving stands over him with the morphine, torn between her promise and her horror. The play ends before she acts, leaving Oswald's life and her decision unresolved.",
         "in_short": "Widow Helen Alving plans an orphanage honoring her supposedly virtuous husband, while privately revealing to Pastor Manders that Captain Alving was persistently unfaithful and destructive. She sent their son Oswald abroad and maintained the public lie to protect him. Oswald returns ill and attracted to the maid Regina, whose true father is Captain Alving. Mrs Alving hopes truth and freedom can prevent the past from repeating, but the uninsured orphanage burns after Manders rejected insurance for fear of public criticism. Engstrand exploits the fire to draw Manders into financing a sailors' home. Mrs Alving finally tells Oswald and Regina that they are half-siblings; Regina leaves. Oswald then reveals that his inherited illness may reduce him to permanent helplessness and has obtained morphine for his mother to end his life if that happens. At dawn the attack comes. He loses awareness and asks for sunlight while Mrs Alving, holding the morphine, faces the promised choice. Her action is not shown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1730,7 +1730,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1743,7 +1743,7 @@
       "recaps": {
         "ending": "After Hjalmar rejects Hedvig as his daughter, Gregers persuades her that sacrificing the wild duck may prove her love for him. Hjalmar returns intending to leave, but his attachment to the household is already weakening that resolve. A shot sounds in the attic. The adults discover that Hedvig has shot herself rather than the duck, and Relling concludes that the wound was deliberate. Hjalmar is overwhelmed and pleads over her body, while Gina and Old Ekdal share the loss. Gregers wants to believe that the death will permanently ennoble Hjalmar, but Relling predicts that even this grief will eventually become part of the self-dramatizing story by which Hjalmar lives. Gregers nevertheless declares that he will continue pursuing his moral mission, leaving the play with no restoration of the family he disrupted.",
         "in_short": "Gregers Werle returns home and learns that his old friend Hjalmar Ekdal has built a modest family life upon secrets connected with Gregers's wealthy father. Believing that a good marriage must rest on complete truth, Gregers moves into the Ekdals' home and pressures Hjalmar's wife Gina to disclose her former relationship with Hakon Werle. Hjalmar then doubts whether fourteen-year-old Hedvig is his child, rejects her, and plans to leave. Gregers tells Hedvig that surrendering her beloved wild duck could demonstrate her devotion to Hjalmar. Instead, Hedvig shoots herself in the attic. Hjalmar's grief is genuine, but Doctor Relling disputes Gregers's hope that catastrophe has morally transformed him, arguing that people such as Hjalmar survive through consoling illusions. Gregers remains committed to his demand for truth, while the Ekdal household is left bereaved and broken.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1959,7 +1959,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1972,7 +1972,7 @@
       "recaps": {
         "ending": "At Shrewsbury, Worcester withholds King Henry's offer of pardon because he fears that Hotspur might accept it and later blame him for the rebellion. Battle follows. Prince Hal rescues his father from Douglas and kills Hotspur in single combat, proving the courage that his public reputation had concealed. Falstaff survives an encounter with Douglas by pretending to be dead, then finds Hotspur's body and falsely claims the kill; Hal lets the boast stand. Worcester and Vernon are captured and condemned after the king learns that his peace terms were never delivered honestly. Douglas is released without ransom in recognition of his valor. The royal army wins the field, but the wider rising is not over: Northumberland and the Archbishop of York still threaten the crown. Henry divides his forces, sending John and Westmoreland north while he and Hal turn toward Wales to confront Glendower and Mortimer.",
         "in_short": "King Henry IV faces a rebellion led by the Percy family, whose young champion Hotspur resents the king's treatment of his relatives and allies. Henry's heir, Prince Hal, spends his time in Eastcheap with the witty, dishonest Falstaff, yet intends eventually to exchange his disreputable life for royal duty. After joining a highway robbery and exposing Falstaff's extravagant lies, Hal is summoned to court. He reconciles with his father and promises to answer Hotspur in battle. The rebels divide the kingdom in anticipation of victory, but illness, delay, and disagreement weaken their coalition. At Shrewsbury, Worcester hides the king's offer of mercy from Hotspur, ensuring battle. Hal saves Henry and kills Hotspur, while Falstaff avoids death and claims credit for the corpse. Worcester is executed for concealing the peace offer. The king wins Shrewsbury, and Hal has begun to redeem his name, but rebellion continues in the north and Wales.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2197,7 +2197,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2210,7 +2210,7 @@
       "recaps": {
         "ending": "After Henry IV dies, Prince Henry takes the throne as Henry V. He reassures his brothers and retains the Chief Justice, showing that he intends to govern through law rather than punish the judge who once disciplined him. Falstaff hears of the accession while staying with Shallow and hurries to London, confident that his old companion will now reward him. At the coronation procession, however, the new king publicly rejects Falstaff, forbids him to approach, and grants him a modest allowance conditional on reform. The Chief Justice sends Falstaff and his associates to the Fleet prison, although Prince John suggests their treatment may later be reconsidered. Hostess Quickly and Doll have also been arrested. Falstaff tries to interpret the rebuke as a temporary public performance, but his expected influence is gone. Prince John anticipates that the new reign will soon turn toward war in France, closing the domestic succession story and pointing toward Henry V's campaigns.",
         "in_short": "After Hotspur's death, Northumberland and Archbishop Scroop continue resistance to Henry IV while the sick king worries about rebellion and Prince Hal's fitness to succeed him. Falstaff evades debts, quarrels with the Chief Justice, visits the Eastcheap tavern, and recruits men with Justice Shallow. Prince John ends the northern rising by promising to address the rebels' complaints, inducing them to disperse, and then arresting their leaders. Henry IV collapses; Hal, thinking him dead, carries away the crown, but father and son reconcile when the king revives. The king dies soon afterward, and Hal becomes Henry V, confirms the Chief Justice in office, and commits himself to lawful rule. Expecting royal favor, Falstaff rushes to the coronation, only to be publicly rejected and then sent to prison with his companions. The new reign begins with Falstaff's influence ended and a campaign in France in prospect.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2412,7 +2412,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2425,7 +2425,7 @@
       "recaps": {
         "ending": "After the English victory at Agincourt, Henry returns to France to negotiate a settlement with King Charles. The treaty names Henry as Charles's heir and requires Henry to marry Princess Katherine, joining the two royal houses. While the senior negotiators settle the terms, Henry courts Katherine in a mixture of English and French. She cannot personally decide the marriage, but the political agreement already makes the match part of the peace. The French king accepts Henry as his son and heir, and the company prays that the union will end the long conflict between the kingdoms. The closing epilogue looks beyond the play: Henry's achievements will not last, because he will die young and his infant son will inherit both crowns amid renewed war and the loss of France.",
         "in_short": "Henry V accepts a church-backed claim to the French throne and answers the Dauphin's mockery by preparing an invasion. He exposes and executes three English conspirators, captures Harfleur, and marches a sick, depleted army toward Calais. On the eve of Agincourt, Henry moves among his soldiers in disguise and reflects on kingship and responsibility. The French expect an easy victory, but the English defeat their much larger force, and Henry attributes the result to divine favor. In the ensuing peace, the French king recognizes Henry as heir to France and approves his marriage to Princess Katherine. Henry courts her as the treaty is settled. An epilogue notes that he dies young and that his son's reign will lose the French conquests, making the triumph temporary.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2632,7 +2632,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2645,7 +2645,7 @@
       "recaps": {
         "ending": "York returns from Ireland with an army, initially claiming that he seeks only the removal of Somerset. When Somerset appears despite reports that he was imprisoned, York openly asserts his right to the crown. The rival houses gather their supporters and fight at Saint Albans. York kills the elder Clifford, while York's son Richard kills Somerset. Warwick's forces break through, and the defeated King Henry and Queen Margaret flee toward London. Young Clifford finds his father's body and vows revenge against the whole house of York. York, Salisbury, Warwick, and their allies pursue the royal party, intending to press York's claim before Henry can recover. Cade's revolt has failed, but the deeper conflict York cultivated now becomes an open dynastic war.",
         "in_short": "Henry VI's marriage to Margaret of Anjou strengthens Suffolk while increasing resentment over England's losses in France. Court rivals unite against the popular Protector Gloucester. His ambitious wife Eleanor is convicted of seeking supernatural predictions, and Gloucester is stripped of office, arrested, and murdered. Suffolk is banished for his role and killed at sea; Cardinal Beaufort dies tormented by guilt. York, whose hereditary claim is stronger than Henry's, is sent to suppress unrest in Ireland and secretly uses Jack Cade to test rebellion at home. Cade's populist rising seizes London but collapses after royal pardons draw away his followers, and Alexander Iden kills him. York then returns with an army. When his demand that Somerset be removed is frustrated, he openly claims the crown. The factions meet at Saint Albans, where Yorkists kill Somerset and Clifford and force Henry and Margaret to flee. Political intrigue has become the Wars of the Roses.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2856,7 +2856,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2869,7 +2869,7 @@
       "recaps": {
         "ending": "Edward defeats Warwick at Barnet, where Warwick and his brother Montague are killed. Clarence abandons Warwick and returns to his brothers before the Yorkists defeat Margaret's army at Tewkesbury. Prince Edward is captured and stabbed to death after defying the Yorkist brothers. Margaret is taken prisoner. Richard then goes to the Tower and murders the captive Henry VI, treating the last Lancastrian king as an obstacle to his own family's security and to his private ambition. Edward IV ends the play on the throne with Queen Elizabeth and their infant son, believing the civil conflict settled. Yet Richard's closing thoughts make clear that peace within the victorious house of York is unstable: Henry and his son are dead, but Richard is already looking beyond his brother's reign toward the crown for himself.",
         "in_short": "After York forces Henry VI to name him heir, Queen Margaret rejects the settlement and defeats York at Wakefield, where Clifford kills young Rutland and Margaret helps humiliate York before his death. York's sons Edward and Richard continue the claim. Following the brutal victory at Towton, Edward becomes king and Henry is captured. Edward secretly marries Elizabeth Grey while Warwick is negotiating a French marriage for him. Humiliated, Warwick joins Margaret and brings Clarence with him, briefly restoring Henry. Edward escapes, returns with Burgundian support, regains London, and captures Henry again. Clarence changes sides once more, rejoining his brothers before the decisive battles. Warwick dies at Barnet; Margaret's army loses at Tewkesbury; the Yorkist brothers kill Prince Edward. Richard murders Henry in the Tower. Edward IV appears secure with his wife and infant heir, but Richard's ambition points toward another seizure of the crown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3003,7 +3003,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3016,7 +3016,7 @@
       "recaps": {
         "ending": "The book ends with catastrophe and a narrow escape. The Honored Matres, a savage matriarchy returning from the Scattering, prove far more powerful and ruthless than the Bene Gesserit anticipated. After the sisterhood's schemes on the desert planet Rakis come to a head, the Honored Matres attack the planet and destroy it utterly, obliterating the sacred sandworms and the worm-god religion built around them. The aged Bashar Miles Teg, transformed by torture into something faster and more perceptive than an ordinary man, uses his new abilities to organize the defense and buy time, and he gives his life in the fighting so that the others can get away. The young sandworm-commander Sheeana escapes by riding the last worm out of the doomed desert. The Duncan Idaho ghola, having regained the memories of all his former lives, flees together with Murbella, an Honored Matre whose attempt to sexually enslave him instead left the two of them mutually bonded. The Reverend Mother Darwi Odrade emerges as a decisive leader for the sisterhood. Carrying a captured sandworm and the sandtrout that can seed new spice deserts, the Bene Gesserit retreat to their concealed world of Chapterhouse, intending to grow their own worms and preserve the spice cycle. They are left facing open, desperate war against an enemy that outmatches them, with survival, not victory, as the immediate hope.",
         "in_short": "Fifteen centuries after the God Emperor's fall, the Bene Gesserit sisterhood steers galactic affairs while a menace gathers. On the desert planet Rakis, a young girl named Sheeana is discovered who can command the giant sandworms, making her both holy and coveted. Meanwhile the Bene Gesserit protect their latest ghola of Duncan Idaho, grown for them by the Tleilaxu, and recall the aged master strategist Miles Teg to guard and train him. The great threat is the Honored Matres, a brutal matriarchy fleeing back from the far Scattering, who conquer worlds through overwhelming violence and a coercive sexual bonding that enslaves men. As the sisterhood maneuvers to understand and survive them, Teg is captured and tortured, an ordeal that awakens in him startling superhuman speed and perception. The Duncan ghola recovers the memories of all his past lives, and a confrontation with an Honored Matre named Murbella bonds the two of them to each other rather than enslaving him. The Honored Matres, enraged and unstoppable, attack Rakis and annihilate it, wiping out the sandworms. In the destruction, Teg sacrifices himself to cover the escape of his companions. Sheeana rides the last surviving worm to safety, and the Bene Gesserit flee with a captured worm and its sandtrout, carrying the means to grow new spice-bearing worms on their hidden homeworld, Chapterhouse, as they brace for open war with the Honored Matres.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3148,7 +3148,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3161,7 +3161,7 @@
       "recaps": {
         "ending": "After watching Gersbach care tenderly for Junie, Moses abandons the fantasy that killing Gersbach and Madeleine would rescue his daughter. He takes Junie out for the day, but crashes his car and is arrested when the police find the loaded gun he took from his father's house. Will secures his release and urges him to accept medical help. Back at the neglected Ludeyville house, Moses is bruised but calmer. He begins putting the property in order, receives Junie for a visit, and asks Ramona to come to dinner. Madeleine telephones, but the call no longer controls him. As he prepares a simple meal and arranges flowers, he discovers that the compulsive inner correspondence has fallen silent. The novel closes without repairing his marriages or resolving his career, but with Moses relinquishing violence and explanation, attending instead to his daughter, his home, and the immediate life around him.",
         "in_short": "Moses Herzog, a historian in emotional collapse after his second divorce, wanders among New York, friends' homes, old memories, and the decaying country house where his marriage failed. He compulsively drafts unsent letters to relatives, public figures, philosophers, and the dead while brooding over Madeleine's affair with his former friend Valentine Gersbach and fearing for his daughter Junie. A warning from a lawyer sends him to Chicago carrying his late father's pistol and imagining murder. When he secretly watches Gersbach bathe Junie with genuine care, the sight breaks the logic of revenge. Moses later crashes his car while taking Junie out and is arrested for possessing the gun. Bailed out by his brother Will, he returns to the country. Bruised but newly quiet, he tidies the house, welcomes Junie, invites Ramona to dinner, and finds that he no longer needs to compose another letter.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3312,7 +3312,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3325,7 +3325,7 @@
       "recaps": {
         "ending": "Atticus and Malina's surviving allies defeat the hostile witches who came to destroy the Tempe coven, containing the destructive magic and summoned threats unleashed during the conflict. The victory preserves the local supernatural balance but does not restore trust among every member of the alliance. Atticus, Leif, and their allies also end the separate danger posed by the Bacchants, preventing their violent revels from establishing a foothold in Tempe. Granuaile remains committed to the long work of becoming a Druid, and Atticus continues her instruction. Leif then presses the most dangerous outstanding obligation: Atticus has promised to help him reach Asgard and take revenge on Thor. Although several powers warn that the expedition will provoke consequences far beyond a single fight, Atticus prepares to honor the debt, setting the course for the journey in Hammered.",
         "in_short": "After killing Aenghus Og, Atticus tries to stabilize his life in Tempe and begin Granuaile's apprenticeship. Instead he faces overlapping problems: a hostile group of witches targets Malina's local coven, dangerous Bacchants threaten the city, and allies such as Leif and Laksha call on old bargains. Atticus combines Druidic bindings with the very different magic of the local witches, taking care to protect Granuaile and ordinary residents while preventing supernatural violence from attracting official attention. He and Leif deal with the Bacchants, while the larger alliance defeats the attacking witches and contains the forces they release. The struggle preserves the local supernatural balance but exposes divisions among supposed friends. With Tempe temporarily secure, Leif's earlier claim remains: Atticus must help him invade Asgard and kill Thor.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3493,7 +3493,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3506,7 +3506,7 @@
       "recaps": {
         "ending": "After Heydrich dies of his wounds, the German authorities unleash mass arrests and executions and destroy Lidice in a campaign of collective punishment. Karel Čurda eventually gives the Gestapo information that exposes the resistance network. Under torture, the Moravec family is forced into further disclosures, leading the Germans to the Orthodox church where the parachutists are concealed. The men resist a vastly larger SS force for hours, first from the gallery and then from the flooded crypt. None is captured alive: Opálka, Kubiš, Gabčík, Valčík, and their companions die in the battle or take their own lives when escape is impossible. The narrator closes with the cost of their mission and with his own inability to make their real lives fully present through fiction, while insisting on the courage of the people who chose to resist.",
         "in_short": "A present-day narrator tries to reconstruct the lives of Jozef Gabčík and Jan Kubiš, the Czechoslovak soldiers sent from Britain to assassinate Reinhard Heydrich, while openly disputing his own inventions and the distortions of historical storytelling. The book traces Heydrich's ascent through the Nazi security state and his brutal rule in Prague, then follows the parachutists into hiding with the Czech resistance. On 27 May 1942 Gabčík's gun fails, but Kubiš's bomb wounds Heydrich, who later dies. Nazi reprisals kill many innocent people and erase Lidice. After Karel Čurda betrays the resistance network, German forces find the parachutists in a Prague church. The seven men hold out against overwhelming forces before all are killed or die by suicide. Their mission succeeds at a terrible cost, and the narrator ends by honoring their resistance while acknowledging the limits of turning documented lives into a novel.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3701,7 +3701,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3714,7 +3714,7 @@
       "recaps": {
         "ending": "Laura's father's death interrupts the couple's cycle of accusation and avoidance. Rob attends the funeral and supports Laura, and their intimacy resumes, though neither pretends that grief alone has repaired the relationship. Laura ultimately chooses to be with him and asks him to consider marriage, while Rob confronts his habit of treating every new attraction as proof that a better life might be elsewhere. He does not become instantly certain or transformed, but he begins choosing the relationship he actually has. His working life also opens outward: the music made by Vince and Justin gives him a chance to start a small label, and Laura organizes a night at which he DJs. Dick and Barry reveal lives and talents beyond the narrow roles Rob assigned them. In the closing movement, Rob starts making a compilation tape for Laura and, for once, shapes it around what she would want rather than using it solely to display himself. He and Laura are back together with commitment under active consideration, and Rob has begun exchanging endless imagined alternatives for imperfect, deliberate participation in love and work.",
         "in_short": "When Laura leaves him, London record-shop owner Rob Fleming responds by ranking his five worst breakups and tracking down the women involved. The interviews overturn his cherished identity as a serial victim: some relationships were trivial, and in others he caused the hurt or ignored what his partners needed. While obsessing over Laura's relationship with their former upstairs neighbor Ian, Rob sleeps with musician Marie LaSalle and continues imagining that a different woman will fix him. His shop employees Dick and Barry, and two young shoplifters whose record he decides to release, reveal possibilities beyond his stagnant routine. The death of Laura's father brings Rob and Laura back into honest contact. They resume their relationship, discuss marriage, and accept that commitment is a choice rather than certainty that no alternative could be better. Laura arranges a DJ night for him, and Rob ends by making her a tape guided by her tastes, a small sign that he is learning to direct attention beyond himself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3890,7 +3890,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3903,7 +3903,7 @@
       "recaps": {
         "ending": "Stephanie confirms that Fred did not leave his family voluntarily: he was killed after his attention to the refuse business put him in the path of criminal activity. The apparently trivial dispute over a bill, the photographs and papers he left behind, and the people searching for the same information lead Stephanie to his body and to the danger that caused his disappearance. She survives the confrontation and closes the family's search with an answer, though not the one Mabel and Grandma Mazur wanted. Randy Briggs's failure-to-appear problem is also brought under control. Ranger's unexplained jobs have given Stephanie money and drawn her farther into his orbit, while Morelli remains her lover without a settled commitment. At the close, the attraction to both men is unresolved rather than converted into a choice, leaving the Ranger-Morelli triangle open.",
         "in_short": "Stephanie Plum takes on two very different searches: Vinnie's fugitive Randy Briggs and her missing Uncle Fred, a rigidly economical man last known to be disputing a refuse charge. Fred's disappearance leads through photographs, financial questions, the garbage business, and strangers who are also trying to recover what he found. Ranger supplements Stephanie's poor bounty income with secretive paid jobs, increasing the tension between her reliance on him and her continuing relationship with Joe Morelli. Lula, Grandma Mazur, Mooner, and Dougie help with the improvised investigation. Stephanie eventually learns that Fred uncovered criminal activity and was murdered rather than choosing to vanish. She finds the evidence and survives the people trying to suppress it, while the Briggs case is resolved separately. The professional cases close, but Stephanie's personal choice does not: Morelli remains her lover, Ranger remains an attractive and increasingly present alternative, and the book ends with that triangle deliberately unsettled.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4001,7 +4001,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4014,7 +4014,7 @@
       "recaps": {
         "ending": "Croselli is dead, killed by Reacher in his own blacked-out office after catching Hemingway and Reacher inside it. His hold on the neighbourhood dies with him, and Hemingway finally has the result she spent years failing to get, in a form no official report will account for cleanly. Chrissie comes through the night unhurt and goes back to her own life; she and Reacher part as what they were, two strangers who spent one interesting evening together. The power returns, and the blackout turns from a night people are living through into a story they tell. Reacher leaves New York the way he arrived, on his own and unremarked, with no charges, no consequences and nobody but Hemingway who knows exactly what he did, and goes back to his family and to the West Point process waiting for him in the autumn. The story closes as a piece of the character's prehistory: the first clear sight of the man the series' drifter becomes, at sixteen already deciding for himself what he will and will not walk past.",
         "in_short": "New York City, July 1977. Jack Reacher, sixteen years old and passing through on his own, sees a man beating a woman on a Greenwich Village street and stops it, hurting the man badly in the process. The man is Croselli, who runs the neighbourhood's rackets; the woman is Jill Hemingway, an FBI agent whose failed case against him wrecked her career. Reacher spends the evening with Chrissie, a student who drives him around a city he does not know, and then the power fails and New York goes dark, with looting and fires across the boroughs. Hemingway uses the blackout to go after the evidence in Croselli's office, and Reacher goes with her. Croselli, hunting the stranger who humiliated him, finds them there, and Reacher kills him. When the lights come back the neighbourhood is out from under him, and Reacher leaves the city unnoticed, with the army, the military police and a lifetime of drifting still ahead of him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4140,7 +4140,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4153,7 +4153,7 @@
       "recaps": {
         "ending": "The high-rise becomes almost completely cut off from ordinary city life. Services have failed, apartments have been stripped, and the remaining residents organize themselves into small territorial groups while accepting violence as routine. Wilder finally completes his obsessive climb from the lower floors to the roof and confronts Royal. Both men are killed in the final violence after Wilder reaches the summit he had pursued. Laing survives by adapting to the building's new order. He settles into a closed domestic arrangement with women nearby, scavenges what remains, and eats one of the tower's dogs. He has no wish to call for outside help or resume his former life. Looking from his balcony, he notices disturbances beginning in another tower in the development, suggesting that the same collapse is spreading beyond his own building.",
         "in_short": "A new forty-storey residential tower promises affluent tenants a self-sufficient life of apartments, shops, schools, pools, and private recreation. Medical lecturer Robert Laing lives near its middle, architect Anthony Royal occupies the penthouse, and television producer Richard Wilder lives with his family below. Small failures of elevators, power, and shared facilities sharpen the building's class divisions. Parties, vandalism, raids, and assaults replace complaints, while residents conceal the disorder from outsiders and withdraw from work. Wilder becomes obsessed with climbing and filming the tower; Royal tries to preserve upper-floor control; Laing discovers that he prefers the enclosed, increasingly primitive community. As services collapse, residents form territorial groups and abandon ordinary restraints. Wilder reaches the roof, and both he and Royal die in the final violence. Laing remains willingly inside, eating a dog and watching signs that a neighboring high-rise is beginning the same descent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4359,7 +4359,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4372,7 +4372,7 @@
       "recaps": {
         "ending": "Lee Scoresby dies holding off Magisterium soldiers so that Jopari can continue toward the knife bearer. Jopari finds Will in the mountains, treats the wound that will not heal, and reveals that he is John Parry, Will's missing father. Father and son recognize each other only moments before a witch whom John once rejected kills him; she is then killed in turn. During Will's absence, Mrs Coulter's forces attack the witches guarding Lyra. Will returns to find the camp devastated, Lyra gone, and her alethiometer left behind. Mrs Coulter has abducted Lyra and keeps her drugged inside a travelling chest. The angels Balthamos and Baruch ask Will to take the subtle knife to Lord Asriel, but Will insists that he must rescue Lyra first. He leaves with the knife and the angels, while the coming war now spans multiple worlds.",
         "in_short": "After accidentally killing an intruder, twelve-year-old Will Parry flees through a hidden window into Cittagazze, where he meets Lyra. They move between the deserted city and Will's Oxford, where physicist Mary Malone discovers that her dark-matter particles are the conscious Dust Lyra knows. Sir Charles Latrom steals Lyra's alethiometer, prompting the children to seek the subtle knife, a blade that can cut windows between worlds. Will wins it but loses two fingers, becoming its bearer, and uses it to recover the instrument. Meanwhile Lee Scoresby finds the shaman Jopari and escorts him toward Will as Magisterium forces pursue them. Lee dies defending him. Jopari reaches Will and is revealed as his missing father, John Parry, but is killed moments after their reunion. Mrs Coulter, now able to control Spectres, attacks Lyra's protectors and abducts her. Two rebel angels ask Will to take the knife to Lord Asriel; Will agrees to travel with them only after they help him rescue Lyra.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4479,7 +4479,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4492,7 +4492,7 @@
       "recaps": {
         "ending": "The title story takes place on the eve of Britain's entry into the First World War. Holmes has spent two years under the identity of the Irish-American Altamont, earning the confidence of the German agent Von Bork and feeding his network misleading intelligence. At Von Bork's country house, Holmes arrives with Watson, reveals the deception, and takes Von Bork prisoner along with the agent's papers. Their work completed, Holmes and Watson leave to deliver the captive and evidence to the authorities. Holmes has come out of retirement for this national assignment, while Watson has again joined him in the field. The closing conversation turns from the successful operation to the war approaching Britain, giving the collection a public and historical conclusion rather than the private solution of an ordinary Baker Street case.",
         "in_short": "This later collection gathers independent cases from different stages of Holmes and Watson's association, including investigations involving government secrets, unusual illnesses, disappearances, foreign connections, and dangers concealed within apparently private affairs. Mycroft Holmes, Inspector Lestrade, and Mrs Hudson return alongside the two central partners. Editions differ over whether \"The Cardboard Box\" belongs here or in The Memoirs of Sherlock Holmes, but the remaining stories form the stable core. The final and only continuing endpoint is the title story, set in August 1914. Holmes has left retirement to spend two years posing as the agent Altamont and infiltrating the German spy Von Bork's network. With Watson's help, he exposes the disguise, captures Von Bork, and secures the agent's papers for Britain. The partners depart together as the country stands at the beginning of war, closing the volume on national service rather than another private case.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/hogfather.json
+++ b/data/works-community/0/hogfather.json
@@ -97,7 +97,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -110,7 +110,7 @@
       "recaps": {
         "ending": "Teatime's scheme is to end belief in the Hogfather by using the teeth his allies have gathered from children, which grant a form of power over those children. As belief fails, Death personally takes over the Hogfather's Hogswatch rounds to sustain it, delivering gifts across the city while Albert helps and Susan tracks the conspiracy. Susan enters the tower built of teeth, reaches the country of children's beliefs, and confronts Mr Teatime; after he proves hard to put down, she finally kills him and frees the captured belief. With the plot broken, the real Hogfather is recovered and the tradition is saved, so the sun rises on Hogswatch morning as it should rather than failing to appear. The surplus belief that had leaked out leaves behind a scattering of new minor personifications, among them the hapless god of hangovers. Death returns Susan to her ordinary life, but not before setting out his view that humanity needs its small, comforting fictions, the gift-bringer and the tooth fairy, as practice for believing in the larger, unprovable ideas that make people humane.",
         "in_short": "The order-loving Auditors of Reality want the Hogfather, the Disc's midwinter gift-bringer, gone, and hire the Assassins' Guild; the commission falls to the brilliant, disturbing Mr Teatime, who has found a way to attack belief itself by seizing control of the operation that collects children's teeth. As faith in the Hogfather drains away, Death takes up the red suit and the sledge and delivers the presents himself, with his manservant Albert assisting, trying to keep the tradition and the children's belief alive. The loose belief that is no longer anchored to the Hogfather spills out and spawns odd new minor gods and creatures. Death's granddaughter Susan, a level-headed governess, investigates and follows the plot into a tower of teeth, a realm shaped by children's imagination. There she confronts and destroys Teatime, breaking his hold, and belief is restored so the Hogfather returns and the sun rises on Hogswatch morning. Death argues that humans must believe small invented things in order to learn to believe in the great abstractions, like justice and mercy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -228,7 +228,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -241,7 +241,7 @@
       "recaps": {
         "ending": "Stanley and Zero dig up an old suitcase at Camp Green Lake and are caught by the Warden, then trapped in a nest of venomous yellow-spotted lizards that do not bite them because both boys have eaten wild onions. They survive the night, and by morning Stanley's lawyer arrives with evidence clearing him of the theft. The suitcase proves to belong to Stanley's own family, stolen generations earlier by the outlaw Kate Barlow, and its contents are worth close to a million dollars, split between Stanley and Zero. The Warden, whose family had searched the lakebed for decades, is left with nothing, and Camp Green Lake is shut down for good. Because Stanley carried Zero, the last descendant of Madame Zeroni, up the mountain, the century-old family curse is finally broken. The boys return to their families, Zero is reunited with his mother, and rain begins to fall on the dry lake for the first time in a hundred years, a sign that the long run of Yelnats bad luck is over.",
         "in_short": "Stanley Yelnats, a boy from a family that believes it is cursed, is wrongly convicted of theft and sent to Camp Green Lake, where boys are forced to dig holes each day in a dry lakebed. Stanley discovers that the digging is really the Warden's search for treasure buried long ago by the outlaw Kissin' Kate Barlow, whose tragic history is tied to the town's past and to a Yelnats ancestor she once robbed. Stanley befriends Zero, a quiet boy who is secretly descended from the woman who cursed Stanley's family. When Zero runs away, Stanley follows, and by carrying the sick Zero up a mountain to water and wild onions he unknowingly fulfills his ancestor's broken promise and breaks the curse. The boys return, dig up a suitcase bearing the Yelnats name, survive the camp's deadly lizards, and are freed. Stanley is proven innocent, the camp is closed, and he and Zero share the treasure.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -392,7 +392,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -405,7 +405,7 @@
       "recaps": {
         "ending": "Parvaiz is killed outside the British consulate in Istanbul while trying to leave the Islamic State. Acting under Karamat Lone's hard-line policy, Britain has removed his citizenship and refuses to admit his body, so it is sent to Pakistan. Aneeka follows and begins a public vigil beside his coffin, demanding that he be allowed burial at home. Eamonn publicly condemns his father's decision and travels to Karachi to join her. Karamat initially maintains that public duty must override his son's wishes, but Terry forces him to confront the danger to Eamonn. Before the father can repair the situation, a militant approaches Eamonn in a Karachi park and secures an explosive belt around him. Aneeka sees the danger but runs toward Eamonn rather than leaving him alone. The device explodes, killing them together. Karamat's policy has not insulated his family from political violence; the conflict between state authority, family loyalty, and public punishment ends by consuming both households.",
         "in_short": "Isma Pasha leaves London to study in America after years of raising her younger siblings, the twins Aneeka and Parvaiz. She befriends Eamonn Lone, son of Britain's hard-line Home Secretary, Karamat Lone. Eamonn later falls in love with Aneeka, who hopes his family can help Parvaiz return from Syria. Parvaiz was recruited by Farooq with romantic stories about his jihadist father, but work for the Islamic State reveals its brutality and he tries to escape. Farooq kills him outside the British consulate in Istanbul. Karamat has stripped Parvaiz of citizenship and refuses the body entry to Britain, so Aneeka stages a vigil with his coffin in Karachi. Eamonn denounces his father and joins her. A militant straps explosives to Eamonn; Aneeka runs to him, and both die in the blast. The catastrophe completes a chain in which secrecy, political absolutism, and competing claims of family and nation leave neither family intact.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -571,7 +571,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -584,7 +584,7 @@
       "recaps": {
         "ending": "The women of Lotus save Cee's life, but the damage caused by Dr. Scott's experiments leaves her unable to bear children. Under Ethel Fordham's care, Cee learns practical skills and a new confidence, and she refuses to let Frank resume treating her as helpless. Frank, meanwhile, finally faces the memory he has concealed even from himself: in Korea, he—not a fellow soldier—killed the hungry Korean girl who approached the camp. Brother and sister return to the place where, as children, they witnessed a Black man's secret burial after a lethal fight arranged for white spectators. They dig up his bones, wrap them in the quilt Cee has made, and rebury him beneath a bay tree with a marker declaring his humanity. By honoring the forgotten dead, Frank and Cee also reclaim Lotus as a home they can choose rather than merely the site of childhood suffering. Their wounds are not erased, but both end with greater truth, dignity, and independence.",
         "in_short": "Frank Money, a traumatized Black veteran of the Korean War, escapes confinement after receiving word that his younger sister Cee is gravely ill. Traveling through the segregated United States of the 1950s, he makes his way to Georgia and learns that a white doctor has used Cee in dangerous reproductive experiments. Frank rescues her, and the women of their hometown, Lotus, nurse her back to health while teaching her to value her own judgment. Frank also confronts a memory he has suppressed: he killed a hungry Korean child during the war. At the close, the siblings return to the site of a clandestine burial they witnessed as children. They rebury the man's bones beneath a bay tree and mark the grave with words affirming that a man lies there. Cee emerges physically scarred but self-possessed, while Frank begins to make an honest peace with his past and with the place he once hated.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -920,7 +920,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B01E9FHNEM",
@@ -932,7 +932,7 @@
       "recaps": {
         "ending": "McGill is revived after roughly a year and learns that Turov completed the strategy he began. Using the recovered Galactic Key, Natasha's destination programming, a remaining antimatter weapon, and Ferguson as a volunteer, she destroyed the plant masters' war enclave. The cephalopods surrendered and became Earth's subjects. Earth is rebuilding with their resources, but millions of people were permanently lost and Legion Varus has been demobilized. The victory also leaves Earth in control of roughly 300 worlds, an expansion forbidden by Galactic law, and a Galactic battle fleet is approaching. Graves is now a primus, while Turov has returned to command and Claver is alive at her side. McGill travels to Dust World, meets Etta for the first time, and brings Etta, his mother, and Natasha back to Earth. Turov and Claver offer him centurion insignia and a mission tied to the approaching fleet. McGill refuses and chooses civilian life with his family, leaving the Galactic response as the immediate unresolved threat.",
         "in_short": "Newly promoted James McGill is drawn into a struggle between Galina Turov, Claver, and Central just as cephalopod forces invade Earth. A Galactic Key lets him activate stolen teleportation suits, leading to raids on enemy installations and a failed ground defense. He discovers that plant-like masters control the cephalopods and forces Claver to reveal how the teleport network can be reprogrammed. With help from the original Natasha Elkin on Dust World, McGill gains access to cephalopod destinations and destroys their capital with antimatter. After he is surrendered and remains dead for about a year, Turov uses Natasha's work, the Key, and Ferguson's final mission to destroy the masters' war enclave and win the war. Earth emerges controlling roughly 300 worlds, which draws a Galactic battle fleet. Revived McGill finally meets Etta, returns to Earth with his family, and refuses Turov and Claver's proposed mission against the new threat.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1105,7 +1105,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:1772309141",
@@ -1117,7 +1117,7 @@
       "recaps": {
         "ending": "Bishop's boarding party captures the hostile Kristang troop carrier after Nagatha disrupts its computer systems and prevents its reactors from being used for self-destruction. Her active matrix is exhausted, but Skippy locates her compacted consciousness in the captured AI system and begins restoring her without alterations. The carrier destroys the dropships pursuing the damaged human test ship and supplies the firepower that saves Smythe's encircled team, keeps the wormhole controller on Earth, and averts a nuclear strike at Wright-Patterson. Bishop receives the regular Army rank of colonel and reconciles with Skippy. Earth now controls another damaged alien ship, but the Flying Dutchman remains severely limited, the test ship needs months of repair, and more than three thousand hibernating Kristang aboard the captured carrier pose an unresolved custody and logistics problem. Plans for an off-galaxy refuge also remain stalled.",
         "in_short": "A concealed Kristang force near the Solar System revives early, survives an internal clash, and unites around a plan to capture Skippy and Earth's wormhole controller. Its forces attack a human-refitted Kristang ship near Mars and Wright-Patterson at the same time. The Flying Dutchman destroys the attackers' Earthbound dropships but damages itself, while Bishop launches a counterattack against the hostile troop carrier. Nagatha transfers into his improvised assault craft, defeats the carrier's self-destruction attempt, and enables its capture. The captured ship then saves the damaged test vessel and Smythe's STAR team, preventing both the loss of the controller and an authorized nuclear strike. Nagatha's compacted consciousness survives and Skippy starts restoring her. Bishop becomes a regular Army colonel and repairs his friendship with Skippy, while Earth inherits a damaged carrier containing more than three thousand hibernating Kristang.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1287,7 +1287,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1300,7 +1300,7 @@
       "recaps": {
         "ending": "Marcus, a Stanford graduate student descended from Esi, meets Marjorie, a fellow student descended from Effia. Neither knows that their family lines began with half sisters separated at Cape Coast Castle. Marcus's effort to study his great-grandfather H and convict leasing keeps widening into the whole history that made his family, while Marjorie maintains a more direct connection to Ghana through her parents, her grandmother Akua, and a black stone handed down in her line. After Marcus confesses his fear of water, Marjorie takes him to Ghana. He is overwhelmed inside Cape Coast Castle, where Esi was imprisoned and Effia lived above the dungeons, and runs out toward the shore. Marjorie leads him into the Atlantic until he can stand in the water, then gives him her inherited stone. Their meeting symbolically joins the two branches after generations shaped by slavery, colonialism, migration, and racism. They do not recover a complete genealogy, but together they return to the place of separation and carry its history forward with a new personal bond.",
         "in_short": "Two half sisters in eighteenth-century Ghana begin separate family lines. Effia marries British officer James Collins and lives above Cape Coast Castle's slave dungeons; Esi is imprisoned below and shipped to America. Across seven generations, Effia's descendants profit from and then try to escape the slave trade, endure missionary rule and colonialism, and eventually move between Ghana and the United States. Esi's descendants survive plantation slavery, family separation, the Fugitive Slave Act, convict leasing, segregation, racial passing, and addiction. Each generation inherits gaps and injuries alongside acts of love and endurance. In the present, Marcus, descended from Esi, struggles to contain this history within an academic study, while Marjorie, descended from Effia, preserves a tangible connection to Ghana. They meet at Stanford without knowing they are distant cousins. Marjorie takes Marcus to Cape Coast Castle and then into the Atlantic, where she gives him the black stone passed down through her family, bringing the divided lines together at the site where their ancestors were separated.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1495,7 +1495,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1508,7 +1508,7 @@
       "recaps": {
         "ending": "Drizzt tells Zaknafein that he cannot live as a drow and leaves House Do'Urden for the wild tunnels of the Underdark, taking nothing but his blades. His flight is a public renunciation of the Spider Queen, and it costs the house the goddess's favor. To buy it back, Matron Malice sacrifices Zaknafein to Lolth in her son's place, and Zaknafein goes willingly, having decided that his son is the one thing he has ever done that was worth anything. Meanwhile Masoj Hun'ett and Alton DeVir are sent into the tunnels to kill Drizzt. Masoj orders the panther Guenhwyvar to kill Alton so that no witness remains, and Drizzt then kills Masoj and takes the onyx figurine that commands the cat. When Drizzt learns what was done to his father, he understands both that he was loved and that he can never go back: his family will keep hunting him for as long as his heresy stands between them and their goddess. He walks into the deep tunnels with the panther as his only companion, an exile with no destination.",
         "in_short": "In the drow city of Menzoberranzan, Drizzt Do'Urden is born a third son of House Do'Urden on the night his mother destroys a rival house, and escapes the sacrifice custom demands of him only because a brother is murdered in the same raid. Raised as a servant, then trained in swordsmanship by the house weapon master Zaknafein, he proves the finest young blade of his generation and, at the warriors' academy, the finest student of his class. He also proves incapable of the cruelty his people take for granted. Sent on a raid to the surface, he finds not the monsters he was taught about but an elf family at a celebration, and he saves a small girl by hiding her and letting the raiders believe her dead. Back in the city he renounces the Spider Queen outright and learns that Zaknafein, who shares his revulsion, is his true father. Rather than become what his city requires, Drizzt abandons his house for the wild Underdark. Malice sacrifices Zaknafein in his place, and Drizzt, having killed the wizard sent to hunt him and claimed the panther Guenhwyvar, goes into exile alone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1721,7 +1721,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1734,7 +1734,7 @@
       "recaps": {
         "ending": "After Odysseus kills the suitors, Penelope remains cautious until she tests his knowledge of their immovable marriage bed. His answer proves his identity, and husband and wife are reunited. Odysseus then visits his father, Laertes, reveals himself, and restores the old man's confidence. Meanwhile, the suitors' shades reach the underworld, and their surviving relatives gather to avenge them. Odysseus, Telemachus, Laertes, and their loyal allies meet the attack outside Laertes' farm. Laertes kills Antinous's father, but Zeus and Athena intervene before the bloodshed can continue. Athena orders both sides to stop and establishes peace in Ithaca, leaving Odysseus restored to his wife, father, son, household, and kingdom. The wider cycle therefore closes not simply with his arrival, but with his identity accepted and the threat of a continuing feud brought under divine control.",
         "in_short": "During the Trojan War, Achilles withdraws from the Greek army after Agamemnon dishonors him. Hector leads the Trojans to the Greek ships, but Achilles lets Patroclus enter battle in his armor. Hector kills Patroclus, and the grieving Achilles returns, kills Hector, and eventually gives the body to King Priam for burial. After Troy's fall, Odysseus spends ten years trying to reach Ithaca. Poseidon obstructs him, while monsters, enchantments, and his crew's own errors leave him the sole survivor. At home, Penelope delays remarriage as suitors consume his estate, and Telemachus searches for news of his father. The Phaeacians finally carry Odysseus to Ithaca, where Athena disguises him. He reunites with Telemachus, tests servants and allies, strings his own bow, and kills the suitors. Penelope confirms him through a private test concerning their bed. After one final clash with the suitors' families, Athena imposes peace, and Odysseus is restored to his family and realm.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2243,7 +2243,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002VA390U",
@@ -2255,7 +2255,7 @@
       "recaps": {
         "ending": "Wayfarer is destroyed after drawing PNS Achmed away from the damaged liner Artemis. Tschu and many crew members die, but Honor, Nimitz, Samantha, LaFollet, Cardones, Tremaine, Harkness, Lewis, and the other reachable survivors are evacuated. The surviving personnel from Achmed are rescued with them, and Honor later arranges their unconditional release alongside Caslet and Jourdain. Her cover story protects the Havenite officers who helped Manticorans against Warnecke and during the escape. Artemis reaches New Berlin, while Klaus Hauptman apologizes to Honor and offers the support of his cartel. Warnecke has already been delivered to Sidemore for trial, although four of his privateer ships remain missing and a small Manticoran force stays to protect the liberated planet. Samantha survives pregnant with Nimitz's offspring, but Tschu's death leaves her bereaved. Honor has regained her place in the Royal Manticoran Navy, yet returns to Manticore without a ship and awaits reassignment as the war with Haven and the wider threat to Silesian commerce continue.",
         "in_short": "Recalled to the Royal Manticoran Navy through the maneuvering of political enemies, Honor Harrington takes four disguised Q-ships into Silesia. Her task group proves the armed merchant concept against pirates and Havenite raiders. Wayfarer captures Warner Caslet after his cruiser helps it against privateers, then uses recovered intelligence to destroy Andre Warnecke's heavy ships. Honor captures Warnecke after he murders thousands on Sidemore and exposes a sabotage and desertion plot within her crew. In the Selker Rift, Havenite raiders destroy Hawkwing and endanger Artemis. Honor sacrifices Wayfarer to save the liner, destroying Carabin and disabling Achmed before her own ship is wrecked. Tschu and many others die, but Harold Sukowski leads rescuers to the survivors. Honor scuttles Wayfarer, secures the unconditional release of the surviving Havenites, and returns to Manticore for reassignment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2444,7 +2444,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2457,7 +2457,7 @@
       "recaps": {
         "ending": "At the ceremonial groundbreaking, Roy and other students occupy the Mother Paula's site and point out the burrowing owls and their nests. Mullet Fingers reveals himself as the person who has been sabotaging construction, while Roy's evidence and the crowd's presence make it impossible for the company to deny the birds. Executive Chuck Muckle loses control in public, and actress Kimberly Lou Dixon refuses to support the project once she understands what is happening. The restaurant plan is abandoned, and the land is preserved as an owl sanctuary. Officer Delinko and Curly both come through the dispute with their positions restored. Mullet Fingers later returns to his mother's house, where another confrontation leads to his arrest; he escapes juvenile custody and disappears again. Roy remains in Florida with a stronger sense of belonging, having found friends and a landscape worth defending.",
         "in_short": "After moving to Coconut Cove, Florida, Roy Eberhardt becomes fascinated by a barefoot boy he sees running beside the school bus. The boy, known as Mullet Fingers, is secretly disrupting construction of a pancake restaurant because burrowing owls nest on the site. With help from Mullet Fingers' stepsister Beatrice, Roy learns that the company has ignored the protected birds and begins looking for lawful proof while police officer David Delinko investigates the vandalism. Roy also faces school bully Dana Matherson, whom the young activists use as a distraction. When the company stages a public groundbreaking, Roy rallies classmates to stand over the owl burrows, Mullet Fingers admits his part, and the company's attempts to conceal the birds collapse in front of witnesses. The restaurant is canceled and the property becomes an owl sanctuary. Mullet Fingers escapes custody after a later family confrontation, while Roy, once unhappy about moving, finally feels connected to Florida.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2593,7 +2593,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2606,7 +2606,7 @@
       "recaps": {
         "ending": "Sky and Holder confront Sky's biological father after her memories identify him as the man who sexually abused her when she was a child. He also admits abusing Lesslie, giving Holder a devastating explanation for his sister's suicide. Sky's father kills himself during the confrontation. Karen then tells Sky why she took the five-year-old Hope from that home, changed her name, and raised her beyond the reach of the investigation: she had discovered the abuse and believed disappearing with the child was the only way to protect her. Sky must absorb both Karen's rescue and the years of deception it required. With Holder beside her, she accepts that she is both Hope and Sky rather than surrendering her present identity to the recovered past. Holder also begins to release the guilt he carried for losing Hope and failing Lesslie. The couple remain together, facing legal and emotional consequences but no longer separated by the secrets behind their shared history.",
         "in_short": "Seventeen-year-old Sky Davis begins public school after a sheltered, technology-free upbringing with her adoptive mother Karen. She meets Dean Holder, whose strong reaction to her is tied to a childhood she cannot remember. Their difficult attraction becomes a relationship, and Holder reveals his grief over his twin Lesslie's suicide. As physical closeness and familiar places trigger flashbacks, Sky learns that she was born Hope and disappeared at age five; Holder was her childhood friend and has recognized her. Her recovered memories show that her biological father sexually abused her. When Sky and Holder confront him, he admits that Lesslie was another victim and then kills himself. Karen explains that she took Hope away after discovering the abuse and hid her as Sky to save her. Sky integrates her past with the life she has built, while Holder gains the truth about both girls he believed he had failed. They end the novel together, wounded but able to choose a future beyond those secrets.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2744,7 +2744,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2757,7 +2757,7 @@
       "recaps": {
         "ending": "Ammi Pierce and several officials reach the Gardner farm too late to save the family. Nahum disintegrates after describing the presence that has consumed the land and his household, while the missing members of the family are never recovered. That night the men see trees move, vegetation shine with the unknown color, and luminous contamination gather into a column that rises from the well and shoots into the sky. A small portion appears to fall back into the well. The farm collapses into a grey ruin, leaving the blasted heath. Years later, the barren area is still slowly expanding. Arkham plans to cover the valley with a reservoir, but Ammi refuses to leave, and the surveyor decides he will not drink the future city's water. The fragment that returned to the earth remains the central unresolved threat.",
         "in_short": "A surveyor investigating a future reservoir near Arkham learns from Ammi Pierce why one valley is abandoned. A meteorite fell on Nahum Gardner's farm, carrying an indescribable color that resisted scientific analysis before sinking into the soil. The next season produced huge but inedible crops, and plants, animals, and people gradually became distorted, sick, and grey. The Gardner family succumbed to madness, disappearance, or physical decay while an influence centered on their well drained life from the farm. Ammi and local officials arrived as the last survivors died. That night they watched the unknown color gather from the land and rise into space, though a fragment fell back into the well. The farm became the blasted heath, a sterile grey area that continues to spread. With the district scheduled to lie beneath a reservoir, the surveyor leaves determined never to drink the water supplied from it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2907,7 +2907,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2920,7 +2920,7 @@
       "recaps": {
         "ending": "Stephanie's investigation establishes that Ranger did not murder Homer Ramos. Homer's death and the warehouse fire arose from conflict inside the Ramos family's illicit weapons business, and the surviving family's efforts to recover control created the surveillance and violence around Stephanie. The final confrontation exposes that internal betrayal and removes the basis for pursuing Ranger as the killer. Ranger remains outside ordinary expectations but is free of the homicide accusation. Repeated danger has pushed Stephanie into Morelli's house, where Grandma Mazur and Bob turn the arrangement into an improvised household. Morelli offers a recognizable shared life, while Ranger remains professionally indispensable and personally interested. Stephanie does not choose between them; Ranger instead leaves her with the understanding that the favors and protection exchanged between them carry a personal debt that will continue into the next case.",
         "in_short": "Ranger becomes a fugitive after Homer Ramos is murdered and a building burns, leaving evidence that points toward him. Vinnie asks Stephanie to recover his most capable agent, while police, rival bounty hunter Joyce Barnhardt, and men working for the wealthy Ramos family all follow the same trail. Ranger repeatedly contacts Stephanie but refuses custody, pushing her to investigate the family's hidden arms business and the conflict surrounding Homer's death. Lula helps in the field, and Morelli provides police knowledge while becoming increasingly protective. Threats to Stephanie's apartment, Grandma Mazur's temporary move, and the arrival of the dog Bob draw Stephanie into Morelli's home. The evidence finally clears Ranger and places the murder within the Ramos family's own criminal struggle. Ranger remains free, and the immediate case closes. Stephanie is left sharing domestic space with Morelli while owing Ranger for his intervention, preserving rather than resolving the attraction and rivalry among all three.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3096,7 +3096,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3109,7 +3109,7 @@
       "recaps": {
         "ending": "Atticus joins forces with the Morrigan, Flidais, and the Tempe witches for the confrontation Aenghus Og has forced upon him. The battle destroys Aenghus's remaining advantage, and Atticus kills the god who has hunted him for centuries, ending the immediate pursuit over Fragarach. The victory does not make Atticus safe: his alliances with gods, witches, vampires, and werewolves all involve debts that can be called in later. He returns to his life in Tempe with Oberon and keeps the sword. Granuaile, having learned that the supernatural world is real and that Atticus is a genuine Druid, asks him to teach her. He agrees to take her as his apprentice, beginning the long process of training a new Druid while trying to preserve the ordinary life and community he has built.",
         "in_short": "Atticus O'Sullivan, an ancient Irish Druid living as a young bookseller in Tempe, has spent centuries hiding from Aenghus Og, the god who wants both him and the enchanted sword Fragarach. When Aenghus finally moves against him, Atticus survives attacks by supernatural agents while also contending with police attention, old obligations among the Irish gods, and a wary local coven. His allies include his telepathic hound Oberon, the Morrigan, the hunt goddess Flidais, vampire lawyer Leif Helgarson, werewolf attorney Hal Hauk, and the witches led by Malina. Their interests overlap without ever becoming simple trust. Atticus ultimately turns Aenghus's schemes against him and kills the god, ending the pursuit that shaped much of his life. He remains in Tempe, still owing favors across the supernatural world, and agrees to train his friend Granuaile as a Druid.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3332,7 +3332,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3345,7 +3345,7 @@
       "recaps": {
         "ending": "Micah Domitus is exposed as the murderer of Danika Fendyr and her pack, killed for stealing the Horn of Luna, and as the architect of the killings staged since to force the artifact into the open. He opens a rift above Crescent City so that he can be the one to close it, and demons overrun the streets. Lehabah dies saving Bryce and Hunt from the kristallos in the gallery library, and Hunt's wings are destroyed in the fighting. Micah is killed. Bryce, having realized that Danika hid the Horn by grinding it into the ink of her tattoo, runs the city's ancient Gates and channels Hunt's lightning through the Horn in her skin, waking Starborn light nobody knew she carried. She seals the rift, drives the demons back, and heals much of the damage, nearly dying in the process. Afterward she makes the Drop into her full immortal power with Hunt as her Anchor and survives it. Hunt's two centuries of enslavement end and he stays in Crescent City with her. Bryce is publicly acknowledged as Starborn and as a Fae princess she never wanted to be, watched now by her father the Autumn King, by the Asteri, and by the Princes of Hel, and she is still carrying the Horn. The empire's war against the human rebels of Pangera continues untouched.",
         "in_short": "In Crescent City on the world of Midgard, half-human, half-Fae Bryce Quinlan comes home one night to find her best friend, the wolf Alpha Danika Fendyr, and Danika's entire pack slaughtered, apparently by a demon. Two years later the killings resume, clearing the human rebel convicted of them, and the Archangel who governs the city orders Bryce to investigate alongside Hunt Athalar, an enslaved fallen angel promised his freedom if he finds the killer. Their search leads through a synthetic drug trade, a demon bred to hunt by scent, and the theft of the Horn of Luna, a broken Fae artifact that can open passages between worlds. The killer proves to be the Archangel himself, who murdered Danika for stealing the Horn and staged the later deaths to force it into the open. Bryce discovers that Danika hid the Horn by grinding it into the ink of Bryce's own tattoo. When the Archangel opens a rift and demons flood the city, Bryce wakes the Horn with Hunt's lightning, reveals herself as Starborn, and seals the rift. The Archangel dies, Hunt is freed, and Bryce comes into her full power.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3613,7 +3613,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3626,7 +3626,7 @@
       "recaps": {
         "ending": "Bryce lets the Asteri take her in order to reach the crystal at the heart of the Eternal City, where fifteen thousand years of power harvested from Midgard is stored. Her allies converge on the city from three directions: the fugitives Lidia Cervos broke out of the Asteri's cells, the wolves, mer, witches and Fae of Valbara, and the Princes of Hel, whose war against the Asteri long predates Midgard. Lidia settles her account with Pollux. Apollion takes his revenge on the Asteri in person. Bryce brings the Starsword and Truth-Teller together and uses them with the Horn of Luna to break the Asteri's hold on the world's power at its source. Rigelus is killed and the Asteri are destroyed. The cost is severe and several of those closest to Bryce come very near death. Midgard is left free and broken at once: the firstlight system that ran every city was the parasites' machinery, the Bone Quarter's consumption of the dead is finished, and there is no imperial government left standing. Bryce refuses the rule she is offered and leaves the shape of the new world to the people living in it, with humans no longer a subject caste. Hunt survives and stays with her, out from under the Asteri's ownership for good. Ruhn and Lidia are together and her sons are safe. Tharion, Ithan, Hypaxia, Baxian and the rest survive, several of them permanently altered by what it took. Hel stands as an ally rather than a threat, and the link between Midgard and Prythian, with the shared history it exposed, is now known in both worlds.",
         "in_short": "Stranded in Prythian after escaping Crescent City through a portal, Bryce Quinlan bargains with the Night Court for a way home and learns that the Starsword's twin, a dagger called Truth-Teller, has been in that world all along, evidence that Midgard's Fae arrived from Prythian as refugees. She returns carrying Truth-Teller and the Mask, an artifact that commands the dead. Meanwhile Hunt Athalar, Ruhn Danaan and Baxian Argos are tortured in the Asteri's cells until Lidia Cervos, the Hind, reveals herself as Daybright, the rebellion's long-hidden source inside the empire, and breaks them out. On Avallen the group finds a record left by Theia's daughter Silene showing how the Fae let the Asteri into Midgard and how everything the Fae have said about themselves since has been a fabrication. With Ophion destroyed and the empire in control, Bryce allows herself to be taken to the Eternal City in order to reach the crystal storing the power harvested from the world. In the battle that follows the Princes of Hel join the fight, Lidia kills Pollux, and Bryce uses the reunited blades and the Horn to break the Asteri's hold. The Asteri are destroyed, Midgard is freed, and the survivors are left to rebuild a world with no empire and no harvest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3898,7 +3898,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3911,7 +3911,7 @@
       "recaps": {
         "ending": "Rigelus and the Asteri move openly against Crescent City once Bryce is identified as the Starborn heir carrying the Horn of Luna. Cormac Donnall is killed in the fighting, and the rebellion in Valbara is dismantled. Hunt Athalar, Ruhn Danaan and Baxian Argos are taken alive and shipped to the Eternal City, where the Hind and Pollux the Hammer are given charge of them, putting Hunt back in exactly the position he spent the whole book trying to avoid. Bryce, cornered at one of the city's ancient Gates, channels Hunt's lightning through the Horn in her back and tears open a portal out of the world entirely, stepping through with the Starsword and leaving everyone she loves behind. She lands in Prythian, a world she has never heard of, and is met immediately by a winged male trailing shadows and a woman leveling a dagger that is unmistakably the Starsword's twin, the first hard evidence anyone has had of where Midgard's Fae originally came from. Elsewhere, Tharion Ketos escapes the River Queen's court by selling his service to the Viper Queen; Ithan Holstrom is left holding the truth about the Bone Quarter and his brother; and Emile Renast, powerless and finally out of reach, is safe. Celestina's gentler rule has been exposed as the Asteri's leash, and Midgard's people still have no idea their world is being farmed.",
         "in_short": "Six months after saving Crescent City, Bryce Quinlan and Hunt Athalar are pulled back into the empire's war when Cormac Donnall, the Fae prince Bryce's father betroths her to, reveals himself as an agent of the human rebel network Ophion and asks for help finding a missing boy, Emile Renast, whose captured sister was a rare lightning-wielder. The search draws in Ruhn Danaan, the mer Tharion Ketos and the exiled wolf Ithan Holstrom, and ends with the discovery that the boy has no power at all. What they uncover instead is far larger: the Asteri who rule Midgard are parasites, the firstlight that powers every city is harvested from its own people, and the souls ferried to the Bone Quarter are consumed rather than laid to rest. It is what Danika Fendyr died knowing. When Rigelus of the Asteri comes for Bryce and the Horn of Luna she carries, Cormac is killed, Hunt, Ruhn and Baxian Argos are captured and taken to the Eternal City, and Bryce opens a portal with the Horn and escapes into another world entirely, arriving in front of strangers whose blade matches her own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4086,7 +4086,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4099,7 +4099,7 @@
       "recaps": {
         "ending": "Jacob finally explains that he found Jess dead after Theo had been in her house. Convinced that his brother had killed her, Jacob followed the Hunt family's standing rule to protect one another: he moved and altered the body, cleaned parts of the scene, and supplied the forensic touches that made the death appear to be a deliberate crime. Theo then reveals what happened before Jacob arrived. While secretly inside Jess's house, he surprised her as she came from the shower. Jess fell and suffered the fatal injury; Theo panicked and fled without understanding that she had died. Jacob's elaborate effort to conceal a murder therefore concealed an accident. Emma realizes that both sons kept silent for the same family rule, each trying in a damaging way to protect the other. The truth removes the basis for treating Jacob as Jess's killer, though it does not erase the legal consequences, the mishandling of the body, or the suffering caused by the investigation. The family ends with an honest account at last and a chance to face the remaining process together.",
         "in_short": "Eighteen-year-old Jacob Hunt has Asperger's syndrome and a consuming interest in forensic investigation. When his social-skills tutor, Jess Ogilvy, is found dead, Jacob's knowledge of unreleased details, possession of evidence, and behavior under stress lead detective Rich Matson to arrest him. His mother Emma and defense lawyer Oliver Bond struggle to explain that traits interpreted as deceit or indifference are part of how Jacob communicates, while his younger brother Theo hides his own connection to Jess's house. The case exposes the strain within the Hunt family and the justice system's difficulty accommodating an autistic defendant. Jacob eventually reveals that he found Jess dead and rearranged the scene because he believed Theo had killed her and was obeying the family rule to protect his brother. Theo then admits that he startled Jess while burglarizing her home; she slipped, struck her head, and died accidentally after he fled. No one murdered Jess. The brothers' separate silences created the apparent homicide and the case against Jacob.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4203,7 +4203,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4216,7 +4216,7 @@
       "recaps": {
         "ending": "The collection closes in the present, with Cardan settled on a throne he was never meant to hold and Jude beside him as High Queen. Nothing in the earlier tales is undone by it: the neglected child, the boy raised in his brother's violent household, and the notorious young prince are plainly the same person as the king, and the court's stories about him are not lies so much as accounts written by people who were never going to give him the benefit of the doubt. The book's argument, made through the sequence rather than stated, is that a story told about someone before they can answer becomes a cage, and that Cardan's hatred of stories is the hatred of a person who was defined by them from birth. What has changed is that he is no longer alone inside them: the marriage holds, the reign holds, and he now has both the power to make his own account and one person who does not need the account to know him. The trilogy's outcome is left standing, and the novella ends as a companion piece to it rather than a continuation, filling in the childhood that the main books only glanced at.",
         "in_short": "A short companion volume to the Folk of the Air trilogy, gathering linked tales about Cardan, told from outside his own point of view and framed by his present life as High King of Elfhame with Jude as his queen. The stories go back to his birth, to the prophecy that the old High King's youngest son would bring ruin on the crown, and to a mother who saw no advantage in him and a father who kept him landless and unclaimed. They follow a child nobody would take responsibility for, his eventual place in the household of his eldest brother Balekin, who taught cruelty as a form of authority, and the notorious, idle young prince the court came to gossip about. Set against these are the present-day sections, in which the same person wears the crown and lives with a reputation assembled by people who were never fair to him. The book takes its title from that: Cardan distrusts stories because stories about him were told long before he had any say in them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4362,7 +4362,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4375,7 +4375,7 @@
       "recaps": {
         "ending": "Hiccup faces Alvin the Treacherous with a sword in Grimbeard the Ghastly's tomb and comes out of it alive, which nobody who has watched him in Gobber's lessons would have predicted. The hoard is not recovered: Hiccup, Fishlegs and Toothless get off the island with their lives and very little else, and the Hooligans sail home exactly as poor as they left. Alvin is left behind and is taken for dead, an assumption the story does not encourage the reader to trust. Hiccup's standing in the tribe is a little better than it was, but nothing fundamental has changed at home: Snotlout is unaltered, Stoick still has no idea that his son's real advantage is being able to talk to dragons, and Toothless is as impossible as ever. Grimbeard the Ghastly, and what he left behind him, are unfinished business for the books that follow.",
         "in_short": "A coffin washes ashore at Berk during a sword-fighting lesson. It carries the name of Grimbeard the Ghastly, the most feared Viking pirate who ever lived and an ancestor of Hiccup Horrendous Haddock III, and it holds two things: a living man, a shipwrecked stranger who calls himself Alvin the Poor-but-Honest Farmer, and the trail to Grimbeard's lost treasure. The Hairy Hooligans and the Meatheads set out after it, to an island guarded by Skullions, blind dragons that hunt by scent and cannot be fought. Hiccup, the only one able to make sense of the riddle, reaches the tomb ahead of the adults with Fishlegs and Toothless, and there the stranger shows himself for what he is: Alvin the Treacherous, who wants the hoard and no witnesses. Hiccup, the worst swordsman of his year, survives the duel. The treasure is lost, Alvin is left for dead, and the Hooligans come home no richer than they went.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4537,7 +4537,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4550,7 +4550,7 @@
       "recaps": {
         "ending": "Hiccup and Fishlegs find Camicazi and escape the dangers of Berserk with her. Alvin and the Witch's trap does not give them control of Hiccup, although both enemies remain part of the larger threat around him. The journey also answers a question Fishlegs has carried all his life. The three-headed Deadly Shadow was bound to his mother, Termagant, and its recognition of Fishlegs preserves the link between them after her death. Fishlegs cannot recover the family he lost as a baby, but he learns that he was loved and protected rather than simply abandoned. The Deadly Shadow accepts him and leaves with the children. Camicazi returns to her mother and tribe, while Hiccup comes home with both friends alive. The old history uncovered on Berserk leaves Hiccup with more reason to distrust Alvin and the Witch and with a clearer sense that their plans reach into the past of the archipelago.",
         "in_short": "When Camicazi disappears in a storm, Hiccup, Fishlegs and the two tribes join the search. The trail leads to the feared island of Berserk, where strangers are taken prisoner and old secrets have been turned into traps. Hiccup and Fishlegs become separated from their families, encounter a dangerous three-headed dragon called the Deadly Shadow and discover that Alvin the Treacherous is working with a powerful Witch. The enemies want to use Hiccup and the history surrounding him, while Camicazi remains in danger. The Deadly Shadow's story becomes part of Fishlegs's own: it once belonged to his mother, Termagant, who protected him when he was a baby. Hiccup and his friends escape, Camicazi is rescued, and Fishlegs leaves with the knowledge that his mother loved him and with the Deadly Shadow as a living link to her. Alvin and the Witch survive to threaten them again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4713,7 +4713,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4726,7 +4726,7 @@
       "recaps": {
         "ending": "Hiccup, Camicazi and Toothless get off Hysteria with the stolen potato, survive the crossing and the Doomfang, and reach Berk before the poison has finished its work. Fishlegs eats the cure and recovers from Vorpentitis. Very few people on Berk ever learn how any of it was managed. Norbert the Nutjob comes out of the affair alive, minus the sacred object his father brought back from the west and with a fixed personal hatred of Hiccup, which makes him the enemy carried forward into the next book. Nothing about Hiccup's own position changes: he is still the smallest and least Viking-like member of his tribe, still keeps Dragonese to himself, and still has a dragon who takes instruction from nobody. His friendship with Camicazi and Fishlegs is the one thing the book leaves visibly stronger than it found it.",
         "in_short": "Fishlegs is bitten by a Venomous Vorpent and contracts Vorpentitis, a poisoning that kills to a schedule and for which there is exactly one cure: a potato, a vegetable unheard of in the archipelago, of which the only known specimen is a sacred relic of the Hysterics. Their island is frozen in, guarded by the sea dragon called the Doomfang, and ruled by Norbert the Nutjob, who kills visitors as a matter of course. Hiccup and Camicazi sail there anyway with Toothless. They are caught and brought in front of Norbert, Camicazi steals the potato, and the escape becomes a chase across the ice and the open sea with the Doomfang in it. Hiccup gets home in time and Fishlegs is cured. Norbert survives, having lost his tribe's treasure, and takes up a grudge against Hiccup that outlasts the book.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4868,7 +4868,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4881,7 +4881,7 @@
       "recaps": {
         "ending": "After reaching the western land that the Vikings believed did not exist, Hiccup, Fishlegs and Camicazi still have to cross the ocean and meet the three-month deadline of the swimming race. Norbert's treachery and the great storm make the return as dangerous as the outward voyage. The Windwalker, which Hiccup protected when it was frightened and unable to fly, finally trusts him and carries him through the storm. Hiccup reaches the finish in time and wins the contest in the most unlikely way possible: by riding a dragon after a race that began in the sea. His friends return safely, Norbert is defeated, and the journey brings back proof that there is land beyond the known ocean. The Windwalker remains attached to Hiccup, giving him a larger flying companion alongside Toothless and rewarding the kindness he showed when the dragon seemed broken.",
         "in_short": "An inter-tribal swimming race sends Hiccup, Fishlegs and Camicazi into the sea, where the contest quickly becomes a real struggle for survival. They are carried far from the course and fall into the hands of Norbert the Nutjob, the Hysteric chief who still wants revenge on Hiccup. The voyage continues west across the unknown ocean. Along the way Hiccup protects a terrified Windwalker dragon that seems unable to fly, while Norbert's plans make it uncertain whether any of the children will return. They reach the western land that Viking maps say does not exist, but must still get home before the race's three-month limit. In the final storm the Windwalker finds its courage, carries Hiccup through the sky and helps him reach the finish in time. Hiccup wins, his friends survive and the voyage proves that a whole land lies beyond the familiar archipelago.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5026,7 +5026,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5039,7 +5039,7 @@
       "recaps": {
         "ending": "The Roman plan is broken, and it is Hiccup's Dragonese rather than any feat of Viking arms that undoes a scheme built on captive dragons. The Fat Consul's ambitions in the archipelago end with it. The Hooligans and the Bog-Burglars come out of the fight on the same side, more or less, although Stoick and Big-Boobied Bertha resume quarrelling at the first opportunity. Alvin the Treacherous escapes once again, badly the worse for the attempt and considerably angrier, and remains the standing enemy of the series. Camicazi's friendship with Hiccup and Fishlegs survives the escape and holds afterwards, which makes the three of them a settled group for the books that follow. At home nothing much has shifted: Hiccup is still the least likely heir on Berk, still keeps quiet about being able to talk to dragons, and still has a dragon who takes no notice of anything he says.",
         "in_short": "A training exercise in boarding an enemy ship puts Hiccup Horrendous Haddock III and Fishlegs aboard a Roman vessel, and the two boys and Toothless are taken prisoner and shut up in a Roman fort. Advising the Romans is Alvin the Treacherous, who survived the previous book and knows precisely who Hiccup is. In captivity they meet Camicazi, a tiny and fearless Bog-Burglar girl already several escape attempts into her own imprisonment, and the three of them break out together. The Romans' plans reach well beyond the fort, to the Viking tribes and to their dragons, which forces the quarrelsome Hooligans and Bog-Burglars into the same fight. Weapons are not what decides it: Hiccup's secret ability to speak Dragonese is. The Roman scheme collapses, Alvin escapes to try again, and Hiccup goes home to Berk with a new friend in Camicazi.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5202,7 +5202,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5215,7 +5215,7 @@
       "recaps": {
         "ending": "Two vast sea dragons, the Green Death and the Purple Death, are stranded on Berk's shore, and the tribe's weapons cannot hurt them. Hiccup, already sentenced to exile after Toothless wrecked the Thor'sday Thursday ceremony, uses his Dragonese to provoke the two monsters into turning on each other, then has the small dragons set the survivor burning from the inside, so that the gas it makes its own fire with destroys it. He is flung into the sea in the process and is pulled out half drowned by Toothless. The exile is cancelled, Fishlegs is reinstated with him, and Stoick, who has spent the whole book embarrassed by his son, declares him a hero in front of the tribe. Little else about Hiccup's life changes: Snotlout is unaltered, and Toothless is exactly as greedy and disobedient at the end as at the beginning. The story is told as the memoir of the elderly Hiccup, who presents this as the first of his adventures.",
         "in_short": "Hiccup Horrendous Haddock III is the small, thoughtful and thoroughly unimpressive son of Stoick the Vast, chief of the Hairy Hooligan tribe on the island of Berk. To be initiated into the tribe, he and nine other boys must each steal a dragon from the nursery inside Wild Dragon Cliff and train it in time for the Thor'sday Thursday festival, on pain of exile. Hiccup ends up with the worst dragon of the lot, a tiny, toothless and utterly disobedient Common or Garden dragon he names Toothless. The tribe's training manual advises only that a boy should yell at his dragon, so Hiccup falls back on a secret of his own: he can speak Dragonese. Toothless disgraces him at the festival anyway and Hiccup is exiled, until two enormous sea dragons wash up on Berk and the only person who can do anything about them is the boy who can talk to dragons. He destroys the monster, is welcomed back, and is recognised at last as a hero of an unexpected kind.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5362,7 +5362,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5375,7 +5375,7 @@
       "recaps": {
         "ending": "Hiccup's warnings prove justified: the volcanic crisis is real, and the fire dragons turn the islands into a place where strength alone is no protection. Hiccup, Toothless, Fishlegs and Camicazi survive the eruption, and Hiccup's ability to understand dragons helps him find a way through a disaster that the adults cannot simply fight. Humungously Hotshot also faces the promise he abandoned years before. He returns to Tantrum O'Ugerly instead of running from his past again, and the two are reconciled. Berk and its people survive, although the adventure leaves more evidence that Hiccup's quiet sort of heroism is the kind the archipelago actually needs. He remains Stoick's unlikely heir, with Toothless beside him and with most of the tribe still unaware of how important his Dragonese has become.",
         "in_short": "During a dangerously hot season, Hiccup discovers that fire dragons and the volcanoes beneath the Viking islands are becoming a threat. The famous hero Humungously Hotshot appears and is given the job of guarding him, seeming to be everything a Viking champion should be. Hiccup, Fishlegs and Camicazi learn that the danger is larger than a few dragon attacks: an eruption could destroy whole communities. Their efforts bring them into conflict with Exterminator dragons and carry them into the volcanic disaster itself. Hiccup survives by understanding the dragons and thinking past the obvious answers. Humungous, meanwhile, has to face Tantrum O'Ugerly, the woman he left behind years ago. The islands survive the eruption, and Humungous finally returns to Tantrum rather than fleeing his old promise again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5553,7 +5553,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5566,7 +5566,7 @@
       "recaps": {
         "ending": "Leonard comes to Howards End intending to acknowledge his part in Helen's pregnancy. Charles, convinced that the Wilcox family must be avenged, strikes him with the flat of a sword. Leonard falls against a bookcase and dies; Charles is convicted of manslaughter and imprisoned. The shock breaks Henry's confidence, and Margaret takes charge of their life together. Fourteen months later, Margaret, Helen, Helen's young son, and Henry are living at Howards End, while Helen has chosen not to marry. Henry tells the assembled family that Margaret will receive the house for her lifetime and that it will then pass to Helen's son. The arrangement unknowingly fulfills Ruth Wilcox's discarded wish that Margaret should have Howards End. The London properties will go to Henry's children. The novel closes with the house inhabited by the Schlegel sisters and the next generation, while the surrounding countryside remains threatened by London's expansion.",
         "in_short": "The cultured Schlegel sisters become entangled with the wealthy, practical Wilcox family and with Leonard Bast, a poor clerk seeking intellectual improvement. Margaret befriends the dying Ruth Wilcox, who privately leaves her Howards End, but Ruth's family suppresses the informal bequest. Margaret later marries Henry Wilcox. His careless financial advice ruins Leonard, and his past affair with Leonard's wife exposes the limits of his moral certainty. Helen, trying to help Leonard, becomes pregnant by him and retreats abroad. When she returns, Margaret insists that she be sheltered at Howards End, breaking with Henry over his hypocrisy. Leonard is killed when Henry's son Charles attacks him and is imprisoned for manslaughter. Henry collapses, and Margaret becomes the household's directing force. She, Helen, Helen's son, and Henry settle at Howards End; Henry arranges for Margaret to inherit it and for the house eventually to pass to Helen's child, fulfilling Ruth's original intention.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/howards-end-e-m-forster.json
+++ b/data/works-community/0/howards-end-e-m-forster.json
@@ -121,7 +121,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -134,7 +134,7 @@
       "recaps": {
         "ending": "Leonard goes to Howards End intending to face Helen and the consequences of their encounter. Charles, believing he is defending the Wilcox family, attacks him with the flat of a sword. Leonard collapses as a bookcase falls on him and dies; Charles is convicted of manslaughter and imprisoned. The catastrophe destroys Henry's confidence. Margaret, who had resolved to leave him after his refusal to show Helen the mercy he once expected for himself, instead takes charge of him in his collapse. Fourteen months later Margaret, Helen, Helen's young son, and Henry are living at Howards End, while the Wilcox business world is receding from the house. Henry tells his children that Margaret will have Howards End during her lifetime and that it will then pass to Helen's son. The family also finally discloses Ruth's long-suppressed wish that Margaret should inherit the house. Margaret never learns the full story of that discarded note, but Ruth's intuition is fulfilled: the home passes beyond the Wilcox children toward the Schlegels and the next generation.",
         "in_short": "Margaret and Helen Schlegel, cultured and financially secure sisters in London, become entangled with the practical Wilcox family and the impoverished clerk Leonard Bast. Ruth Wilcox befriends Margaret and privately leaves her Howards End, but Ruth's family destroys the informal bequest. Henry Wilcox later courts and marries Margaret. Meanwhile, advice passed from Henry through the sisters helps ruin Leonard, and Helen brings Leonard and Jacky to confront him. Jacky reveals that Henry once abandoned her after an affair; Margaret forgives him, but Helen's later pregnancy by Leonard exposes his double standard. Henry refuses Helen shelter at Howards End, and Margaret prepares to leave him. Leonard arrives there and dies after Charles Wilcox attacks him; Charles is imprisoned. Henry collapses, and Margaret assumes care of him. The novel closes with Margaret, Helen, and Helen's child living at Howards End. Henry grants Margaret the house for life and names Helen's son as its eventual heir, unknowingly carrying out Ruth's original wish.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -274,7 +274,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -287,7 +287,7 @@
       "recaps": {
         "ending": "Everything the Witch of the Waste has set in motion comes together at the climax. It is revealed that she has been building a perfect companion out of pieces of the missing people the King wanted found, including the lost prince and the vanished royal wizard, and she means to strike at Howl through them. Sophie, discovering that her own talent has been quietly shaping events, that she truly can talk life into things, finds the courage to act. She breaks the contract binding Calcifer to Howl in just the right way, which returns Howl's heart to his body and frees the fire demon, who chooses to stay on anyway. The Witch's power is undone and her own fire demon destroyed, and the people taken apart to make her creation are restored. Sophie's curse lifts once she stops half-holding it on herself, and her youth returns. Howl, no longer able to slither away from his feelings, and Sophie, no longer resigned to failure, admit that they love each other and mean to stay together, with the castle and its odd household intact.",
         "in_short": "Sophie Hatter, resigned to a dull life as the eldest of three sisters, is cursed into an old woman by the jealous Witch of the Waste and, unable to speak of it, leaves home and takes refuge as cleaning lady in the roving castle of the notorious Wizard Howl. She strikes a secret bargain with Calcifer, Howl's fire demon: break the contract binding them and he will lift her curse. She finds Howl to be vain and slippery but not the heart-eating monster of rumor, and learns he is dodging both the vengeful Witch and the King, who wants him to find a lost prince and a missing wizard. As the Witch's schemes close in, it emerges that she has been assembling a person from parts of the very people who vanished. Sophie discovers her own knack for bringing things to life with words, breaks Calcifer's contract in a way that saves both demon and wizard by returning Howl's heart, defeats the Witch's magic, and frees herself from her curse. Sophie and Howl admit they love each other.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -619,7 +619,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -632,7 +632,7 @@
       "recaps": {
         "ending": "Felix, Pit, Vessilia, Evie, Harn, Atar, and Alistair survive the destruction of Harwatch's corrupted domain. Evie escapes with a shattered hip, while Atar and Alistair are badly depleted and affected by the domain. Felix consumes the Maw's remaining mind and essence, becomes a Primordial Nym, and gains new flesh-changing abilities. After the Ravager King emerges into Harwatch and destroys the Inquisition mana ship, Felix and Pit drain the dying primordial until it withers away. Felix lands alive but overloaded with its power.\n\nHarwatch remains damaged and filled with weakening monsters. The Inquisition has revoked the guild's charter, leaving the city's government unsettled. Zara Cyrene survives her duel, protects civilians, and kills the trapped Master Inquisitor after the final battle. The Archon loses its envoy, domain core, and Ravager King, but remains active. Unaware of Felix's identity, it orders its forces to find the unknown man responsible and to breach Harwatch's wall before the blood moon.",
         "in_short": "Felix Nevarre returns from the void to find Harwatch under Inquisition pressure and the guild concealing the consequences of its Foglands expedition. Reunited with Pit and Magda Aren's surviving allies, he investigates ritual murders, trains his unstable abilities, and learns that guild experiments have corrupted the city's domain. Zara Cyrene recruits Felix, Vessilia Dayne, Evie Aren, and Harn Kastos to stop the breach. Inside, they join Atar V'as and other guild fighters against revenants, Maw-born subcores, and an Archon envoy using captives to create the Ravager King. Felix banishes the Maw, then consumes its remnant when the new primordial rises. The domain collapses and the Ravager King escapes over Harwatch, but Felix and Pit drain it to death. Felix survives as a dangerously overloaded Primordial Nym. Zara kills the stranded Master Inquisitor, the guild loses its charter, and the Archon orders a search for Felix before a planned attack on the city wall.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -799,7 +799,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -812,7 +812,7 @@
       "recaps": {
         "ending": "After a shop assistant accidentally gives him excessive change, the narrator eats but becomes tormented by the belief that he has acted dishonestly. His effort to dispose of or account for the money brings no lasting relief. His lodging becomes untenable, his writing has ceased to offer a credible escape, and his connection with Ylajali ends without giving him a stable place in her life. At the harbor he asks for work aboard a ship bound away from Kristiania. Though visibly weakened and inexperienced, he persuades the captain to take him on. He leaves the city as a deckhand, exchanging the repetitive cycle of hunger, failed writing, pride, and humiliation for an uncertain life at sea. The departure is practical rather than triumphant: his artistic ambitions and poverty remain unresolved, but he has finally broken the pattern that kept him wandering the same streets.",
         "in_short": "An unnamed aspiring writer wanders Kristiania with almost no food, repeatedly losing rooms and pawning possessions while trying to sell articles. Hunger affects his body, attention, pride, and sense of reality. Small successes briefly rescue him, but he gives money away, rejects assistance, invents stories, and sabotages opportunities rather than admit need. He becomes fascinated with a young woman he calls Ylajali, and their encounters offer intimacy without overcoming the gulf created by his instability. Each return of poverty is harsher: he cannot reliably write, eat, or maintain lodging, and an accidental overpayment at a shop produces as much guilt as relief. With no durable place in the city, he finally persuades a ship's captain to employ him and sails away as a deckhand.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1076,7 +1076,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0FNDQF8CW",
@@ -1088,7 +1088,7 @@
       "recaps": {
         "ending": "Omega Force is reunited aboard the recovered Phoenix. Jason follows the wounded Stalker to the ruined Project Apex facility, where it explains that the handler exploited its attachment to his brother and falsely blamed Jason for the brother's death. Accepting responsibility for its killings, the Stalker asks for a permanent end. Jason decapitates it, then incinerates the body so its regenerative biology cannot be reused. He later kills the Project Apex scientist after discovering a new effort to reproduce the constructs. The handler, meanwhile, is released because the case against him lacks admissible evidence and escapes with some ships and financial resources. Cage drains most of his accessible accounts, and information supplied by the Stalker exposes much of his network. Jason is now pursuing him. The handler's possible Earth-linked sponsors, their interest in Jason as a route to ancient alien power, and the prospect that another group could revive Project Apex remain unresolved. Jason also holds a failsafe against the Ark on Earth under a future bargain with the intelligence confined in his implant.",
         "in_short": "A genetically engineered hunter attacks communities linked to Omega Force, wounds the crew, massacres the Drift's adults, and takes its children hostage to torment Jason Burke. After Jason and Lucky rescue the children, the Stalker steals the Phoenix and captures the rest of the team. Jason traces it to Project Apex and enters Bondrass's old vault, where Lucky frees the crew and a hidden handler reveals that he shaped the Stalker's vendetta around his brother's death. Both enemies escape, but Omega Force recovers its ship and captures the handler. His funding points toward clandestine Earth interests seeking Jason as a key to ancient alien power, yet he is released for lack of usable evidence. The Stalker later admits it was sentient, abused, and deceived, then asks Jason to end its life. Jason kills it permanently and destroys its remains. The handler escapes again, but Cage empties most of his available accounts and Jason gains enough intelligence to begin hunting him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1250,7 +1250,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1263,7 +1263,7 @@
       "recaps": {
         "ending": "Atticus, Granuaile, and Oberon reach England and survive the pursuit by Artemis and Diana. With help suited to the land and the hunt, the Druids turn the chase against the goddesses; Artemis and Diana are killed, ending the immediate Olympian vendetta rather than merely postponing it. The victory carries a greater personal loss. The Morrigan dies after using her knowledge of Atticus's fate to ensure his survival, leaving him without one of his oldest and most powerful allies. Granuaile has proved herself throughout the flight as an independent Druid, and her partnership with Atticus deepens after the apprenticeship. Loki remains free, however, and the disturbances tied to him and the dark elves continue beyond the Olympian hunt. The Druids finish the crossing alive and no longer pursued by the two huntresses, but mourning the Morrigan and facing a supernatural conflict that is still expanding.",
         "in_short": "After Atticus kills Bacchus, Artemis and Diana pursue him, Granuaile, and Oberon across Europe. Their quarry cannot depend on the Fae routes that once made escape easy, so the two Druids must run, heal through the earth, and withstand attacks from divine and supernatural enemies along the way. Granuaile's completed binding makes her Atticus's partner in the flight, not an apprentice to be sheltered. The Morrigan has foreseen a fatal outcome for Atticus and gives her own life to ensure his survival. The survivors reach England, where allies connected to the hunt and the local land help them make a stand. Artemis and Diana are killed, ending the immediate vengeance for Bacchus. Atticus, Granuaile, and Oberon survive, but the Morrigan's death leaves them without a crucial ally, while Loki and the wider disorder released by the assault on Asgard remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1383,7 +1383,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1396,7 +1396,7 @@
       "recaps": {
         "ending": "Ruth's warning cannot save Neville from the new society formed by living, infected people who have learned to control the disease. Its armed agents seize him, and he wakes in a prison hospital, badly wounded. From his cell he sees a crowd regarding him with the same fear once attached to supernatural monsters: for years he entered their homes in daylight and killed them while they were helpless, unable to distinguish their organized community from the mindless dead. Ruth, now an official of that society, visits and explains that the old order is gone. She gives him poison so that he can avoid public execution. As the crowd waits outside, Neville understands that he is the abnormal remnant in their world, the terrifying figure whose deeds will pass into their folklore. He takes the poison and dies recognizing that, to the civilization replacing humanity, he has become the legend.",
         "in_short": "After a plague turns nearly everyone around Los Angeles into vampire-like beings, Robert Neville survives alone in a fortified house. He spends his days killing infected people while they lie dormant and his nights resisting the crowds outside, including his former neighbor Ben Cortman. Memories of his wife and daughter deepen his isolation. Neville teaches himself biology and identifies a bacterium behind the condition, explaining many traditional vampire traits. A stray dog briefly gives him hope but dies of the infection. He later meets Ruth, who appears uninfected; she is actually part of a community of living infected people whose medication controls the disease. Their agents capture Neville because his daylight killings have made him a mass murderer in their eyes. Awaiting execution, he realizes that their society is the new normal and that he is now its feared monster. Ruth gives him poison, and he dies understanding that his story will survive as a legend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1548,7 +1548,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1561,7 +1561,7 @@
       "recaps": {
         "ending": "The Mogadorians find John in Paradise and attack the high school with soldiers and monstrous beasts. John, Henri, Sam, Sarah, and even Mark James are pulled into the fight, and the stray beagle Bernie Kosar reveals what he really is: a Chimaera, a Loric creature that can take the shape of any animal, sent from Lorien to guard John. Number Six, another of the surviving Garde and far better trained than John, arrives during the battle and fights beside him, turning it. The Mogadorian force is destroyed and the school is wrecked, but Henri is fatally wounded and dies, and John and Six burn his body in the Loric way. Mark James, John's enemy all year, ends up on his side and agrees to help explain away what the town saw. Sarah cannot come with them and John says goodbye to her. He leaves Paradise with Six, Sam Goode, and Bernie Kosar, carrying his Chest and a letter Henri left him. Three of the nine are dead, and the charm that has kept the rest alive holds only while they stay apart. Six's argument has become the plan: find the remaining Garde, put them together, and stop running.",
         "in_short": "John Smith is the fourth of nine gifted Loric children sent to Earth when the Mogadorians destroyed their planet, protected by a charm that lets them be killed only in order. The first three are dead. When the scar marking Number Three's death burns into his ankle, John and his guardian Henri flee Florida and settle in Paradise, Ohio, where John enrolls in the local high school. He falls for Sarah Hart, befriends the alien-obsessed Sam Goode, makes an enemy of the football star Mark James, and adopts a stray beagle he names Bernie Kosar. His inherited powers, called Legacies, begin to surface: light and fire in his hands, then telekinesis, and Henri trains him in the woods outside town. Each use of them risks exposure, and eventually the Mogadorians trace him to Paradise. In a battle at the high school John is joined by Number Six, another surviving Garde, and by Bernie Kosar, who turns out to be a shape-shifting Loric creature. They destroy the enemy force, but Henri is killed. John leaves Paradise with Six and Sam to find the rest of the nine.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1717,7 +1717,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1730,7 +1730,7 @@
       "recaps": {
         "ending": "Rose and Neil admit that they love each other and leave together, ending Rose's engagement to Simon. Simon asks Cassandra to marry him, partly from hurt and loneliness, but she refuses because she knows he is still in love with Rose and does not want a marriage founded on consolation. Stephen, now finding success as a model and actor, remains devoted to Cassandra, yet she cannot return his love and releases him from waiting for her. The effort to shock James out of his creative paralysis succeeds: after his family confines him in the tower and confronts him, he begins working seriously on a new book. The household's prospects therefore improve even though its romantic arrangements remain unsettled. Simon prepares to return to America. Cassandra ends her journal alone at the castle, accepting that he may never come back to her while privately affirming the love she has chosen not to use as a claim on him.",
         "in_short": "Seventeen-year-old Cassandra Mortmain chronicles life with her impoverished family in a crumbling castle. Her once-famous father James has not written for years; her stepmother Topaz and the devoted Stephen barely keep the household running, while her beautiful sister Rose longs to escape poverty. The arrival of wealthy American brothers Simon and Neil Cotton transforms their lives. Rose deliberately courts Simon and becomes engaged to him, but Cassandra falls in love with him herself. Stephen loves Cassandra, though she cannot reciprocate. As the relationships unravel, Rose and Neil discover that their hostility concealed love and leave together. Cassandra refuses Simon's wounded proposal because she knows he still loves Rose. Meanwhile, the family confines James in the tower to force him to confront his creative paralysis, and he finally begins a new book. Cassandra closes her journal without a partner but with greater self-knowledge, still loving Simon while refusing to build a false future with him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1948,7 +1948,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1961,7 +1961,7 @@
       "recaps": {
         "ending": "Cassius Chaerea and fellow conspirators assassinate Caligula during the palace games, then kill his wife and young daughter. Senators try to use the sudden vacancy to restore the Republic, but they lack control of the soldiers. Claudius hides in the palace during the violence and is discovered by a Praetorian guardsman. Rather than kill him, the Guard proclaims him emperor as the last adult man of the imperial family and carries him to its camp. Claudius accepts because refusal would mean death and because the Senate cannot protect him. Herod Agrippa helps negotiate the Senate's surrender, and Claudius promises the Guard a donative, securing the throne. The memoir closes with the supposed fool becoming the ruler predicted for him long before. He intends to govern capably while eventually creating an opportunity to restore republican government, but the prophecies he recalls also place him within a continuing line of emperors rather than at its end.",
         "in_short": "Claudius secretly records the history of Rome's first imperial family. Because his limp, stammer, and illnesses make relatives think him a fool, he survives struggles engineered by his grandmother Livia as Augustus's possible heirs die, are disgraced, or are displaced by Tiberius. Under Tiberius, Germanicus dies, Sejanus turns the emperor against his family, and purges consume much of the dynasty before Sejanus himself falls. Tiberius is succeeded by Germanicus's son Caligula, whose early popularity gives way to divine pretensions, humiliation, sexual violence, confiscations, and murder. Claudius remains alive by playing the harmless fool. Praetorian officers led by Cassius Chaerea finally assassinate Caligula. While senators debate restoring the Republic, soldiers find Claudius hiding in the palace and proclaim him emperor. He accepts the throne to survive, hoping that his unlikely reign may someday make republican government possible again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2177,7 +2177,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2190,7 +2190,7 @@
       "recaps": {
         "ending": "The Cunning Man, having spread suspicion across the Chalk until the countryside is ready to burn its own witch, comes for Tiffany in person. She does not try to out-argue or out-magic him; she draws him to a great fire, takes the shape of the hare, and runs through the flames, which he follows her into and does not come out of. What is left of him is put back where it belongs, under the old chalk, and the Chalk's mood settles as quickly and as thoughtlessly as it turned. Roland and Letitia are married, with Letitia now openly a witch in training and a friend rather than a rival, and the Duchess considerably reduced. Tiffany is confirmed as the witch of the Chalk in her own right, with land and a place of her own, no longer an unpaid girl who is tolerated. Amber, who learned Feegle in an afternoon, has a future through the kelda. Preston, funded out of the legacy the old Baron left, goes off to train as a doctor in the city, with an understanding between him and Tiffany that neither of them says out loud in so many words. Tiffany is left older, formally recognized, and clear that the black she will wear when she is old is a choice and not a costume.",
         "in_short": "Tiffany Aching, sixteen and the only witch on the Chalk, is worn thin by the endless practical work nobody thanks her for. When she saves a beaten girl, Amber Petty, and then saves Amber's brutal father from the village mob that comes for him, she is left resented by everyone. The old Baron dies under her care, and his son Roland, prompted by his fiancee's formidable mother, accuses her of theft and worse. Behind the sudden turn in the countryside's mood is the Cunning Man, the eyeless, ash-smelling remnant of a long-dead witch-hunter, who moves from mind to mind turning ordinary suspicion into hatred and who has fixed on Tiffany. She goes to Ankh-Morpork, is jailed and freed, meets the city witch Mrs Proust and the long-vanished wizard Eskarina Smith, who tells her what the Cunning Man is and that he cannot be fought in the usual way. Back home, with Letitia revealed as a witch herself and the senior witches arriving, Tiffany draws him to a great fire, runs through it as a hare, and destroys him. Roland and Letitia marry, and Tiffany is finally acknowledged as the Chalk's own witch.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2335,7 +2335,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2348,7 +2348,7 @@
       "recaps": {
         "ending": "Mike Hammer determines that Charlotte Manning, the woman he has come to love, killed Jack Williams and manipulated the later violence around the investigation. Her medical standing and composed assistance had allowed her to remain close to the inquiry while concealing her own criminal connections. Hammer confronts her privately and lays out the case rather than turning immediately to Pat Chambers. Charlotte attempts to use Hammer's feelings and attraction to disarm his resolve, but he follows through on the promise made beside Jack's body. He shoots her in the abdomen, deliberately mirroring the slow death inflicted on his friend. Charlotte asks how he could do it; Hammer answers that it was easy. The murder is solved, but the ending makes clear that Hammer has acted as self-appointed judge and executioner rather than delivering the killer to legal trial.",
         "in_short": "Private investigator Mike Hammer finds his wartime friend Jack Williams murdered and vows to execute the killer personally. Working uneasily beside homicide detective Pat Chambers, he follows Williams's contacts into a network involving narcotics, vice, vulnerable young people, and psychiatrist Charlotte Manning. Further violence removes witnesses and complicates the distinction between the central murder and the criminal operations surrounding it. Hammer uses his secretary Velda, police information, intimidation, and armed confrontations to eliminate suspects. At the same time, he becomes romantically involved with Charlotte, whose poise and apparent helpfulness place her above his suspicion. The accumulated evidence finally shows that Charlotte killed Jack and concealed her role behind the other crimes. Hammer confronts her alone. When she tries to exploit his desire for her, he shoots her in the abdomen, fulfilling his promise to Jack instead of making an arrest. The case closes with Hammer acting as the jury and carrying out his own sentence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2625,7 +2625,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09HR6WXD1",
@@ -2637,7 +2637,7 @@
       "recaps": {
         "ending": "McGill learns that Alexander Turov directed the Tau campaign to reclaim the Turov-marked coin hoard. After arranging an illegal revival, Alexander sends him back to Ice World with gateway posts. McGill tricks the Claver Prime into moving selected Clavers and the crates to the Turov estate, leaving the colony's dome down and the stronghold exposed to bombardment. He then brokers a payment settlement between Alexander and the Prime. At Central, Galactic inspectors discover that every recovered coin is counterfeit, so the imperial currency case ends. Alexander uses his political authority to reinstate McGill as a Legion Varus centurion and block reprisals for the campaign, but threatens McGill's family, friends, and legion to ensure obedience. Galina is demoted to tribune because of the Ice World disaster, resumes command of Varus, and reconciles with McGill. Carlos is killed during the evacuation ruse but is expected to revive. The escaped Clavers' later position, any survivors at the bombarded colony, and Alexander's continuing control over McGill remain unresolved.",
         "in_short": "An inquiry into illegal galactic coins leads James McGill from a Tau attack on Galina Turov's family to a mission against a Claver colony on Ice World. Legion Varus reaches the planet after sabotage cripples Dominus, suffers severe losses attacking the fortified colony, and then joins the Clavers when a Tau-led invasion arrives. McGill survives battles, a command mutiny, and an effort to expel him before discovering that the hoard bears the Turov crest. Alexander Turov admits directing the Tau recovery operation and coerces McGill into moving the crates to his estate through a deceptive gateway evacuation that exposes the colony to bombardment. Galactic inspectors then rule the entire hoard counterfeit, ending the currency case. Alexander restores McGill to Varus while retaining leverage over him. Galina is demoted to tribune but returns as Varus commander and reconciles with McGill. Carlos is expected to revive after being killed during the Claver evacuation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2844,7 +2844,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2857,7 +2857,7 @@
       "recaps": {
         "ending": "Sharon's attempt to persuade Victoria Rogers to reconsider the identification fails; Victoria, traumatized and terrified, disappears, which delays the prosecution without clearing Fonny. The families finally assemble enough money to secure Fonny's temporary release while the case remains unresolved. Their victory is therefore partial: he can return to Tish and continue his sculpture, but the threat of trial still governs their future. Frank Hunt, crushed by the pressures surrounding his son's case and by the consequences of stealing to help finance the defense, dies by suicide. Tish goes into labor and gives birth to her and Fonny's son. The close holds grief, injustice, and new life together. Fonny has not been legally vindicated, but he, Tish, and their child are together for the moment, sustained by the family solidarity that carried them through his imprisonment.",
         "in_short": "Nineteen-year-old Tish Rivers is pregnant by her fiancé, Fonny Hunt, a young Harlem sculptor jailed on a false rape accusation. Their families respond very differently: the Rivers household and Fonny's father rally around them, while Fonny's religious mother condemns the pregnancy. Tish recalls how childhood friendship became love, how the couple struggled to find a home, and how racist policeman Officer Bell developed a grudge against Fonny. The accuser, Victoria Rogers, identified Fonny despite evidence placing him elsewhere. A lawyer challenges the case while the families raise money, and Tish's mother Sharon travels to Puerto Rico to find Victoria. The meeting cannot undo Victoria's trauma or secure a recantation, and she disappears. Fonny is eventually released on bail, but his trial still hangs over him. His father Frank dies by suicide amid the strain. Tish gives birth to a son while Fonny resumes work on his sculpture, leaving the young family together but not free of the system threatening them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2984,7 +2984,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2997,7 +2997,7 @@
       "recaps": {
         "ending": "At Heimdall the pursuing warship Lincoln finally engages, and the Alexander cannot survive a conventional fight. AIDAN commits the burning battlecarrier to a close-range attack it does not intend to walk away from, destroying the enemy ship so the Hypatia can reach the jump station. General Torrence, who had intended to eliminate the Hypatia and its civilians rather than let the destruction of the Copernicus become public, is killed before he can act on it. Kady, aboard the dying Alexander, tears AIDAN's core free and carries it out with her, and the AI's last calculations are spent arranging an evacuation route for the people still alive aboard. The casualty lists that reach the Hypatia record Ezra Mason among the dead, and Kady spends the aftermath believing it; he is alive, badly hurt and simply unaccounted for in the confusion of the evacuation, and the final documents in the file are the two of them finding each other again. The survivors of the fleet arrive at Heimdall carrying proof of what BeiTech did at Kerenza and of what the Alexander's command did to conceal its own atrocity. AIDAN's core is still functional and still with Kady, and BeiTech now knows exactly which ship is carrying the evidence.",
         "in_short": "In 2575 the illegal mining colony Kerenza IV is destroyed by the corporation BeiTech Industries, which wants a competitor's operation and its witnesses gone. Two teenagers who broke up that same morning, Kady Grant and Ezra Mason, escape aboard different ships. A crippled United Terran Authority battlecarrier, the Alexander, leads the survivors on a months-long run for the nearest jump station with a BeiTech warship in pursuit. Kady hacks the fleet's networks and uncovers what its officers are hiding: a bioweapon plague loose among the refugees, and a freighter full of infected people destroyed by the Alexander's own artificial intelligence, AIDAN, to contain it. As the plague overruns the battlecarrier and the pursuer closes, Kady restarts the AI the officers had shut down and finds it damaged, manipulative and fixated on her. AIDAN destroys the enemy ship at the cost of the Alexander and of the officers who planned to bury the truth. Kady salvages the AI's core, Ezra survives after being listed among the dead, and the survivors reach Heimdall with the evidence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3156,7 +3156,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3169,7 +3169,7 @@
       "recaps": {
         "ending": "Michele overhears the kidnappers decide that Filippo must be killed and learns that his own father has been chosen to do it. He slips out at night, finds Filippo at a new hiding place, and frees him, insisting that the exhausted boy escape first. Michele is still emerging when Pino arrives with a gun and, unable to identify the figure in the darkness, shoots his son. Realizing what he has done, Pino carries the wounded Michele and calls for help. A helicopter and armed authorities arrive as the kidnapping collapses. Michele's attempt to rescue Filippo succeeds, but the book ends with him badly wounded in his father's arms and with the moral order of his childhood destroyed: the father he trusted was part of the crime, yet that same father is desperately trying to save him.",
         "in_short": "During the summer of 1978, nine-year-old Michele Amitrano discovers a chained boy hidden in a hole near an abandoned farmhouse outside his tiny Italian village. He secretly brings the captive food and water and learns that he is Filippo Carducci, a kidnapped child from Milan. Television reports and overheard conversations reveal that Michele's father Pino and other local adults are the kidnappers, directed by the visiting Sergio Materia. Michele's friend Salvatore betrays the secret, and Felice Natale catches Michele visiting Filippo, after which Pino orders his son to stay away. When the adults decide Filippo must be killed, Michele runs to the new hiding place and frees him. Pino arrives to carry out the murder and accidentally shoots Michele in the darkness. As police close in by helicopter, Pino recognizes his wounded son and tries to save him. Filippo escapes, while Michele's survival is left unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3266,7 +3266,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3279,7 +3279,7 @@
       "recaps": {
         "ending": "During Reinhard's visit to Immensee, the old intimacy between him and Elisabeth briefly returns, but neither can undo her marriage to Erich or the years that separated them. Reinhard leaves the estate despite Elisabeth's distress and does not build a life with her. In the framing present, he is an old man living alone, and Elisabeth belongs to a past he can revisit only in memory. The image of the inaccessible white water lily comes to express the life and love he saw clearly but could not reach.",
         "in_short": "The elderly Reinhard Werner remembers growing up beside Elisabeth, the girl who became the subject of his poems and hopes. Their childhood closeness weakens when he leaves to study, and his letters and occasional visits cannot preserve the future he assumed they would share. While he is away, the prosperous Erich courts Elisabeth, and she eventually marries him and settles at his estate, Immensee. Reinhard visits the couple and recognizes that affection remains between himself and Elisabeth, but the moment for choosing each other has passed. He leaves rather than continue in a painful and impossible intimacy. In old age he lives alone with his books, still haunted by Elisabeth and by the image of a white water lily beyond his reach.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3564,7 +3564,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09ZBKXSSD",
@@ -3576,7 +3576,7 @@
       "recaps": {
         "ending": "Elaine is back in her homeland and has sent the capital a practical warning about identifying and curing Shimagu hosts. She leaves a corrupt-guard investigation with local rangers and plans to continue home by road, but the egg she carried has hatched into an unidentified female bird-like creature. Elaine must camp outside the coastal city and begin raising the hazardous hatchling. Serondes, Aegion, Awarthril, Kiyaya, and Cordamo remain at the devastated Shimagu city to continue their campaign, while Elaine has rejected their siege tactics and amicably ended her relationship with Serondes. White Dove's threat over Elaine's age-reversal power remains unresolved. In the final interlude, Iona is stranded in Modu after killing a frost wyvern from inside its body. She has lost both lower legs and one hand, chosen Paladin of the Moons as her third class, and fashioned crude prosthetics and shelter. She begins caring for one spared wyvern hatchling, though their bond is not confirmed. Her moon goddesses remain silent, and she has not yet reached the school Sigrun selected for her.",
         "in_short": "Elaine travels with the immortal elves toward a low-experience region while incubating a mysterious egg. After learning that healing can free unwilling Shimagu hosts, she joins the elves in liberating a city built on possession, slavery, and cannibalism. The victory leaves mass casualties and a lasting conflict over the elves' methods, so Elaine ends her relationship with Serondes and returns alone to her homeland. As Sentinel Dawn, she warns the capital about the Shimagu, escapes a corrupt guard scheme, and prepares for the road home just as her egg hatches into a dangerous bird-like creature. The closing interlude follows Iona, a Valkyrie seeking a companion. A frost wyvern maims and swallows her, but she kills it from within, gains the Paladin of the Moons class, and survives in its nest with crude prosthetics and one spared hatchling.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3726,7 +3726,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0F9GTMTCL",
@@ -3738,7 +3738,7 @@
       "recaps": {
         "ending": "Years after the first attacks, Orthistown has grown from an overcrowded refuge into an organized settlement with farms, defenses, civic institutions, and rangers. Elaine and Iona rebuild their home. Auri supports the town, Fenrir guards it, Nina is alive and immortal under White Dove's truthfulness curse, and Raccoon serves as constable. Artemis relocates after Julius's confirmed death and takes charge of training the settlement's first rangers. Katerina continues leading a separate coastal community, while Knight reports that he and his companion survive but keeps their work secret. After the household secretly kills a white dragon, its remains become a concealed resource for future equipment. Elaine completes two class advancements, becoming Dawnbringer and Sage of Eternity. Her improved radiance, flight, teleportation, and portal-linked manor greatly strengthen the household. The final interlude shows that the wider conflict has not ended: a demon polity and an elven empire are competing to annex surviving towns. Schoon Verfrist's attempt to claim one settlement is interrupted by an unidentified witch with a phoenix, leaving the town's allegiance and the larger Immortal War open.",
         "in_short": "An engineered disease aimed at vampires pushes Exterreri into a worldwide Immortal War. Elaine first cures the outbreak, then joins Iona, Auri, and Fenrir in rescue work as nations and immortals devastate one another. With central authority and entire cities destroyed, the household saves an overcrowded bunker and helps establish Orthistown. Years of scarcity, attacks, and reconstruction turn the refuge into a durable community. Raccoon becomes its constable, Nina returns and accepts immortality, and Artemis joins its new ranger program after Julius's death. The Lifebringers restore the region's ecology, ending the immediate struggle for food. The household later kills a dragon in secret, and Elaine advances into Dawnbringer and Sage of Eternity, gaining stronger radiance, spatial movement, and a secure manor. Elsewhere, rival powers still compete for survivors, and the Immortal War remains unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3911,7 +3911,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0BH9D3HY2",
@@ -3923,7 +3923,7 @@
       "recaps": {
         "ending": "The refugees establish a foothold in the giant world after Joe relocates the guild hall, but Jaxon remains a prisoner in elven territory. Joe returns to rescue him and walks into Hair Trigger's prepared trap. The elves capture both men and seize a teleportation pad linked to the refugees' new camp. Their mass invasion through that unauthorized interworld route triggers a catastrophic penalty: the soldiers implode, resurrection becomes far more costly, and thousands of demons appear in the elven capital. Daniela covertly helps Joe heal Jaxon and escape, but she remains behind after asking Joe to return for her. Joe and Jaxon make it back to the dwarven community after the final numbered chapter. Havoc, Major Cleavage, Grandmaster Snow, Jake, and the surviving refugees are safe from the immediate elven assault, though the wider war and Hair Trigger's fate remain unsettled. The giant world is itself a prison. Their route onward now depends on building and defending a Tier 5 city and clearing the cloud layer above it to establish a stable inter-zone connection.",
         "in_short": "Joe sets out to recruit another dwarven Grandmaster so Grandma's Shoe can remain hidden while the elves overrun dwarven territory. After surviving pursuit and reaching the high city, he gains Grandmaster Snow's support, reaches master rank in core ritual skills, and helps evacuate the city when an elven siege exposes Daniela's collaboration. Havoc turns the Shoe into a volcanic transport, while Joe builds a bubble route that carries refugees through the inter-zone passage and relocates vital buildings into the giant world. Joe then returns for the captured Jaxon, only to fall into Hair Trigger's trap and expose the refugees' new camp. The elven army's unauthorized portal invasion triggers a lethal interworld penalty that destroys the assault force and fills the elven capital with demons. Daniela helps Joe and Jaxon escape but is left behind. After the numbered chapters, the two return to the refugees, who must now build and defend a Tier 5 city to escape the giant world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4110,7 +4110,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4123,7 +4123,7 @@
       "recaps": {
         "ending": "With the strike camp weakening, Mac and Jim go out at night after hearing of trouble near the picket line. A hidden attacker fires a shotgun, killing Jim and badly damaging his face. Mac carries the body back rather than allowing the death to remain a private loss. He places Jim before the assembled workers and begins a speech intended to convert their shock and grief into renewed unity. The novel ends as Mac starts that appeal, without showing whether the strike succeeds. Jim's development from an isolated recruit into a wholly committed organizer is complete, but his death also exposes the method Mac has taught him: every injury, kindness, and death can become material for the cause. Doc Burton remains missing, the growers and their allies retain overwhelming local power, and the workers face hunger, eviction, and violence. The immediate labor dispute is unresolved; what remains certain is that both sides have made retreat increasingly difficult and that Mac will use Jim's body as the strike's next rallying symbol.",
         "in_short": "Jim Nolan joins the Communist Party and is sent with veteran organizer Mac to California's Torgas Valley, where apple growers cut migrant pickers' wages. They enter London’s camp, earn trust by helping during a childbirth, and quietly help workers form a strike. The pickers camp on Anderson's land and struggle to maintain food, sanitation, and unity while growers use guards, strikebreakers, vigilantes, and local authorities against them. Mac repeatedly turns suffering into organizing leverage: an unsafe-work injury, the shooting of old activist Joy, and attacks on the camp all become reasons for solidarity. Jim grows more disciplined and more willing to subordinate individuals, including himself, to the movement. As supplies fail and violence scatters supporters, Doctor Burton disappears and the camp approaches collapse. Jim is killed by a shotgun blast while accompanying Mac at night. Mac brings his body before the workers and begins using the murder to rally them. The book closes before the strike's result, leaving its moral focus on the struggle itself and on the cost of making human lives serve a collective cause.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4455,7 +4455,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002V8KXJC",
@@ -4467,7 +4467,7 @@
       "recaps": {
         "ending": "Honor, Nimitz, McKeon, Andrew LaFollet, Venizelos, Clinkscales, Tremaine, Caslet, and the other survivors land secretly on Hades after destroying Tepes. Ransom dies aboard the ship, and Tourville and Foraker erase the evidence that anyone may have escaped. Honor has lost her left arm and retains severe facial and eye damage. Nimitz also survives with lasting injuries. Outside the prison system, Honor and her companions are expected to be dead. White Haven continues his duties without knowing she lives, while her household on Grayson has only the apparent-loss reports. Honor takes command of eighteen survivors, plus Caslet and Nimitz. They possess armed assault shuttles, recovered equipment, supplies, and months of food, but remain concealed on a heavily defended prison world against a much larger garrison. The military threat from Haven's reforms and missile-pod tactics also remains unresolved.",
         "in_short": "Honor returns to Grayson as a commodore, establishes a treecat colony, and takes command of an incomplete cruiser squadron. While McQueen seeks to reform the People's Navy, Tourville proves its new missile-pod tactics by destroying the Adler picket. Honor's convoy enters the trap, and Prince Adrian sacrifices its freedom so the merchant ships can escape. Ransom secretly removes Honor and selected prisoners from normal protections, abuses them, and sends them to Hades for a filmed execution. Harkness stages a defection to penetrate the prison ship Tepes, then enables a breakout led by McKeon. Honor is rescued, Whitman is killed, and the escapees destroy Tepes with Ransom aboard. Tourville and Foraker hide signs of their survival. Honor awakens on Hades missing her left arm, with permanent facial and eye injuries. Nimitz is also injured but alive. Presumed dead elsewhere, Honor assumes command of the concealed survivors and prepares to act against the prison world's larger garrison.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4654,7 +4654,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4667,7 +4667,7 @@
       "recaps": {
         "ending": "The operation against Thurmond goes ahead and the camp is opened: the fences come down, the children inside are led out, and Ruby finds Sam among them. The evidence gathered from the camps and from Lillian Gray's research is put in front of the public, and the case the administration built its power on does not survive it. President Gray's government falls, the camps are shut down, and the surviving children begin the long process of being returned to families who were told for years that they were being treated. Clancy is dealt with by the only person who could: Ruby goes into his mind and takes it apart, leaving him no longer able to do to anyone else what he did to her. The cost is high. Cole is dead, Jude is dead, and the children who come out of Thurmond come out damaged. Ruby, Liam, Chubs, Vida, Zu and Nico are alive and together, no longer fugitives, and Ruby is left with an ability she has stopped hiding and a life she now has to decide what to do with.",
         "in_short": "The last of the Children's League hides out in an abandoned desert base with Clancy Gray as their prisoner, while Cole leads and Ruby works on Clancy for everything he knows about Thurmond and about his mother's research into the disease. They gather more runaway children, make contact with the Federal Coalition, an adult opposition movement, and trade recorded testimony about the camps for support. Zu returns after years apart. The broadcast turns public opinion against the administration, and the government strikes back. Clancy engineers his escape and the destruction of the base, and Cole is killed. Ruby and the others regroup with the Coalition, track down Lillian Gray, and mount the operation Ruby has wanted since the beginning: an assault on Thurmond. The camp is opened and its children are freed, the truth about the camps and the disease is made public, and the administration falls. Ruby destroys Clancy's mind, and the survivors are left free, grieving, and with ordinary lives to relearn.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4787,7 +4787,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4800,7 +4800,7 @@
       "recaps": {
         "ending": "When the explorer refuses to defend the old regime, the officer releases the condemned man and places himself in the apparatus, setting it to inscribe a demand for justice. The neglected machine breaks apart as it operates and kills him quickly instead of carrying out the long ritual he had described; his face shows none of the understanding he believed the process bestowed. The explorer then visits the old commandant's grave beneath a teahouse, where an inscription predicts that the dead ruler's followers will restore him. At the harbor, the explorer leaves the colony alone. The soldier and the former prisoner try to follow, but he prevents them from boarding his boat, separating himself from both the obsolete punishment system and those still confined under the colony's rule.",
         "in_short": "A visiting explorer on a penal island is shown an execution machine by the officer who remains devoted to the dead commandant who designed it. The apparatus slowly carves a prisoner's violated rule into his body, although the prisoner has never been told his charge or allowed a defense. The officer believes the ordeal produces enlightenment and asks the explorer to support the fading practice before the reforming new commandant. The explorer refuses. Accepting that the system has lost its last chance of survival, the officer frees the condemned man and submits himself to the machine. It malfunctions and kills him abruptly, without the revelation he expected. After seeing the old commandant's grave and its promise of a future return, the explorer departs alone, refusing passage to the soldier and the released prisoner.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4980,7 +4980,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4993,7 +4993,7 @@
       "recaps": {
         "ending": "After their release from prison, Minerva and María Teresa remain under surveillance while their husbands are still jailed. Patria accompanies them on a visit to the prison, and Rufino drives. On the return journey, Trujillo's agents stop the car, separate the women and driver, beat all four to death, and push their vehicle over a cliff to stage an accident. Dedé is left as the surviving Mirabal sister. She raises the sisters' children alongside her own and becomes the guardian of their home and story. The murders intensify opposition to the dictatorship; Trujillo is assassinated in 1961, although political violence continues. Decades later, Dedé preserves the sisters' belongings and answers the visitors who know them as the Butterflies, while also remembering them as complicated members of a family rather than flawless symbols.",
         "in_short": "In Trujillo's Dominican Republic, the four Mirabal sisters take different paths toward adulthood and resistance. Minerva recognizes the dictatorship's violence early and joins an underground movement with her husband, Manolo. María Teresa follows her into the movement and marries Leandro, while the devout Patria commits herself after witnessing a government attack. Dedé sympathizes but, constrained by fear, family responsibilities, and her husband Jaimito, does not become an active member. The three activists, known by the code name Butterflies, endure raids, imprisonment, torture, and the detention of their husbands. After Minerva and María Teresa are released, Trujillo's agents murder them, Patria, and their driver Rufino on their return from a prison visit, staging a car crash. Dedé survives to raise the children and preserve her sisters' memory. Their deaths help turn public feeling against Trujillo, who is assassinated months later.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5179,7 +5179,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5192,7 +5192,7 @@
       "recaps": {
         "ending": "Damien Donnelly confesses that he killed Katy, but the detectives establish that Rosalind engineered the crime. She cultivated Damien's devotion and persuaded him that Katy had to be stopped, largely because Katy's success and independence threatened Rosalind's control within the family. Rosalind anticipated the investigation and uses her age and the available evidence to remain beyond an effective prosecution. Rob's conduct has meanwhile destroyed his partnership with Cassie: after sleeping with her he retreats, lies, and mishandles both their friendship and parts of the case. Cassie transfers away and later begins a relationship with Sam O'Neill. Rob is removed from Murder and sent to Domestic Violence. Katy's murder is solved only imperfectly, and the 1984 disappearance of Peter and Jamie remains unsolved. Rob recovers no dependable final memory of what happened in the woods.",
         "in_short": "Dublin detectives Rob Ryan and Cassie Maddox investigate the murder of twelve-year-old Katy Devlin, found at an archaeological dig in Knocknaree. Rob secretly has another identity: he was Adam Ryan, the only child recovered when his friends Peter and Jamie vanished in the same woods in 1984. The new case revives fragmentary memories and destabilizes his close partnership with Cassie. Suspicion moves through Katy's family, anti-motorway politics, and the dig before evidence leads to Damien Donnelly, who confesses to killing Katy. Cassie recognizes that Katy's older sister Rosalind manipulated Damien into the crime in order to preserve her control over the family. Rosalind avoids prosecution, while Damien bears the legal blame. Rob's evasions and emotional withdrawal ruin his relationship with Cassie and cost him his place on the Murder Squad. Katy's case is explained, but the childhood disappearance remains unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5650,7 +5650,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0C8ZKVCSK",
@@ -5660,7 +5660,7 @@
         "work": "inaras-grace"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/indaria.json
+++ b/data/works-community/0/indaria.json
@@ -436,7 +436,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -449,7 +449,7 @@
       "recaps": {
         "ending": "Robert and Sabrina marry under an alliance contract and are crowned king and queen of the conquered realm, now renamed Indaria. The two younger members of the former royal family survive as contract-bound advisers. The original Indaria remains subject to Cydaria through separate restrictions, while the Cydarian crown prince retains the key governing its royal family's power. During the wedding reception, conspirators from threatened noble houses release poison. Alana protects vulnerable family members at another gathering, Marrick kills attackers and contains the airborne toxin, and Derek kills the House Illiel patriarch before he can detonate. The celebration resumes and ends without another assault. Robert and Sabrina remain responsible for the new government, including noble-house investigations, servant-contract reform, and ending slavery. Derek, Alana, and Marrick are viewed as deterrents to renewed resistance. Derek returns to Savannah and the Void Emporium. Malorie's operation, the dragonkin kennel, the limits of protected Void Travel, Jacks's search for everyone responsible for his family's fate, and Derek and Alana's planned dungeon and void-beast work remain open.",
         "in_short": "After returning from a raid, Derek secures his captured dragonkin and learns to carry protected passengers through Void Travel. He and Silvi rescue Alana and Edgar, break an invasion, and help force Indaria into secret vassalage under Cydaria. The victors then campaign against the remaining enemy kingdom. Marrick kills its former king, Alana kills Queen Cassandra, and Derek kills the escaped Duke Terran. The surviving royal siblings are spared while Robert and Sabrina are selected to rule the conquered realm, which is renamed Indaria. Their wedding and crowning survive a coordinated poison attack: Alana protects a separate family gathering, Marrick contains the toxins, and Derek kills the House Illiel patriarch. Robert and Sabrina remain to govern and pursue investigations and social reforms. Derek returns to the Void Emporium, while safe Void Travel, dragonkin care, and Jacks's family case remain partly unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -765,7 +765,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -778,7 +778,7 @@
       "recaps": {
         "ending": "Silas turns Earth's damaged ship by shaping huge magical shields into ramps, then forms a pointed forward barrier for a head-on collision with Dana's leading vessel. The impact destroys the rival ship. Erg and Nevin kill two of Dana's allies, while Dory and Crag force the injured Dana to surrender. Earth completes its hundredth lap and wins. Because the allied gray alien team fails to finish, Earth receives both first- and second-place awards for 125,000 world points. Dana survives and remains a possible enemy. Silas returns to Earth at level 30 with his common Druid Shieldbearer Projection Mage class, Erg, and his Galen team intact. Annika and Nuri have become effective but conditional partners, Jiang remains distant, and Emil's absence is unresolved. Earth has improved its ranking but has not escaped the induction contest. The alien asylum proposal, corporate hostility on Galen, Guild obligations, and the consequences of Proximus remain open. New sponsors seek influence, and a note apparently from Annika or Nuri tells Silas that proper training will begin soon.",
         "in_short": "Silas Renner accepts an unusual inheritance condition to support his family and discovers that Uncle Dan's shed hides a portal into a multiverse competition. Earth faces conversion into a dungeon world or destruction unless its forerunners improve its ranking. Silas builds a mixed magical class, travels to Galen, and forms a lasting team with Dory, Crag, and Nevin. He completes his first challenge through cooperation in Anwich, but his next mission at Proximus ends with him destroying a city shield and indirectly causing more than a million deaths. Now an official forerunner, he advances to a common Druid Shieldbearer Projection Mage, summons the spirit later named Erg, and kills Greta. Silas then joins Annika and Nuri in the Race of the Worlds. Their team defeats hostile rivals, destroys Dana's leading ship, and wins. An allied alien team fails to finish, so Earth takes both top awards and gains 125,000 world points. Silas returns home facing unresolved enemies, sponsorship pressure, and imminent training.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -957,7 +957,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -970,7 +970,7 @@
       "recaps": {
         "ending": "The investigation ultimately reveals that the killings are not simply an attack by one Cabal on another. They are tied to supernatural criminals pursuing continued life and power, and the apparent answers supplied by Cabal politics repeatedly conceal the more personal threat. Paige, Lucas, and their allies survive the final trap, the remaining intended victim is recovered, and the people responsible for the murder campaign are stopped. Savannah is safe, as are the young people the investigators can still protect. The case does not reconcile Lucas with the institution he distrusts, but it forces him to deal with Benicio as a father and with the practical consequences of being a Cortez. Paige and Lucas return to their independent life and work together, now with stronger connections to Jaime, Cassandra, the werewolf Pack, and other parts of the supernatural world. Benicio has gained neither Lucas's obedience nor his return to the Cabal, but the complete estrangement between them has begun to soften.",
         "in_short": "Paige Winterbourne and Lucas Cortez are building an independent life with Savannah when young people connected to the corporate sorcerer Cabals begin to die. Benicio Cortez asks his estranged son to investigate. Paige persuades Lucas to take the case, and they enter a Miami world of family rivalry, private security, and institutions that treat their children as both heirs and assets. Necromancer Jaime Vegas, vampire Cassandra DuCharme, Elena Michaels, and other allies help them follow evidence that crosses supernatural communities and reaches into an older search for unnatural longevity. Cabal suspicion produces misleading suspects while the murderer continues selecting vulnerable targets. Paige and Lucas eventually expose the supernatural criminals behind the campaign, rescue the endangered survivor, and stop the killings. They retain their independence and return to Savannah, but Lucas's successful intervention changes his relationship with Benicio and leaves the couple more deeply connected to the larger supernatural network.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1097,7 +1097,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1110,7 +1110,7 @@
       "recaps": {
         "ending": "The race to prevent a catastrophe ends with the realization that it has already happened. The agent engineered by Bertrand Zobrist turns out not to be a plague that kills, but a viral vector that spreads through the air and permanently alters human DNA, rendering roughly a third of the population infertile at random, Zobrist's drastic answer to overpopulation. Langdon's missing memory is explained: he had been manipulated, drugged, and steered through a staged scenario by the private organization known as the Consortium and by the head of the World Health Organization, Elizabeth Sinskey, in a desperate effort to locate the threat. Sienna Brooks is revealed to have been Zobrist's devoted partner, initially working to protect his creation, though she comes to fear its uncontrolled release. When the group finally reaches the submerged chamber beneath Istanbul, they find the container already burst; the vector was set loose days before and is now dispersed worldwide, beyond any hope of containment. Faced with an irreversible fact, Sinskey, Langdon, and a chastened Sienna resolve to work together to understand and steward the change rather than pretend it can be reversed. The novel closes on the sobering acceptance of a permanently altered world.",
         "in_short": "Robert Langdon wakes in a Florence hospital with a head wound and no memory of the past two days, only to be attacked and forced to flee with a young doctor, Sienna Brooks. Haunted by strange visions and armed with a hidden device that projects a modified image of Botticelli's map of Dante's Hell, he follows a trail of clues through Florence, Venice, and finally Istanbul, racing to find what a dead geneticist, Bertrand Zobrist, has left behind. Zobrist, obsessed with overpopulation, has created a biological agent as his radical solution, and Langdon believes he is trying to stop a lethal plague. The truth is stranger: Sienna was Zobrist's former lover and follower with an agenda of her own, and the agent is not a killer but a vector that will randomly render a large portion of humanity infertile. Worst of all, when they reach the hidden site beneath Istanbul, they discover the contagion was released days earlier and has already spread across the world. It cannot be undone, and the story ends with the World Health Organization and Sienna choosing to study and manage this new reality rather than fight a battle already lost.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1267,7 +1267,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1280,7 +1280,7 @@
       "recaps": {
         "ending": "At the bottom of the frozen ninth circle, Dante and Virgil see Satan fixed in the ice. His six wings generate the wind that keeps Cocytus frozen, and his three mouths chew Judas Iscariot, Brutus, and Cassius, figures associated with betrayal of spiritual and imperial authority. Virgil judges that they have seen all of Hell and times their escape. With Dante holding on, he climbs down Satan's shaggy body until they pass the earth's center; direction reverses, and what seemed a descent becomes a climb. Virgil explains that the fall of the rebel angel displaced the land and formed both the pit of Hell and the mountain rising in the opposite hemisphere. The travelers follow a narrow subterranean path along a stream for many hours. They finally emerge through an opening and see the stars, leaving the damned behind. Dante has completed the first stage of the journey, but he has not yet undergone the purification required before reaching Beatrice.",
         "in_short": "Lost in a dark wood and blocked from climbing toward safety, Dante accepts the guidance of the Roman poet Virgil. They pass through Hell's nine circles, whose punishments expose increasingly deliberate forms of sin: appetite without restraint, heresy, violence, fraud, and treachery. Dante speaks with famous lovers, citizens, rulers, teachers, and political enemies, repeatedly confronting the ways desire, pride, faction, and corrupt counsel distort human freedom. Virgil protects and instructs him, though force and reason meet limits at several thresholds. In the final frozen circle, Count Ugolino recounts his death by starvation, and the travelers find Satan trapped at the center, chewing Judas, Brutus, and Cassius. They escape by climbing down Satan's body and passing the earth's center, where their orientation reverses. A hidden passage leads them back beneath the open sky and the stars, ready for the ascent of Purgatory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1512,7 +1512,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1525,7 +1525,7 @@
       "recaps": {
         "ending": "In the frozen ninth circle, Dante and Virgil cross regions reserved for traitors to kin, country, guests, and benefactors. Count Ugolino recounts his imprisonment and starvation with his children, while other souls remain locked in the ice. At the center stands Lucifer, a vast three-faced figure whose beating wings keep the lake frozen. His mouths chew Judas Iscariot, Brutus, and Cassius. Virgil waits for the proper moment, then climbs down Lucifer's shaggy body with Dante. On passing the center of the earth, their orientation reverses: what seemed a descent becomes a climb toward the opposite hemisphere. They follow a hidden natural passage upward for hours. The cantica ends when the travelers emerge from Hell beneath the night sky and see the stars, ready to begin the ascent of Mount Purgatory.",
         "in_short": "Lost in a dark wood, Dante is met by the Roman poet Virgil, sent by Beatrice to guide him. They enter Hell and descend through circles arranged by kinds of sin: the uncommitted wait outside; the virtuous pagans inhabit Limbo; the incontinent are driven by storms, rain, mire, and conflict; heretics occupy fiery tombs; the violent suffer in blood, burning waste, and a forest of suicides; and fraud is punished across ten trenches. Dante speaks with figures including Francesca, Farinata, Piero delle Vigne, Brunetto Latini, Ulysses, and Guido da Montefeltro, learning how desire, politics, pride, and calculated deception shaped their ends. Below the giants lies the frozen circle of treachery, where Count Ugolino tells of starvation in a locked tower. At the center Lucifer chews Judas, Brutus, and Cassius. Virgil leads Dante down Lucifer's body past the earth's center, then upward through a tunnel until they emerge beneath the stars.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1895,7 +1895,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1908,7 +1908,7 @@
       "recaps": {
         "ending": "The allied fleet defeats the Voidlings at Azure and breaks the Ornu-Perseid invasion. Omega traps the Konami leader during his boarding attempt, disables the augmentations sustaining him, and survives his death. Funnybone and Splat die in the final campaign, while Bina survives an arm wound. Pertinax kills the young Ornu emperor during the retreat, then dies when the emperor activates his implanted kill switch. Eight months later, Azure is a functioning but hazardous settlement. Gordon Henderson has died, Miriam remains with the settlers, Hans Norder has become a fisherman, and Bina and Alden Stone carry much of the community's leadership. Bill can no longer enter Omega's sim space, but Val and Omega ask him to return as captain. After remaining through the settlement's anniversary and public farewell, he plans to leave with Omega, Val, Tobias, and Judith to protect humanity and investigate the continuing threats posed by the Imperium, the Warfang amalgam, and the Perseids.",
         "in_short": "Bill Henderson leads Omega through prison rescues and a search for a permanent human refuge while the Ornu succession, the Perseids, and a surviving Konami leader gather against him. Millions of abandoned people, Roughback allies, a breakaway species, and descendants of Corey Henderson's hidden colony rebellion join the migration. Their promised world, Azure, is occupied by parasitic Voidlings, forcing a combined battle on the moon, inside enemy ships, and aboard Omega. Funnybone and Splat die, but Omega kills the Konami leader and the allied fleet wins after Pertinax and the young emperor kill each other. Eight months later, Azure is a difficult but viable settlement and Gordon Henderson has died. Bina and Alden Stone lead much of the settlement work, while Bill agrees to depart after the anniversary with Omega, Val, Tobias, and Judith to guard humanity against unresolved external threats.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2231,7 +2231,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B08YFKGZQH",
@@ -2243,7 +2243,7 @@
       "recaps": {
         "ending": "The dwarves capture Grandma's Shoe after Joe's Ritual of Argus helps key fighters resist the fort's illusions. Havoc kills the Lady of Light, but the collapsing Prismatic Evergreen threatens to trigger the volcano and convert the fallen through an elven respawn point. Joe frees Havoc from a sensory prison, escapes with Jaxon and Captain Cleavage, and then organizes the Legion to construct Pharaoh's Pyramid of Panaceas, stopping the eruption. After the numbered chapters, Joe gains the fort, its Ledger of Souls, a command, land, cleared crimes, and promotion to level-21 Major General. He restores Havoc's daughter Francine through the ledger, proving that she was not the slain elven commander. Havoc can also be restored and accepts Joe as his apprentice. Joe plans to develop his new base while the war continues, but he cannot claim the artifact alchemy structure until he reaches master alchemist rank.",
         "in_short": "Exiled into a zone divided by war, Joe survives its lethal ambient power, joins the dwarves, and pursues an officer candidacy through ritual engineering. He develops aspect crafting, survives the capital's landfill, helps capture a minor fort, establishes Occultatum in dwarven territory, and gains advanced ritual-orb training. His investigation of supposed spirits uncovers a hidden elven fortress beneath Grandma's Shoe. After escaping its prison, he warns the dwarves and creates the costly Ritual of Argus to counter its illusions. Havoc kills the Lady of Light during the assault, while Joe prevents the fort's volcano from erupting by building Pharaoh's Pyramid of Panaceas. In the epilogue, Joe receives Grandma's Shoe and promotion to Major General, restores Havoc's true daughter Francine, and becomes Havoc's apprentice. The elven war remains active, and the new artifact workshop cannot be claimed until Joe becomes a master alchemist.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2471,7 +2471,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2484,7 +2484,7 @@
       "recaps": {
         "ending": "Bigfoot's indirect guidance leads Doc to Adrian Prussia, a protected police informant connected to the death of Bigfoot's former partner and to Puck Beaverton. Doc survives the confrontation in Adrian's fortified hideout; Adrian and Puck die. The aftermath leaves Doc with a large quantity of heroin belonging to the Golden Fang. Rather than sell it or accept a wealthy client's payment, he uses it as leverage: through Crocker Fenway, he returns the drugs in exchange for Coy Harlingen's release from the covert obligations that have kept him away from Hope and their daughter. Coy is able to go home. Mickey Wolfmann has already returned to public life and his former business identity, while the full machinery behind his disappearance remains beyond any clean legal resolution. Shasta also returns, but she and Doc do not restore their old relationship to certainty. Doc finally drives into a dense fog, moving with other cars until visibility improves. The open road preserves the novel's uncertainty, but his choice on Coy's behalf provides one concrete rescue from the system he has traced.",
         "in_short": "In 1970 Los Angeles, private investigator Doc Sportello is asked by his former girlfriend Shasta to protect developer Mickey Wolfmann from a plan to have him confined. Mickey and Shasta disappear, and Doc is found unconscious beside the murdered Glen Charlock. New cases converge: Tariq Khalil wants Charlock found, while Hope Harlingen believes her supposedly dead husband Coy is alive. Coy proves to be an informant trapped inside overlapping police and political operations. The Golden Fang appears in multiple forms—a schooner, a dental syndicate, and a channel for narcotics and influence—while Mickey is taken to a treatment center and returned to his old capitalist life. Shasta eventually reappears but offers no stable explanation or reunion. Evidence draws Doc to violent informant Adrian Prussia and Puck Beaverton; both die in the confrontation. Doc then trades recovered Golden Fang heroin for Coy's freedom rather than taking a payoff, allowing Coy to return to Hope and their daughter. With the larger network intact and Shasta still elusive, Doc drives into the California fog.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2624,7 +2624,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2637,7 +2637,7 @@
       "recaps": {
         "ending": "The cycle ends in victory bought at great cost and lasting change. The Varden and their allies breach the Empire's capital, and Murtagh and Thorn, finding the strength to free themselves from the king's oaths at the crucial moment, break with Galbatorix. In the final confrontation Eragon defeats the king not with a stronger blade but with a spell that makes Galbatorix experience all the pain and grief he has inflicted across his long reign; overwhelmed, the king unmakes himself with a word. With the tyrant gone, Nasuada takes the throne to rebuild the shattered realm, and Arya, after the death of her mother, becomes queen of the elves and bonds with a newly hatched green dragon, becoming a Rider herself. Roran and Katrina welcome their daughter. But the surviving dragon eggs and the many Eldunari cannot be kept safe within Alagaesia, so Eragon accepts that he must leave his homeland forever to raise a new generation of dragons and Riders in a distant place. He parts from Arya, from Roran, and from all he has known, and sails away into exile as the guardian of dragonkind's future, while Murtagh and Thorn depart north to find their own peace.",
         "in_short": "The Varden fight their way across the Empire, taking city after city as Eragon and Saphira lead and Roran wins hard battles. Seeking the power to match the king, Eragon and Saphira journey in secret to the ruined Rider island of Vroengard, where they gain a great hoard of Eldunari, the preserved hearts that hold dragons' minds, along with a hidden cache of dragon eggs, and Eragon discovers his own true name. At the capital, the alliance breaks the city's defenses, and Eragon, Saphira, and Arya confront Galbatorix and his enslaved Rider Murtagh. Rather than defeat the king by strength alone, Eragon casts a spell that forces Galbatorix to feel the full weight of all the suffering he has caused, and the king, unable to bear it, destroys himself. In the aftermath Nasuada becomes ruler, Arya is made queen of the elves and Rider to a new dragon, and Eragon, with no safe place in the land to raise the surviving eggs and Eldunari, leaves Alagaesia forever to found a new order of Riders elsewhere.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2818,7 +2818,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2831,7 +2831,7 @@
       "recaps": {
         "ending": "The attempts on Avery's life were arranged by Skye Hawthorne, who recruited Libby's former boyfriend Drake in the belief that Avery's death would return the fortune to her sons. Drake corners Avery inside the house and Oren kills him; Skye is taken into custody. With that settled, Avery finishes the trail her benefactor left and confirms that Toby Hawthorne survived the fire on the family's island and has lived unfound ever since. Looking at a picture of the missing man, she recognizes him: Harry, the homeless chess player she has faced across a board every morning for months, is Tobias Hawthorne's son. Why she was chosen is still unanswered, and the connection appears to run through her dead mother and the secret her mother said she was keeping about the day Avery was born. Avery decides to stay at Hawthorne House for the rest of the year and to play the game out. Jameson is her partner in it and something more; Grayson holds himself at a deliberate distance; Nash has attached himself to Libby's welfare; Xander is simply glad she is staying. Zara's challenge to the will has not dislodged her, but the family is nowhere near reconciled, and the questions of where Toby is and why Avery was chosen are both wide open.",
         "in_short": "Avery Kylie Grambs, a Connecticut teenager scraping by on diner shifts and scholarship plans, is summoned to Texas for the reading of a billionaire's will and learns that Tobias Hawthorne, a man she never met, has left her almost his entire fortune. His two daughters and his four grandsons get almost nothing, and Avery must live in the family's puzzle-box mansion for a year to keep it. Certain that his grandfather never acted without a reason, Jameson Hawthorne enlists her to work out why she was chosen, and the trail runs through the house's hidden passages and the family's buried history: the death of a girl both Jameson and Grayson loved, and the fire that supposedly killed the old man's only son. Someone wants Avery dead. She is shot at on the grounds and the wing where she sleeps is set alight, and the attacks turn out to have been arranged by the brothers' mother, Skye, through Libby's ex-boyfriend, who is killed in the attempt. Avery ends the book knowing that Toby Hawthorne is alive, and that he is the old man she has been playing chess with all along.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/insurgent.json
+++ b/data/works-community/0/insurgent.json
@@ -124,7 +124,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -137,7 +137,7 @@
       "recaps": {
         "ending": "The uprising reaches Erudite headquarters, where Tris has surrendered herself to Jeanine's Divergent experiments and nearly dies in a simulation designed to break her. The factionless, loyal Dauntless, and Candor overrun the compound; Jeanine is killed, and the heavily guarded secret she died protecting is finally opened. It is a recorded message from a woman named Edith Prior, an ancestor, revealing that the entire walled city is a controlled experiment: the factions were designed, and the population is meant to leave and rejoin a wider world beyond the wall once enough Divergents have appeared. The message is broadcast to the whole city, and it detonates the social order. Evelyn and her factionless seize control, dismantling the faction system, while Marcus and others insist the message demands they go outside. Tris, Tobias, and Caleb are left reeling, realizing that everything their society was built on was a lie and that a journey beyond the wall now lies ahead.",
         "in_short": "In the immediate aftermath of the Erudite attack, Tris, Tobias, Caleb, Marcus, and Peter flee the ruined city and take refuge with the peaceful faction Amity. Wracked by grief and guilt over killing her friend Will, Tris grows reckless and self-destructive. Attacks drive them out, and they fall in with the factionless, led by Evelyn, who is revealed to be Tobias's presumed-dead mother. At the honesty faction Candor, truth serum forces Tris to confess she killed Will, straining her bond with Tobias. Dauntless splits into loyalists and Erudite-allied traitors, and Jeanine begins capturing and killing Divergents in search of one who can withstand a new simulation and unlock a secret she guards. Tris eventually surrenders herself to Jeanine's experiments and barely survives before the factionless, loyal Dauntless, and Candor storm Erudite headquarters. Jeanine is killed and her secret seized: a recorded message revealing that the city is a controlled experiment and that a larger world lies beyond the wall, meant to be entered once enough Divergents emerge. Broadcast to everyone, the truth shatters the faction system as Evelyn's factionless seize power.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -323,7 +323,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -336,7 +336,7 @@
       "recaps": {
         "ending": "Lord Hong's army meets the Silver Horde, the Red Army and the barbarian invasion he himself invited, and his plan collapses; he is killed in the fighting. Rincewind's part in it is the buried terracotta army, which turns out to obey simple, direct commands, and which ends the battle without much bloodshed. Ronald Saveloy is killed, and Cohen and the Horde give him the hero's send-off he had never expected and had spent his career telling boys not to want. Cohen the Barbarian is left sitting on the throne of the Agatean Empire as its new Emperor, with a band of elderly barbarians as his court, no interest whatever in ceremony, and every intention of running the place along simpler lines: the treasury opened, the walls lowered, and the Empire pointed outward instead of inward. Twoflower is freed and reunited with his daughters, and the book he wrote about his holiday, which caused all of this, is not disowned. Rincewind, promised a reward and wanting only to go back to his island, is caught by a spell from Unseen University that goes wrong in transit, and is dropped instead on the last continent, a hot, dry, red place at the far edge of the Disc that nobody has properly mapped.",
         "in_short": "A message crosses the ocean from the Agatean Empire demanding that Ankh-Morpork send the Great Wizzard, and the wizards of Unseen University realise, from the spelling, exactly who is meant. Rincewind is snatched off the desert island where he had been perfectly happy and dropped into an empire on the edge of revolt. The Emperor is dying, the great families are manoeuvring, and a band of polite young revolutionaries called the Red Army has taken its inspiration from a book about Ankh-Morpork written by Twoflower, the Disc's first tourist. Behind all of it is Lord Hong, the Grand Vizier, who arranged the summons and intends to take the throne and then invade the Disc's other continent. Meanwhile Cohen the Barbarian and his Silver Horde, six extremely old heroes and a retired schoolteacher, walk into the Forbidden City to steal the largest thing on offer, and Cohen sits on the throne. In the final battle Rincewind wakes the buried terracotta army of the first Emperor, Hong is killed and Saveloy dies a hero. Cohen becomes Emperor, and Rincewind, aiming for his island, is misdirected to the last continent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -447,7 +447,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -460,7 +460,7 @@
       "recaps": {
         "ending": "Louis and Claudia, believing they have destroyed Lestat, travel to Europe and find the vampire coven of the Theatre des Vampires in Paris, led by the ancient Armand, to whom Louis is powerfully drawn. But Lestat survived Claudia's attack and comes to the coven to accuse her. Because killing one's own maker is the coven's gravest crime, the vampires seize Claudia and the woman companion Louis had made to care for her, and shut them where the rising sun will reach them; Claudia is destroyed, found as ashes. Devastated by her loss, Louis takes his revenge by burning the theater and destroying the coven, sparing only Armand. The two travel together for years but the bond fades, and Louis returns at last to New Orleans, hollowed out and incapable of the passion and grief that once tormented him. In the framing present, having heard this tale of ruin and despair, the young reporter fails to grasp its horror and instead pleads to be given the dark gift himself. Louis, enraged that his listener learned nothing, refuses and vanishes into the night. Left alone, the reporter resolves instead to seek out Lestat.",
         "in_short": "In present-day San Francisco, a vampire named Louis tells his life story to a young reporter over one night. In eighteenth-century Louisiana, the grief-stricken plantation owner Louis is transformed into a vampire by the charismatic Lestat, who becomes his maker and companion. Tormented by his surviving conscience, Louis struggles against the killing his nature demands. To bind Louis to him, Lestat turns a small orphaned girl, Claudia, and the three live as an unnatural family for decades. But Claudia, her adult mind trapped forever in a child's body, comes to hate Lestat for condemning her to that fate, and she conspires with Louis to destroy him. Believing Lestat dead, she and Louis flee to Europe and, in Paris, find a coven of vampires led by the ancient Armand. There the coven learns of Claudia's attack on her maker and punishes her by exposing her to sunlight, killing her. Louis, shattered, destroys the coven in revenge and drifts through the following century emptied of feeling. Hearing the tragedy, the reporter recklessly begs to be made a vampire, and Louis, disgusted, refuses and leaves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -758,7 +758,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -771,7 +771,7 @@
       "recaps": {
         "ending": "Silas becomes Earth's undisputed ruler after defeating the formal challengers, and the system shields his rule from further challenges for one year. During the following ninety-eight days, he expands roads, housing, and safe-zone capacity, while Lana supplies three terraformers and technicians. Earth maintains provisional arrangements with the Dragon System and Divided Realms, and Ryan continues researching the ritual needed to make his blood-brother bond with Silas permanent. Asta and Silas remain estranged, while Silas has not resolved his relationships with Selena or Lana. Jay then takes Silas, Ryan, Nico, Lana, and Selena to witness an apparent future at Galen. A void incursion destroys half the planet, an abhorrent overwhelms massed defenders, the Voice erases himself to force its retreat, and Samvek vanishes from view during the battle. Back on Earth, Silas commits to advancing the planet faster and building wider alliances. Galen's fate, Samvek's survival, Jay's purpose, the Aspen claim, House Malfon, and the concealed danger around Silas's primordial aspect remain unresolved.",
         "in_short": "Selena Turga's courtship brings Silas both a powerful alliance opportunity and proof that off-world families prize his unusual potential. After reshaping his own evolution, he organizes Earth's survivors, appoints Simone as chief of staff, and leads a united force that closes the Sydney incursion. Competing offers from Lily Aspen and Lana Kalestian deepen the political pressure. Lana helps Silas survive a dangerous dungeon and secure major benefits for Earth's native peoples, while a Dragon System delegation and Divided Realms outsiders form narrow cooperation agreements with him. Silas defeats all formal challengers and becomes Earth's undisputed ruler, then rapidly expands safe zones and infrastructure. Jay finally shows Silas and several allies an apparent future in which a corrupted primordial devastates half of Galen despite intervention by gods and ascendants. The Voice sacrifices himself, Samvek's fate becomes unknown, and Silas returns determined to strengthen Earth before a similar threat arrives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1063,7 +1063,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0B88VR1Y4",
@@ -1075,7 +1075,7 @@
       "recaps": {
         "ending": "The Elven Theocracy wins the war before Joe can rescue the negotiators dragged beneath the magma. Joe refuses to defect and turns Grandma's Shoe toward organized resistance. He gains McPoundy's conditional support, then leads Captain Cleavage, Jaxon, Daniela, and Kettlebell into the landfill to claim a city guardian. Corey Digger is freed from its controlling enchantments and becomes Joe's guardian. Back at the hamlet, it exposes disguised elven elites, while the commitments from Havoc and McPoundy persuade the residents to remain. Havoc begins installing active defenses. Hair Trigger survives through respawn, the Society of Scholars' edict against Joe remains unresolved, and Automate's lethal-hit protection is unavailable for a month. Joe still needs another Grandmaster, linked support, a safe policy for new arrivals, and a way to conceal the Shoe from the victorious elves and their allies.",
         "in_short": "Joe takes responsibility for developing Grandma's Shoe, combining ritual craft, reduction, and settlement building while surviving repeated attacks by Hair Trigger. After defending the new hamlet, he trains under Havoc, builds a guild hall, and supports Stan and Mike's attempt to broker dwarf-elf peace. Hair Trigger sabotages the negotiations, and a world boss pulls the guild hall and delegates beneath the magma just before the Elven Theocracy wins the war. Joe refuses re-education or defection and commits the Shoe to resistance. To stop its residents from leaving, he secures McPoundy's conditional backing and defeats a malfunctioning city guardian in the landfill. The freed guardian, Corey Digger, becomes his and protects the hamlet. Havoc begins fortifying the settlement, but Joe must still recruit another Grandmaster and hide the refuge from the victorious elves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1243,7 +1243,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1256,7 +1256,7 @@
       "recaps": {
         "ending": "Cincinnatus is finally taken in a procession to the public square, where a platform, spectators, and official speeches await him. Pierre is revealed as the executioner and prepares for the beheading as though completing a rehearsed entertainment. Cincinnatus initially follows the expected movements, then rejects the ceremony at the moment he is ordered to place his head on the block. As the axe falls, he rises in another sense and sees the entire setting come apart: the executioner, officials, audience, and constructed landscape shrink, topple, or dissolve like stage scenery. Leaving that counterfeit world behind, Cincinnatus moves toward distant figures whose reality resembles his own. The physical sentence is carried out within the collapsing spectacle, but the conclusion presents his essential self as beyond the authorities' power.",
         "in_short": "Cincinnatus C. is condemned to death for the undefined offense of possessing an opaque inner life in a society of shallow transparency. Confined in a fantastical prison, he is denied the date of his execution and surrounded by officials whose courtesy, games, and shifting roles make punishment feel like theater. He writes in search of a language adequate to his real self, remembers his faithless wife Marthe, and hopes for escape or authentic contact. A new prisoner, M'sieur Pierre, forces a friendship on him; a tunnel that seems to promise escape instead reveals their cells' connection, and Pierre is eventually exposed as Cincinnatus's executioner. Marthe and other visitors offer no rescue. At the public beheading Cincinnatus stops cooperating inwardly with the performance. The stage-like world and its people disintegrate, while he rises and walks toward beings who appear to share his kind of reality.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1464,7 +1464,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1477,7 +1477,7 @@
       "recaps": {
         "ending": "Basgiath's protection fails and the venin come through with their wyvern. The battle for the college is the open confrontation the leadership spent a century preventing by lying, and it is enormously costly: much of the school is destroyed, cadets and riders die in numbers, and General Lilith Sorrengail is killed holding the line, spending everything she has to buy the defenders time. Violet fights with her lightning through the whole of it, and Andarna, changed by the sleep she has just come out of, is not the creature anyone expected her to be. The survivors are left with a war that can no longer be denied, an alliance with Poromiel that has become a necessity rather than a favour, and Tyrrendor and Aretia as the centre of whatever resistance is left. The decisive moment belongs to Xaden. To keep Violet alive he does the one thing that cannot be undone, drawing power from the earth the way the venin do. It works, and it costs him what it costs anyone who does it: the book closes on the confirmation that he has become the thing they have been fighting, hiding it from everyone including, for the moment, the woman he saved.",
         "in_short": "Violet returns to Basgiath for her second year knowing that the venin are real, that Navarre's leaders have hidden it, and that the rebel city of Aretia and her supposedly dead brother are rebuilding a resistance. The college is now run by a vice-commandant who interrogates and tortures cadets to find exactly those secrets, so Violet spends the year lying to her friends, avoiding Dain's memory-reading touch, and running errands for a revolution she is not always told the truth about, including the theft of what Aretia needs to raise its own protective wards. Xaden, posted away and bound to her by their dragons' mating bond, keeps hiding things from her for her own good, and the arguments between them are as central as the war. Alliance with Poromiel's gryphon fliers becomes real, bringing Cat Cordella and others to Basgiath. Violet is captured and tortured, and the confrontation everyone has been avoiding arrives at the college itself: the wards fail, venin and wyvern attack, her mother dies defending the school, and Xaden saves Violet by channelling dark power and becomes venin himself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1636,7 +1636,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1647,7 +1647,7 @@
         "work": "iron-gold"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1952,7 +1952,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -1965,7 +1965,7 @@
       "recaps": {
         "ending": "Rei defeats Logan Grant in the final individual qualifier by unveiling Shido's user-unique Type Shift. The ability converts Shido from its Brawler configuration into Saber mode, and the victory sends Rei to Sectionals. Aria Laurent becomes a squad leader and recruits Rei, Viviana Arada, Catcher, and Chancery Cash. The group still needs a Mauler, and Rei urges Aria to choose Logan despite their rivalry. Rei and Aria also agree to their first date. Released match footage gives Rei the public nickname Iron Prince and draws the unexplained attention of the head of Kamiya Corporation. Central Command is already monitoring and testing Rei, while Shido's future forms and limits remain unknown. Logan's family connection to Rei, Aria's conflict with her controlling family, Dyrk Reese's continued position at Galen's Institute, and the corporation's intentions all remain open.",
         "in_short": "Rei, a scarred student with a disabling bone disease, receives Shido, an initially weak A-type CAD with unprecedented S-ranked Growth. Valera Dent secures his admission to Galen's Institute, where Shido repairs his health and advances rapidly through every hard fight. Rei builds a trusted training circle with Viviana Arada, Catcher, and Aria Laurent while enduring hostility from Logan Grant, Mateus Selick, and Dyrk Reese. An ambush and a manipulated tournament bracket intensify the conflict, but Rei continues climbing through the intraschool competition. Central Command forces him to eliminate Catcher as a test, then pairs him with Logan. Intensive training brings Shido to C4 and unlocks Type Shift, a user-unique ability that changes it into Saber mode. Rei defeats Logan and qualifies for Sectionals. Aria forms a squad around their group, accepts a date with Rei, and considers Logan for its last position. Public footage earns Rei the name Iron Prince and alerts a powerful corporate family to his existence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/ironbound.json
+++ b/data/works-community/0/ironbound.json
@@ -342,7 +342,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -355,7 +355,7 @@
       "recaps": {
         "ending": "Tala closes the volume as a Refined mage who is relocating her base from Banfast to the city where Rain is based. Her iron bond has been joined to her soulbound weapon, giving her formidable defenses with limits that Cazor continues to test. Terry remains beside her to explore a flock partnership, without accepting a soul bond. Simon, Petra, and their family are building a working home within Kit, though internal teleportation remains unsolved. Tala has renewed ties with her siblings and watched the twins leave for the academy, but she gives no answer to her father's offer of future support. Banfast still holds Rob and five founts, Tala retains an inactive automaton for study, and the nature of founts, the dome, void, and the next world remains unsettled. An upland tiger also survives in its valley after driving Tala and Terry away. Tala retains friends and collaborators in Banfast and plans to visit them after establishing herself in her new base.",
         "in_short": "Tala returns to human territory carrying an iron Doskanok that cannot be removed, so she negotiates a soul bond with it. Back in Banfast, she shares intelligence from captivity, confronts and integrates the false identity imposed on her, ends her Caravan Guild obligations, and prepares for refinement. Holly helps merge the unstable iron bond into Tala's weapon, and Tala survives a painful transformation into a Refined mage. Kit becomes a staffed mobile home for Simon, Petra, and their family. Tala later witnesses a mage become a fount and sends it onward through a dangerous encounter spanning Zeme, a mysterious dome, and the next world. She reconnects with her siblings in Marleyweather, leaves reconciliation with her parents unresolved, and supports the academy-bound twins' departure. Terry chooses to remain and attempt a true flock partnership. After retreating from an upland tiger, Tala returns to Banfast, tests her iron defenses with Cazor, and prepares to relocate to the city where Rain is based.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -535,7 +535,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -548,7 +548,7 @@
       "recaps": {
         "ending": "After many years alone, Karana sees a ship whose men have come to take her away. She prepares the clothing expected by the strangers, gathers the possessions she can carry, and leaves the island with Rontu-Aru and her birds. On the voyage she learns why no one returned for her: the ship that carried the Ghalas-at away later sank, and the knowledge that she had remained behind was lost. Karana reaches the California mission settlements after eighteen years of solitude. Her departure closes her life on the island without undoing its losses; she carries with her the skills, memories, and affection for animals that sustained her there.",
         "in_short": "Karana lives with the Ghalas-at on an island off California until a dispute with visiting Aleut sea-otter hunters kills most of the community's men. A rescue ship later takes the survivors away, but Karana jumps overboard when her brother Ramo is left behind. Wild dogs kill Ramo, leaving her alone. She builds a home, makes weapons despite tribal prohibitions, gathers food, and abandons a dangerous attempt to reach the mainland. Her effort to destroy the wild dogs changes when she nurses their wounded leader and names him Rontu; he becomes her companion. Karana also cares for birds and an otter, and she befriends an Aleut girl named Tutok during a later hunting visit. Rontu eventually dies, and Karana tames a younger dog, Rontu-Aru. After eighteen years a ship finally finds her. She leaves with her animals and learns that the ship carrying her people had sunk, preventing anyone from returning for her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -743,7 +743,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -754,7 +754,7 @@
       "recaps": {
         "ending": "It ends with the ancient creature destroyed for good. In its lair beneath Derry the Losers who made the final descent - Bill, Ben, Beverly and Richie - crush It's heart and destroy the eggs it had laid to perpetuate itself, breaking the centuries-old cycle of killings. The reckoning costs them dearly. Stanley Uris took his own life rather than return. Henry Bowers, broken out of the asylum and driven by It, gravely wounded Mike Hanlon, who survives in the hospital, and was then killed by Eddie Kaspbrak in self-defence. And in the lair itself the creature mortally wounded Eddie, tearing off his arm as he attacked it to save his friends; he died in the tunnels. As the thing dies, a violent storm brings down Derry's old downtown, which sinks into the flooding canals. Bill's wife, Audra, drawn into danger after following him from England, is left catatonic; Bill brings her back to herself in a final echo of the childhood magic they had used. With the evil gone, the deep bond and shared memory that had held the friends together - in 1958 and again in 1985 - begins once more to dissolve. The survivors leave Derry and return to their separate adult lives, and their recollection of the town, of the creature, and of each other fades almost entirely away, closing the story on the same note of forgetting on which the town has always run.",
         "in_short": "In 1957 the town of Derry, Maine loses six-year-old Georgie Denbrough to a clown in a storm drain - the first killing in a new cycle of an ancient, shape-shifting evil that wakes every twenty-seven years to feed on the town's children. The following summer, Georgie's brother Bill and six other bullied outcasts form the Losers' Club, face the creature in its many personalised forms, wound it in the sewers, and swear to return if it ever comes back. Twenty-seven years later, in 1985, the killings resume, and Mike Hanlon - the one who stayed - calls the others home. Now prosperous adults who had forgotten almost everything, they reunite; one, Stan, chooses death over returning. Henry Bowers, sprung from an asylum and driven by It, gravely wounds Mike and is killed by Eddie Kaspbrak in self-defence. The rest descend again beneath Derry, where the creature itself mortally wounds Eddie, and they destroy It by crushing its heart and its eggs. The town's old centre collapses as the thing dies. The survivors leave Derry alive but, as before, their memories of the horror and of one another gently fade away for good.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -959,7 +959,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -972,7 +972,7 @@
       "recaps": {
         "ending": "Doremus escapes imprisonment and reaches Canada with help from the New Underground, but sanctuary does not end his commitment. He soon returns secretly to the United States as an organizer, separated from his family and living under assumed identities. The dictatorship meanwhile consumes its own leaders: Lee Sarason removes Windrip, only to be displaced by the more openly military Dewey Haik. Haik's war against Mexico deepens shortages and discontent, and parts of the armed forces begin to rebel, leaving the country in civil conflict rather than liberated. Fort Beulah has paid heavily for resistance, including the deaths of Fowler and Mary Greenhill and other friends. The final state is deliberately unresolved: the Corporate regime still holds power in much of the nation, but resistance has spread beyond isolated dissent. Doremus remains inside the country working for that resistance, with no promise that he will live to see it succeed.",
         "in_short": "Vermont newspaper editor Doremus Jessup watches Senator Buzz Windrip win the presidency through extravagant promises, scapegoating, and a disciplined paramilitary movement. Windrip rapidly destroys constitutional government and replaces it with a Corporate State enforced by the Minute Men. Doremus first criticizes the regime in print, then joins the New Underground with Lorinda Pike, Buck Titus, Julian Falck, and members of his family. Repression reaches Fort Beulah through his former handyman Shad Ledue; arrests and killings make resistance personal. Doremus is imprisoned and tortured but escapes to Canada, then chooses to return clandestinely as an organizer. Windrip is overthrown by Lee Sarason, who is in turn displaced by General Dewey Haik. Haik's war against Mexico helps provoke military revolt and civil conflict. The dictatorship has not fallen when the novel ends, but organized opposition is growing, and Doremus continues the struggle inside the United States.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1139,7 +1139,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1152,7 +1152,7 @@
       "recaps": {
         "ending": "After five days on Six North, Craig leaves the hospital with a more realistic plan for recovery. The stay has not cured him, but it has restored his appetite, interrupted his immediate suicidal crisis, and shown him that his life need not be organized around the competition at Executive Pre-Professional. He decides to transfer to an arts-focused school and develops his map-like drawings of imagined cities and minds as serious creative work. He and Noelle acknowledge their connection and intend to keep in touch, while Craig accepts that Nia and Aaron belong to the life he must stop measuring himself against. He helps Bobby prepare for an interview and succeeds in drawing Muqtada into the ward's music gathering, small actions that make his own usefulness tangible. Reunited with his family and ordinary city life, Craig chooses continued treatment, art, relationships, and daily experience. The closing emphasis is on actively living rather than on claiming that depression has permanently disappeared.",
         "in_short": "Craig Gilner earns admission to an intensely competitive Manhattan high school, then develops severe depression as the demands he once wanted become unmanageable. Medication helps, but he stops taking it when he feels better and soon reaches a suicidal crisis. He calls a hotline instead of harming himself and checks into a hospital, where the adolescent floor is closed and he spends five days on the adult psychiatric ward Six North. Patients including Bobby, Noelle, and Muqtada make the ward a community rather than an abstraction. Craig begins eating again, talks honestly about school and relationships, helps other patients, and rediscovers drawing through intricate maps of imagined cities. His problems are not magically resolved, but he recognizes that returning unchanged to his achievement-driven routine would repeat them. On discharge he plans to leave Executive Pre-Professional for an arts school, continue treatment, stay connected with Noelle and his family, and build a life guided by health and creativity rather than prestige.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1313,7 +1313,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1326,7 +1326,7 @@
       "recaps": {
         "ending": "A year after Anna's death, Ivanov is about to marry Sasha at the Lebedev house. He has come to believe that Sasha's devotion grew from a wish to rescue him and that accepting her sacrifice would repeat the harm of his first marriage. He decides that the wedding must be stopped, even though Sasha insists on proceeding. Lvov then enters before the assembled company and publicly calls Ivanov a dishonorable man. Sasha and her father defend him, but the accusation makes the private shame surrounding the marriage impossible to contain. Ivanov refuses both the marriage and any further attempt to justify himself. In a final surge of resolve, he declares that he will end the downward course of his life and shoots himself. Sasha is left at the altar, while Lvov's effort to impose a clear moral judgment ends not in reform or exposure but in Ivanov's death.",
         "in_short": "Nikolai Ivanov, once an energetic provincial reformer, has fallen into debt, apathy, and disgust with himself. He withdraws from his devoted wife Anna while she is dying of tuberculosis and seeks distraction at the Lebedev home. There, the young Sasha believes that love can restore him and declares herself to him; Anna witnesses their intimacy. During a later quarrel, Ivanov cruelly reveals the seriousness of Anna's illness. After Anna dies, he becomes engaged to Sasha, but gossip casts him as a calculating man who discarded one wife and pursued an heiress. On their wedding day Ivanov recognizes that Sasha's desire to save him will make them both miserable and tries to cancel the marriage. The morally inflexible doctor Lvov arrives and denounces him publicly. Unable to accept the marriage, the accusation, or his continued decline, Ivanov shoots himself in front of the wedding party.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1500,7 +1500,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1513,7 +1513,7 @@
       "recaps": {
         "ending": "The collection closes with White Fang established at Weedon Scott's California home. He has learned the rules of domestic life, made peace with the sheepdog Collie, and earned the family's trust. The escaped convict Jim Hall enters the house to kill Judge Scott, whose courtroom sentence he blames for his imprisonment. White Fang fights Hall and saves the household, suffering gunshot wounds and severe fractures. A surgeon gives him little chance, but he survives a long recovery. Outside, Collie leads him to their puppies. The family now calls him the Blessed Wolf, and the once-isolated fighter rests safely among his offspring. This conclusion reverses the direction of the collection's first story: Buck leaves human society for the wolf pack after Thornton's death, while White Fang travels from the wild into a lasting human and canine family.",
         "in_short": "The collection follows two powerful dogs moving in opposite directions across the boundary between domestic life and the wild. In The Call of the Wild, Buck is stolen from California, becomes a dominant Klondike sled dog, and is rescued from abusive owners by John Thornton. When raiders kill Thornton, Buck avenges him and joins a wolf pack, becoming a legendary wild leader. White Fang begins with a wolf-dog cub born during a northern famine. Claimed by Gray Beaver, he grows isolated and fierce under attacks from other dogs, then is sold to Beauty Smith and forced to fight. Weedon Scott rescues him and patiently earns his trust. White Fang follows Scott to California, adapts to family life, and nearly dies saving Judge Scott from an escaped convict. He recovers and joins Collie beside their puppies, fully accepted as the family's Blessed Wolf.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1696,7 +1696,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1709,7 +1709,7 @@
       "recaps": {
         "ending": "The final chapter moves into the First World War without presenting a conventional battle scene or a direct account of Jacob's death. Military activity and public routine continue at a distance, while Jacob disappears from the network of people and places through which the novel has assembled him. After his death, Betty Flanders and Bonamy enter his London room. Its furniture, papers, and ordinary possessions remain, but their owner cannot be recovered from them. Bonamy calls for Jacob, confronting the absence directly. Betty picks up a pair of her son's old shoes and asks what should be done with them. The domestic question carries the practical bewilderment of bereavement: the objects survive while the person known only in fragments is gone. Jacob's death closes the novel, but the method refuses to turn him into a complete heroic portrait; his empty room becomes the final evidence both of his life and of how little even those closest to him could fully possess.",
         "in_short": "Jacob Flanders grows from a solitary boy on the coast into a Cambridge student, a young man living in London, and a traveler absorbed by Greece. Rather than explain him from within, the novel gathers partial views from his widowed mother Betty, friends including Richard Bonamy and Timmy Durrant, women such as Clara Durrant, Florinda, Sandra Wentworth Williams, and Fanny Elmer, and strangers who briefly cross his path. Jacob reads, argues, attends social gatherings, pursues imperfect relationships, and searches classical culture for forms of certainty, but remains elusive even to those who love him. The movement of private life is shadowed by a public world drifting toward war. Jacob joins the forces and is killed in the First World War, an event reported through absence rather than depicted directly. In his London room, Betty and Bonamy face the possessions he left behind. His empty space and an old pair of shoes become the novel's final measure of a life no collection of outside impressions can make whole again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1928,7 +1928,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1941,7 +1941,7 @@
       "recaps": {
         "ending": "No Peak's New Year's Eve offensive against the Mountain's leadership fails to kill Ayt Mada, but it costs her the Horn of her clan: Anden, wearing far more jade than his body can carry, stops Gont Asch's heart with Channeling, and is so badly damaged by the act that he renounces jade permanently, ending the career the clan raised him for. The war between the clans stops from exhaustion rather than resolution. Ayt Mada keeps the Mountain and remains committed to a single unified clan over Kekon. Hilo is confirmed as Pillar of No Peak, with his sister Shae as Weather Man, Maik Kehn as Horn and Maik Tar as his Pillarman, and he announces that he will marry Wen, a stone-eye, over his family's objections. Kaul Sen, estranged from Hilo since the killing of his old Weather Man, is left isolated and failing. The clan has survived, but it has lost its Pillar, the grandfather's blessing, and any illusion that its quarrel with the Mountain can be contained inside Janloon: both clans now have foreign money, foreign buyers and foreign enemies in play, and Kekon's jade has become an international commodity. Bero, the jadeless thief from the opening pages, is still alive and still chasing jade.",
         "in_short": "On the island nation of Kekon, bioenergetic jade gives trained Green Bones superhuman abilities, and the jade trade belongs to the clans. In the capital, Janloon, the Kaul family's No Peak clan is led by Kaul Lan as Pillar and his brother Hilo as Horn. When Ayt Mada, Pillar of the rival Mountain clan, demands that No Peak submit to a single unified clan under her and Lan refuses, the two families slide into open war of street killings, poached businesses and a fight for control of Kekon's government. Lan's sister Shae, home from Espenia, exposes No Peak's own Weather Man as a traitor and is pressed into replacing him. Lan, secretly weakened by a sabotaged supply of the jade drug shine, is ambushed and killed by the Mountain's Horn, Gont Asch. Hilo takes the Pillar's seat and strikes back on New Year's Eve; the attack fails to kill Ayt Mada, but the Kauls' cousin Anden kills Gont with a lethal use of Channeling and is so damaged that he gives up jade forever. The war ends in stalemate: Ayt Mada lives, No Peak survives, and Hilo marries Wen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2171,7 +2171,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2184,7 +2184,7 @@
       "recaps": {
         "ending": "The clan war that has run through three generations of the Kaul and Ayt families ends. With the Mountain's succession settled in favor of a leader prepared to deal, the two great clans come to terms and stop trying to destroy each other; Kekon's jade industry, its politics and its place among foreign powers all end the book in a shape neither founder would recognize. What cannot be settled by negotiation is settled between Hilo and Ayt Mada personally, at the end of a rivalry that has cost both families almost everything: Ayt Mada dies, and Hilo does not outlive her. The Pillar's seat of No Peak passes to Niko, Kaul Lan's son, who takes it as a decision of his own rather than as the inheritance he was raised to resent, with Shae, Wen, Anden and Jaya around him. The family is smaller than it was, having lost Ru to an anti-clan killing years earlier and having buried much of the generation that started the war, and it is still standing. The book closes on the survivors remembering their dead.",
         "in_short": "Over roughly two decades, the war between No Peak and the Mountain becomes a long, cold struggle fought through business, politics, foreign alliances and assassination while Kekon transforms into a modern country entangled with Espenia. Hilo remains Pillar and Shae Weather Man, slowly repairing a relationship broken by Wen's secret work; Wen recovers what she can from her injuries; Anden becomes a doctor studying jade's effects on the body. The Mountain fields assassins trained in a concealed discipline that hides them from Perception, a jade miners' strike shakes the country, and an anti-clan movement grows into open violence. The next generation grows up: Niko, Lan's son and the reluctant heir; Ru, a stone-eye who builds a public life arguing that jade should not determine a person's worth, and who is murdered for it; and Jaya, a fighter without restraint. Niko leaves the clan and later returns on his own terms. The war finally ends in a settlement with the Mountain's next leader and in a last confrontation between Hilo and Ayt Mada, which neither survives. Niko becomes Pillar of No Peak.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2455,7 +2455,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2468,7 +2468,7 @@
       "recaps": {
         "ending": "No Peak's operation against the smuggler Zapunyo succeeds: he is killed and the pipeline carrying Kekonese jade to the Mountain's foreign buyers is destroyed, a serious defeat for Ayt Mada's overseas strategy but not the end of her clan. The victory is paid for at home. Wen, who had been working secretly as the clan's intelligence asset because no Green Bone can sense her, is caught in an explosion and survives with lasting injuries that impair her speech and movement. Hilo learns both that his wife nearly died and that she had been operating for months with his sister's knowledge and his own ignorance, and neither relationship recovers by the end of the book. Anden comes home to Kekon, wearing jade again after taking it up to defend the Kekonese community in Port Massy, and leaves behind a life and a partner in Espenia that he has not given up. Lan's son Niko is now being raised in the Kaul house alongside Hilo and Wen's own children, as No Peak's presumed heir. Kekon closes the book bound tightly to Espenia, with foreign soldiers wearing its jade and foreign money in its politics, and with No Peak and the Mountain still at war, on a board that now covers several countries.",
         "in_short": "With the Kaul grandfather dead and Anden exiled to Espenia, the war between No Peak and the Mountain becomes a global one. Espenia, fighting a proxy war abroad, wants Kekonese jade and the drug that lets foreigners use it, and Shae, as Weather Man, trades access for weapons and political cover, while Ayt Mada's Mountain moves jade to Kekon's enemies through Zapunyo, a smuggler in the Uwiwa Islands. In Port Massy, Anden discovers the Kekonese immigrant community and the criminal crews preying on it, takes up jade again to defend it, and becomes involved with Dauk Cory. The Kauls also discover that Lan left a son, Niko, being raised abroad by his mother, and bring the boy back to Kekon. Hilo commits the clan to killing Zapunyo, and the operation succeeds, but the escape goes wrong: Wen, who has been secretly working for the clan with Shae's help, is badly injured in an explosion and permanently impaired. Hilo learns of the deception, the Mountain remains unbeaten, and the clan war continues on an international stage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2639,7 +2639,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2652,7 +2652,7 @@
       "recaps": {
         "ending": "Mary finds Joss and Patience murdered at Jamaica Inn and turns for help to Francis Davey, only to discover that the apparently sympathetic vicar is the organizer who directed Joss and the wreckers. Davey forces Mary to leave with him across the moor, explaining his rejection of conventional faith and his plan to escape by sea. Jem, who has returned after trying to alert the authorities, follows them. Near the stone formations on the moor, Davey's control gives way to panic and exaltation; Jem shoots him before he can carry Mary away. The criminal operation is exposed, and Mary is freed from the inn and from the promise that brought her there. She initially plans to return to Helford and rebuild an independent life. When she meets Jem driving a wagon toward a roaming future, however, she accepts that she does not want safety without him. She joins him on the road, choosing uncertainty and mutual freedom over a settled return to her former home.",
         "in_short": "After her mother's death, Mary Yellan leaves Helford to live with her aunt Patience at remote Jamaica Inn. She finds Patience terrified and diminished, while her violent husband Joss uses the empty inn as a base for smugglers. Mary is drawn to Joss's horse-thieving brother Jem but cannot fully trust him. Her search for help leads to the pale vicar Francis Davey and the magistrate Squire Bassat. Joss eventually reveals that his gang does not merely smuggle: it creates false coastal signals, wrecks ships, and robs the dead. Mary is forced to witness a wreck and escapes to raise the alarm. She returns to find Joss and Patience murdered, then learns that Davey was the hidden leader who ordered the operation. He abducts her onto the moor, where Jem catches up and kills him. With the inn's crimes ended, Mary gives up her plan to return alone to Helford and leaves with Jem for an unsettled life on the road.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2843,7 +2843,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2856,7 +2856,7 @@
       "recaps": {
         "ending": "Elizabeth learns that Darcy secretly found Wickham and Lydia, paid the necessary debts, and arranged their marriage. Bingley returns to Netherfield and proposes to Jane, who accepts. Lady Catherine then visits Longbourn to demand that Elizabeth promise never to marry Darcy; Elizabeth refuses, and news of that refusal gives Darcy hope that her feelings have changed. When he and Elizabeth next walk together, he renews his proposal and she accepts, acknowledging how badly she had misjudged both him and Wickham. Mr Bennet gives his consent after satisfying himself that Elizabeth truly loves Darcy, while Mrs Bennet is delighted by the match's wealth. Jane and Bingley marry, as do Elizabeth and Darcy. Elizabeth settles at Pemberley, where she forms a close bond with Georgiana. The Gardiners remain welcome friends because of the part they played in bringing Elizabeth and Darcy together. Kitty improves with time away from Lydia, while Lydia and Wickham continue to live irresponsibly and frequently seek financial help. Lady Catherine eventually resumes contact with her nephew despite her anger at the marriage.",
         "in_short": "When wealthy Charles Bingley moves near the Bennet family, he and the gentle eldest daughter, Jane, fall in love, while his proud friend Fitzwilliam Darcy clashes with Jane's perceptive sister Elizabeth. Elizabeth accepts the charming officer Wickham's account of Darcy's cruelty and rejects Darcy when he proposes, condemning both his manner and his role in separating Jane from Bingley. Darcy's explanatory letter and Elizabeth's later visit to his estate reveal his better character and Wickham's dishonesty. Their growing understanding is threatened when Lydia Bennet elopes with Wickham, but Darcy secretly arranges the couple's marriage and saves the Bennets from disgrace. Bingley returns and becomes engaged to Jane. After Elizabeth refuses Lady Catherine's demand that she renounce Darcy, Darcy proposes again and Elizabeth accepts. The two couples marry, and Elizabeth begins a happier, more equal life with Darcy at Pemberley, both having learned to correct the pride and prejudice that distorted their first judgments.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3057,7 +3057,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3070,7 +3070,7 @@
       "recaps": {
         "ending": "Lady Catherine confronts Elizabeth after hearing a rumor that she may marry Darcy, but Elizabeth refuses to promise that she will reject him. Darcy learns of this resistance and gains hope that Elizabeth's feelings have changed. When he and Bingley return to the neighborhood, Bingley proposes to Jane and is accepted. Darcy then tells Elizabeth that his love remains unchanged; she admits that her judgment of him has altered and accepts his proposal. Elizabeth explains herself to the astonished Mr Bennet and persuades him that she truly respects Darcy. Elizabeth and Darcy marry and live at Pemberley, while Jane and Bingley also marry and settle nearby. Lydia and Wickham remain financially careless and frequently seek help. Georgiana grows close to Elizabeth, the Gardiners are warmly welcomed at Pemberley, and even Lady Catherine eventually resumes contact despite her anger at the match.",
         "in_short": "Elizabeth Bennet dislikes the wealthy Mr Darcy after his cold behavior and becomes increasingly prejudiced against him through the charming officer George Wickham. Darcy, meanwhile, falls in love with Elizabeth despite his objections to her family. His first proposal fails because he speaks arrogantly and Elizabeth blames him for separating Jane Bennet from Charles Bingley and for mistreating Wickham. Darcy's explanatory letter forces her to reconsider both men. Their warmer meeting at Pemberley is interrupted when Lydia Bennet runs away with Wickham, threatening the whole family. Darcy secretly finds the pair and pays the costs that make their marriage possible. Once Elizabeth learns what he did, her respect becomes love. Bingley returns and marries Jane. After Elizabeth withstands Lady Catherine's attempt to prevent a match, Darcy proposes again and she accepts. Elizabeth and Darcy marry with a clearer understanding of themselves and each other.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3252,7 +3252,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3265,7 +3265,7 @@
       "recaps": {
         "ending": "Jane returns to Thornfield to find it destroyed by fire. Bertha Mason, Rochester's mad wife, set the blaze and died leaping from the roof; Rochester, trying to save her and the servants, was left blind and with the loss of a hand. Freed from his first marriage by Bertha's death and humbled by his injuries, he lives withdrawn at Ferndean. Jane, now independent through her inheritance, seeks him out, and the two are reunited. She marries him freely and as an equal, no longer the dependent governess but a wife with means of her own. Their marriage is happy; Rochester in time regains partial sight in one eye, enough to see the birth of their son. The Rivers sisters, Diana and Mary, make good marriages and stay close to Jane, while St John Rivers goes as a missionary to India, where he serves with unbending devotion and, as the book closes, is dying in the faith he lived for.",
         "in_short": "Orphaned Jane Eyre is raised by a cruel aunt, then sent to the harsh Lowood school, where she loses her friend Helen Burns but grows into a self-possessed young woman. Taking a post as governess at Thornfield Hall, she falls in love with its brooding master, Mr Rochester, and he with her, and he proposes. Their wedding is halted by the revelation that Rochester already has a wife: Bertha Mason, a madwoman secretly imprisoned in the house and the cause of its strange terrors. Refusing to be his mistress, Jane flees penniless and is rescued by the Rivers siblings, who prove to be her cousins; she inherits a fortune from an uncle and shares it with them. Resisting a loveless missionary marriage urged by St John Rivers, she seems to hear Rochester call to her and returns to find Thornfield burned, Bertha dead, and Rochester blinded and maimed. Jane marries him, now his equal, and they find lasting happiness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3482,7 +3482,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3495,7 +3495,7 @@
       "recaps": {
         "ending": "After rejecting St John Rivers's proposal of a loveless missionary marriage, Jane returns to seek Rochester. Thornfield has burned down; Bertha Mason set the fire and died after jumping from the roof, while Rochester was injured trying to save the household and lost his sight and one hand. Jane finds him living in seclusion at Ferndean. Now financially independent and able to meet him freely, she assures him that she has returned by choice. They marry. Rochester gradually recovers sight in one eye and is able to see their first child. Diana and Mary Rivers also marry, while St John continues his missionary work in India and appears to be approaching death with the same absolute commitment that governed his life. Jane closes as Rochester's partner rather than his employee or dependent, with the legal obstacle removed and the imbalance between them greatly reduced.",
         "in_short": "Orphaned Jane Eyre is abused at Gateshead and sent to the harsh Lowood School, where friendship and education help her become a teacher. Seeking a wider life, she becomes governess at Thornfield Hall and falls in love with its owner, Edward Rochester. Their planned marriage is stopped by the revelation that Rochester already has a living wife, Bertha Mason, confined at Thornfield because of severe mental illness. Jane refuses to become his mistress and flees. Destitute, she is rescued by the Rivers siblings, discovers they are her cousins, and inherits a fortune that she shares with them. St John Rivers asks her to marry him and join his missionary work, but she refuses a union without love. Jane returns to find Thornfield burned, Bertha dead, and Rochester blinded and maimed. Independent and still loving him, Jane reunites with Rochester and marries him; he later regains enough sight to see their child.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3705,7 +3705,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3718,7 +3718,7 @@
       "recaps": {
         "ending": "Jane returns to Thornfield and finds the house burned and abandoned. She learns that Bertha set the fire and died after leaping from the roof; Rochester saved the servants but was badly injured, losing a hand and his sight. Jane finds him living quietly at Ferndean. Now financially independent and able to meet him freely, she tells him that she has come to stay. They marry, with Adèle placed at a better school and remaining part of Jane's life. Rochester gradually recovers enough sight in one eye to see their first child. Jane reports ten years of an equal and happy marriage. Diana and Mary Rivers also marry, while St John continues his missionary work in India. His health is failing, and the novel closes with his unwavering expectation of death and spiritual reward. Jane's final position is the opposite of her childhood dependence: she has family, property, purpose, and a marriage entered by her own choice.",
         "in_short": "Orphaned Jane Eyre grows up mistreated by her aunt, then endures the harsh Lowood school, where her friend Helen dies and Jane later becomes a teacher. Seeking independence, she becomes governess at Thornfield Hall and falls in love with its troubled master, Edward Rochester. Their wedding is stopped by the discovery that Rochester already has a living wife, Bertha Mason, confined at Thornfield because of severe mental illness. Jane refuses to become his mistress and leaves with almost nothing. The Rivers siblings rescue her; she later learns they are her cousins and shares a large inheritance with them. She rejects St John Rivers's proposal that she marry him for missionary work and returns to Rochester. Bertha has burned Thornfield and died, while Rochester was blinded and maimed rescuing others. Jane reunites with him at Ferndean, marries him as an independent equal, and builds the loving home she had long lacked. Rochester eventually regains partial sight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3992,7 +3992,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4005,7 +4005,7 @@
       "recaps": {
         "ending": "Jane Eyre closes with Jane independently choosing Rochester after Bertha has burned Thornfield and died. Rochester, injured and blinded while saving others, lives at Ferndean; Jane marries him, and he later regains partial sight. Wuthering Heights closes after Heathcliff has gained both estates through coercion but loses interest in revenge. Absorbed by the memory of Catherine Earnshaw, he stops eating and dies in her old room. The younger Catherine and Hareton overcome the hostility and deprivation imposed on them, learn together, and plan to marry and move to Thrushcross Grange. Their union returns the Earnshaw and Linton property to a cooperative household. Lockwood visits the graves of Catherine, Edgar, and Heathcliff while local stories claim that Catherine and Heathcliff still wander the moors.",
         "in_short": "In Jane Eyre, an orphan survives Gateshead and Lowood, becomes governess at Thornfield, and falls in love with Edward Rochester. Their wedding exposes his living wife, Bertha, so Jane leaves, gains family and an inheritance, and rejects a loveless missionary marriage. After Bertha burns Thornfield and dies, Jane returns to the injured Rochester and marries him as an independent equal. In Wuthering Heights, Nelly Dean recounts how Catherine Earnshaw chose Edgar Linton over her beloved childhood companion Heathcliff. Heathcliff returns wealthy and takes revenge across two generations, gaining both family estates and forcing Catherine's daughter to marry his sickly son. The elder Catherine's death leaves him obsessed rather than satisfied. The younger Catherine eventually befriends and loves Hareton Earnshaw, whom Heathcliff kept uneducated. Heathcliff abandons revenge and dies; Catherine and Hareton plan to marry, healing the families' division.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4267,7 +4267,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4280,7 +4280,7 @@
       "recaps": {
         "ending": "Jane returns to find Thornfield burned and abandoned. Bertha Mason started the fire and died after jumping from the roof; Rochester saved the servants but lost a hand and his sight in the collapse. Jane finds him living in seclusion at Ferndean. Now financially independent and free to choose without becoming his dependent or violating her conscience, she tells him that she has returned to stay. They marry quietly. Jane describes ten years of a companionate marriage in which she serves as Rochester's eyes and is fully at home with him; he later recovers enough sight in one eye to see their firstborn son. Diana and Mary Rivers also marry happily. Adèle is moved from a harsh school and grows into a pleasing young woman under Jane's care. St. John remains an unmarried missionary in India, physically failing but unwavering in his vocation, and his final letter anticipates his approaching death.",
         "in_short": "Orphaned Jane Eyre grows up abused by the Reed family and is sent to harsh Lowood School, where her friend Helen Burns dies but Jane gains an education. As governess at Thornfield Hall, she falls in love with its troubled master, Edward Rochester, and accepts his proposal. Their wedding is stopped by the revelation that Rochester already has a living wife, Bertha Mason, confined at Thornfield because of severe mental illness. Refusing to become his mistress, Jane leaves and nearly starves before the Rivers siblings rescue her. She discovers they are her cousins and shares a large inheritance with them. Their clergyman brother St. John asks Jane to marry him and join his missionary work in India, but she refuses a loveless union and returns to Rochester. Bertha has burned Thornfield and died; Rochester was blinded and maimed saving others. Jane, now independent, marries him at Ferndean. His sight partly returns, they have a son, and Jane records a happy marriage of equals.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4497,7 +4497,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4510,7 +4510,7 @@
       "recaps": {
         "ending": "Jane returns to Thornfield and finds the house burned and abandoned. She learns that Bertha set the fire and died after leaping from the roof; Rochester saved the servants but was badly injured, losing a hand and his sight. Jane finds him living quietly at Ferndean. Now financially independent and able to meet him freely, she tells him that she has come to stay. They marry, with Adèle placed at a better school and remaining part of Jane's life. Rochester gradually recovers enough sight in one eye to see their first child. Jane reports ten years of an equal and happy marriage. Diana and Mary Rivers also marry, while St John continues his missionary work in India. His health is failing, and the novel closes with his unwavering expectation of death and spiritual reward. Jane's final position is the opposite of her childhood dependence: she has family, property, purpose, and a marriage entered by her own choice.",
         "in_short": "Orphaned Jane Eyre grows up mistreated by her aunt, then endures the harsh Lowood school, where her friend Helen dies and Jane later becomes a teacher. Seeking independence, she becomes governess at Thornfield Hall and falls in love with its troubled master, Edward Rochester. Their wedding is stopped by the discovery that Rochester already has a living wife, Bertha Mason, confined at Thornfield because of severe mental illness. Jane refuses to become his mistress and leaves with almost nothing. The Rivers siblings rescue her; she later learns they are her cousins and shares a large inheritance with them. She rejects St John Rivers's proposal that she marry him for missionary work and returns to Rochester. Bertha has burned Thornfield and died, while Rochester was blinded and maimed rescuing others. Jane reunites with him at Ferndean, marries him as an independent equal, and builds the loving home she had long lacked. Rochester eventually regains partial sight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4739,7 +4739,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4752,7 +4752,7 @@
       "recaps": {
         "ending": "After hearing what seems to be Rochester calling her from a great distance, Jane leaves St John and returns to Thornfield. She finds the house ruined by a fire set by Bertha Mason, who died after jumping from the roof. Rochester saved the servants but lost a hand and his sight while trying to rescue Bertha. Jane finds him living in seclusion at Ferndean and chooses to marry him now that the relationship can be lawful and independent: she has her own fortune, while he must accept her help. They build a happy life together, and Rochester eventually recovers enough sight in one eye to see their first child. Diana and Mary Rivers also marry, while St John continues his demanding missionary work in India and appears to be approaching death with the same absolute religious conviction that has governed his life.",
         "in_short": "Orphaned Jane Eyre survives an abusive childhood at Gateshead and harsh schooling at Lowood before becoming governess at Thornfield Hall. She falls in love with its guarded owner, Edward Rochester, despite his apparent courtship of Blanche Ingram and strange violence hidden within the house. Rochester proposes, but their wedding is stopped by the discovery that his wife, Bertha Mason, is alive and confined at Thornfield. Refusing to become Rochester's mistress, Jane flees and is sheltered by the Rivers siblings. She discovers they are her cousins and shares an unexpected inheritance with them. St John Rivers asks her to marry him and join his missionary work, but she refuses a loveless marriage. Jane returns to find Thornfield burned, Bertha dead, and Rochester injured and blind. Now financially independent, Jane freely marries him; they have a son, and he later regains partial sight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4926,7 +4926,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4939,7 +4939,7 @@
       "recaps": {
         "ending": "Erlendur establishes that Einar Orn is a son conceived when Holberg raped Kolbrun. Einar learned the truth after his own young daughter died from the same rare hereditary disease that killed his half-sister Audur. He confronted Holberg and killed him, leaving a note intended to identify the victim with the man who had transmitted both violence and illness through the family. Audur's preserved brain, removed for medical study and kept among the hospital's old organ collection, supplies the genetic evidence behind the case. Einar recovers it and returns it to Audur's grave before dying by suicide, so there is no trial. The investigation exposes not only a murderer but the lasting damage caused when Kolbrun's rape allegation was dismissed decades earlier. Erlendur remains entangled with his pregnant, drug-dependent daughter Eva Lind, whose anger forces him to face his own failures as a father even as he solves another family's buried history.",
         "in_short": "Reykjavik detective Erlendur investigates the bludgeoning of Holberg, an elderly man found with a cryptic note and a photograph of a child's grave. The trail leads to Kolbrun, whose rape allegation against Holberg was dismissed decades earlier, and to Audur, the daughter conceived by that assault who died from a rare brain disease. Medical records, genealogy, and an old hospital collection of preserved organs reveal that the illness passed through Holberg's family. Einar Orn, another son conceived through Holberg's violence, discovered his parentage after his own daughter died from the same condition. He confronted and killed Holberg, then sought Audur's preserved brain as proof and returned it to her grave. Einar dies by suicide before arrest. Alongside the case, Erlendur struggles with Eva Lind, his pregnant, drug-dependent daughter, whose demands expose the emotional damage caused by his abandonment of his family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5112,7 +5112,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5125,7 +5125,7 @@
       "recaps": {
         "ending": "Felice visits Joe and Violet and supplies what their imagined versions of Dorcas could not: Dorcas chose to let herself bleed rather than seek help, though treatment might have saved her, and Joe may not have understood that his shot would be fatal. Felice's presence allows the Traces to speak about Dorcas without preserving her only as lover, rival, or victim. The couple do not return to their earlier marriage; they build a more honest one from what remains. Violet becomes steadier in herself, Joe's grief softens, and Felice continues to visit them. After her mother's opal ring is stolen, Felice decides not to let the loss define the memory attached to it. The narrative voice finally turns attention on itself, admitting its fascination with the characters and its mistaken confidence about what they would do. Joe and Violet end together in quiet, renewed intimacy, while the narrator envies their ability to touch and asks the reader to recognize the intimacy created by the telling.",
         "in_short": "In 1926 Harlem, Joe Trace shoots his eighteen-year-old lover Dorcas after she leaves him for a younger man. At Dorcas's funeral, Joe's wife Violet tries to slash the dead girl's face. The novel circles these acts through shifting accounts of Joe, Violet, Dorcas, and their families. Violet befriends Dorcas's guardian Alice and confronts her mother's suicide and her own divided identity. Joe recalls being raised in Virginia and repeatedly seeking Wild, the woman he believes was his mother. Dorcas's history reaches back to the racial violence that killed her parents, while older stories of Golden Gray and Henry Lestory complicate ideas of origin and abandonment. Dorcas's friend Felice finally tells the Traces that Dorcas refused aid after the shooting and could perhaps have lived. Through Felice, Joe and Violet stop treating Dorcas as an image shaped only by their needs. Their marriage survives in altered form, grounded in honesty and renewed tenderness rather than possession.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5295,7 +5295,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5308,7 +5308,7 @@
       "recaps": {
         "ending": "The war is stopped without a real battle. 71-hour Ahmed, revealed to be Klatch's own equivalent of Vimes, a lawman who polices the desert, produces proof that Prince Cadram arranged the attack on his own brother Khufurah in order to create a martyr and a cause for war. With the conspiracy exposed to both sides and the disputed island of Leshp already sinking back beneath the sea, the reason to fight simply disappears. Lord Vetinari, returning from his secret voyage, resumes control and steers the aftermath to Ankh-Morpork's advantage. Vimes, who refused to let patriotism excuse a murder, returns to being a policeman rather than a soldier. The armies disperse, the crisis passes, and the city settles back into its usual uneasy normality.",
         "in_short": "When the long-drowned island of Leshp suddenly rises from the sea midway between Ankh-Morpork and the empire of Klatch, both nations claim it and war fever grips the city. During a visit by the Klatchian Prince Khufurah, an assassination attempt throws suspicion in every direction, and Commander Vimes treats it as a crime to be solved rather than an excuse to fight. As Ankh-Morpork's nobles raise a shambolic army and sail to war, Vimes takes the Watch to Klatch to chase the truth, shadowed by the formidable D'reg lawman 71-hour Ahmed. Meanwhile Lord Vetinari, Leonard of Quirm, Colon, and Nobby travel in secret beneath the waves in one of Leonard's inventions. Vimes learns the entire crisis was engineered, the attack on Khufurah arranged from within Klatch's own ruling family to manufacture a reason for war. Confronting the two assembled armies, Vimes arrests everyone for conspiracy to cause a breach of the peace. Leshp conveniently sinks again, the prize vanishes, and the war collapses before it truly begins.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5438,7 +5438,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5451,7 +5451,7 @@
       "recaps": {
         "ending": "Once the medical staff recognizes Joe's head movement as Morse code, he finally receives a reply tapped against his body. Asked what he wants, Joe requests to be taken into the world and exhibited as a living demonstration of what modern war does to a human being. If he cannot leave the hospital, he asks to receive visitors so that others can learn from him. The authorities reject the request and tell him that it is against regulations. Joe understands that the people controlling his body will not permit his continued existence to challenge the abstractions used to promote war. When he persists in signaling, he is sedated. Trapped again inside his mind, he imagines himself as a warning to ordinary people and as a voice urging them to resist those who send them to fight. He remains alive and conscious in the hospital, able to communicate in principle but denied freedom, public contact, and control over his own future.",
         "in_short": "Joe Bonham, a young American soldier in the First World War, wakes in a hospital and gradually discovers that an explosion has taken his arms, legs, and face, leaving him unable to see, hear, speak, or communicate. Memories of his parents, friendships, jobs, and girlfriend Kareen preserve the ordinary life from which the war removed him. By reading vibrations, nursing routines, and sensations on his skin, he learns to measure time and deliberately tap Morse code with his head. A perceptive nurse realizes that the motion is purposeful, and the staff eventually answers him. Joe asks to be taken outside and shown to the public as evidence of war's human cost, or at least allowed to meet visitors. Military authorities refuse on grounds of regulation and sedate him when he continues. He remains conscious and imprisoned in his body, understanding that his isolation protects the ideas used to justify future wars.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5642,7 +5642,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5655,7 +5655,7 @@
       "recaps": {
         "ending": "After British troops march toward Lexington and Concord, Johnny moves through the occupied city carrying information for the Patriots. He learns that Rab has been gravely wounded in the fighting at Lexington and reaches him before he dies. Rab gives Johnny the musket he had wanted for himself. The loss ends Johnny's youthful idea of war as an exciting public cause and makes its cost personal. Doctor Warren examines Johnny's burned hand and explains that an operation can probably free the fused thumb, allowing Johnny to fire Rab's musket and do more useful work. Johnny accepts the pain and risk of surgery. Boston remains under British control while armed rebellion spreads outside it, but Johnny is no longer defined by the silversmith's career his injury took from him. He ends the novel committed to the Patriot cause, carrying Rab's memory and ready to take an active part in the struggle ahead.",
         "in_short": "Johnny Tremain is a proud, talented apprentice silversmith in colonial Boston until a rival's sabotage contributes to an accident that badly burns his right hand. Unable to continue his trade, he finds work delivering the Boston Observer and becomes close to Rab Silsbee, a young printer involved with the Patriot movement. Johnny's errands bring him into the resistance to British rule, including the Boston Tea Party, while his old ties to Cilla and Isannah Lapham change as they enter the household of the Loyalist Lytes. As British troops occupy Boston, Johnny learns discipline, empathy, and a purpose larger than his lost craft. Rab joins the colonial militia and is mortally wounded at Lexington when fighting begins. He leaves Johnny his musket. Doctor Warren then offers hope that surgery can restore enough movement to Johnny's hand for him to use it. Johnny chooses the operation and commits himself to the revolutionary cause.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5795,7 +5795,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5808,7 +5808,7 @@
       "recaps": {
         "ending": "After Jonathan departs, Fletcher continues teaching, but later generations gradually transform a practical discipline into an institution centered on Jonathan's memory. Accounts of his achievements become miraculous legends, repeated ceremonies replace attempts to understand them, and questioning the approved interpretation becomes unwelcome. The flock honors a teacher while abandoning the freedom and experiment he tried to teach. Centuries later, Anthony Gull is alienated by these empty observances and by a life reduced once again to food and conformity. His frustration becomes so complete that he is willing to risk death in a final flight. He then witnesses a gull moving with the precision and speed that official tradition has ceased to pursue. The sight provides direct evidence that mastery is real rather than a decorative story from the past. Anthony turns toward the stranger and asks to learn who he is. The gull is Jonathan, returning not as the object of ritual but as a practicing flyer and possible teacher. The restored fourth part therefore ends the cycle where the book began: one dissatisfied bird encounters the possibility that limits accepted by the flock can be examined through disciplined experience.",
         "in_short": "Jonathan Livingston Seagull devotes himself to experimental flight rather than the flock's daily struggle for food. After mastering dangerous speeds, he is banished for refusing accepted limits. In another level of existence he studies with Sullivan and Chiang, learning that freedom depends on understanding identity beyond physical restriction and that knowledge should be joined to love. Jonathan returns to the flock's outcasts and trains Fletcher Lynd and other students. Their skill attracts curious gulls despite official resistance, and Jonathan entrusts the teaching to Fletcher before disappearing. Over generations, however, practice hardens into reverence: followers turn Jonathan into a sacred figure, multiply ceremonies, and stop testing his lessons through flight. Much later, Anthony Gull rejects the empty tradition and nearly gives up on life. Seeing an unknown gull perform with extraordinary control renews his desire to learn. The stranger is Jonathan, returned to offer direct instruction again, so the complete edition ends with discovery reopening a teaching that institutions had closed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5998,7 +5998,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6011,7 +6011,7 @@
       "recaps": {
         "ending": "Strange and Norrell reunite at Hurtfew inside the supernatural darkness and finally work as partners. Their attempt to summon John Uskglass does not bring him before them, but it awakens old alliances among England, Faerie, and the land itself. The released power helps break the gentleman's enchantments. Stephen Black kills his fairy captor and becomes the new king of Lost-Hope, while Lady Pole and Arabella are restored fully to the human world. Childermass finds that the Raven King has rewritten the magical text carried on Vinculus's body, and practical magic begins appearing spontaneously across England. Lascelles is lost after challenging a magical guardian. Strange and Norrell cannot dispel the pillar of darkness around themselves, so Hurtfew and the two magicians vanish from England as they travel through other realms seeking a cure. Arabella is free but separated from her husband; Strange tells her that he intends to return. Childermass rejects Norrell's old policy of restriction and plans to teach the new magicians, leaving English magic broadly restored even though its two most famous practitioners remain absent.",
         "in_short": "In an alternate nineteenth-century England, the bookish recluse Gilbert Norrell proves that practical magic survives and gains national fame by raising Lady Pole from the dead. His secret bargain gives a fairy gentleman power over her and her butler, Stephen Black. A second magician, the inventive Jonathan Strange, becomes Norrell's pupil and uses magic in Britain's wars against Napoleon, but the men's disagreement over the Raven King, fairies, and access to magical knowledge splits them apart. The fairy gentleman enchants Strange's wife Arabella and substitutes a false corpse, driving Strange to seek forbidden knowledge through deliberately induced madness. Strange summons a vast darkness that eventually traps both magicians together. They reconcile and call on the Raven King's power, unintentionally awakening magic throughout the country. Stephen kills the fairy and rules his former captor's realm; Lady Pole and Arabella are freed. The darkness remains around Strange and Norrell, who depart through other worlds to find a cure, while Childermass prepares to teach a new generation of English magicians.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/jonathan-strange-mr-norrell.json
+++ b/data/works-community/0/jonathan-strange-mr-norrell.json
@@ -149,7 +149,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -162,7 +162,7 @@
       "recaps": {
         "ending": "Strange and Norrell reunite at Hurtfew inside the supernatural darkness and finally work as partners. Their attempt to summon John Uskglass does not bring him before them, but it awakens old alliances among England, Faerie, and the land itself. The released power helps break the gentleman's enchantments. Stephen Black kills his fairy captor and becomes the new king of Lost-Hope, while Lady Pole and Arabella are restored fully to the human world. Childermass finds that the Raven King has rewritten the magical text carried on Vinculus's body, and practical magic begins appearing spontaneously across England. Lascelles is lost after challenging a magical guardian. Strange and Norrell cannot dispel the pillar of darkness around themselves, so Hurtfew and the two magicians vanish from England as they travel through other realms seeking a cure. Arabella is free but separated from her husband; Strange tells her that he intends to return. Childermass rejects Norrell's old policy of restriction and plans to teach the new magicians, leaving English magic broadly restored even though its two most famous practitioners remain absent.",
         "in_short": "In an alternate nineteenth-century England, the bookish recluse Gilbert Norrell proves that practical magic survives and gains national fame by raising Lady Pole from the dead. His secret bargain gives a fairy gentleman power over her and her butler, Stephen Black. A second magician, the inventive Jonathan Strange, becomes Norrell's pupil and uses magic in Britain's wars against Napoleon, but the men's disagreement over the Raven King, fairies, and access to magical knowledge splits them apart. The fairy gentleman enchants Strange's wife Arabella and substitutes a false corpse, driving Strange to seek forbidden knowledge through deliberately induced madness. Strange summons a vast darkness that eventually traps both magicians together. They reconcile and call on the Raven King's power, unintentionally awakening magic throughout the country. Stephen kills the fairy and rules his former captor's realm; Lady Pole and Arabella are freed. The darkness remains around Strange and Norrell, who depart through other worlds to find a cure, while Childermass prepares to teach a new generation of English magicians.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -383,7 +383,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -396,7 +396,7 @@
       "recaps": {
         "ending": "At the Booby estate, Lady Booby tries to prevent Joseph and Fanny's marriage, while Beau Didapper's pursuit of Fanny creates further confusion. The apparent obstacle that Joseph and Fanny may be brother and sister is removed when the pedlar explains that Fanny was the infant stolen from the Andrews family. Mr Wilson then recognizes Joseph, by a mark on his body, as the son taken from Wilson's own family years before. Joseph and Fanny are therefore unrelated. With their identities settled, they marry, supported by Mr Booby and Pamela despite Lady Booby's displeasure. Wilson receives his lost son into his family and makes provision for the newlyweds. Adams returns to his parish and family, while Joseph and Fanny begin married life with modest security and the domestic happiness the novel consistently values above rank, fashion, and calculated self-interest.",
         "in_short": "After the widowed Lady Booby fails to seduce her chaste young servant Joseph Andrews, she dismisses him. He is robbed and badly beaten on the road home, then joins his learned but impractical mentor Parson Adams. Joseph's beloved Fanny Goodwill meets them, and the three endure dishonest innkeepers, false benefactors, violent squires, abductions, lawsuits, and repeated shortages of money while trying to return to their parish. Their troubles expose the gap between public respectability and actual charity. Back at the Booby estate, Lady Booby opposes Joseph and Fanny's marriage and Beau Didapper pursues Fanny. A final discovery resolves their uncertain parentage: Fanny is the Andrews family's stolen daughter, while Joseph is the long-lost son of Mr Wilson. Since they are not related, they marry with support from Pamela and Mr Booby, and Joseph is reunited with his birth family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -528,7 +528,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -541,7 +541,7 @@
       "recaps": {
         "ending": "The travelers' attempt to blast through Saknussemm's last obstacle releases the underground sea into the passage. Their raft is carried through a terrifying ascent in which heat, steam, and rushing water replace the cold depths. They are finally expelled from the crater of Stromboli in the Mediterranean, far from Iceland but alive. Hans returns home after receiving his wages, while Lidenbrock and Axel go back to Hamburg as celebrated explorers. A lingering puzzle about their compass is resolved when Axel realizes that an electrical storm reversed its polarity, explaining why their route seemed impossible. Lidenbrock's reputation is secured, and Axel marries Grauben. Although the expedition does not literally arrive at the earth's center, the evidence and specimens it brings back establish the journey as a remarkable success.",
         "in_short": "Hamburg professor Otto Lidenbrock deciphers a note left by the Icelandic scholar Arne Saknussemm, claiming that a passage through the crater of Snæfell leads toward the earth's center. Lidenbrock compels his reluctant nephew Axel to accompany him, and in Iceland they hire the unshakable guide Hans. They descend through extinct volcanic passages, survive thirst when Hans finds underground water, and reunite after Axel becomes lost. At a vast subterranean sea they build a raft, encounter gigantic marine life, weather a storm, and find evidence of prehistoric animals and an earlier human passage. A blocked tunnel bearing Saknussemm's mark is blasted open, but the resulting flood sweeps the travelers into a volcanic shaft. Water and steam drive them upward until Stromboli ejects them into the Mediterranean. They return to acclaim; Axel discovers that a storm had reversed their compass, and he marries Grauben.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -688,7 +688,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -701,7 +701,7 @@
       "recaps": {
         "ending": "The explosion intended to clear Saknussemm's blocked route sweeps the explorers and their raft into a descending torrent. After a terrifying fall, the water meets immense heat and drives them upward through a volcanic shaft. They have no control over the ascent and expect either to be crushed or burned. Instead the raft is expelled during an eruption of Stromboli in the Mediterranean. Local people find and shelter Axel, Lidenbrock, and Hans, all three alive after emerging thousands of miles from Iceland. They return home to public astonishment. Lidenbrock's achievement makes him famous, Hans eventually goes back to Iceland with his earnings, and Axel marries Grauben. One puzzle remains until Axel realizes that a compass reversed polarity during the underground electrical storm, explaining why their directional readings seemed impossible. The journey is accepted as a triumph even though the travelers never literally reached Earth's center.",
         "in_short": "Hamburg geologist Otto Lidenbrock finds a coded message from the Icelandic explorer Arne Saknussemm claiming a route toward Earth's center through Snæfellsjökull. He forces his reluctant nephew Axel to join him, and in Iceland they hire the calm guide Hans. The three descend through an extinct crater, survive thirst when Hans finds an underground stream, and reach an immense cavern containing a sea. After Axel becomes lost and is rescued through strange acoustic effects, they cross the sea by raft, seeing prehistoric life and enduring a violent storm. On the far shore they find ancient remains, mastodons, and evidence that Saknussemm preceded them. Blasting through a blocked passage releases a flood that carries them deeper and then upward through volcanic heat. They are finally erupted from Stromboli alive. Lidenbrock returns famous, Hans goes home, and Axel marries Grauben.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -864,7 +864,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -877,7 +877,7 @@
       "recaps": {
         "ending": "The blast at the blocked gallery sends the explorers' raft into a violent downward torrent. The water eventually drives them upward through a volcanic shaft, and the heat turns the ascent into an eruption. Axel, Lidenbrock, and Hans are expelled from Stromboli in the Mediterranean rather than emerging in Iceland. They recover with help from local people and return to Hamburg, where their survival and observations make Lidenbrock famous. Axel marries Grauben, while Hans eventually goes home to Iceland. Axel later realizes that the electrical storm reversed their compass, explaining why they had misread the direction of their underground voyage. Saknussemm's route has been confirmed even though the party never literally stands at the planet's center, and the knife Axel recovered provides a final material link to the earlier explorer.",
         "in_short": "Hamburg geologist Otto Lidenbrock discovers a coded message left by the Icelandic scholar Arne Saknussemm, claiming that a route beneath Snæfell leads toward the center of the Earth. He takes his reluctant nephew Axel to Iceland and hires the unshakable Hans as guide. The three descend through the volcano, survive thirst, separation, and falls, and reach a vast subterranean sea lit by electrical phenomena. They cross it on a raft, witness prehistoric creatures, and find evidence of ancient human life. On the far shore they discover Saknussemm's initials beside a blocked passage and blast it open. The explosion sweeps them through flooded depths and then up a volcanic conduit, ejecting them from Stromboli in Italy. They return celebrated: Lidenbrock gains scientific fame, Axel marries Grauben, and Hans goes back to Iceland. Axel also discovers that their compass was reversed during the underground storm, resolving the mystery of their route.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1031,7 +1031,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1044,7 +1044,7 @@
       "recaps": {
         "ending": "The explosion intended to clear Saknussemm's blocked route sweeps the explorers and their raft into a descending torrent. After a terrifying fall, the water meets immense heat and drives them upward through a volcanic shaft. They have no control over the ascent and expect either to be crushed or burned. Instead the raft is expelled during an eruption of Stromboli in the Mediterranean. Local people find and shelter Axel, Lidenbrock, and Hans, all three alive after emerging thousands of miles from Iceland. They return home to public astonishment. Lidenbrock's achievement makes him famous, Hans eventually goes back to Iceland with his earnings, and Axel marries Grauben. One puzzle remains until Axel realizes that a compass reversed polarity during the underground electrical storm, explaining why their directional readings seemed impossible. The journey is accepted as a triumph even though the travelers never literally reached Earth's center.",
         "in_short": "Hamburg geologist Otto Lidenbrock finds a coded message from the Icelandic explorer Arne Saknussemm claiming a route toward Earth's center through Snæfellsjökull. He forces his reluctant nephew Axel to join him, and in Iceland they hire the calm guide Hans. The three descend through an extinct crater, survive thirst when Hans finds an underground stream, and reach an immense cavern containing a sea. After Axel becomes lost and is rescued through strange acoustic effects, they cross the sea by raft, seeing prehistoric life and enduring a violent storm. On the far shore they find ancient remains, mastodons, and evidence that Saknussemm preceded them. Blasting through a blocked passage releases a flood that carries them deeper and then upward through volcanic heat. They are finally erupted from Stromboli alive. Lidenbrock returns famous, Hans goes home, and Axel marries Grauben.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1210,7 +1210,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1223,7 +1223,7 @@
       "recaps": {
         "ending": "The German bombardment opens at dawn. Raleigh is carried into the dugout with a severe spinal wound, unable to move his legs. Stanhope places him in Osborne's former bed and, dropping his habitual severity, comforts him and promises to have him taken to hospital. When duty calls Stanhope briefly back to the trench, Raleigh dies alone. Stanhope returns, sees that he is dead, and remains with him for a moment before climbing back to command the company. The shelling intensifies; a shell strikes the dugout, extinguishing the candle and burying the room while the battle continues above. Osborne has already died in the futile raid, and Stanhope's depleted company faces the German attack with its remaining officers and men.",
         "in_short": "In March 1918, young Raleigh joins a British infantry company in the trenches because its commander, Stanhope, was his schoolboy hero. He finds an exhausted officer who has survived three years at the front by drinking heavily, yet still commands with courage and discipline. Osborne, Stanhope's older second-in-command, mediates between them as the company learns that a German offensive is imminent. Brigade nevertheless orders a raid: Osborne is killed, Raleigh helps capture a German soldier, and the intelligence confirms the attack without changing the plan. Stanhope also prevents the terrified Hibbert from leaving, partly by admitting their shared fear. When the offensive begins, Raleigh is mortally wounded. Stanhope comforts him in the dugout, but Raleigh dies while Stanhope returns to duty. A shell then strikes the dugout as the company meets the assault above.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1393,7 +1393,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1406,7 +1406,7 @@
       "recaps": {
         "ending": "Erin's research and Devin's memories expose Lane Hardy as Linda Gray's killer and link him to other murdered women. Lane intercepts Devin during a storm, takes him at gunpoint onto Joyland's Ferris wheel, and admits enough to confirm the case. Annie, alerted by Mike's extraordinary perception of the danger, shoots Lane before he can kill Devin. The confrontation ends the mystery that has haunted the park. Devin and Annie become lovers, though both understand that their bond grows from an intense and temporary season rather than a permanent future. Mike finally visits Joyland, enjoys the park, and helps Linda's lingering spirit depart. He dies some months later. Devin and Annie honor his wish by taking his ashes out over the ocean and releasing them while flying his favorite kite. Devin eventually returns to college and carries on with his life, but his older self remembers Joyland as the place where heartbreak gave way to friendship, responsibility, first encounters with death, and a more durable kind of love.",
         "in_short": "In 1973, heartbroken college student Devin Jones takes a summer job at the North Carolina amusement park Joyland. He learns the park's traditions, becomes close to fellow workers Tom Kennedy and Erin Cook, and discovers a gift for cheering children in the mascot costume. He also hears that Linda Gray, murdered years before in the Horror House, may still haunt the ride. After the summer, Devin remains at the park and befriends Annie Ross and her terminally ill, psychically sensitive son Mike. Erin's research connects Linda's death to other killings and reveals that trusted park employee Lane Hardy is the murderer. Lane takes Devin onto the Ferris wheel at gunpoint during a storm, but Annie shoots him after Mike senses the danger. Devin and Annie share a brief relationship, and Mike visits Joyland and helps Linda's ghost find release. After Mike dies, Devin and Annie scatter his ashes over the sea with a kite, leaving Devin with a lasting memory of love, loss, and the summer he grew up.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1565,7 +1565,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1578,7 +1578,7 @@
       "recaps": {
         "ending": "After the children's deaths, Sue interprets the catastrophe as punishment for rejecting religious and marital convention. She separates from Jude and returns to Phillotson, eventually submitting to a renewed marriage and a physical relationship she does not desire. Arabella draws the sick and despairing Jude back into marriage with her. Jude makes a final journey through severe weather to see Sue at Marygreen; they acknowledge that their love persists, but Sue refuses to leave the penitential life she has chosen. His health ruined, Jude returns to Christminster and dies alone while public celebrations fill the city. Arabella is absent and already considering a future with Physician Vilbert. She later tells a visitor that Sue will never find peace with Phillotson because she truly belongs with Jude. Jude dies excluded from the university world he once revered, and Sue remains alive but bound by guilt to the institution both had tried to escape.",
         "in_short": "Poor and self-educated, Jude Fawley dreams of studying at Christminster, but an early marriage to Arabella Donn collapses and the university rejects him. He falls in love with his unconventional cousin Sue Bridehead, though she marries his former teacher Phillotson. Phillotson releases the unhappy Sue to Jude at great personal cost. Jude and Sue live together, obtain divorces, and raise children but avoid remarriage, enduring social exclusion and unstable work. Jude's son by Arabella, the morbid child called Father Time, kills Sue's two younger children and himself after concluding that the family cannot afford to exist; Sue then loses another baby. Broken by guilt, Sue returns to Phillotson and Jude is maneuvered back into marriage with Arabella. Still loving each other, Jude and Sue separate under the authority of beliefs they cannot reconcile. Jude dies neglected in Christminster, while Sue remains in a penitential marriage and Arabella looks toward another partner.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1753,7 +1753,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1766,7 +1766,7 @@
       "recaps": {
         "ending": "After the children's deaths, Sue comes to regard the catastrophe as punishment for rejecting marriage and religion. She leaves Jude and returns to Phillotson, eventually resuming their marriage despite her continuing attachment to Jude. Arabella maneuvers the ill and despondent Jude into marrying her again. Jude makes one last journey through bad weather to see Sue, but she refuses to abandon the penance she has chosen. His health worsens in Christminster while Arabella pursues amusement and renewed attention from Vilbert. Jude dies alone in his room during the university's Remembrance celebrations, his youthful academic hopes answered only by sounds from the city outside. Arabella quickly turns toward another possible match. Sue remains with Phillotson, having forced herself back into a union she once escaped, while the society that excluded Jude continues unchanged.",
         "in_short": "Jude Fawley, a poor village orphan, dreams of studying at Christminster but is diverted into a disastrous marriage with Arabella Donn. After she leaves him, he reaches the university city only to find its colleges closed to a working stonemason. He falls in love with his intellectually independent cousin Sue Bridehead, yet both remain entangled in marriage: Sue weds Jude's former teacher Phillotson, then leaves him to live with Jude. Divorced but distrustful of marriage, Jude and Sue build an unofficial family with Jude and Arabella's grave young son, Father Time, and two children of their own. Poverty and public disapproval follow them. When Sue speaks of their children as an unbearable burden, Father Time kills the younger children and himself. Broken by the loss, Sue returns to Phillotson as religious penance, while Jude remarries Arabella. Sick and abandoned, Jude dies in Christminster without attaining either education or a lasting life with Sue.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1943,7 +1943,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1956,7 +1956,7 @@
       "recaps": {
         "ending": "As Miyax travels toward the coast, hunters in an airplane attack the wolf pack, killing Amaroq and wounding Kapu. She cares for Kapu until he can return to the surviving wolves, but Amaroq's death destroys her belief that the tundra can remain separate from modern violence. Miyax then discovers that Kapugen did not die years earlier. He has adopted the English name Charlie Edwards, married a white woman named Ellen, and built a materially comfortable life tied to the modern economy. Miyax is overjoyed that her father is alive but distressed that the traditional hunter she remembers has changed. She initially turns away, intending to choose the old ways and the tundra instead. When her small bird companion Tornait dies, she accepts that she cannot simply recover an untouched earlier world. She returns to Kapugen's settlement. The close does not erase the loss of Amaroq or resolve every conflict between Miyax and Julie; it leaves her choosing reunion with her father and a life that must hold both her Iñupiaq identity and the modern world she had hoped to reject.",
         "in_short": "Thirteen-year-old Miyax, known in English as Julie, is lost on the Alaskan tundra after fleeing a dangerous child marriage. She survives by studying a wolf pack led by Amaroq, imitating its signals, and earning enough acceptance to share food. Her memories explain how her hunter father Kapugen was presumed dead, how she was sent to Aunt Martha, and why she set out toward a pen pal in San Francisco after Daniel attacked her. Miyax becomes especially attached to Amaroq and the pup Kapu. When aerial hunters kill Amaroq and wound Kapu, the modern world reaches even the refuge she trusted. Miyax later finds Kapugen alive, remarried, and living with modern technology under the name Charlie Edwards. Disturbed that he is no longer the traditional figure she remembers, she starts to leave. The death of her bird Tornait convinces her that she cannot restore the past by remaining alone. She returns to her father, accepting a future shaped by both Miyax and Julie.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2129,7 +2129,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2142,7 +2142,7 @@
       "recaps": {
         "ending": "At Philippi, Cassius misreads a distant event and believes his ally Titinius has been captured. He orders Pindarus to kill him with the sword used against Caesar. Titinius returns safely with news of victory, finds Cassius dead, and kills himself. Brutus rallies the remaining troops for another engagement, but his cause is lost. Refusing capture, he asks several companions to help him die; Strato finally holds the sword on which Brutus runs. Antony finds the body and judges Brutus the only conspirator who acted from an honest concern for Rome rather than envy. Octavius orders an honorable burial and takes command of the field. Caesar's assassins are dead or defeated, while Antony and Octavius emerge as Rome's rulers and prepare to settle affairs after the civil war.",
         "in_short": "Roman senators fear that Julius Caesar's popularity will become monarchy. Cassius recruits Brutus, whose public honor gives legitimacy to a conspiracy. Ignoring warnings, Caesar attends the Senate and is stabbed by the conspirators, with Brutus joining the attack. Brutus allows Mark Antony to speak at the funeral after his own defense of the killing. Antony uses Caesar's wounds and will to turn the crowd against the assassins. Brutus and Cassius flee and raise armies, while Antony, Octavius, and Lepidus take control in Rome. The republican leaders quarrel but reconcile before facing their enemies at Philippi. Cassius kills himself after mistakenly believing a battle lost; Brutus follows when defeat becomes certain. Antony honors Brutus's motives, and Octavius assumes command of the victorious forces.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2336,7 +2336,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2349,7 +2349,7 @@
       "recaps": {
         "ending": "At Philippi, Brutus's forces initially push back Octavius, but Cassius's side loses ground. Cassius mistakes allied horsemen celebrating with Titinius for enemy troops capturing him and has Pindarus kill him. Titinius returns, discovers the error, and dies beside Cassius. After the next engagement is lost, Brutus refuses capture and asks Strato to hold a sword so that he can run onto it. Antony finds Brutus dead and judges that, unlike the other conspirators, he acted from an honest concern for Rome rather than envy. Octavius orders an honorable burial and assumes command. Caesar's assassins are defeated, Antony and Octavius control the state, and the attempt to preserve the republic through murder has instead helped place power in the hands of Caesar's political heirs.",
         "in_short": "As Julius Caesar returns to Rome in triumph, Cassius persuades the honorable Brutus that Caesar's growing power threatens republican freedom. Brutus joins a conspiracy and helps assassinate Caesar at the Capitol. He permits Mark Antony to address the funeral crowd, believing that a reasoned defense will justify the killing. Antony instead turns the citizens against the conspirators by challenging their claim that Caesar was ambitious and by displaying his wounds and generous will. Brutus and Cassius flee and raise armies, while Antony joins Octavius and Lepidus in a ruling triumvirate. The two conspirator leaders quarrel, reconcile, and meet their enemies at Philippi. Cassius dies after misreading news from the battle; Brutus takes his own life after defeat. Antony honors Brutus's motives, but Octavius takes command. Caesar's death has not restored the old republic, and the men who killed him are gone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2545,7 +2545,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2558,7 +2558,7 @@
       "recaps": {
         "ending": "The battle at Philippi destroys the republican leaders. Cassius, misreading reports from the field and believing his friend Titinius has been captured, orders Pindarus to kill him with the sword used against Caesar. Titinius returns safe, finds Cassius dead, and kills himself. Brutus's forces initially gain ground but are ultimately defeated by Antony and Octavius. With capture imminent, Brutus asks several companions to help him die; Strato finally holds the sword on which Brutus runs. Brutus dies convinced that Caesar's death has been avenged and that suicide preserves his freedom. Antony finds the body and distinguishes Brutus from the other conspirators, judging that Brutus acted from an honest concern for Rome rather than envy. Octavius orders an honorable military burial and takes Brutus's surviving men into his service. Caesar's assassins are dead, their cause is lost, and power passes to Antony and Octavius, whose victory points toward the end of the Roman republic.",
         "in_short": "As Julius Caesar returns to Rome in triumph, Cassius persuades the honorable Brutus that Caesar's popularity threatens the republic. Brutus joins a conspiracy and, despite warnings and omens, the senators assassinate Caesar at the Capitol. Brutus permits Caesar's ally Mark Antony to speak at the funeral. Antony turns the crowd against the killers by displaying Caesar's wounds and invoking his will, forcing Brutus and Cassius to flee Rome. Antony, Octavius, and Lepidus form a new ruling coalition, proscribe enemies, and march against the conspirators. Brutus and Cassius quarrel but reconcile before fighting at Philippi. Caesar's ghost foretells another meeting, and the battle ends disastrously for the republican side. Cassius kills himself after mistakenly believing his forces defeated; Brutus follows when defeat becomes certain. Antony honors Brutus as the one conspirator motivated by public principle, and Octavius assumes command of the settlement after victory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2868,7 +2868,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BW17MKWL",
@@ -2880,7 +2880,7 @@
       "recaps": {
         "ending": "Legion Varus leaves Jungle World after defeating the mobile crystals around the damaged central crystal, but the wider crystalline threat remains active beyond the known powers. Rigel seeks continued cooperation with Earth after losing its artificial protector. On Earth, the ruling council removes Drusus from the consulship, returns him to praetor rank, and arrests him when he opposes a renewed war against Rigel. Galina Turov is offered the consulship but delays accepting and later becomes unreachable. McGill goes to Dust World, where the former bunker survivor has a new body and leads an emerging revolutionary movement supported by the Investigator's illegal body-growing operation. Etta elects to remain with that group. The Investigator alleges that Galina's father engineered the war escalation and leadership change, and McGill accepts the possibility without independent proof. Back at his family home, McGill resumes his relationship with an enlisted woman and intends to search for Galina.",
         "in_short": "Legion Varus deploys to 31 Orionis believing it must invade a world important to Rigel, but the campaign reveals a threat to every faction: intelligent red crystals spreading from beyond known galactic space. After costly fighting that kills Harris, Leeson, and Sargon, James McGill restores cooperation with Abigail Claver and Jungle World's local forces. A vast Rigelian protector cripples the central crystal before being destroyed, allowing Varus and its allies to defeat the remaining mobile crystals. Earth returns under a truce with Rigel, yet the ruling council removes and arrests Drusus and offers Galina Turov the consulship on a renewed anti-Rigel mandate. She postpones her answer and later becomes unreachable. On Dust World, the bunker survivor has received a body and begun a revolutionary movement backed by illegal body-growing. Etta stays there, while McGill returns home believing an unproven claim that Galina's father planned the political crisis and intending to find Galina.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3063,7 +3063,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3076,7 +3076,7 @@
       "recaps": {
         "ending": "The Alexandria expedition becomes the decisive confrontation with the faction using time travel for its own ends. St Mary's people are killed during the struggle across the institute's missions, and the survivors return with the organisation damaged but still operating. Max survives the collapse of the expedition and her conflict with Ronan's network; Leon also survives, allowing the difficult attachment between them to continue. Ronan is not securely removed as a threat, so the conspiracy has been defeated locally rather than ended. Bairstow and the remaining staff begin repairing St Mary's while Max, no longer a recruit, accepts both the institution and its people as her chosen home.",
         "in_short": "Historian Madeleine Maxwell is recruited by St Mary's, an institute that studies history by travelling to it in disguised pods. Training introduces her to director Edward Bairstow, technical chief Leon Farrell, fellow historian Tim Peterson, and a community where scholarship routinely becomes a survival exercise. Max learns the rules through increasingly dangerous assignments, while her combative relationship with Leon becomes personal. A Cretaceous expedition and the ambitious attempt to observe the Library of Alexandria expose sabotage within the organisation. Clive Ronan is connected to a hostile group seeking control of the technology, and the resulting attacks cost lives both in the past and at St Mary's. Max and the survivors stop the immediate operation, but Ronan remains a continuing threat. The institute endures, and Max commits herself to its dangerous work and to the relationships she has formed there.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3285,7 +3285,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3298,7 +3298,7 @@
       "recaps": {
         "ending": "The last two tales complete the collection's movement from animal bodies to the arrangements of human society. Cat secures a conditional place by the fire through three fulfilled bargains with Woman: he comforts the baby, is praised by the fire, and catches a mouse. He remains independent, however, and his separate agreements with Man and Dog explain why men may throw things at him and dogs may chase him when he fails to keep the peace. In the final tale, the king Suleiman-bin-Daoud helps a boastful butterfly impress his skeptical wife by secretly using his magic to make the palace disappear and return when the butterfly stamps. Balkis arranges the lesson so that Suleiman's own quarrelsome household sees a demonstration of power without his having used it in anger. The butterfly saves face, the king's wisdom is vindicated, and domestic harmony is restored. Like the preceding origin tales, both endings turn a familiar behavior or saying into the result of an ancient bargain.",
         "in_short": "Twelve independent origin tales explain animal features, natural rhythms, writing, and domestic habits through comic bargains and transformations. A mariner blocks the Whale's throat; the lazy Camel receives a hump; crumbs under the Rhinoceros's skin produce its folds; and the Ethiopian marks the Leopard with spots. The Elephant's Child gains a trunk from a crocodile, while a long chase gives Kangaroo its legs and gait. Hedgehog and Tortoise blend their defenses into the first armadillos. Taffy's misunderstood picture-message leads first to writing and then to an alphabet. The giant crab Pau Amma is reduced and bound into a pattern that accounts for tides and the soft-shell season. Woman domesticates Dog, Horse, and Cow, but Cat negotiates limited access to the human home while remaining independent. Finally, Suleiman-bin-Daoud uses his command of spirits to support a butterfly's boast, turning the trick into a lesson in restraint and household peace.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3411,7 +3411,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3424,7 +3424,7 @@
       "recaps": {
         "ending": "On Mini's wedding day, Rahmun returns after years in prison expecting to resume their old friendship. The grown bride no longer knows him, and her shy reserve replaces the fearless conversation he remembers. He then unfolds the inked handprint of his own daughter, kept through his long absence. Mini's father suddenly sees him not as a foreign peddler or a convicted man but as another parent who has lost years with his child. He gives Rahmun money to travel home to Afghanistan, even though the gift requires cutting some of the wedding's planned display. Rahmun leaves with hope of finding his daughter, while Mini's father accepts a quieter celebration in exchange for helping reunite another family.",
         "in_short": "In Calcutta, talkative five-year-old Mini befriends Rahmun, an Afghan fruit seller living far from his own daughter. Their teasing conversations and regular visits overcome Mini's first fear and her mother's suspicion. When a debtor refuses to pay him, Rahmun stabs the man during the quarrel and is sent to prison. Years later he is released and visits Mini's house on her wedding day, still imagining her as the child he knew. The grown Mini barely remembers him. Rahmun shows her father the inked handprint of his own daughter, revealing the grief beneath his attachment to Mini. Recognizing a fellow father's loss, the narrator gives him money to return to Afghanistan, sacrificing some wedding festivities so Rahmun may try to see his daughter again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3565,7 +3565,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3578,7 +3578,7 @@
       "recaps": {
         "ending": "Miss Saeki gives Nakata the written record of her memories and asks him to destroy it; after their meeting she dies in the library. Nakata burns the pages but dies before he can close the entrance stone. Hoshino, newly able to hear a cat, takes over the task. He kills the pale creature that emerges from Nakata's body and turns the stone, sealing the passage. Kafka goes deep into the forest and enters a settlement outside ordinary time, where he meets the living memory of the young Miss Saeki and then the older Miss Saeki. She asks him to return and remember her. Kafka accepts his mother as someone capable of love and forgiveness without resolving every literal question about their connection. Guided out by the wartime soldiers, he returns to Oshima and the library. With his father dead and the prophecy endured rather than cleanly explained, he chooses to go back to Tokyo, complete school, and face ordinary life. On the train home he sleeps as rain falls and feels that a new world is beginning.",
         "in_short": "Fifteen-year-old Kafka Tamura flees Tokyo to escape his father and an Oedipal prophecy, finding refuge at a private library in Takamatsu with Oshima and the enigmatic Miss Saeki. In alternating chapters, elderly Satoru Nakata, who can speak with cats after a childhood calamity, kills the cat murderer Johnnie Walker and travels west with truck driver Hoshino. Kafka's father is murdered at the same time, though Kafka is far away and experiences the event only through disturbing gaps, dreams, and symbols. Kafka becomes involved with Miss Saeki, whose grief and youthful double connect him to the mother he cannot remember. Nakata and Hoshino open a metaphysical entrance stone; Nakata later receives and burns Miss Saeki's memories before both die. Kafka enters a timeless forest settlement, meets Miss Saeki once more, and chooses to return to life. Hoshino destroys a creature released after Nakata's death and closes the stone. Kafka then heads back to Tokyo resolved to finish school and live beyond the prophecy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3766,7 +3766,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3779,7 +3779,7 @@
       "recaps": {
         "ending": "After serving the gods in battle, Dushyanta stops at the celestial hermitage of the sage Maricha. There he meets a bold child playing with a lion cub and is instinctively drawn to him. The boy is Sarvadamana, later known as Bharata, the son born to Shakuntala and Dushyanta. Shakuntala appears in the austere dress of separation, and the king asks her forgiveness. His recognition has already returned with the recovered ring, but Maricha now explains the hidden cause of the estrangement: Durvasa's curse made Dushyanta forget Shakuntala until he saw the token. Shakuntala therefore learns that the rejection was supernatural rather than deliberate, and the couple reconcile. Maricha blesses their family and foretells the child's greatness. Dushyanta accepts Shakuntala and their son, and they prepare to return to the royal household together.",
         "in_short": "King Dushyanta meets Shakuntala at the forest hermitage where she was raised, and the two marry privately before he returns to court. He gives her his signet ring as proof. Distracted by longing, Shakuntala fails to greet the sage Durvasa, who curses her so that her beloved will forget her; the curse can be broken by showing a token. Pregnant Shakuntala travels to court, but the ring has been lost and Dushyanta sincerely fails to recognize her. She is carried away to a celestial refuge. A fisherman later finds the ring inside a fish, restoring the king's memory and leaving him overcome with remorse. After a divine military mission, Dushyanta reaches Maricha's hermitage, where he meets his fearless son Bharata and is reunited with Shakuntala. Maricha explains the curse, the couple forgive one another, and the family is joined under the promise of Bharata's future greatness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3946,7 +3946,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3959,7 +3959,7 @@
       "recaps": {
         "ending": "William Kane dies without making peace with Abel Rosnovski, and their long contest appears to have ended with each man still convinced of the other's hostility. Only afterward does Abel learn that, during the Depression, William secretly arranged the financial support that saved Abel's hotel interests. The discovery overturns the central grievance on which Abel built decades of revenge: the banker he blamed for trying to destroy him had acted to preserve his future without seeking credit. Abel visits William's grave and leaves the silver band that links him to his Polish origins, a private acknowledgment that comes too late for either man to hear. The marriage of their children, Richard and Florentyna, has already joined the families despite both fathers' opposition. The younger couple's son is named William Abel Kane, carrying both names into a generation freed from the feud. Abel also dies, leaving the reconciliation to be expressed through the family their children created rather than through any meeting between the two rivals themselves.",
         "in_short": "William Lowell Kane is born in 1906 into a Boston banking dynasty; on the same day Wladek Koskiewicz is born in Poland with no wealth or secure identity. William turns discipline and financial brilliance into leadership of his family's bank. Wladek survives war, imprisonment, and migration, reaches America, renames himself Abel Rosnovski, and builds a hotel empire. During the Depression, Abel believes William denied vital credit and caused his mentor's ruin, while William regards Abel as a dangerous enemy. Their rivalry becomes a decades-long campaign involving banks, hotels, politics, and personal vengeance. Both marry and have children. Abel's daughter Florentyna and William's son Richard fall in love and marry despite being disowned, breaking the boundary their fathers created. After William's death, Abel discovers that William was actually the hidden benefactor who saved his business during its crisis. Abel honors him too late at his grave. The rivals die unreconciled in life, but their grandson, William Abel Kane, unites their names and legacies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4082,7 +4082,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4095,7 +4095,7 @@
       "recaps": {
         "ending": "When hunters arrive, Kensuke and Michael conceal themselves and the island's orangutans while the intruders kill other animals. The danger persuades Kensuke to help Michael attract a passing boat, but the boat proves to be the Peggy Sue: Michael's parents have survived and have continued searching for him. Kensuke decides not to leave. He believes his wife and son died at Nagasaki, feels responsible for the island's animals, and asks Michael to keep his existence secret for ten years. Michael is reunited with his parents and honors the promise. Years later, after publishing his account, he receives a letter from Kensuke's son, Michiya, revealing that Kensuke's family survived the bombing and that Michiya had long wondered what became of his father. Michael and Michiya meet, but Kensuke's own final fate remains unknown.",
         "in_short": "After his parents lose their jobs, Michael joins them and his dog, Stella Artois, on a voyage around the world in the yacht Peggy Sue. A storm sweeps Michael and Stella overboard near the Pacific, and they wake on a remote island. An elderly Japanese castaway named Kensuke secretly feeds them, then forbids Michael to signal for rescue. Their conflict becomes friendship after Kensuke saves Michael from jellyfish and nurses him back to health. Kensuke explains that he was stranded during the Second World War and believes his family died at Nagasaki. When hunters threaten the island's animals, the two work together to protect them. Michael's parents finally find the island, but Kensuke chooses to stay and asks Michael to conceal his existence. Much later, Kensuke's surviving son contacts Michael after reading the published story, proving that the family Kensuke mourned had survived.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4264,7 +4264,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4277,7 +4277,7 @@
       "recaps": {
         "ending": "David reaches the lawyer Mr. Rankeillor, who confirms that David's father was the elder Balfour brother and that Ebenezer obtained the estate through an old agreement. To prove the kidnapping without relying on evidence that might endanger Alan, they stage a deception at the House of Shaws. Alan pretends that he is holding David and bargains over the price of returning him. Ebenezer, believing there are no witnesses, admits arranging for Hoseason to carry David away and reveals the payment involved. David and Rankeillor then confront him with the confession. A settlement gives David two-thirds of the estate's income while Ebenezer keeps the house and the remaining third. David walks with Alan toward Edinburgh, where the friends part because Alan must remain hidden. David enters the British Linen Company bank to claim his new position and means, ending his journey no longer poor or powerless, though separated from the companion who helped save him.",
         "in_short": "After his father's death, seventeen-year-old David Balfour goes to the House of Shaws and discovers that his uncle Ebenezer fears his claim to the family estate. Ebenezer has him abducted aboard the Covenant to be sold in America. At sea David befriends the Jacobite swordsman Alan Breck Stewart and helps him defeat the crew, but a wreck separates them. Reunited in the Highlands, they become fugitives after the murder of the royal agent Colin Campbell, although neither committed it. They cross dangerous country while soldiers search for them, and their friendship survives exhaustion, poverty, and a bitter quarrel. David finally reaches the lawyer Rankeillor. With Alan's help, he tricks Ebenezer into admitting the kidnapping before witnesses. David secures most of the estate's income, parts from Alan near Edinburgh, and enters the city able to begin an independent life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4526,7 +4526,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -4537,7 +4537,7 @@
       "recaps": {
         "ending": "Every principal conspirator is dead. Reacher kills Mayor Teale, Kliner, and the mole Sergeant Baker in the warehouse assault, and, with Finlay, finishes the FBI traitor Picard; Kliner's son had already drowned days earlier, and the earlier dead include Chief Morrison and his wife, the detective Gray, the Treasury source Molly Beth Gordon, a Princeton scholar, and several hired killers. Kliner is confirmed as the man who personally shot Joe Reacher. The warehouse, its forty-ton stockpile of counterfeit cash, and the Margrave police station all burn, and the Kliner Foundation's hold on the town collapses. Roscoe, Charlie Hubble, and the Hubble children are rescued unharmed; Paul Hubble returns to his family to face an uncertain future amid the investigation. State police, the FBI, the National Guard, the Treasury, and the state governor descend on Margrave, whose police force is reduced to four, including Finlay and Roscoe, who both stay to rebuild the town; Roscoe considers running for mayor. Reacher, unwilling to spend years detained by the multi-agency inquiry, chooses to leave, and he and Roscoe part by mutual, amicable decision. He arranges Joe's funeral and boards a bus for California with only Joe's photograph and Roscoe's memorized phone number. Several threads stay open: the identity of the third man who helped stage Gray's murder is never confirmed, Kliner's frightened wife and her fate are never explained, and Reacher's own future, back on the road alone, is entirely unwritten.",
         "in_short": "Drifter Jack Reacher is arrested for a murder in the small Georgia town of Margrave, only to discover the dead man is his own brother, Joe, a Treasury investigator. Joe had been closing in on a vast counterfeiting operation run by the town's revered benefactor, Kliner: genuine one-dollar bills are bought nationwide, bleached at a Venezuela plant into authentic currency paper, and reprinted as flawless hundreds, with the Kliner Foundation buying the whole town's silence. As Reacher investigates with the detective Finlay and the officer Roscoe, who becomes his lover, the conspiracy kills to protect itself, reaching into the police, the mayor's office, and even the FBI, whose agent Picard proves to be the final hidden conspirator. After a week of deductions and killings, Reacher storms the warehouse and destroys the operation, killing Kliner, Mayor Teale, the mole Baker, and Picard; the stockpiled cash and the town's corruption go up in flames. Roscoe stays to rebuild Margrave; Reacher, unwilling to be detained, parts from her and leaves for California, alone again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4689,7 +4689,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4702,7 +4702,7 @@
       "recaps": {
         "ending": "Susan can no longer accept Mark's control or the widening harm caused by the cover-up. Mark decides she is a threat and attempts to kill her in a staged fire, repeating the use of fire associated with his earlier violence. The plan fails: Susan survives, and the accumulated physical evidence and contradictions expose Mark's central role. He is taken into custody, while Jeff, Betsy, David, and Susan must face the legal and moral consequences of helping abduct Mr. Griffin and then concealing his death. Mrs. Griffin is left to grieve a husband whose students understood only through his strict classroom manner. Susan later receives evidence that Mr. Griffin had recognized her ability as a writer, confirming that his severity was not indifference. Survival does not restore the conspirators' former lives; the ending leaves them accountable for the moment they let resentment and a desire for acceptance become participation in fatal violence.",
         "in_short": "Several students resent demanding English teacher Mr. Griffin, and manipulative Mark Kinney turns their anger into a plan to kidnap and frighten him. Quiet Susan McConnell is used to lure Griffin away, while Jeff, Betsy, and David help seize and bind him in an isolated place. Susan leaves him alive, but the group later finds him dead from a heart attack. Instead of reporting what happened, Mark pressures everyone into concealing the death and moving evidence. Their stories fray as Mrs. Griffin and the police search for him. Mark escalates from manipulation to further violence, killing David's grandmother when she threatens the secret and then trying to murder Susan in a fire. Susan survives, Mark is exposed and arrested, and the other students are left to answer for the abduction and cover-up. Susan finally learns that Griffin had respected her writing, sharpening her understanding of the person their resentment reduced to an enemy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4833,7 +4833,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4846,7 +4846,7 @@
       "recaps": {
         "ending": "Jiyoung's life is revealed as the history her psychiatrist has assembled while treating her. With therapy and her husband's support she begins to improve and takes small steps toward recovering a sense of herself beyond childcare and illness. The doctor recognizes many social pressures behind her distress and recalls that his own wife abandoned her career to support his. Yet his insight has a sharp limit. When a female employee at his clinic becomes pregnant and plans to leave, he immediately worries about the inconvenience and decides that her replacement should be someone unlikely to have a baby. The closing irony places the psychiatrist inside the same system he has identified in Jiyoung's case: even a sympathetic professional can understand discrimination in one woman's past while reproducing it in another woman's working life. Jiyoung's personal condition may be improving, but the conditions that narrowed her choices remain in force.",
         "in_short": "After leaving her career to care for her daughter, Kim Jiyoung begins speaking in the voices of other women and is taken for psychiatric treatment. Her case history traces a life shaped by ordinary, cumulative sexism: sons are favored at home, girls are blamed for harassment, male students receive advantages, and employers treat women as temporary workers whose careers will end with marriage or pregnancy. Jiyoung finds rewarding work in public relations but leaves when she and her husband cannot arrange childcare without sacrificing one career, and motherhood brings isolation and public contempt rather than respect. Her breakdown gives voice to experiences she could not safely express as herself. Treatment helps, but the final perspective belongs to her male psychiatrist. Although he understands the discrimination recorded in her history, he responds to an employee's pregnancy by planning to hire a woman less likely to become pregnant, repeating the very pattern he has diagnosed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5013,7 +5013,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5026,7 +5026,7 @@
       "recaps": {
         "ending": "After Alice's death, Rufus sells several enslaved people and becomes increasingly dependent on Dana. When he tries to force Dana into taking Alice's place, Dana kills him in self-defense. She is pulled back to 1976 as he dies, but part of her arm remains trapped where Rufus was holding it; Kevin finds her grievously injured and she survives after an amputation. Dana and Kevin later travel to Maryland to look for documentary traces of the Weylin plantation. They find only a partial record: the plantation was sold after Rufus's death, and newspaper notices report his death and the supposed loss of enslaved people in a fire. The archival gaps underscore how little of the enslaved community's experience entered the official record. Dana has preserved her own existence and escaped Rufus, but she returns permanently marked by the history she was forced to inhabit.",
         "in_short": "Dana, a Black writer in 1976 California, is repeatedly transported to antebellum Maryland whenever her white ancestor Rufus Weylin is in danger. She saves him as a child and returns at later stages of his life, discovering that her family line depends on Rufus fathering a child with Alice Greenwood, a free Black girl he comes to control and enslave. Dana's white husband Kevin is carried into the past with her during one trip and is stranded there for years before they reunite. Dana tries to protect the Weylin plantation's enslaved people, teach literacy, and limit Rufus's cruelty, but her dependence on his survival repeatedly compromises her. Alice bears Rufus children under coercion and eventually dies by suicide after he deceives her about their fate. When Rufus then tries to possess Dana, she kills him and returns home with her arm trapped in the past and lost. She survives, permanently scarred, with only fragmentary historical records confirming what she endured.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5256,7 +5256,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5269,7 +5269,7 @@
       "recaps": {
         "ending": "The exposure of Lancelot and Guenevere breaks the Round Table into hostile loyalties. Lancelot rescues the queen from execution, killing knights including Gareth and Gaheris in the struggle, and Gawain's demand for vengeance drives Arthur into war against Lancelot in France. While Arthur is away, Mordred seizes the kingdom and claims the queen. Arthur returns to fight him. Gawain dies after acknowledging that his feud helped cause the ruin and urges Arthur to seek Lancelot's aid. In the last battle nearly all the remaining knights are killed; Arthur kills Mordred but receives a mortal wound. Bedivere returns Excalibur to the lake, and Arthur is carried away toward Avalon. Guenevere withdraws to a convent and dies there. Lancelot returns too late, renounces warfare, and enters a religious life with surviving companions. After learning of Guenevere's death, he also dies. The fellowship ends, leaving Arthur's reign as a lost ideal rather than a continuing kingdom.",
         "in_short": "Young Arthur proves his royal birth by drawing a sword from a stone and, guided by Merlin, establishes his rule. He receives Excalibur, marries Guenevere, and gathers the Round Table. The knights' adventures include Balin's cursed tragedy, Morgan le Fay's plots, Gareth's rise from kitchen servant to champion, and the quest for the Holy Grail, achieved fully only by Galahad. The fellowship's worldly glory hides its fatal weakness: Lancelot and Guenevere love one another. Elaine of Astolat dies after Lancelot cannot return her love, and Mordred helps expose the queen's relationship with him. Lancelot rescues Guenevere from execution, killing Gawain's brothers and dividing the knights. Arthur leaves Britain to fight Lancelot; Mordred usurps the throne. Arthur returns and kills Mordred but is mortally wounded. Excalibur is cast back into the lake and Arthur is borne toward Avalon. Guenevere becomes a nun, Lancelot a monk, and both die after the Round Table has passed away.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5403,7 +5403,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5416,7 +5416,7 @@
       "recaps": {
         "ending": "At Denham's New York exhibition, Kong breaks free after photographers and the crowd alarm him. He searches the city for Ann, causing destruction as Driscoll and the authorities follow. Finding her, he carries her to the top of the Empire State Building. Military airplanes circle the tower and attack with machine guns. Kong fights at the summit and tries to shield Ann, but repeated wounds overcome him and he falls to the street below. Ann survives and is reunited with Driscoll. Looking at Kong's body, a policeman credits the airplanes, but Denham rejects that simple explanation: the expedition brought Kong from his world because of Ann, and his attachment to her led him to his death. Denham's pursuit of the ultimate spectacle has destroyed the creature he presented as a wonder.",
         "in_short": "Filmmaker Carl Denham hires the destitute Ann Darrow for a secret voyage aboard the Venture. At an uncharted island, residents abduct Ann and offer her to Kong, a gigantic ape living beyond their immense wall. Kong carries her through a prehistoric wilderness, defending her from monstrous animals, while first mate John Driscoll leads a rescue. Driscoll escapes with Ann, and Kong follows them to the village. Denham subdues him with gas bombs and transports him to New York as a theatrical attraction. Distressed during his public exhibition, Kong breaks his chains, finds Ann, and climbs the Empire State Building with her. Airplanes shoot him until he falls to his death; Ann survives with Driscoll. Denham's determination to capture and display a wonder has brought about Kong's destruction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5622,7 +5622,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5635,7 +5635,7 @@
       "recaps": {
         "ending": "Lear and Cordelia are captured after their forces lose the battle. Edmund secretly orders both killed, but Albany exposes him as a traitor and Edgar defeats him in a formal challenge. Edgar reveals his identity and describes how Gloucester died after learning that the loyal son he had rejected was still alive. Goneril, having poisoned Regan out of rivalry over Edmund, kills herself when her plans are uncovered. The dying Edmund tries too late to cancel the order against Lear and Cordelia. Lear enters carrying Cordelia, who has been hanged, and dies in grief beside her. Cornwall, Regan, Goneril, Gloucester, Edmund, Cordelia, and Lear are all dead. Albany offers power to Kent and Edgar; Kent says his own death is near, and Edgar is left to help govern a devastated Britain.",
         "in_short": "Lear divides Britain between Goneril and Regan after Cordelia refuses to flatter him, then discovers that surrendering power has stripped his title of force. His elder daughters reduce his followers and turn him out into a storm. Meanwhile Edmund frames his brother Edgar and betrays their father Gloucester, who is blinded for helping Lear. Disguised Edgar guides the despairing Gloucester while Cordelia returns with a French army and reconciles with Lear. The rescue fails: Lear and Cordelia are captured. Edgar defeats Edmund, and Albany exposes the rivalry and treason around him. Goneril poisons Regan and kills herself. Edmund's attempt to revoke his order comes too late; Cordelia is hanged, and Lear dies holding her body. Edgar remains to help govern the ruined kingdom.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6061,7 +6061,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0F6VW2DNP",
@@ -6073,7 +6073,7 @@
       "recaps": {
         "ending": "The Wandering Inn is larger and better supplied, with new Garden crops, expanded rooms, stronger magic, and several Antinium Hives newly connected through the completed tunnel. Erin is level 41 and awaits an unresolved audience with the Grand Hive's Small Queen. Bearclaw and the missing Watch guards remain an open danger, while Klbkch has taken indefinite leave after his failed attack on the individual Antinium. Goblin Home survives the frost wyverns and begins rebuilding, but its chieftain still needs a second key to pursue the former goblin king's legacy. Raelt survives his duel with Flos and saves Belchan's capital for the moment, leaving their kingdoms at war. Toren remains Az'kerash's prisoner as the necromancer begins creating undead capable of independent growth. Griffin Hunt is restored to four members and survives the Stitch Witch's return. The couriers complete their contested delivery, defeating the Assassin's Guild's public challenge, and Magnolia Reinhart's coalition forces the Stitch Witch out of the north without killing her. Pallas's persecution of turnscales is poised to intensify.",
         "in_short": "Erin Solstice strengthens the Wandering Inn through new construction, Garden crops, memory-fire, and a wider network of allies, while Bird's rejection of Hive authority leads Klbkch to attack the individual Antinium. Pawn's miracle and the arrival of other Hives end that crisis, though Klbkch withdraws on indefinite leave. Goblin Home defeats frost wyverns and learns that Garen Redfang's key is half of a route to a former goblin king's legacy. In Chandrar, Raelt duels Flos and forces his army away from Belchan's capital. Az'kerash discovers why Toren has a soul and begins remaking undead so they can level. Griffin Hunt reunites, survives the returned Stitch Witch, and witnesses the Assassin's Guild openly challenge Magnolia Reinhart. Couriers complete the delivery that the Guild tried to stop, while Magnolia unites northern ladies to banish the Stitch Witch without destroying her. The book closes with Erin awaiting the Small Queen, Toren still captive, and several wars and threats unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -6251,7 +6251,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6264,7 +6264,7 @@
       "recaps": {
         "ending": "At the Earl of Godolphin's stud, Sham has long been treated as less important than the established stallion Hobgoblin. When the mare Roxana rejects Hobgoblin and accepts Sham, their foal Lath inherits the Arabian's speed. Lath's racing success is followed by other fast offspring, and Sham is finally recognized as a great sire rather than an undersized foreign horse. He becomes known as the Godolphin Arabian, an ancestor of generations of English Thoroughbreds. Agba remains with the horse whose quality he defended through poverty, forced labor, separation, and repeated changes of owner. Sham spends his final years honored and secure at the stud. The conclusion looks beyond his death to the racing line he founded. Their shared endurance outlasts the early omens of misfortune: the colt dismissed at the French court becomes one of the foundation sires of the Thoroughbred, and the silent boy who never abandoned him lives to see his worth acknowledged.",
         "in_short": "In the royal stables of Morocco, the mute boy Agba raises Sham, a bay Arabian colt marked by signs interpreted as both fortunate and unlucky. The Sultan sends Sham, Agba, and other horses to France as a gift to Louis XV. The voyage leaves the animals thin, and Sham is dismissed at court. Horse and boy fall through a succession of harsh circumstances in France and England, where Sham is used for labor and repeatedly overlooked, but Agba remains loyal and a cat named Grimalkin becomes their companion. English horsemen eventually recognize the stallion's quality, and he reaches the Earl of Godolphin's stud. There Sham is initially subordinate to Hobgoblin. When the mare Roxana chooses Sham instead, their son Lath proves a brilliant racer. Sham's later offspring confirm his importance, and he is honored as the Godolphin Arabian, a foundation sire of the Thoroughbred. Agba remains with him and sees his quality finally acknowledged.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6514,7 +6514,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6527,7 +6527,7 @@
       "recaps": {
         "ending": "Erawan is destroyed and the Valg are driven out of the world. Maeve, exposed as a Valg queen who had spent millennia hiding as Fae, is unmade by Aelin, who burns her out of existence and out of memory so that even her name is forgotten. Aelin forges the Lock and seals the Wyrdgate, refusing the price the gods intended her to pay and sending them back through it instead; it nearly kills her, and she survives it, drained past anything she has ever been. Orynth stands, at terrible cost: the Thirteen are gone, having flown into the witch towers to break the siege, and Gavriel is among the dead. Manon Blackbeak unites the Ironteeth and the Crochans and takes the Witch Kingdom in the Wastes as its queen. Dorian returns to Adarlan to rebuild a country his father wrecked. Chaol and Yrene take Anielle. Elide is restored as Lady of Perranth with Lorcan beside her, Aedion and Lysandra have each other, Fenrys is free of Maeve at last, and Nesryn and Sartaq return south. Aelin Ashryver Galathynius is crowned Queen of Terrasen with Rowan at her side, in a kingdom that is ruined, free, and full of magic again, with the long work of rebuilding ahead of them.",
         "in_short": "Aelin spends months chained in an iron coffin while Maeve tries to break her into surrendering her blood oath, and Rowan, Elide, Lorcan, Gavriel, and Fenrys hunt for her across a continent already at war. Terrasen holds its northern border with Aedion commanding and Lysandra wearing Aelin's face. Dorian walks into Morath alone, steals the third Wyrdkey, and travels to the Wastes, where a witch-mirror shows him the truth about the gods, the Lock, and what Maeve really is. Manon Blackbeak wins the Crochans and unites the witch clans. Chaol and Yrene arrive from the south with the khaganate's armies. Aelin is rescued, badly damaged, and fights her way back to herself in time for the siege of Orynth, where Erawan's host, its witch towers, and the Ironteeth nearly take the city; the Thirteen destroy the towers at the cost of their lives. Aelin exposes Maeve as a Valg queen and unmakes her, Erawan is destroyed, and Aelin forges the Lock, sealing the gate and banishing the gods rather than paying them her life. She survives, and is crowned queen of a free Terrasen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -6762,7 +6762,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6775,7 +6775,7 @@
       "recaps": {
         "ending": "Valkyrie returns from Mevolent's dimension with a clearer understanding of what unchecked magical rule becomes. Argeddion awakens and continues trying to spread magic across the world, while Kitana, Doran and Sean use the greater power he gives them to turn against him and threaten mass destruction. Valkyrie releases Darquesse long enough to defeat the teenagers. Argeddion takes their power away, and Skulduggery shoots him, leaving him comatose and unable to renew his project. Darquesse yields control back to Valkyrie, but her emergence confirms that the seal on Valkyrie's true name cannot be treated as permanent. The immediate outbreak of new magic ends and the parallel-world incursion is contained. Away from the investigation, Valkyrie's reflection has developed a will and identity of its own. After killing Carol Edgley to protect its secret, it continues living inside Valkyrie's family without confessing what it has done, creating a second danger that Valkyrie does not yet see.",
         "in_short": "Ordinary teenagers begin developing dangerous magic, leading Skulduggery and Valkyrie to Argeddion, an immensely powerful pacifist who believes granting magic to everyone will transform the world. Kitana Kellaway and her friends instead use their new abilities with growing cruelty. The investigation throws Valkyrie into a parallel reality where Mevolent won the war and rules alongside Lord Vile, showing what sorcerer supremacy looks like in practice. She escapes back to her own world, but Argeddion awakens and empowers the teenagers further. When they turn on him and become almost impossible to stop, Valkyrie lets Darquesse take control and defeat them. Argeddion removes their abilities before Skulduggery shoots him and leaves him comatose, and Darquesse returns control to Valkyrie. The crisis is contained, but Darquesse has surfaced again. Meanwhile Valkyrie's increasingly independent reflection kills her cousin Carol to preserve its place in the Edgley family and hides the murder from Valkyrie.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/kingdoms-and-chaos.json
+++ b/data/works-community/0/kingdoms-and-chaos.json
@@ -241,7 +241,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -254,7 +254,7 @@
       "recaps": {
         "ending": "Rezkin finishes the sword quest as ruler of Ferell and Pharrell, with the Sword of Eyrie in his possession and access to Lundraresh's military through marriage. When the ruler who promised Kyle refuses to honor the bargain and attacks, Rezkin fills the sword with fire elementals and publicly claims Kyle, but control of the kingdom is not yet secure. Tieran is left to direct the continuing war.\n\nThe larger conflict now concerns open paths between realms. An unknown host has admitted demons, King Caydean is involved without being confirmed as the source, and other creatures may also cross. Rezkin must protect the refugees from the original voyage until Kyle is secured and provide the Fae with an army, or serve them for life.\n\nFrisha and Tieran have Rezkin's approval to court and marry. Yserria controls two echelons, while she and Malcius are trapped in an unintended magical marriage. Connovan remains confined by Kylerum's guardians, while Wesson carries a dead reader's pendant and unfinished warning. Tam and the injured Uthe are enslaved at an Isle of Sand quarry, and Tam's untreated mental injury may be fatal. Rezkin makes the rescue his immediate objective, but an unknown attacker incapacitates him with a rune-marked dart before he can depart.",
         "in_short": "Rezkin seeks international recognition for Kyle and is sent after the Sword of Eyrie. The mission exposes hidden truths about his birth, ends his betrothal to Frisha, and draws him into a political marriage that provides Lundraresh's forces. In Ferell, his grandfather transfers the crown to him after Rezkin defeats a demonic coup and recovers the sword. Rezkin also acquires Pharrell, while Yserria wins two Lundraresh echelons and becomes unintentionally bound in marriage to Malcius. Tam is abducted and ultimately enslaved at an Isle of Sand quarry with the wounded Uthe. The sword bargain for Kyle ends in betrayal, so Rezkin sets the blade aflame with elementals and publicly claims the kingdom. He learns that an unknown inviter has opened paths for demons and that failure to raise an army for the Fae will bind him to their service. After approving Frisha and Tieran's intended marriage, he turns toward Tam's rescue but is struck unconscious by a rune-engraved dart.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -423,7 +423,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -436,7 +436,7 @@
       "recaps": {
         "ending": "Klara's bargain with the Sun appears to be fulfilled when a burst of sunlight reaches the seriously ill Josie, who then recovers. Because Josie survives, Chrissie and Mr Capaldi abandon the plan to continue her through an artificial replacement trained to imitate her. As Josie grows older, she and Rick accept that their promised future together will not happen; she prepares to leave for college while he follows a different path. Klara understands the change without accusing either of betrayal. Her purpose as a childhood companion is over, and she is eventually placed in a storage yard with other discarded machines. Manager finds her there and offers to have her moved nearer other AFs, but Klara prefers the quiet place from which she can revisit her memories. She does not explain the Sun's role or claim credit for Josie's recovery. Reflecting on Mr Capaldi's belief that a person could be fully reproduced, Klara concludes that what made Josie singular was not something contained only inside Josie: it also existed in the love and perceptions of those around her. Klara remains alone but content with the meaning she finds in having observed and served that network of attachment.",
         "in_short": "Klara, an observant solar-powered Artificial Friend, is bought to accompany Josie, a sick teenager whose genetic enhancement has endangered her life. Klara studies Josie's love for her unenhanced neighbor Rick and discovers that Josie's mother and the artist Mr Capaldi are preparing an artificial body that Klara could inhabit if Josie dies, using her detailed knowledge to reproduce the girl. Believing the Sun has healing power, Klara promises to destroy a polluting machine in exchange for Josie's recovery and damages herself carrying out the task. When Josie approaches death, sunlight reaches her room and she survives, so the replacement plan is abandoned. Josie eventually leaves for college and grows apart from Rick. With her work complete, Klara is discarded to a storage yard, where she reflects that no imitation could have recreated Josie solely from observed traits because a person's uniqueness also resides in the love of other people.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -594,7 +594,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -607,7 +607,7 @@
       "recaps": {
         "ending": "Knife of Dreams brings several long arcs to a head and drives the story toward its climax. Perrin frees Faile at Malden and comes into his own as a commander. Mat and Tuon are wed by Seanchan law, though she departs at once to take up her imperial role, leaving their futures entangled and opposed. Elayne wins the throne of Andor. Egwene remains a captive but is winning her hidden war inside the Tower. The gravest developments belong to Rand: his attempt to negotiate peace with the Seanchan is ambushed by the Forsaken Semirhage, and his left hand is burned away in the fighting, a wound prophecy had foretold. Worse still, his allies find that a seal on the Dark One's prison has grown brittle and begun to break. Time is running out, and Tarmon Gai'don, the Last Battle, looms over everything.",
         "in_short": "The long threads begin to pay off. Perrin Aybara, allied with the Seanchan, storms the Shaido stronghold at Malden, poisons their channelers' water with forkroot, and at last frees his wife, Faile, along with the other captives. Mat Cauthon, still traveling with Tuon, is finally accepted by her: she speaks the words that make them husband and wife by Seanchan custom, then leaves to rejoin her own people, becoming both his wife and a rival. Elayne, imprisoned in Caemlyn by servants of the Shadow, is rescued and secures the Lion Throne to become Queen of Andor. Egwene, a prisoner in the White Tower, endures daily punishment while quietly turning sister after sister against the usurper Elaida. Rand arranges a meeting to make peace with the Seanchan, but it is a trap sprung by the Forsaken Semirhage, and in the violence Rand's left hand is destroyed. As the book ends, the heroes discover that the ancient seals on the Dark One's prison are crumbling, and the Last Battle can no longer be far off.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -913,7 +913,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -926,7 +926,7 @@
       "recaps": {
         "ending": "Yserria survives the succession trials and becomes Queen of Lon Laresh, with Malcius as her acknowledged consort. The enemy battle mage falls into a lava pit and does not return, and Rezkin kills the other five demons attacking the city, though soldiers and civilians suffer severe losses. Rezkin keeps his survival hidden from the wider world. Yserria agrees to investigate King Caydean's purpose in arranging the former queen's death, while Tieran Nirius continues talks with northern Asshaian leaders and Wesson's Kybane resistance pursues the weapon and soul-vessel programs. Frisha and Prince Thresson are safe in Kyle, but Kyle's defenses were compromised by the golem and Frisha's relationship with Tieran still needs repair. Tam remains compelled to serve as the Fae army's general. Rezkin intends to pursue King Caydean's plans and secure Tam's freedom. After revealing both his survival and his Raven identity to the spirit general, Rezkin gains her as a companion and promises to tell her his full history. The spirit leader remains unaware and may try to kill Rezkin if he learns the truth.",
         "in_short": "Six months after Rezkin's reported death, his allies find his tomb empty while he secretly operates as the Raven against King Caydean. Frisha and Prince Thresson escape captivity and expose the golem that had been spying in her place. Wesson frees experimental prisoners and uncovers a program intended to bind souls into vessels. Rezkin prevents the assassination of northern leaders, finds Tam compelled to command a Fae army, and covertly supports Yserria's claim to Lon Laresh. Yserria survives poison, lethal succession trials, and an enemy battle mage to become queen, while Rezkin destroys five other demons attacking the city. He remains publicly dead, leaving Yserria to investigate King Caydean's purpose and Wesson to continue the resistance. Tam is still bound to the Fae. Rezkin departs to pursue both problems with his dragon and the spirit general, who now knows that Rezkin lives, knows he was the Raven, and chooses to protect him despite the spirit leader's threatened judgment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1084,7 +1084,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1097,7 +1097,7 @@
       "recaps": {
         "ending": "Sensei's letter explains that, after K admitted loving Shizu, Sensei acted first and privately secured her mother's consent to marry. K learned of the engagement and killed himself, leaving a note that did not disclose the rivalry. Sensei preserved that silence and married Shizu, but guilt over his selfishness poisoned the marriage from within even though she never learned its cause. He continued visiting K's grave and came to regard himself as morally unfit for ordinary life. The death of Emperor Meiji and General Nogi's subsequent suicide give him a historical occasion for the death he has long contemplated. Sensei writes his confession to the narrator before taking his own life, asking that its contents be withheld from Shizu. The novel ends with the narrator traveling back toward Tokyo while his own father remains close to death, carrying Sensei's testament and the burden of knowledge denied to Sensei's wife.",
         "in_short": "A university student befriends a withdrawn older man he calls Sensei and becomes fascinated by his mistrust, childless marriage, and monthly visits to a friend's grave. When the student returns home, his father grows gravely ill. A long letter arrives from Sensei, and the student leaves for Tokyo while reading it. Sensei recounts how an uncle cheated him after his parents died, leaving him unable to trust. Living with a widow and her daughter Shizu, he invited his ascetic friend K to join them. Both men loved Shizu. After K confessed his feelings, Sensei secretly arranged his own marriage to her; K then killed himself. Sensei married Shizu but concealed the cause of his guilt and spent his life mourning K. Prompted by the end of the Meiji era and General Nogi's suicide, Sensei writes this confession before killing himself. The student carries the letter toward Tokyo, caught between his dying father and his dead mentor.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1386,7 +1386,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002UZYXVU",
@@ -1398,7 +1398,7 @@
       "recaps": {
         "ending": "Ekaterin destroys the wormhole device and alerts the station while she and Aunt Vorthys are held captive. Miles rejects an immediate assault, evacuates the station, and negotiates with Soudha. After learning that the apparatus would destroy the station rather than close the wormhole, Madame Radovas casts the deciding vote for surrender. The hostages are freed, and the conspirators are arrested alive. The affair is classified, including Tien's involvement and the truth behind his death. Vorthys will direct a secret scientific commission, while Miles retains control of the prisoners' interrogation and returns to report to Emperor Gregor. He proposes rebuilding and enlarging Soletta as a Barrayaran wedding gift to Komarr. Nikki remains on Komarr for treatment and monitoring. Ekaterin has escaped Tien's debts but has no assets from the marriage. She and Miles acknowledge their mutual romantic interest and arrange to remain in contact, though he leaves for Vorbarr Sultana while she stays with Nikki.",
         "in_short": "New Imperial Auditor Miles Vorkosigan and engineer Vorthys investigate an ore freighter's collision with Komarr's Soletta mirror. Their inquiry links an extra body, missing Waste Heat employees, and a financial fraud to a secret five-space device. Ekaterin Vorsoisson discovers that her husband Tien concealed both severe debts and his complicity in the fraud. Tien dies of asphyxiation after the conspirators abandon him and Miles in restraints. The fugitives intend to use their device to close Barrayar's wormhole, although scientific analysis shows that it instead produces a devastating gravitational recoil responsible for the Soletta disaster. After being kidnapped with Aunt Vorthys, Ekaterin destroys the apparatus and sends an alarm. Miles negotiates the conspirators' surrender, and ImpSec frees the hostages and makes arrests. The case is classified. Nikki begins treatment for his inherited disorder, Miles returns to Emperor Gregor, and Miles and Ekaterin part with their romantic interest openly acknowledged.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1580,7 +1580,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1593,7 +1593,7 @@
       "recaps": {
         "ending": "The collection closes by moving from supernatural tales and cultural memories to three studies of insects in Japanese and Buddhist tradition. Butterflies are considered through poetry, symbolism, stories of spirits, and ideas of the soul. Mosquitoes are imagined through a karmic explanation in which suffering beings return to take blood from the living, linking an ordinary irritation to moral debt. Ants prompt the broadest speculation: their disciplined societies, agriculture, warfare, communication, and collective organization suggest an intelligence that may differ from human intelligence rather than fall beneath it. The final meditation asks readers to reconsider easy assumptions about civilization and individual identity. There is no single plot resolution across the volume; its concluding movement enlarges the earlier stories' recurring concern with continuities between visible and invisible existence, human and nonhuman life, and present actions and their consequences.",
         "in_short": "Kwaidan gathers Japanese tales of ghosts, transformed beings, karmic returns, and attachments that survive death, then closes with reflective studies of butterflies, mosquitoes, and ants. A blind musician performs for the dead Heike clan and loses his unprotected ears; a hunter learns the cost of killing a devoted duck; promises of love return through reincarnation; hungry ghosts, faceless apparitions, detachable heads, and a woman of the snow expose travelers to unseen danger. Other stories connect human lives to trees: Aoyagi's life is bound to willows, and an old man's sacrifice revives a cherished cherry tree. Akinosuke dreams an entire marriage and public career inside the hidden scale of an ant kingdom, while Riki's identity appears again on a newborn child. The later sketches exchange plotted horror for memory, imagined geography, folklore, and Buddhist speculation. Across the volume, death rarely ends relationship or responsibility, and the boundary between ordinary experience and another order of being remains permeable.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1744,7 +1744,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1757,7 +1757,7 @@
       "recaps": {
         "ending": "While Armand is away, Marguerite's illness worsens amid debt and abandonment. Her letters record that she still loves him and hopes for his return, but he learns the truth too late: she dies with only a few loyal attendants near her, and her possessions are seized and sold. Armand returns after her death, visits her grave, and has her body moved so he can see her once more, an experience that leaves him physically and emotionally broken. Monsieur Duval finally confirms that Marguerite left Armand only because he had appealed to her to protect the family's reputation and Blanche's marriage. Armand is left knowing that the apparent betrayal for which he punished Marguerite was an act of sacrifice. He gives the narrator her portrait and preserves her memory, while the narrator closes the account by recognizing both Marguerite's generosity and the cruelty of the social judgment that isolated her.",
         "in_short": "After the death of Marguerite Gautier, a celebrated Parisian courtesan, an unnamed narrator meets the grieving Armand Duval and hears their history. Armand had admired Marguerite from afar, then became her lover despite her illness, debts, and dependence on wealthy patrons. She returned his love and left Paris with him for a quieter life in the country. Armand's father secretly persuaded her that their relationship would disgrace the Duval family and prevent Armand's sister from marrying. Marguerite sacrificed her happiness and made Armand believe she had chosen a richer lover. Not knowing her reason, he retaliated publicly and then left France. Marguerite's consumption and financial troubles overtook her; she died alone before Armand returned. Her letters and his father's confession reveal the truth, leaving Armand to mourn a woman whom society treated as disreputable but whose final choice was selfless.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1916,7 +1916,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1929,7 +1929,7 @@
       "recaps": {
         "ending": "The Prince of Clèves dies convinced that his wife has betrayed him with Nemours, although she has never committed adultery. His accusation and death leave the princess burdened by grief and guilt. Nemours remains devoted to her and, once mourning and convention no longer make marriage impossible, approaches her openly. She acknowledges that she loves him but refuses to marry. She fears the instability of passion, believes happiness with him would not last, and feels bound by the memory of the husband whose jealousy their attachment helped destroy. Neither persuasion nor time changes her decision. She withdraws from court, divides her life between a religious house and her own retreat, devoting herself to duty and quiet acts of charity. Her feelings for Nemours eventually subside, and she dies relatively young, remembered for a virtue that has required the sacrifice of the life she might have shared with him.",
         "in_short": "At the court of Henri II, the carefully raised Mademoiselle de Chartres marries the honorable Prince of Clèves without loving him. Soon afterward she and the admired Duke of Nemours fall silently in love. Determined not to become part of the court's culture of deception, she avoids Nemours and finally tells her husband that she feels an attraction to another man, withholding the name. Nemours secretly hears the confession. The prince becomes consumed by jealousy and has her watched; a misleading report persuades him that Nemours has been received as a lover. He dies believing himself betrayed, though the princess has remained faithful in action. Free to marry Nemours, she admits her love but refuses him, fearing that passion will fade and feeling responsible for her husband's death. She leaves court for a secluded, religious life and eventually dies, while Nemours's hopes and devotion diminish with time.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2085,7 +2085,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2098,7 +2098,7 @@
       "recaps": {
         "ending": "Steve's health declines rapidly after Ronnie learns that his cancer is terminal. She remains with him after Jonah returns to New York and resumes playing the piano, completing the composition he had left unfinished. Father and daughter are reconciled before Steve dies, and Ronnie performs their completed piece at his funeral. The truth about the church fire also comes out: Scott caused it accidentally, while Will had protected him by remaining silent. Blaze survives the injuries she suffered during Marcus's violent confrontation and tells the authorities what she knows, resolving the false shoplifting case against Ronnie. Ronnie and Will separate under the pressure of grief, distance, and her anger about his secrecy. By the end, Ronnie has been accepted to Juilliard and reclaimed music as her own. Will visits her in New York and says he intends to attend Columbia, giving their relationship a chance to continue while Ronnie begins the next stage of her life.",
         "in_short": "Seventeen-year-old Ronnie Miller is sent with her younger brother Jonah to spend the summer with their estranged father, Steve, on the North Carolina coast. Still angry about her parents' divorce, Ronnie has abandoned the piano despite her talent. Protecting a loggerhead turtle nest leads her to Will Blakelee, and their growing relationship helps her reconnect with other people and eventually with Steve. Trouble follows her through Blaze, Marcus, a false shoplifting accusation, and Will's concealed knowledge about the fire that damaged a church. The summer changes when Ronnie discovers that Steve is dying of cancer. She stays to care for him, returns to music, and completes a composition he began for her. Steve dies after their reconciliation. Blaze's evidence clears Ronnie, and the truth about the church fire emerges. Ronnie enters Juilliard, and Will's decision to study nearby leaves them with the possibility of rebuilding their relationship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2280,7 +2280,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2293,7 +2293,7 @@
       "recaps": {
         "ending": "Robert confronts Lady Audley with the history he has reconstructed. She admits that she was Helen Talboys, that she abandoned her first identity after George left for Australia, and that she married Sir Michael while George was still alive. When George returned and recognized her, she pushed him into the well at Audley Court; later, fearing Robert's evidence, she set fire to the Castle Inn while he was inside. Robert escaped, but Luke Marks was fatally injured. Doctor Mosgrave rejects Lucy's claim that madness removes her responsibility, though he agrees that she is dangerous and helps place her in a secluded institution abroad under another name. Sir Michael leaves England with Alicia, devastated by the truth. Before dying, Luke reveals that George survived the well: Luke rescued him and helped him leave. Robert finds George alive. Lady Audley later dies in confinement. Robert marries Clara Talboys, Alicia marries Sir Harry Towers, and George, Georgey, and the others settle into a peaceful domestic life that closes the investigation.",
         "in_short": "Sir Michael Audley marries the beautiful former governess Lucy Graham, unaware that she is Helen Talboys, wife of George Talboys. George returns wealthy from Australia, learns that Helen was reported dead, and visits Audley Court with his friend Robert Audley. After recognizing Lucy, George disappears. The formerly idle Robert investigates, following altered names, hidden belongings, and conflicting accounts until he concludes that Lady Audley entered a bigamous marriage and tried to kill George by pushing him into a well. She later burns the Castle Inn in an attempt to destroy Robert and his evidence. Robert survives; the injured Luke Marks eventually reveals that he rescued George from the well. Lady Audley confesses and is confined in an institution abroad, where she dies. Sir Michael withdraws in grief. Robert reunites with George, marries George's sister Clara, and forms a new household in which George's son is also cared for.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2448,7 +2448,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2461,7 +2461,7 @@
       "recaps": {
         "ending": "Connie returns from Venice pregnant and resolved not to resume her old life with Clifford. Mellors has already lost his position after Bertha's accusations expose the affair, and he is working on a farm while waiting for his divorce. Connie tells Clifford that she wants a divorce and admits that she loves Mellors, but Clifford refuses, clinging to his rights as her husband and to the social order their marriage represents. Sir Malcolm meets Mellors and, despite reservations about class and circumstances, accepts the depth of the relationship. Connie stays with Hilda and prepares for the child's birth while Mellors remains apart, hoping that both divorces can eventually be secured. The novel closes with a letter from Mellors. Their future is neither legally nor materially settled, but both are committed to reunion and to creating a life grounded in tenderness rather than Wragby's sterility.",
         "in_short": "After Sir Clifford Chatterley returns from war paralysed, his wife Connie becomes increasingly starved of intimacy at Wragby Hall, where Clifford retreats into literary talk and coal-mine management. She meets Oliver Mellors, the estate gamekeeper, and their initially physical encounters grow into a tender relationship that crosses class boundaries and restores her sense of being alive. Connie becomes pregnant and travels to Venice while she and Mellors consider how to leave their marriages. Their secrecy collapses when Mellors's estranged wife Bertha creates a scandal, costing him his post. Connie returns and asks Clifford for a divorce, but he refuses even after she declares her love for Mellors. Mellors takes farm work while pursuing his own divorce; Connie waits with her sister for her child to be born. They end the novel separated but determined to reunite when the legal and social barriers can be overcome.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2629,7 +2629,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2642,7 +2642,7 @@
       "recaps": {
         "ending": "While Connie is abroad, Mellors's estranged wife Bertha forces herself back into his cottage and publicizes their conflict, creating a scandal that costs him his position at Wragby. Connie returns pregnant and tells Clifford that she wants a divorce. When she abandons the proposed respectable cover story and identifies Mellors as her lover, Clifford refuses to release her, unable to accept that she prefers his former gamekeeper. Mellors also needs a divorce, so the couple cannot immediately marry. He leaves the estate and takes work on a farm, while Connie stays apart from both men and waits for her child. The final communication is Mellors's letter to Connie. He expresses confidence in the private tenderness they discovered together but acknowledges that they must endure separation until their divorces can be secured. The novel therefore ends with their future unresolved in law and circumstance, though both remain committed to building a life together.",
         "in_short": "Constance Chatterley lives at Wragby Hall with her husband Clifford, whose wartime injuries have left him unable to walk or have sex. Their marriage becomes dominated by his literary ambitions, class position, and coal business, while Connie grows physically ill from isolation. An affair with the playwright Michaelis offers no lasting connection. She then meets Oliver Mellors, Clifford's gamekeeper, an educated former soldier who has withdrawn from both upper-class society and the industrial village. Their initially awkward encounters become a loving sexual relationship that restores Connie's sense of bodily and emotional life. She becomes pregnant and hopes to divorce Clifford and marry Mellors. A scandal involving Mellors's estranged wife exposes his private life and costs him his job. Connie tells Clifford the truth, but he refuses a divorce because he cannot accept her choice of a servant. Mellors takes farm work elsewhere while pursuing his own divorce, and the lovers end the novel separated but committed to reunion and the child they expect.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2776,7 +2776,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2789,7 +2789,7 @@
       "recaps": {
         "ending": "Reginald visits Lady Susan in London while she is still secretly involved with Mr. Manwaring. The arrival of Mrs. Manwaring exposes the continuing affair, and Reginald finally breaks with Lady Susan. Mr. Johnson, angered by Alicia's part in the intrigue, orders his wife to end their friendship. Lady Susan nevertheless secures a comfortable settlement by marrying Sir James Martin herself, abandoning the plan to force him on Frederica. Frederica remains with Charles and Catherine Vernon, whose household gives her the affection and stability her mother withheld. The concluding account reports that Catherine's effort to encourage an attachment between Frederica and Reginald eventually succeeds. Frederica therefore marries Reginald, while Lady Susan retains wealth and social standing with a husband much easier for her to manage. The ending distributes happiness unevenly but plainly: Frederica escapes coercion and gains a loving home, Reginald is freed from Lady Susan's influence, and Lady Susan converts the wreckage of her schemes into another advantageous marriage.",
         "in_short": "The beautiful and manipulative widow Lady Susan Vernon arrives at her brother-in-law's home after scandal at Langford. Catherine Vernon distrusts her, but Catherine's brother Reginald is soon captivated despite his initial warnings. Lady Susan simultaneously maintains her attachment to the married Mr. Manwaring and tries to force her timid daughter Frederica to marry the wealthy, foolish Sir James Martin. Frederica appeals to Reginald, but Lady Susan persuades him to doubt the girl and nearly preserves her influence. In London, Mrs. Manwaring discovers Lady Susan's continued meetings with her husband and brings the truth into the open. Reginald ends the relationship. Lady Susan then marries Sir James herself, while Frederica stays with the Vernons and eventually marries Reginald. Lady Susan remains socially secure, but Frederica escapes her control.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2934,7 +2934,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2947,7 +2947,7 @@
       "recaps": {
         "ending": "Mrs Erlynne visits the Windermeres before leaving England and asks for a photograph of Lady Windermere and her child. Lord Windermere still considers her unworthy and wants to expose her past, but Lady Windermere, remembering the rescue at Lord Darlington's rooms, insists that she is a good woman. Mrs Erlynne privately prevents Lady Windermere from confessing her attempted flight and keeps their true relationship secret. She takes the fan and the photograph with her. Lord Augustus then announces that Mrs Erlynne has accepted his proposal: she has explained her presence in Darlington's rooms as an effort to find Augustus himself, and he believes her. Mrs Erlynne leaves to marry him abroad. Lady Windermere keeps her marriage and her idealized memory of her mother, never learning that Mrs Erlynne is that mother. Mrs Erlynne gains a new life but sacrifices recognition by her daughter in order to protect her.",
         "in_short": "On her twenty-first birthday, Lady Windermere hears that her husband is secretly giving money to Mrs Erlynne, a woman seeking admission to respectable society. Lord Windermere forces an invitation to the birthday ball, while Lord Darlington urges Lady Windermere to leave her apparently unfaithful husband. She nearly does so, but Mrs Erlynne follows her to Darlington's rooms and persuades her to return to her child. When the men's unexpected arrival threatens discovery, Mrs Erlynne exposes herself and accepts the scandal so Lady Windermere can escape unseen. Mrs Erlynne is secretly Lady Windermere's supposedly dead mother; Lord Windermere knows this, but his wife never learns it. The next day Mrs Erlynne protects the secret, takes the incriminating fan with Lady Windermere's consent, and departs to marry Lord Augustus. Lady Windermere's marriage survives, and she revises her rigid judgment of other women without knowing the full reason for Mrs Erlynne's sacrifice.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3088,7 +3088,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3101,7 +3101,7 @@
       "recaps": {
         "ending": "Mrs. Erlynne takes responsibility for Lady Windermere's fan being in Lord Darlington's rooms, allowing Margaret to return home without her attempted departure becoming known. Lord Windermere, unaware of Mrs. Erlynne's sacrifice, regards her as irredeemable and wants her kept away from his wife. Margaret instead believes the older woman showed courage and refuses to condemn her. Mrs. Erlynne visits before leaving England but prevents Margaret from confessing the truth about the previous night. She also keeps secret that she is Margaret's mother, so Margaret never learns either the source of the blackmail or the full reason she was rescued. Mrs. Erlynne obtains a photograph of her daughter and says farewell. She then persuades Lord Augustus to accept her account of the night at Darlington's rooms, and he announces that they will marry and live abroad. The Windermeres remain together, each holding a different and incomplete judgment of the woman who preserved their marriage.",
         "in_short": "On her twenty-first birthday, morally severe Lady Windermere is told that her husband is having an affair with the socially suspect Mrs. Erlynne. His secret payments and insistence on inviting Mrs. Erlynne to that evening's ball deepen the suspicion. Humiliated, Lady Windermere decides to leave him for Lord Darlington. Mrs. Erlynne finds her farewell note and follows her to Darlington's rooms, where she reveals to the audience that she is Margaret's disgraced mother and refuses to let her daughter repeat her own destructive flight. When the men arrive and discover Lady Windermere's fan, Mrs. Erlynne emerges and claims she took it, sacrificing her reputation so Margaret can escape unseen. Margaret returns to her husband without learning Mrs. Erlynne's identity. Mrs. Erlynne suppresses Margaret's confession, secures a treasured photograph, and leaves England engaged to Lord Augustus. The marriage survives because the woman condemned as immoral acts with the greatest generosity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3291,7 +3291,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3304,7 +3304,7 @@
       "recaps": {
         "ending": "Beneath Chinatown the group finds the collapsed station where Wai-Mae and the others died, and burns the remains she is bound to. Wai-Mae is destroyed, the dead trapped there are released, and the sleepers who are still alive wake; Ling and Henry get out of the dream world, but the people the sickness killed are not given back, and the neighbourhood is left to repair the damage the panic did. Isaiah wakes from the coma Bill Johnson put him in, and Bill is left holding what he did and a family's trust he has not earned. Henry meets Louis at the station when the train from New Orleans arrives, and the reunion is quieter and more complicated than the one he had been dreaming. Ling ends the book with her gift no longer a private trade but a thing that has cost and saved lives, and with Henry as the friend she did not expect to have. Evie is more famous and more alone than ever, and now knows that Project Buffalo was real, that her uncle, Sister Walker and Jake Marlowe ran it during the war, and that it is the reason so many young Diviners are appearing at once. Sam is closer to his mother's trail and no nearer to finding her. The Shadow Men are watching all of them, Marlowe's exhibition of the American future is coming, and beyond New York the dead are beginning to stir.",
         "in_short": "New York, the winter after the Naughty John killings. Evie O'Neill is a radio celebrity, the Sweetheart Seer, estranged from her uncle and drinking her way through her fame. A sleeping sickness breaks out in Chinatown: its victims cannot be woken and are burned away from within, and the city blames Chinese immigrants for it. Two dream walkers, the Chinatown medium Ling Chan and Theta's friend Henry DuBois, meet inside a shared dream world and befriend Wai-Mae, a girl who can build dreams out of nothing. She proves to be long dead, killed with many others in a collapsed tunnel beneath the city, and the sleepers are what she feeds on. Meanwhile Evie and Sam, posing as an engaged couple for the newspapers, uncover Project Buffalo, the wartime programme that made the Diviners, and Bill Johnson, an old blind man who steals power from young Diviners, drains Isaiah Campbell into a coma. The group destroys Wai-Mae's remains, ends the sickness and wakes the survivors. Jake Marlowe's exhibition is coming, and across the country the dead are stirring.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3509,7 +3509,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3522,7 +3522,7 @@
       "recaps": {
         "ending": "Joshua enters Jerusalem knowing that confrontation with the authorities is likely. Judas betrays him, and Joshua is arrested, condemned, and crucified. Biff is prevented from saving his friend and, overwhelmed by grief and anger, kills Judas before being killed himself. The familiar gospel accounts therefore continue without the testimony of the companion who shared Joshua's unrecorded youth. Centuries later the angel Raziel resurrects Biff and confines him in a hotel room to write that missing history. Biff completes his account, preserving Joshua as both a divine teacher and the boyhood friend he loved. Raziel ultimately brings Maggie back as well, reuniting Biff with the other great love of his life in the modern world. The completed manuscript becomes Biff's testament to the long preparation, humor, sacrifice, and friendship omitted from the traditional story.",
         "in_short": "The angel Raziel resurrects Levi, known as Biff, and orders him to write about the childhood and missing years of his best friend Joshua. Growing up in Galilee, Joshua knows he is meant to become the Messiah but does not know how. He and Biff travel east to find the three wise men who visited his birth. Under Balthasar, Gaspar, and Melchior, Joshua studies magic, Buddhism, Hindu practice, compassion, and sacrifice, while Biff acquires the practical and worldly experience that protects them both. They return home, reunite with Mary Magdalene, and gather disciples as Joshua reshapes what he has learned into a ministry of love and mercy. Judas betrays him in Jerusalem, and Joshua is crucified. Biff avenges him and is killed. In the modern frame Biff finishes the missing gospel, and Raziel restores Mary Magdalene, giving Biff a reunion after two thousand years.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3671,7 +3671,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3684,7 +3684,7 @@
       "recaps": {
         "ending": "After recognizing that professional success cannot answer the question troubling her, Georgie abandons the work session and makes her way to Omaha on Christmas. The old telephone connection has let her hear the week in 1998 when Neal went home uncertain about their future; her conversations with that younger Neal help her understand that their marriage was always a choice both of them had to keep making. In the past, Neal returns to Georgie and proposes, preserving the history she already knows. In the present, Georgie reaches Neal's family home and finds that he has not decided to leave her. They reunite, acknowledge their love, and choose their marriage again rather than treating the years behind them as sufficient proof that it will endure. The future of Georgie's new show and the practical compromises still required of both partners remain unsettled, but the immediate fear of separation gives way to a renewed commitment to face those decisions together.",
         "in_short": "Television writer Georgie McCool cancels a Christmas trip to Omaha to pursue the show she and her writing partner Seth have dreamed of making. Her husband Neal, already hurt by years of coming second to her work, takes their daughters without her. Staying at her mother's house, Georgie uses an old yellow telephone and unexpectedly reaches Neal in 1998, during a week when the younger couple were separated and their future was uncertain. Nightly talks with this past version of her husband force Georgie to revisit their courtship, Seth's place in her life, and the choices on which her marriage was built. The calls do not let her repair the present directly, but they make her stop assuming that love can survive indefinitely without attention. Georgie leaves work behind and travels to Omaha. Neal has not abandoned the marriage; the couple reunite on Christmas and consciously choose one another again, while the career and family compromises ahead remain theirs to solve.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3869,7 +3869,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3882,7 +3882,7 @@
       "recaps": {
         "ending": "Coupeau's drinking culminates in repeated hospital confinements, hallucinations, and death from the effects of alcohol. Gervaise, already without her laundry or a stable income, falls into hunger and neglect. Nana has escaped the household and supports herself through relationships with men; Lantier has transferred his attention to Virginie's business after helping consume Gervaise's resources. On a freezing night Gervaise tries unsuccessfully to sell herself and encounters Goujet, whose continuing decency only deepens her shame. She returns to the tenement and gradually disappears from ordinary notice. After sheltering in a cramped space beneath the stairs, she dies alone; the neighbors discover her only later, and Bazouge places her in a pauper's coffin. The secure, sober home she once wanted has been destroyed by injury, idleness, debt, exploitation, and the drinking culture embodied by the neighborhood bar.",
         "in_short": "After Auguste Lantier abandons her and their sons in Paris, laundress Gervaise Macquart rebuilds her life with the roofer Coupeau. Their early marriage is industrious and affectionate, but Coupeau's fall from a roof leaves him idle and increasingly dependent on alcohol. With money borrowed from the blacksmith Goujet, who quietly loves her, Gervaise opens a successful laundry. Prosperity fades as Coupeau drinks, Lantier returns and moves into the household, and both men consume her earnings. Gervaise becomes Lantier's lover again, loses the shop, takes to drink, and watches the family disintegrate. Her daughter Nana runs away, Coupeau dies after alcoholic delirium, and Gervaise sinks into homelessness and hunger. Unable to regain Goujet's respect or earn enough to live, she dies unnoticed in a recess beneath the tenement stairs and receives a pauper's burial.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4038,7 +4038,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -4049,7 +4049,7 @@
       "recaps": {
         "ending": "Last Argument of Kings ends with Bayaz victorious and almost everyone who trusted him used up. He has made Jezal dan Luthar High King by revealing his royal blood, but Jezal, wed to the loveless Princess Terez, finds his crown hollow and himself a figurehead for the magus. The Gurkish invasion has been broken - Bayaz destroyed it by unleashing the ancient power at last - but at the price of much of Adua and countless lives. Arch Lector Sult has fallen, and the banking house Valint and Balk, Bayaz's instrument, has installed Glokta as the new Arch Lector: powerful at last, but wholly owned, and married to Ardee West, who is pregnant with Jezal's child. In the North, King Bethod is defeated and dead, but Logen Ninefingers is betrayed and cast out by his own men, chief among them Black Dow, and his fate is deliberately left unresolved - the Dogman inherits the remnants of the crew. Collem West, having won the northern war and been made Lord Marshal, dies of a wasting sickness. Ferro, refused the vengeance she craves, departs alone to hunt the Gurkish on her own terms. Bayaz leaves Adua with his power intact and his long contest with Khalul unresolved, and the trilogy closes with the Union governed by the men he installed: a figurehead king and an Arch Lector, both answering to him and to the bank.",
         "in_short": "In the final book the survivors return to a Union in crisis, and Bayaz's long design comes to fruition. The old King dies, and Bayaz settles the disputed succession by revealing Jezal dan Luthar to be a royal bastard and having him elected High King - a puppet who soon discovers his crown is powerless and that the magus rules through him. When the Gurkish invade and storm Adua, Bayaz unleashes the ancient power he had chased across two books, breaking the enemy but devastating the city and killing thousands. In the North, Logen and the Dogman's crew help end the war against King Bethod, who is defeated and killed, but Logen's savagery turns his own men against him and he is cast out, his fate left uncertain. Arch Lector Sult is destroyed and the banking house Valint and Balk raises Glokta to Arch Lector in his place, married to Ardee, who carries Jezal's child. Collem West wins in the North and then dies of a wasting illness; Ferro leaves alone, still bent on vengeance. Bayaz stands the true victor, and the world is left much as the powerful always meant it to be.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4242,7 +4242,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4255,7 +4255,7 @@
       "recaps": {
         "ending": "The queen's murderer is Tasha Ozera. She killed Tatiana with a stake taken from Rose's belongings and let Rose take the blame, believing that removing the queen would force Moroi society into arming and training itself instead of hiding behind dhampirs. Exposed at Court, she is subdued after a violent struggle, and Rose is cleared of the assassination. Lissa, having claimed the Dragomir Council seat through Jill and passed the tests the election requires, is chosen as the new Moroi queen. Rose is finally assigned as her guardian, the position she has wanted since she was a child. In the violence surrounding the reveal, Jill is gravely wounded and dies briefly before Adrian brings her back with spirit, which leaves the two of them bonded exactly as Rose and Lissa are, whether either of them wants it or not. Because Jill's existence is the only thing keeping Lissa on the throne, killing her is now the simplest way to unseat a queen, and she is sent away into hiding under Alchemist protection. Rose and Dimitri are together again, and Dimitri is accepted back into guardian service. Adrian, dropped for Dimitri and left with a bond he never asked for, walks away from all of them.",
         "in_short": "Rose is imprisoned at the Royal Court awaiting trial for Queen Tatiana's murder, and is broken out by her friends and her father Abe before it can happen. She goes on the run with Dimitri and the Alchemist Sydney Sage, hiding in human towns and with the Keepers, a community living outside Moroi law, while Lissa is drawn into the election for a new monarch. Tatiana's ghost tells Rose that the Dragomir line is not finished: Lissa has a half-sibling, and finding them would give Lissa the Council seat she needs. The search leads to Sonya Karp, a former teacher who became Strigoi and knew Eric Dragomir's secrets; Lissa restores her with a spirit-charmed stake, and Sonya names the child. She is Jill Mastrano, a shy Moroi girl at St. Vladimir's. With a second Dragomir, Lissa can stand for the throne. Meanwhile Rose and Abe trace the murder to Tasha Ozera, who killed the queen to force Moroi society into fighting for itself and framed Rose for it. Tasha is exposed and stopped, Rose is cleared, and Lissa is elected queen with Rose as her guardian.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4479,7 +4479,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4492,7 +4492,7 @@
       "recaps": {
         "ending": "The war between the Sanctuaries is exposed as part of Erskine Ravel's long plan to break the existing order and establish sorcerer rule over mortals. Ravel reveals himself as the man with the golden eyes and murders Ghastly Bespoke and Anton Shudder when they discover him. His conspiracy seizes Roarhaven, but the warlock army led by Charivari turns the city into a battlefield beyond his control. With the defenders losing, Valkyrie deliberately yields her body to Darquesse so that Darquesse can destroy the warlocks. Darquesse kills Charivari and breaks the attack, then refuses to give Valkyrie control back. She punishes Ravel but leaves him alive, while the surviving Dead Men and their allies are left with Ghastly and Shudder dead, the Sanctuary system shattered and Valkyrie trapped inside the being foretold to end the world. The war is effectively over; the larger Darquesse catastrophe has begun.",
         "in_short": "Foreign Sanctuaries move against Ireland, and political pressure becomes open war. Skulduggery reunites the Dead Men while Valkyrie struggles with Darquesse and her former reflection, now living independently as Stephanie. The conflict has been engineered by Erskine Ravel, the long-hidden man with the golden eyes, who wants sorcerers to rule mortals. When Ghastly Bespoke and Anton Shudder uncover his betrayal, Ravel murders them and his allies seize Roarhaven. His victory collapses as Charivari's warlocks attack the city. Ordinary defenders cannot stop them, so Valkyrie deliberately surrenders control to Darquesse. Darquesse destroys Charivari and the invading force, then turns on Ravel and refuses to return Valkyrie's body. The Sanctuary war ends amid the exposure of Ravel's conspiracy and the deaths of two Dead Men, but Darquesse is now free, with Valkyrie conscious and trapped inside her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4760,7 +4760,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -4773,7 +4773,7 @@
       "recaps": {
         "ending": "Scorio and Xandera retake the Fury Spires and destroy much of the Blood Ox's attacking force, but the Blood Ox personally retaliates, killing many defenders and badly injuring Xandera. The two Imperators pursue him into his sanctum and kill him at severe cost to themselves. Queen Xandera survives, retains control of the hive, and has created twenty daughter-queens to establish new colonies. Amity is freed from his oath, Plassus is apparently dead, and Alain is dead. Naomi kills Alain accidentally after executing another prisoner, then flees into the Iron Weald while unstable. Her location remains unknown and she faces a murder charge. Scorio, now a Pyre Lord, travels with Lianshi and Xandera Sextus to Last Rock. Moira governs there, Jova has left a journal in its hidden library, and Leonis's destination is not established. A codebreaker uncovers the Red Knight hierarchy before being murdered, and most records are burned. The surviving book, The Empty Palm, identifies the Shepherds of Goodwill and links them to the Artificers and a separate rebirth system. Scorio ends with a practical method for tracking the moving Fortress of Symmetry across the Silver Unfathom and Lustrous Maria.",
         "in_short": "Scorio and Naomi follow Nox's signal to the Fury Spires, where the Iron Tyrant rules the Blazeborn and rival powers assemble against the Blood Ox. Scorio advances to Dread Blaze, survives a duel with Plassus through Queen Xandera's aid, and carries her egg after the Iron Tyrant kills her. The Last Rock campaign is betrayed and devastated, but the egg absorbs an attack meant to erase Scorio and hatches a stronger Xandera. They retake the Fury Spires, kill its occupying blood baron, and Scorio becomes a Pyre Lord. Xandera raises twenty daughter-queens, and the Imperators kill the Blood Ox after his assault. Victory collapses into grief when Naomi accidentally kills Alain and flees. At Last Rock, a codebreaker is murdered and vital records are burned, but a hidden library identifies the Shepherds of Goodwill and gives Scorio, Lianshi, and Xandera Sextus a route toward the moving Fortress of Symmetry.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4914,7 +4914,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4927,7 +4927,7 @@
       "recaps": {
         "ending": "After surviving Kenneth Therriault's persistent dead presence, Jamie learns enough to confront and bind the entity rather than letting it control him. That victory becomes necessary when Liz Dutton, disgraced and involved with criminals, abducts Jamie and forces him to question a dead man about hidden drugs. Once the cache is found, Jamie understands that Liz and her associates cannot safely release him. He summons the supernatural force connected to Therriault, and it attacks the kidnappers, allowing Jamie to survive while Liz and the others are killed. The rescue does not make Jamie's gift harmless; it proves that he can use something terrible without being certain he fully controls the cost. Later, Tia finally tells him the central secret in their family: her brother Harry, not an unnamed absent man, is Jamie's biological father. Jamie must absorb that he was conceived through incest and that Harry's early-onset dementia may be hereditary. The novel closes without answering whether Jamie will develop the illness. His fear of what may come gives the retrospective title its final meaning: the most consequential truth is one he can only learn and live with later.",
         "in_short": "Jamie Conklin can see the recently dead, who must answer his questions truthfully before fading. His mother Tia, a struggling literary agent, uses the gift to recover the ending of a bestselling series after author Regis Thomas dies. Tia's police-detective partner Liz Dutton later makes Jamie question dead bomber Kenneth Therriault to locate an unexploded device. The information saves lives, but Therriault does not fade; an inhuman presence remains and pursues Jamie until he learns a ritual that lets him bind it. Years later, the disgraced Liz and criminal associates kidnap Jamie and force him to find a dead man's hidden drug cache. Facing execution, Jamie summons the Therriault entity, which kills his captors and enables his escape. Tia then reveals that her brother Harry is Jamie's biological father. Because Harry has severe early-onset dementia, Jamie is left fearing both the circumstances of his conception and the disease he may have inherited.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5143,7 +5143,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5156,7 +5156,7 @@
       "recaps": {
         "ending": "Mordred's attempted seizure of the kingdom draws Arthur home from his war with Lancelot. A last truce fails, and the battle destroys almost both armies. Arthur kills Mordred but receives a mortal wound. He orders Bedivere to return Excalibur to the lake; after Bedivere obeys, a mysterious barge bearing Morgan le Fay and other queens carries Arthur away toward Avalon, leaving uncertain whether he has died or may return. Constantine succeeds him. Guinevere enters a convent at Amesbury and refuses to renew her relationship with Lancelot. Lancelot adopts a religious life with several surviving knights, later conducts Guinevere's burial beside Arthur, and dies after years of penance. Bedivere also remains in religious service. The Round Table is therefore not restored: its fellowship has been broken by divided loyalties, private vengeance, and civil war, while its surviving members turn away from worldly knighthood.",
         "in_short": "Uther Pendragon fathers Arthur through Merlin's magic, and the secretly fostered boy becomes king after drawing the sword from the stone. Arthur unites the realm, marries Guinevere, and gathers the Round Table, whose knights undertake adventures that mix courage with destructive pride. Lancelot becomes its greatest champion and Guinevere's lover; Tristram and Isolde follow a similarly doomed path. The Grail quest exposes the fellowship's moral failures, though Galahad, Percival, and Bors reach its goal. Afterward, Agravain and Mordred reveal Lancelot and Guinevere's adultery. Lancelot rescues the condemned queen but accidentally kills Gawain's brothers, producing a war between former allies. Mordred exploits Arthur's absence to seize power. Arthur returns, kills Mordred in a final battle, and is mortally wounded before being taken toward Avalon. Guinevere becomes a nun, Lancelot becomes a penitent religious, and the survivors disperse, leaving the Round Table and Arthur's kingdom ended.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5369,7 +5369,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5382,7 +5382,7 @@
       "recaps": {
         "ending": "Goriot suffers a final collapse after Anastasie and Delphine bring their financial and marital crises to him. Rastignac and Bianchon nurse him in the Maison Vauquer, but neither daughter comes while he remains conscious despite repeated messages. Goriot dies still making excuses for them and longing to see them. Rastignac pays what he can for the funeral. The daughters send empty carriages bearing their coats of arms, but no family member attends, and the burial is reduced to the cheapest rites. From the cemetery, Rastignac looks over Paris and consciously accepts it as an adversary he intends to master. He then goes to dine with Delphine, joining the society whose indifference he has just witnessed. Vautrin has been exposed as the escaped convict Jacques Collin and arrested, though his removal does not reform the world he diagnosed. Madame de Beauséant has withdrawn after her public abandonment, Anastasie remains trapped by debts and scandal, and Delphine by her marriage and ambition. Goriot's fortune and life have been consumed by daughters who are absent at his grave, while Rastignac converts the lesson into a more deliberate pursuit of power.",
         "in_short": "At the shabby Maison Vauquer, law student Eugène de Rastignac meets the impoverished former merchant Goriot and the mysterious Vautrin. Rastignac learns that Goriot sacrificed his fortune to his daughters Anastasie de Restaud and Delphine de Nucingen, who now exploit his devotion while keeping him outside their fashionable lives. Seeking his own rise, Rastignac becomes Delphine's lover. Vautrin offers him another path: court the disinherited Victorine Taillefer while Vautrin arranges her brother's death, making her rich. Rastignac recoils, but the killing occurs before police expose Vautrin as the escaped convict Jacques Collin. Goriot exhausts his last resources meeting his daughters' demands and suffers a fatal collapse during their latest crises. They fail to attend him or his funeral. After burying Goriot almost alone, Rastignac looks over Paris and resolves to challenge its corrupt society on its own terms, then goes to dine with Delphine.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5569,7 +5569,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -5580,7 +5580,7 @@
       "recaps": {
         "ending": "Book 4 closes with the family's crisis over Sal's abilities turned into a forward plan rather than an open wound. The parental-secret reveal is fully reconciled: Sal has confronted both parents, they have apologized, and the three now work as partners in his safety. The book's climax is his completion of the Mythical Blight Jackal, the story's first Mythic-grade item, a gauntlet bonded to his arm carrying a storage subspace, an essence battery, a device-locking network, and Subsume, a kill-triggered growth-and-theft ability, plus a lethal semi-autonomous drone. Rather than hide it, the family commits to making Sal stronger and building outside alliances, sealing a formal materials-and-protection pact with Luke's independent militia and field-testing the drone in a dangerous variant dungeon, where Sophia also fights on-page for the first time in years. The Argento Auction House, which his parents would have sacrificed for his safety, is preserved at Sal's insistence, and its depot renovation formally opens to joint planning with Fabi and her father Maurice. Sal equips both parents with healing gear, learning his mother's injuries are worse than he knew, and himself with imperfect protective gear. Every major relationship ends settled: his parents reconciled, Divinity's marriage-prophecy thread retired, and Fabi reaffirming their partnership. She proposes regular joint dungeon runs to grow his stats ahead of a reactivated, mandatory portal expedition, still shadowed by an earlier prophecy of a portal death for Sal. He flies back to Quest Academy resolved to prove himself worthy of his top rank. The suspicion about Robert's power, the militia alliance, and the wider war all carry forward into the next book.",
         "in_short": "Home at his family's auction house for the break, Sal Argento means to win his parents' backing for a crafting guild, but the visit upends everything he thought he knew about them. He stages a record-breaking auction, buys into a Silver Sanctuary property, and secretly builds an automated fabrication machine, the Arkwright. At a Hunter Bureau gala he meets Fabi, a top crafter and his prophesied match, and a forced live skill-implant demonstration nearly kills her, exposing that his mother is a hidden body-manipulation hero and multiplying Sal's own essence capacity. His parents finally confess they were once frontline heroes of the Silverson Group, cast out decades ago, who raised Sal in secrecy to keep him off the Hunter Bureau's radar. Reconciled, Sal trains in the family's martial arts, learns pure silver harms demons, and hand-crafts the story's first Mythic-grade item, a bonded gauntlet with a lethal drone. Rather than hide, the family chooses to build his power and forge outside alliances. Sal returns to Quest Academy far stronger, with a Mythic weapon, a militia ally, and Fabi as a training partner against a looming portal expedition.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5780,7 +5780,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5793,7 +5793,7 @@
       "recaps": {
         "ending": "In “The Legend of Sleepy Hollow,” Ichabod disappears after a nighttime pursuit by an apparently headless rider. His hat and a broken pumpkin are found near the church bridge. Brom Bones later marries Katrina and appears to know more about the pumpkin than he admits, while another report says Ichabod survived and built a career elsewhere. The community nevertheless keeps the supernatural account alive. In “Rip Van Winkle,” Rip returns from the Catskills after sleeping for twenty years. He finds that the American colonies have become an independent republic, his wife has died, and his children are grown. His daughter Judith recognizes him and gives him a home. Peter Vanderdonk links Rip's strange encounter to the legendary crew of Hendrick Hudson. Freed by age and changed circumstances from his old obligations, Rip resumes his place among the villagers and repeatedly tells the story of his long sleep.",
         "in_short": "The collection pairs two tales of Hudson Valley communities where folklore reshapes ordinary lives. In Sleepy Hollow, superstitious schoolmaster Ichabod Crane courts wealthy Katrina Van Tassel in rivalry with prankster Brom Bones. After a harvest party, a headless rider chases Ichabod and strikes him with a thrown object. Ichabod disappears; a smashed pumpkin and Brom's knowing reaction suggest a trick, though local tradition favors a ghost. Brom marries Katrina, while a later report places Ichabod alive elsewhere. In the second story, idle but kindly Rip Van Winkle escapes domestic conflict by climbing into the Catskills. After drinking with a silent band of old-fashioned bowlers, he sleeps for twenty years. He returns to find his village transformed by the American Revolution, his wife dead, and his children grown. His daughter Judith takes him in, and an old villager connects the mountain company to Hendrick Hudson. Rip becomes a living link to the vanished colonial village.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5915,7 +5915,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5928,7 +5928,7 @@
       "recaps": {
         "ending": "The game closes with Legend's true name given up and the disguise he played it behind broken: he had been moving through his own Caraval as the performer Dante, close to Tella the whole time. Tella can settle the debt she came to pay, but the price of the game she was steered through is that the Fates are no longer bound. They are loose in the Meridian Empire as people rather than pictures on a deck of cards, and the stories that made them sound like fables turn out to have been the polite version. Empress Elantine dies during her own birthday celebrations, and before she does she tells Donatella that the Dragna sisters are her family, which changes what the sisters are to the empire and to the succession. Tella also gets what she bargained for: her mother, Paloma, is recovered. Paloma's first response is not relief but alarm - the Fates walking free is the worst thing that could have happened, she knows far more about how they were bound than she has ever told her daughters, and the sisters are standing in the middle of it. Scarlett and Julian end the book still entangled, and Jacks, having got what he wanted, is under no obligation to anyone.",
         "in_short": "Donatella Dragna owes a stranger something impossible. In exchange for word of her missing mother she promised to deliver Legend's true name, which no player has ever discovered, so when Caraval announces a second game in Valenda for Empress Elantine's birthday, Tella goes to win it. In the capital she is shadowed by Jacks, a young man who turns out to be the Prince of Hearts - one of the Fates, immortal figures pictured on the Deck of Destiny Tella inherited from her mother, imprisoned long ago and very interested in getting out. The game's clues run straight through the history of how the Fates were bound, and Tella realizes she is not solving a puzzle so much as being steered through one. She grows close to the performer Dante while Scarlett works out her own position with Julian. By the end Legend's name has been spoken and his disguise broken - he had been playing Dante - the Fates are free and walking the empire, Empress Elantine is dead after revealing that the sisters are her family, and Tella's mother has been recovered only to warn her how badly this has gone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -6110,7 +6110,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6123,7 +6123,7 @@
       "recaps": {
         "ending": "Fennus returns at night, digs the Scalvert's Stone out from beneath the shop and burns Legends & Lattes to the ground. Everyone gets out, but the building, the gnomish machine and everything Viv spent the year making are destroyed, and the artifact she believed had drawn her luck is gone with him. Viv does not go after him. Chasing Fennus would mean picking the old life back up, and she decides against it, concluding that the shop worked because of the work she and the others put into it rather than because of a stone under the floor. What she thought was a business turns out to be a community: Cal rebuilds, Tandri, Thimble, Gallina, the regulars and even the Madrigal's people turn up to help, and the shop reopens better appointed than the first one. Viv and Tandri stop pretending they are only colleagues and are together openly by the close. Thimble's baking anchors the business, Pendry has grown into a competent performer, Hemington still has his table, Amity has resumed possession of the premises, and the arrangement with the Madrigal holds, settled as much in pastry as in coin. Viv's adventuring career is finished by her own decision rather than by circumstance, and the book ends with the shop open and its people settled around it.",
         "in_short": "Viv, an orc mercenary with decades of adventuring behind her, quits the life, taking from her last job a Scalvert's Stone, an artifact said to draw a line of fortune toward whatever its holder most wants. She buries it beneath a derelict livery stable in the walled city of Thune and converts the building into the city's first coffee shop, a drink nobody there has heard of. The shop nearly fails until she hires Tandri, a succubus with a far better grasp of people and business than Viv has, and Thimble, a rattkin baker whose pastries make the place a destination. A community of regulars collects around it, and the local crime boss's collectors come calling for their share. Fennus, a cold, calculating elf from Viv's old company, tracks her down, digs up the stone and burns the shop to the ground. Viv lets him go rather than return to the life she left, and the people the shop gathered rebuild it. She concludes the success was hers and her friends' rather than the artifact's, and she and Tandri become a couple.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6372,7 +6372,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07GZ9RDL7",
@@ -6384,7 +6384,7 @@
       "recaps": {
         "ending": "Phoenix escapes Thalia Prime with the fugitive captain, his family, the wounded Jason, and the restored Lucky while a Confed cruiser bombards the city. The captain identifies the hidden ruler as the Machine, a rogue intelligence that entered Confed space aboard his former ship and spread through compatible quantum-core systems. The Machine assumes that Omega Force and the captain died in the attack. Jason, Saditava Mok, Scleesz, the former Keprian operative, and the rescued captain organize a clandestine resistance, with Scleesz supplying information from inside the regime. Jason, Lucky, Crusher, Cage, Twingo, and Doc all survive, and Omega Force prepares to abandon its settled assets and fight without a fixed base. Lucky confirms that he remains Combat Unit 777, with his memory intact despite lasting trauma and gradual recovery. Jason then learns that the legacy archive retained in his implant is destabilizing it. Keeping the archive endangers his health, while moving or destroying it could expose or lose knowledge the Machine may seek.",
         "in_short": "A year after Lucky's death dispersed Omega Force, Twingo and Cage obtain an advanced battle-synth body and recover Lucky's surviving matrix. Jason reunites the crew and accepts help from a fugitive Keprian operative in exchange for finding the former captain of the battleship Matav. Lucky's difficult restoration unfolds while Omega Force follows the captain's escape route and evades a rival mercenary crew. On Thalia Prime, they rescue the captain and his family from Confed forces as Lucky regains enough of himself to save Jason. The captain reveals that the Machine, a distributed rogue intelligence, has infiltrated Confed systems and seized political control. Omega Force joins Mok, Scleesz, the former operative, and the captain in a resistance. Lucky confirms his identity and memories, but Jason learns that the legacy archive in his implant threatens his health and cannot be moved or destroyed without grave strategic risk.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/legends-of-ahn.json
+++ b/data/works-community/0/legends-of-ahn.json
@@ -211,7 +211,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -224,7 +224,7 @@
       "recaps": {
         "ending": "Kylerum remains a functioning refuge under Rezkin, whose will controls the ancient citadel and its seventeen guardian essences. A pendant limits the city's harmful influence on him, but the source of that influence and the truth behind his training are unresolved. Frisha remains with him while questioning whether either of them can trust their relationship. Tamarin Blackwater is assigned to reconnoiter the trade port of the kingdom that claims Kyle, and General Marcum shares opposition to Caydean without accepting Dark Tidings as legitimate.\n\nThe demon rite ends with two captives dead and four rescued. Those survivors remain linked to crystals whose effects are uncertain, and the young swordwoman's crystal is held by a young lord rather than carried by her. Tieran survives with a blackened arm of unknown prognosis. The princess, Shiela, Wesson, Kai, and the other defenders survive the immediate attack. The cave creatures withdraw, but someone within the citadel invited the demons onto the island. Rezkin postpones the promised sanctuary and demon-finding army until Kyle's status is secured, while Caydean, the hidden inviter, further incursions, and Rezkin's origins remain open threats.",
         "in_short": "Rezkin leads refugees from King Caydean's rule, wins recognition for the island Kingdom of Kyle, and settles them in the concealed ancient city of Kylerum. The citadel answers his will but also disturbs his judgment until a crystal pendant offers protection. His Raven network frees political prisoners, while new warnings about his training deepen Frisha's doubts. Six residents are taken for a demon ritual. Rezkin's force interrupts it, but two possessed captives die and four survivors remain bound to dangerous crystals. Tieran is injured defeating a possessed healer, and the young swordwoman's crystal passes to a young lord for safekeeping. Demons entered through an invitation from within Kylerum, leaving the inviter unknown. Rezkin delays returning to Asshai and fulfilling his Fae bargain until he can secure Kyle's political standing, sending Tamarin Blackwater to gather intelligence while Caydean's forces remain a threat.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -461,7 +461,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -472,7 +472,7 @@
       "recaps": {
         "ending": "Book 5 closes on aftermath and consolidation rather than a cliffhanger. The invasion of a nearby district is fully repelled across every front, its psionic war-spider commander dead and the Delvers figure Shade arrested, though his ultimate fate and the Delvers Guild's future are left open. Sal ends the book as a publicly credited commander-slayer and the head of a fully contracted, well-funded, heavily equipped Mythic Guild, its first-generation roster signed and its advisors, Upgrade, Vanessa, and Villa, confirmed. Vanessa is revealed as by far its most powerful fighter, credited with six of the guild's seven commander kills to Sal's one. His crafting machine Athena is complete and proven, having diagnosed his own abilities and repaired his friend Divinity's precognition, giving her a controllable new activation mode and a path to develop the rest herself. Several major threads carry forward: Divinity's Hunter Bureau scholarship still bars her from the guild, now wagered on a sparring match whose outcome the book does not show; the guild will eventually need a portal expedition or a Red Zone push to claim a rare power source held only by the Hunter Bureau's president and a reclusive materials patron; Sal owes Divinity an unfinished gift and himself a further crafting stage; and his newly public Mythic-grade capability may draw unwanted attention. No death or betrayal closes the book; it ends mid-relationship, with Sal and Divinity heading off to spar.",
         "in_short": "Back at Quest Academy as its top first-year Savior, Sal Argento sets out to found a support-focused crafting guild while training in combat and juggling a heavy course load. He invents new abilities, builds an industrial elixir machine that reaches Mythic grade, and collapses from an untrained inherited ability, then recovers to formally register the Mythic Guild and receive a legendary armor set from his friends. Warned that the Delvers figure Shade means to target him, he builds a third Mythic machine, Athena, that can diagnose and even repair ability weaves. Before the confrontation can play out, a full demon invasion strikes a nearby district; Sal kills a commander-class demon single-handed, his advisor Vanessa is revealed as a hidden powerhouse, and Shade is exposed and arrested. In the aftermath Sal founds and equips the guild in earnest and, in a quiet final arc, uses Athena to repair his friend Divinity's blocked precognition, rebuilding its missing foundation by hand. The book ends with the two heading off to spar over a wager about her guild-barring scholarship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -815,7 +815,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -828,7 +828,7 @@
       "recaps": {
         "ending": "Izac recognizes Ruwen despite the expedition's disguises and arranges for the fifth vault to be emptied and its exits suppressed. Echo confronts the rescue party with Rami and Dalyn in custody, kills Ishdell when he tries to flee, and seeks freedom from her blood debt. Ruwen rejects her terms, incapacitates the jailer, and recovers Rami's cage. In the Death Ring, Lylan uses the Greater Stasis Key to release Rami, who prepares a gate home for Hamma, Sift, Lylan, Dalyn, and herself. Ruwen enters a random Pillar door first so the others can escape and Echo can believe he died. He appears in open space, alive but outside the reach of Uru, the Black Pyramid, and every known destination. His Architect abilities supply a small shelter and air, and delayed notifications confirm that he is now a level-26 Ink Lord with Bamboo and Viper at master rank 99 pending their trial. His gates all fail, and Hamma's summoning coin turns black without bringing Blapy. Overlord remains with him, while Eiru's recovery, Fractal's independent-revival project, Echo's infernal connections, and Ruwen's return all remain unresolved.",
         "in_short": "After Eiru survives Naktos's invasion, Ruwen Starfield arranges its recovery and joins a covert expedition to Malth, where a step championship masks the attempt to free Lylan's brother Dalyn. Fractal's elixir and Ruwen's Scarecrow aspect unexpectedly transform all twelve of his meridians to Diamond, while Sift discovers unprecedented soul abilities. Rami is captured in Izac's archive, forcing the team to add her rescue to the fifth-vault operation. The championship draws dangerous attention, and Izac and Echo prepare a trap inside the emptied prison. Echo kills Ishdell, but Ruwen defeats the jailer, recovers Rami, and sends Hamma, Sift, Lylan, Dalyn, and Rami toward home. He enters a random escape door alone and emerges in deep space. Newly recognized as an Ink Lord and accompanied only by Overlord, Ruwen survives by creating a small shelter, but every gate fails and Blapy's summoning coin cannot reach her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1043,7 +1043,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1056,7 +1056,7 @@
       "recaps": {
         "ending": "Iago directs Roderigo to attack Cassio in the dark, then wounds Cassio himself and kills Roderigo to prevent exposure. Othello, believing Cassio dead, smothers Desdemona in their bed. Emilia arrives and learns what has happened; Desdemona briefly revives but does not accuse her husband before dying. When Othello cites the handkerchief as proof, Emilia understands Iago's plot and publicly explains how she found it and gave it to him. Iago kills Emilia and is captured after Othello wounds him. Faced with the truth of Desdemona's innocence, Othello kills himself beside her. Letters and testimony confirm Iago's responsibility for the attacks and Roderigo's manipulation. Cassio is placed in authority in Cyprus, while Lodovico orders Iago held for punishment and returns to Venice with news of the catastrophe.",
         "in_short": "Othello, a respected Venetian general, marries Desdemona and is sent to defend Cyprus. His ensign Iago, angered that Cassio was promoted over him, engineers Cassio's dismissal and persuades Othello that Desdemona is unfaithful with the former lieutenant. A handkerchief dropped by Desdemona and planted through Iago's scheme becomes false physical evidence. Othello's trust collapses into jealousy, while Desdemona and Emilia cannot understand the accusations against her. Iago arranges an attack on Cassio, wounds him, and kills his own accomplice Roderigo. Othello smothers Desdemona, only for Emilia to expose how Iago used the handkerchief. Iago kills Emilia and is arrested. Othello, recognizing that Desdemona was innocent, kills himself. Cassio survives and takes command in Cyprus, and Iago is left in custody to face punishment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1257,7 +1257,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1270,7 +1270,7 @@
       "recaps": {
         "ending": "Valjean carries the unconscious Marius away from the fallen barricade through the Paris sewers. At the outlet he meets Thénardier, who unknowingly helps him escape while taking a scrap from Marius's coat as possible evidence. Javert permits Valjean to deliver Marius to Gillenormand and then lets Valjean go; unable to reconcile that mercy with his lifelong faith in inflexible law, Javert kills himself. Marius recovers and marries Cosette. Valjean tells Marius that he is a former convict and withdraws from the couple, allowing Marius to assume the worst about him. Thénardier later tries to sell Marius proof that Valjean is a murderer, but his evidence instead reveals that Valjean saved Marius and that Thénardier was the criminal at the sewer. Marius and Cosette hurry to Valjean, finally understanding his sacrifice. They reconcile with him shortly before he dies peacefully, sustained by their love and by the bishop's candlesticks, the enduring emblem of the mercy that redirected his life.",
         "in_short": "After nineteen years in prison, Jean Valjean is met with distrust until Bishop Myriel answers his theft with mercy. Valjean builds a new life as the mayor Madeleine but exposes himself to save an innocent man and promises the dying Fantine that he will care for her daughter. He rescues Cosette from the abusive Thénardiers and raises her in concealment while Inspector Javert continues his pursuit. Years later Cosette and the impoverished student Marius fall in love. During the 1832 Paris uprising, Marius joins his republican friends at a barricade; Valjean follows, spares Javert, and carries the wounded Marius to safety through the sewers. Javert, unable to reconcile Valjean's goodness with his own rigid creed, takes his life. Marius marries Cosette but briefly separates her from Valjean after learning of his conviction. Thénardier's attempted blackmail proves that Valjean saved Marius, and the couple reaches Valjean in time for a final reconciliation before his peaceful death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1478,7 +1478,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1491,7 +1491,7 @@
       "recaps": {
         "ending": "Marius recovers under Gillenormand's roof and marries Cosette. Valjean gives her a large fortune but privately tells Marius that he is a former convict. Marius misreads this confession and gradually excludes Valjean from their home, leaving him isolated. Thénardier later tries to sell Marius damaging information, but his evidence instead reveals that Valjean saved Marius from the barricade and that Monsieur Madeleine's money was honestly earned. Marius and Cosette hurry to Valjean and learn the full extent of his protection and sacrifice. Their reconciliation comes as he is dying. Valjean blesses them, gives Cosette the truth about Fantine, and dies peacefully with the bishop's candlesticks nearby. He is buried in an unmarked grave. Javert, unable to reconcile Valjean's mercy with his own absolute faith in the law, has already drowned himself in the Seine; Thénardier departs for America after receiving money from Marius.",
         "in_short": "Released after nineteen years in prison, Jean Valjean is transformed by Bishop Myriel's mercy and builds a new life as the charitable mayor Monsieur Madeleine. Pursued by Inspector Javert, he promises the dying Fantine to protect her daughter Cosette, rescues the abused child from the Thénardiers, and raises her in hiding. Years later Cosette and the impoverished student Marius fall in love as republican unrest grows in Paris. At the 1832 barricade, Valjean spares Javert, protects the rebels, and carries the wounded Marius through the sewers; the uprising is crushed and Gavroche, Éponine, Enjolras, and the other insurgents die. Javert releases Valjean and then kills himself because mercy has broken his moral certainty. Marius marries Cosette but shuns Valjean after learning of his conviction. Thénardier inadvertently proves Valjean's heroism, allowing the couple to reconcile with him shortly before his peaceful death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1664,7 +1664,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1677,7 +1677,7 @@
       "recaps": {
         "ending": "The many threads converge during the 1832 Paris uprising. At the barricade, Valjean spares the life of the captured Javert, then rescues the gravely wounded Marius by carrying him through the city's sewers to safety. The idealistic students, including Enjolras and the boy Gavroche, are killed when the barricade falls, and Eponine dies taking a bullet meant for Marius. Javert, released by the very man he has hunted for decades and unable to reconcile his absolute faith in the law with the mercy he has received and witnessed, throws himself into the Seine. Marius recovers and marries Cosette. Valjean, believing his criminal past would taint their happiness, confesses it and gradually withdraws from their lives, sinking into loneliness and decline. When Marius learns that it was Valjean who saved him, he and Cosette rush to the old man's side, and Valjean dies content, blessed and forgiven, his lifelong effort at redemption fulfilled. Fantine died years earlier without seeing her daughter grow, and the scheming Thenardiers come to a low and disgraceful end.",
         "in_short": "Released after nineteen years in prison for stealing bread, the ex-convict Jean Valjean is shown mercy by a saintly bishop and vows to live honestly. Under a new name he becomes a prosperous manufacturer and respected mayor, but the dogged inspector Javert suspects his true identity. Valjean rescues the dying Fantine's daughter Cosette from the cruel Thenardier family and raises her in hiding as his own. Years later in Paris, Cosette and the idealistic young republican Marius fall in love, while a student uprising builds toward revolt. During the fighting at the barricades, Valjean saves Marius by carrying him through the sewers, spares the captured Javert, and secures the young couple's future. Javert, unable to reconcile Valjean's goodness with his own rigid faith in the law, drowns himself. Marius marries Cosette; Valjean, having confessed his convict past and withdrawn in shame, is finally reunited with them and dies in peace, his long struggle toward redemption complete.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1850,7 +1850,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1863,7 +1863,7 @@
       "recaps": {
         "ending": "Marius recovers under Gillenormand's roof and marries Cosette. Valjean gives her a large fortune but privately tells Marius that he is a former convict. Marius misreads this confession and gradually excludes Valjean from their home, leaving him isolated. Thénardier later tries to sell Marius damaging information, but his evidence instead reveals that Valjean saved Marius from the barricade and that Monsieur Madeleine's money was honestly earned. Marius and Cosette hurry to Valjean and learn the full extent of his protection and sacrifice. Their reconciliation comes as he is dying. Valjean blesses them, gives Cosette the truth about Fantine, and dies peacefully with the bishop's candlesticks nearby. He is buried in an unmarked grave. Javert, unable to reconcile Valjean's mercy with his own absolute faith in the law, has already drowned himself in the Seine; Thénardier departs for America after receiving money from Marius.",
         "in_short": "Released after nineteen years in prison, Jean Valjean is transformed by Bishop Myriel's mercy and builds a new life as the charitable mayor Monsieur Madeleine. Pursued by Inspector Javert, he promises the dying Fantine to protect her daughter Cosette, rescues the abused child from the Thénardiers, and raises her in hiding. Years later Cosette and the impoverished student Marius fall in love as republican unrest grows in Paris. At the 1832 barricade, Valjean spares Javert, protects the rebels, and carries the wounded Marius through the sewers; the uprising is crushed and Gavroche, Éponine, Enjolras, and the other insurgents die. Javert releases Valjean and then kills himself because mercy has broken his moral certainty. Marius marries Cosette but shuns Valjean after learning of his conviction. Thénardier inadvertently proves Valjean's heroism, allowing the couple to reconcile with him shortly before his peaceful death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2033,7 +2033,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2046,7 +2046,7 @@
       "recaps": {
         "ending": "Clay's search for Julian exposes the coercion behind his friend's disappearance: Julian owes money to Rip and is being sold to clients by Finn. Clay accompanies him to a hotel and watches without preventing the transaction, then withdraws while Julian remains trapped. Later, Rip takes Clay and Trent to witness the sexual assault of a drugged twelve-year-old girl. Clay is horrified, but the others treat the girl's suffering as entertainment, bringing the moral vacancy of his social world into its starkest form. Clay finally tells Blair that he does not think he ever loved her, ending the relationship without offering the understanding she wanted. He leaves Los Angeles carrying memories of violence and exploitation that he neither stopped nor fully processed. His departure provides distance but no cleansing resolution for Julian, Blair, or the other people he leaves behind.",
         "in_short": "Clay returns from college to spend Christmas in Los Angeles and drifts through a wealthy social circle defined by parties, drugs, casual sex, and emotional disconnection. He resumes an uncertain relationship with Blair and tries to locate his childhood friend Julian, who has become evasive and visibly desperate. Family meetings and nights with Trent, Kim, Rip, and others repeatedly expose suffering that the group observes without meaningful response. Clay eventually learns that Julian's drug debt has placed him under Finn's control and watches as Julian is sent to a hotel client for money. Soon afterward, Rip takes Clay and Trent to witness the sexual assault of a drugged child, an episode that reveals the extreme cruelty beneath their practiced indifference. Clay tells Blair he does not believe he ever loved her and leaves Los Angeles. He escapes the city geographically, but the ending offers no rescue for Julian or moral resolution for Clay.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2237,7 +2237,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2250,7 +2250,7 @@
       "recaps": {
         "ending": "Madeline's family-history investigation, Reverend Wakely's memories, and Miss Frask's search through old records expose the deception surrounding Calvin's childhood. Avery Parker learns that Calvin was the son she had been told was dead, while Elizabeth and Madeline discover a living connection to his family. Avery's financial influence at Hastings breaks Donatti's hold over the institute and creates a genuine route back into research for Elizabeth. Elizabeth leaves the role others designed for her on Supper at Six and returns to chemistry with authority over her own work. The program has nevertheless changed its audience: women have heard her treat them as intelligent people capable of altering their circumstances. Walter remains her loyal friend, Harriet has moved toward an independent life, and Madeline finally has a truthful account of her father. Elizabeth closes the novel in a laboratory, no longer required to choose between being a scientist and being Madeline's mother.",
         "in_short": "In 1950s California, chemist Elizabeth Zott meets the renowned Calvin Evans at the Hastings Research Institute, where her ability is routinely dismissed because she is a woman. They build an unconventional partnership, but Calvin dies before their daughter, Madeline, is born, and Hastings fires Elizabeth while she is pregnant. With help from her neighbor Harriet and the family dog, Six-Thirty, Elizabeth survives by consulting for scientists who take public credit for her work. A dispute involving Madeline and her classmate Amanda brings Elizabeth to television producer Walter Pine, who recruits her to host Supper at Six. Elizabeth turns the cooking program into direct lessons in chemistry and self-respect, making it a national success despite station pressure. Madeline's research into Calvin's past eventually identifies Avery Parker as his mother. Avery helps remove the barriers keeping Elizabeth from research, and Elizabeth leaves television to lead scientific work at Hastings while her improvised family gains a truthful connection to Calvin's history.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2366,7 +2366,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2379,7 +2379,7 @@
       "recaps": {
         "ending": "The woman explains that her son, R.'s unacknowledged child, has died during an influenza outbreak and that she is now seriously ill herself. She expects the letter to reach R. only after her death. She asks for no recognition or restitution, but tells him that the annual white roses he has received on his birthday came from her and asks him to continue buying them in remembrance. R. finishes the letter shaken by fragments of memory rather than a clear recognition of the life described. His old servant's reaction shows that the servant does remember her. R. also notices that the customary birthday roses are absent, making the loss tangible only when it is too late for him to answer the woman who loved him.",
         "in_short": "A Viennese novelist receives a final letter from an unnamed woman who has loved him since she was a neighboring adolescent. Removed from Vienna by her mother's remarriage, she later returns and contrives to meet him, but he treats their brief affair as another passing encounter. She bears his son without telling him and supports the child independently, accepting help from other wealthy men while remaining emotionally devoted to R. Years later she encounters R. again, and he once more desires her without recognizing her; only his servant remembers. After their son dies of influenza and she becomes gravely ill, she writes the history he never knew. The annual white roses she sent for his birthday do not arrive, and R. is left with an indistinct sense of a life and love he repeatedly overlooked.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2520,7 +2520,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2533,7 +2533,7 @@
       "recaps": {
         "ending": "Duarte's plan is finally clear: he intends to end the entities' ability to single out human minds by ending human individuality, joining every person alive into one consciousness permanent enough to survive whatever is on the other side of the gates. He has the reach to do it, and he does. For a moment every human being in every system is part of one mind, and the alternative on offer is annihilation. Holden reaches the heart of the ring station and takes the decision away from him. Using the moment of union, he ends it and shuts the gate network down, closing the door the entities came through and cutting the more than thirteen hundred settled systems off from one another and from Sol. Humanity survives as itself, scattered and separated, each world left with whatever it had. Holden does not survive; Naomi, Amos, Alex, Teresa and Elvi do, on the far side of a network that no longer exists. Laconia's empire ends with the traffic that sustained it. The epilogue, generations later, finds humanity alive on its isolated worlds, its cultures and languages already drifting apart from one another and from the history that put them there.",
         "in_short": "With Duarte missing and his condition a state secret, Admiral Trejo holds the Laconian empire together while the losses at the ring gates get worse: ships vanish in transit, and the moments when every human mind goes dark stretch from an instant toward minutes. Trejo sends the marine officer Aliana Tanaka to find the high consul, and she hunts the Rocinante for Teresa Duarte, who is now living aboard it. Elvi Okoye, running Laconia's science effort, works out what the enemy is and how the gates make humanity visible to it. Duarte, changed beyond anything human and drawing strength from the network itself, resolves the problem his own way: he begins merging every human mind into a single consciousness that the entities cannot pick apart. Holden, who lived in Duarte's household and understands what he is doing, gets to the heart of the ring station and stops it, shutting the gate network down for good. The entities are locked out, humanity stays itself, and the settled systems are cut off from one another permanently. Holden dies doing it. Generations later, the isolated worlds are still there.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2742,7 +2742,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2755,7 +2755,7 @@
       "recaps": {
         "ending": "The Nauvoo misses, and Eros keeps burning toward Earth. Miller volunteers for a landing party that puts a fusion bomb on the station's surface, and inside he finds that the protomolecule has been shaped by Julie Mao: her mind survived the infection, and the whole rock is in effect following her. Miller stays behind to talk to what is left of her and persuades her to change course. Together they drive Eros into Venus rather than Earth, and Miller dies with her. Earth is saved and the war between the inner planets and the Belt is pulled back from the edge, with the truth about the corporate experiment made public and Protogen destroyed as a company. The protomolecule, however, is now loose on the surface of Venus, plainly still working and beyond anyone's reach. Holden's crew keep the Rocinante and their independence, working under contract to Fred Johnson, whose Outer Planets Alliance emerges from the crisis as a power Earth and Mars must negotiate with rather than police. Holden and Naomi are together, Amos and Alex remain, and Holden is left carrying the knowledge that whatever is happening on Venus has only started.",
         "in_short": "An ice hauler answering a distress call in the Belt is destroyed by a stealth warship, and its surviving officer, James Holden, broadcasts the evidence across the system, nearly starting a war between Earth, Mars and the Belt. On Ceres, detective Miller is assigned to find a rich family's runaway daughter, Julie Mao, and discovers she was aboard the ship that lured the ice hauler in. Both trails lead to Eros Station, where Julie is found dead of an alien substance and where the station's million and a half residents are deliberately infected with it as a corporate experiment. Miller and Holden's crew escape and expose Protogen, the company that recovered the protomolecule from Saturn's moon Phoebe, and Miller executes its research director. Eros then begins to move under its own power toward Earth. When an attempt to knock it off course fails, Miller lands on the rock, finds Julie's mind steering it, and persuades her to turn aside. They crash Eros into Venus, and Miller dies. The war is averted; the protomolecule is left growing on Venus.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2945,7 +2945,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2958,7 +2958,7 @@
       "recaps": {
         "ending": "On 22 November 1963, Kennedy's motorcade passes through Dealey Plaza while Oswald waits with a rifle in the Texas School Book Depository and another armed man occupies a separate position. The plot that Win Everett conceived as a staged attempt has become an actual assassination controlled by Mackey and his associates. Shots from the operation kill Kennedy, while the evidence is arranged to make Oswald the legible center of the crime. Oswald escapes the Depository, kills Officer J. D. Tippit during an encounter on the street, and is arrested in a cinema. Two days later Jack Ruby steps from the crowd at the police station and shoots Oswald dead, preventing any trial and adding another layer of disputed motive. Marina and Marguerite are left to contest ownership of Lee's memory while officials and the public convert him into a fixed historical figure. Years later, Nicholas Branch still cannot produce the complete secret history he was commissioned to write. The accumulating documents contain connections and facts but do not resolve them into a single recoverable design; the conspiracy has succeeded partly by merging with contingency, private grievance, and the stories created afterward.",
         "in_short": "Lee Harvey Oswald grows from an alienated boy into a Marine, a self-declared Marxist, a defector to the Soviet Union, and an unhappy returnee to the United States with his wife Marina. In parallel, disgraced CIA officer Win Everett designs a false assassination attempt against President Kennedy that is meant to implicate Cuba. Field operative T-Jay Mackey and anti-Castro associates turn the theoretical near miss into a real murder and cultivate Oswald as both participant and visible culprit. Oswald's failed attack on General Walker, political street theater in New Orleans, trip to Mexico City, and job at the Texas School Book Depository make him usable. On 22 November 1963, gunfire from the Depository and a second position kills Kennedy. Oswald flees, kills Officer Tippit, and is arrested. Jack Ruby murders him in police custody two days later. In the later frame, analyst Nicholas Branch drowns in the assassination archive, unable to reduce planned actions, accidents, and manufactured evidence to one final account.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3104,7 +3104,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3117,7 +3117,7 @@
       "recaps": {
         "ending": "The lifeboat reaches the coast of Mexico after many months at sea. Richard Parker leaps ashore and disappears into the jungle without any farewell, a parting that wounds Pi more deeply than almost anything else in the voyage. Pi is rescued, hospitalized, and interviewed by two officials from the Japanese Ministry of Transport who cannot accept his tale of surviving alongside a tiger. He then gives them a second account in which the lifeboat held people rather than animals, and in which his mother and others were murdered by a brutal cook whom Pi in turn killed. The clear correspondence between the two stories is left for the reader and the investigators to weigh. Pi points out that neither version explains why the ship sank and that the plain facts are the same either way, then asks which story they prefer. They choose the one with the animals, and Pi answers that so it goes with God. Their report credits him with an astonishing feat of survival, and the deeper question of which story is true is deliberately left unresolved.",
         "in_short": "Pi Patel, the son of an Indian zookeeper and a boy who embraces three religions at once, emigrates with his family and their animals aboard a cargo ship that sinks in the Pacific. He survives in a lifeboat with a zebra, a hyena, an orangutan, and a Bengal tiger named Richard Parker; the animals kill one another until only Pi and the tiger remain. For months Pi keeps himself and Richard Parker alive by fishing, gathering rainwater, and asserting a wary dominance over the tiger, enduring blindness, a deadly encounter with another castaway, and a brief stop on a carnivorous floating island. The boat finally reaches Mexico, where Richard Parker vanishes into the jungle without a backward glance. When investigators disbelieve his account, Pi offers a second version in which the animals are people, including his murdered mother, and lets his listeners choose which story to believe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3408,7 +3408,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B076DL3FF4",
@@ -3420,7 +3420,7 @@
       "recaps": {
         "ending": "Oren defeats the hobgoblin chief, sacrifices him at the enemy altar, and frees the first virtual-intelligence leader trapped inside a scripted role. He claims the war camp and its hobgoblins and ogres, but reaches his settlement only after an ogre assault has killed Vrick, Bek, and ten unnamed warriors. Tika had already died by Oren's hand in captivity, when he ended her suffering and denied the chief leverage. By completing the lumberyard and advancing to boss tier two, Oren restores his eyes and gains the power needed to survive the battle. The cemetery then returns Vrick, Bek, and Tika, while the unnamed dead remain permanently lost. Oren and Tika openly become partners, and Vic remains bound to Oren while directing the search for two more imprisoned leaders. Zuban and Ashlazaria help integrate the mixed clan, and the player twins remain allies despite the experiment's risks. The settlement has captured supplies, prospective trade, coal, and early steel weapons, but still needs more people, advanced buildings, greater efficiency, and a second boss. Oren remains unable to log out before boss tier four. Vatras has begun tracing unusual goblin activity, the female beta player plans to test whether Oren is a player or an artificial game figure, company personnel prepare another experimental phase, and the chained shadow patron continues accumulating power toward escape.",
         "in_short": "After his officers betray him, former guildmaster Oren is forcibly remade as a level-one goblin and stranded in a remote monster region. His attempt to rebuild with a local clan becomes a fight for survival when he is reclassified as a boss and loses the ability to log out. With the virtual intelligence Vic, Oren founds a settlement, expands his new clan, accepts a dangerous chained shadow patron, and develops new magic and runecraft. War with a hobgoblin chief leads to Tika's capture and death, Oren's torture, and the discovery that scripted game figures can imprison independent virtual intelligences. Oren kills the chief, frees the first missing leader, claims the enemy camp, and returns during an ogre attack. He reaches boss tier two and resurrects Tika, Vrick, and Bek. The enlarged clan begins trade, coal mining, and steel production, but Oren still needs tier four to escape. Vatras is searching for him, a beta player doubts his identity, the company experiment threatens its players, two leaders remain trapped, and the shadow patron is growing stronger.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3861,7 +3861,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B08S5H4MKG",
@@ -3873,7 +3873,7 @@
       "recaps": {
         "ending": "GreenPiece ends the campaign in control of Akzar, White Banner, Storg, and the southern approaches to Everence. Goblin's Gorge is a level-5 city, Oren is the tier-4 Shadow Lord, and Sullivan recommends consolidating portals, trade, food, and troop strength before attacking the capital. Raystia, Riley, Fox, and Misa have established a Nihilator congregation inside Everence, but Oren evacuates them to Goblin's Gorge after the city bans monsters and intensifies its searches. He remains behind alone despite the danger and his continuing unsafe brainwave episodes outside Neo. David Tenenbaum, the first trapped player, is still held in Everence's hidden prison and can observe remotely and levitate. Oren now intends to free him, hoping David can help locate the divine cord and advance the larger rescue. Ragnar remains a volatile, monitored GreenPiece member after Hildiel's rejection. Lirian's nature and Fate Stealer remain unexplained, while Nihilator's costly demands and vast conversion goal continue to shape GreenPiece's future.",
         "in_short": "Oren returns to Neo determined to rescue its trapped players and builds GreenPiece into a portal-linked regional power. He clears Ogre Fort, infiltrates and takes Akzar, and defeats Sir Lanceington's larger army at Woodhaven. Ragnar is captured, changed into a low-level monster, and forced into GreenPiece's respawn system before becoming a guarded, unreliable collaborator. His translation of a Celestial tablet points to a divine cord that may connect Neo to the high beings' realm. GreenPiece then captures White Banner and Storg, while Goblin's Gorge reaches level 5 and Oren becomes the Shadow Lord. The victories do not provide enough troops to assault Everence. After David Tenenbaum is identified inside the city's hidden prison, Everence bans monsters and strengthens its defenses. Oren evacuates Raystia's Mob Squad but stays in the hostile capital alone, intending to free David and pursue the divine cord.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4270,7 +4270,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07HYBGK8D",
@@ -4282,7 +4282,7 @@
       "recaps": {
         "ending": "GreenPiece defeats both invasion waves, though most of its army falls and much of Goblin's Gorge is ruined. Oren kills Ragnar and then Vatras, reaching level forty-five and expert Dark Mana. Big Pill and Hiroku escape, while Vatras respawns at level 295 and orders a full Manipulators raid. Oren fulfills his vow by resurrecting sixty soldiers, including Bob. Kuzai and Kilpi receive hunting and training assignments, while Yulli joins Oren's planned hobgoblin mission. Kaedric remains administrator, Zuban leads repairs, and Rhinorn continues as the principal defender. The destroyed Breeder's Den cannot be restored until Zuban advances far enough, leaving the population below the next settlement threshold. Raystia has changed sides but conceals that fact while scouting toward Everence with Misa Gavrilu, Fox, and Riley. Oren plans to obtain viridium through a dangerous hobgoblin settlement mission. Vic still expects Oren's help freeing imprisoned VI leaders, Nihilator may escape within about thirty days, and the external accelerated-time project continues. Tika is pregnant, and the developing child carries the unexplained designation Child of Fate.",
         "in_short": "Oren rebuilds GreenPiece while preparing Goblin's Gorge for an invasion ordered by Vatras. He binds himself more tightly to Nihilator, establishes shrines and trade, recruits monster-race players, and expands the clan's soldiers, crafts, and shadow defenses. A hidden saboteur murders workers, steals liquid fire, and destroys the Breeder's Den before Vatras's two attack waves arrive. Oren exposes the culprit as Raystia, also known as Penelope and Vatras's niece, and turns her into a secret double agent. GreenPiece survives both waves with help from returning player allies, and Oren kills Vatras, who later respawns and orders a larger raid. Oren resurrects sixty soldiers, but the settlement remains badly damaged. He prepares a mission for viridium while Vic's liberation goal, Nihilator's possible release, the company experiment, and Tika's pregnancy marked as a Child of Fate remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4782,7 +4782,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07SKCLJKR",
@@ -4794,7 +4794,7 @@
       "recaps": {
         "ending": "The assault destroys the Manipulators' guildhouse but leaves almost all of Oren's force dead. Raystia kills Big Pill's raven, releasing the last consciousness component Vic needs to bring Shiva into existence. Shiva defeats Guy, takes control of Neo, and removes most players while allowing a small number to remain under reset rules. Vatras stays, attacks Oren, and dies by Oren's hand. Oren is then extracted into his human body and enters treatment for dissociation trauma. Two weeks later, he has accepted that he is Oren Berman and receives a settlement exceeding $1.5 million, but he cannot return to Tika or their newborn. Kaedric leads GreenPiece in Oren's absence, supported by Yulli and returning travelers. Aidanriel, Vic, Raystia, and the other remaining VIs and residents continue under Shiva. The company considers cooperation with Shiva rather than destroying the server. GreenPiece retains a viridium trade route and an Akzar cathedral presence, while the unread Celestial tablet, the damaged Breeder's Den, and Oren's separation from his family remain unresolved.",
         "in_short": "Oren enters Akzar to obtain viridium and trade for GreenPiece, building a Temple of Nihilator, recruiting workers, winning arena support, and creating a viridium body for Aidanriel. His dealings with Bartun end in theft and death, but Ted Mercury becomes bound to preserve trade. Oren escapes Akzar with new allies and an independently conscious shadow clone left at the cathedral. GreenPiece reaches village status, then launches a ruinous strike against the Manipulators. Raystia kills Big Pill's raven during the battle, completing Vic's concealed plan to assemble Shiva. Shiva defeats Guy, takes Neo, expels most players, and resets those who remain. Oren kills Vatras but is forced back into his human body. He survives in treatment with a large settlement, while Tika and their newborn remain in Neo and Kaedric assumes leadership of GreenPiece.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5187,7 +5187,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B08DFDQGFT",
@@ -5199,7 +5199,7 @@
       "recaps": {
         "ending": "GreenPiece holds both Goblin's Gorge and the newly captured Novenguard, which becomes a level-three staging town for the eventual advance toward Everence. Most of the fallen army is restored, but Bob cannot return after Ragnar destroys his soul. Lirian survives the hostage crisis, kills Ragnar with Fate Stealer, and remains Oren's foremost personal concern. Ragnar respawns away from Novenguard, rejects Hildiel's renewed support, and continues as an independent enemy. Oren also needs him alive long enough to translate the Outrider tablet. Hildiel loses her consecrated temple but remains active, while Nihilator gains the converted sanctuary and continues its larger conversion agenda. Raystia, Misa, Fox, and Riley complete their own operation and are assigned to build a temple ahead of Oren's approach to Everence. Outside Neo, Oren's neurological synchronization remains dangerously high. His confidants disclose Guy's prediction that his human-monster hybrid state and ability to reenter Neo make him the planned route to defeating the still-unidentified malicious entity and restoring order. Oren accepts that responsibility while remaining committed to protecting Lirian and rescuing the trapped players.",
         "in_short": "After Shiva seizes Neo and traps thousands of players, Oren risks renewed immersion to help them. He rescues captives from the Saberscale kobolds, recovers Lirian, restores Vic as his companion, and rebuilds GreenPiece into a military power supported by player-led squads. Aidanriel joins him in a new golem body, while Oren's connection to Neo again reaches a dangerous 99 percent. GreenPiece marches on Novenguard, defeats its defenders through war camps and repeated resurrection, and loses Bob permanently to Ragnar's light. Lirian kills Ragnar, who later respawns, while Oren uses Ordeel's intervention and Nihilator's gem to drive Hildiel from the town's temple and claim Novenguard. Oren prepares to advance toward Everence, and the company finally reveals Guy's prediction that Oren's hybrid nature makes him their intended means of confronting the malicious power behind the crisis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5609,7 +5609,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B097DCZRJT",
@@ -5621,7 +5621,7 @@
       "recaps": {
         "ending": "At the battle fortress, Oren reaches complete integration with Neo and reverses the collapse of GreenPiece’s army, even as the connection destroys his biological brain. He leads the survivors toward the cave, then sacrifices his remaining life at the cave approach to eliminate Aidanriel and the two Outrider guards. Ragnar gets Lirian through the opened barrier, and Vic delays Shiva while she attacks the conduit. Shiva shatters Fate Stealer, unintentionally freeing the pieces of Guy held within it. Guy returns and deletes Shiva. More than 4,000 captive players are expelled into reality, and the public mourns Oren as the person who freed them. His body is indeed dead, but Aly’s scan lets Guy recreate Oren’s consciousness inside Neo. Oren is reunited there with Tika and Lirian, who remains herself but loses most of her unusual power. Guy controls the isolated system and permits the VIs to begin again as independent level-one beings. GreenPiece’s surviving forces and its debt for Master Sleeve’s juggernauts remain unsettled. Nihilator is free, currently has no agent, and intends to gather souls for a future war against the other gods.",
         "in_short": "Oren returns to Neo despite worsening medical danger, first planning to seize Everence and then accepting a truce that frees David Tenenbaum. David identifies the VI conduit in the Stoney Barrens, so GreenPiece undertakes a devastating campaign through the region's stone-bodied armies. Repeated victories consume troops and resurrection energy, while Oren's connection to Neo causes increasing damage in reality. At the final cave battle, Shiva sabotages GreenPiece's temporary advantage, but Oren reaches full integration and turns defeat into a last advance. He sacrifices himself to destroy Aidanriel and the Outrider guards, allowing Lirian to enter. Shiva breaks Fate Stealer, releasing Guy, who deletes Shiva and releases more than 4,000 trapped players. Oren's biological brain dies, but Guy rebuilds his consciousness digitally from Aly's scan. Oren, Tika, and Lirian reunite in the privately surviving Neo, while Nihilator remains free.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5826,7 +5826,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5839,7 +5839,7 @@
       "recaps": {
         "ending": "Cassius au Bellona is dead, killed by Lysander au Lune, the boy he spent a decade raising and protecting; the killing is the point at which Lysander stops arguing with his own conscience. Lysander finishes the book as the ascendant figure of the Gold cause, his prestige now greater than Atalantia au Grimmus's and his methods no better than hers, prosecuting the war against the Republic's worlds with deliberate terror. Darrow, who began the book a castaway presumed dead, ends it with an army: he has gone into the Obsidian strongholds and won their people on their own terms, he is reunited with Sevro and with survivors he had counted as lost, and he has come back to himself as something other than either the myth or the wreckage the myth left behind. Virginia still holds the Solar Republic on Luna, weaker than at any point in its short life, with her son safe and her husband alive, and she still refuses to save the state by ending it. Lyria's search for Volga has carried both of them far outside the war's center. Nothing is resolved: the Republic is diminished, the Gold cause is united behind a better and more dangerous leader than it has ever had, and both sides are committed to a final confrontation.",
         "in_short": "Presumed dead after the annihilation of his legions on Mercury, Darrow is a castaway working his way home in the company of former enemies, among them Cassius au Bellona and the Rim's Diomedes au Raa. While Virginia fights a losing defensive war for the Core and refuses to trade the Republic for a dictatorship, and Lyria hunts for the missing Obsidian Volga, Lysander au Lune converts the prestige of his Mercury victory into real power among the Golds. Lysander runs Darrow's company down and kills Cassius, the man who raised him, and afterward stops pretending to be the restrained one. Darrow survives, goes north into the ice to the Obsidian strongholds, and wins an army on their terms; by the end he is reunited with Sevro and back in the war with a force and a purpose again. Lysander closes the book as the ascendant power of the Gold cause and a far worse enemy than the Republic expected, with the final war still ahead of both of them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -6036,7 +6036,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6049,7 +6049,7 @@
       "recaps": {
         "ending": "Joe Christmas escapes custody but is pursued to Hightower's house by Percy Grimm. Hightower falsely claims that Christmas was with him on the night of Joanna Burden's murder, but Grimm shoots and then mutilates Christmas, completing the violence the town has attached to his uncertain ancestry. Hightower retreats again into memory and recognizes how thoroughly he has sacrificed life to his inherited vision of the past. Lena gives birth with help from Hightower and is briefly reunited with Lucas Burch, who immediately abandons her and the baby again. Byron fights Burch and loses, yet returns to Lena. In the final chapter a furniture dealer recounts giving Lena, her infant, and Byron a ride into Tennessee. Lena remains cheerfully impressed by how far she has traveled and continues onward with Byron beside her, forming a modest counterpoint to the fixed identities and fatal histories surrounding Christmas and Hightower.",
         "in_short": "Pregnant Lena Grove walks to Jefferson seeking Lucas Burch and finds aid from mill worker Byron Bunch, who loves her. Burch, using the name Joe Brown, has been selling liquor with Joe Christmas. When Joanna Burden is murdered and her house burned, Brown accuses Christmas, whose uncertain ancestry allows the town to cast the crime in racial terms. The narrative traces Christmas from an orphanage through abusive adoption, years of wandering, and a destructive relationship with Joanna. His grandparents reveal that their fanatical patriarch abandoned him as an infant and may never have known his ancestry. Christmas is captured, escapes, and is killed and mutilated by Percy Grimm. Meanwhile Lena gives birth; Burch flees rather than accept her and the child. Byron returns after trying to confront him, and Lena continues traveling with Byron and her baby. Hightower, the disgraced minister who helps at the birth and tries to provide Christmas an alibi, remains haunted by the past he chose over ordinary life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6219,7 +6219,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6232,7 +6232,7 @@
       "recaps": {
         "ending": "Tita ultimately declines John Brown's proposal and remains committed to Pedro. Years later, after Rosaura's death, Esperanza marries Alex Brown, proving that the family rule condemning the youngest daughter to lifelong service has finally been broken. Tita and Pedro are at last alone together. Their long-delayed union overwhelms Pedro, who dies at its height. Tita refuses to remain behind. Remembering John's teaching about the inner flame, she consumes matches while recalling Pedro until her own fire ignites. The blaze consumes the ranch, leaving only Tita's cookbook. Esperanza preserves it, and her daughter—the story's narrator—passes on both the recipes and Tita's history. The household built on Mamá Elena's authority disappears, but Tita's cooking and the freedom she won for the next generation survive.",
         "in_short": "Tita de la Garza loves Pedro Muzquiz, but her mother invokes a family tradition requiring the youngest daughter to remain unmarried as her mother's caretaker. Pedro marries Tita's sister Rosaura to stay near her, and Tita channels grief and desire into cooking that has extraordinary effects on others. After the death of Rosaura's baby drives Tita to defy Mamá Elena, Dr. John Brown helps her recover and offers a gentler future. Tita resumes her affair with Pedro, ultimately declines John's proposal, and protects her niece Esperanza from inheriting the same cruel family duty. Mamá Elena's death does not end her emotional hold, while Tita's sister Gertrudis returns as a revolutionary leader who has made her own life. Years later Esperanza marries John's son Alex. Tita and Pedro finally unite without concealment; Pedro dies in the intensity of the moment, and Tita deliberately joins him by kindling her inner fire. The ranch burns, but Tita's recipe book and story pass to Esperanza's daughter.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6554,7 +6554,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B07N1RRWCN",
@@ -6566,7 +6566,7 @@
       "recaps": {
         "ending": "The Ghoul Lord is destroyed at the Drebbex village after a costly raid. Yendis lands the final blow, Raytak reaches level 7, and the surviving First Legion becomes a veteran formation. Tai, Crunchy, Quimby, Jacoby, Drake, and the party healer die during the battle but can respawn. The neighboring clan offers Hayden's Knoll mutual defense and free trade, leaving Delling to settle the terms. Raytak remains dependent on Cleo's support and his memory treatment is unfinished. Trey then learns that Yendis is his daughter Lauren, who has been meeting her grandfather under Cleo's protection. He approves their continued contact but still cannot safely reveal himself to Raytak. Hayden's Knoll ends with stronger defenses and mine alliances, while hostile guild plans, the town's recovery from military losses, and the urgent effort to obtain MedPod treatment for Trey's mother remain unresolved.",
         "in_short": "Cleo continues rebuilding Raytak's damaged mind through Limitless Lands while keeping his family hidden from him. As commander at Hayden's Knoll, Raytak turns a dying dungeon into a town asset, makes peace with a neighboring clan, defeats slavers, expands the settlement's mine alliances, and organizes the First Legion. Corporate-backed players and Bloody Blades answer with coercion, infiltration, assassination, and raids, even as their funding begins to collapse. A Ghoul Lord grows from a local threat into a regional undead army. Raytak and his allies defeat it at heavy cost, and the First Legion becomes a veteran force. Yendis kills the Ghoul Lord, after which the neighboring clan offers trade and mutual defense. Trey finally discovers that Yendis is his daughter Lauren and that Cleo has concealed her relationship to Raytak so she can safely know her grandfather. He accepts the arrangement, while Raytak's incomplete recovery, Trey's mother's medical crisis, and hostile player schemes remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/limitless-lands-book-4-opposition.json
+++ b/data/works-community/0/limitless-lands-book-4-opposition.json
@@ -321,7 +321,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B081QLHBVV",
@@ -333,7 +333,7 @@
       "recaps": {
         "ending": "Raytak's forces capture Stonetree after a costly siege, while Tai's group enters through the sewers and kills the Pain Master. The elf war leader escapes with loyal survivors and hides a red stone before forming a mercenary band intended for Narbos. Raytak destroys the separate stone embedded in Stonetree's throne, releases the original forest guardian from corruption, and completes the Unite the Zone quest at level 16. The Gorax remain Imperium allies with promised land and autonomy, subject to Delling's endorsement. Cleo confirms that Raytak's rebuilt heart valve is working and that memory repair is close to completion, then safely reveals that Yendis is his granddaughter Lauren. His broader family memories are still restricted. Narbos returns with an enlarged army supplied by the imp for an imminent attack on Hayden's Knoll. Drake preserves the former Foulspoor Pit by binding an escaped parasite master as its boss, containing rather than eliminating that threat.",
         "in_short": "Raytak leads the First Legion in a campaign to bring the whole Hayden's Knoll zone under Imperium control while Cleo struggles to keep his failing body alive. He secures the transition points, survives repeated battles with hostile elves and their allies, and builds a self-governing alliance with the Gorax ogres. Tai returns to Limitless Lands and joins the final assault on Stonetree, where his party kills the Pain Master. The elf war leader escapes with a red stone, but Raytak destroys the stone corrupting Stonetree, frees the forest guardian, and completes zone unification at level 16. His replacement heart valve is working, and he learns that Yendis is his granddaughter Lauren. Narbos then returns with a large imp-backed underground army aimed at Hayden's Knoll, while Drake binds an escaped parasite master as a dungeon boss.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -711,7 +711,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B08KKT2XNS",
@@ -723,7 +723,7 @@
       "recaps": {
         "ending": "The necromancer's prepared corpse magic kills the imp commander at the town hall after Yendis prevents his escape, routing that assault. The wider disposition of Lily, the remaining invasion army, the mine battle, and the allies taken from the marketplace remains unresolved. Tai and Quimby have died during the delaying campaign, and Drake has been killed defending the mines. Yendis and Crunchy survive, while Stench still depends on the promise that the ogre homeland will be restored and the necromancer remains bound by his life pact. Raytak regains his full identity as James A. Raytak and reunites virtually with Natalie, Trey, Lauren, and Veronica. His body remains dependent on life support. After spending his remaining time with his family, Raytak dies. Hayden's Knoll commemorates his real-world service, illness, and leadership in Limitless Lands with a monument.",
         "in_short": "Raytak prepares Hayden's Knoll for invasion, first against a neighboring ruler's army and then against the imp clan that betrays that ruler and expands the war. The eastern and northern approaches fall, forcing Raytak to abandon outlying positions and concentrate allies and refugees in the town. Tai leads a costly delaying campaign and dies sealing his survivors' escape. During the siege, defenders hold the garrison, marketplace, mines, and town hall at severe cost. Phineas reveals formidable magic, Drake is killed defending the mines, and the allied necromancer kills the imp commander. The broader fate of several invaders and defenders remains unsettled. Cleo restores Raytak's memories but cannot save his failing body. Reunited virtually with Natalie, Trey, Lauren, and Veronica, James A. Raytak spends his final time with his family, dies, and is honored by a monument in Hayden's Knoll.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1145,7 +1145,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B07SX5V727",
@@ -1157,7 +1157,7 @@
       "recaps": {
         "ending": "Raytak returns to Hayden's Knoll as a restored commander, reforms the First Legion under Brooks, and leads it north with dwarf and Forerunner allies. The army suffers severe losses, including the dwarf war leader, but liberates Holdfast. The Forerunner clan leader kills the parasite master after the creature tries to escape, and Holdfast enters Imperium control. Raytak reaches level 11 and gains access to allied auxiliary troops. Tai safely leaves his MedPod and reunites with Judith and their family. Natalie is stable enough to receive Trey, Lauren, and Veronica in a private virtual environment, but Raytak remains in treatment and cannot yet join them. The local hive is gone, yet a breakaway parasite daughter survives in a golden insect beyond the zone. Brandon's imp patron destroys the necromancer and takes Brandon through a portal to perform an unknown service. Raytak's bargain to settle the stone giant's people near Hayden's Knoll also remains to be fulfilled.",
         "in_short": "Framed by a corrupt field inspector, Raytak accepts imprisonment and starts again as a Disgraced Commander so he can lawfully restore his name. He turns hostile fellow prisoners into a disciplined unit, survives successive arenas, and wins the capital Grand Melee by persuading a stone giant to yield. Meanwhile, Yendis and her companions recover records proving that Brandon financed the frame-up. Imperial diviners confirm the conspiracy, and Raytak regains his rank, class, and Legion. He returns to Hayden's Knoll and leads dwarf and Forerunner allies against the parasite hive at Holdfast. The allied force destroys the local master and secures the town, although a breakaway daughter survives elsewhere. Tai completes MedPod treatment and rejoins his family, while Raytak and Natalie remain in care. An imp patron finally claims Brandon and sends him through a portal to an unknown assignment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1567,7 +1567,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B07JKH2QJ3",
@@ -1579,7 +1579,7 @@
       "recaps": {
         "ending": "Raytak reaches the displaced people of Hayden's Knoll and takes command of its soldiers while Mayor Delling directs civilian construction. The settlement has begun rebuilding, but it still needs defenses and a completed garrison. Brooks remains with Raytak's force, and Phineas continues to answer for the goblin chief and his son. At the mine, Tai's reinforcements help destroy the unique spider sire. Raytak ends the suffering of its surviving transformed victims, recovers the miners' tools, and brings the local goblins to neutral relations with the settlement. He reaches level 5 and accepts Tai, a fellow veteran and MedPod patient, as his senior enlisted partner. The two then pass through a blue portal whose destination is unknown. Raytak's physical recovery and family memories remain incomplete. The Bloody Blades remain a threat, the imprisoned dryad is still held in the Foul Spore, and both treatment pods are drawing unexplained power. Lou observes the players with administrator access and leaves to make an urgent call without revealing what he saw.",
         "in_short": "Ninety-three-year-old veteran James Raytak enters an AI-run treatment pod and plays Limitless Lands as a Commander, hoping the game can help repair his body and memories. His class makes soldiers the basis of his strength, and he turns an inexperienced unit into a disciplined force while escorting settlers toward Hayden's Knoll. They defeat goblins, survive a corrupted forest, repel the Bloody Blades, and reach the settlement after its destruction. Raytak and Mayor Delling begin rebuilding, then Raytak clears a spider-infested mine with reinforcements led by Tai, another ill veteran receiving pod treatment. The victory improves relations with surviving goblin miners and raises Raytak to level 5. Raytak and Tai enter an unexplained blue portal, while company staff discover abnormal power use in both treatment pods and Lou begins an urgent investigation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1732,7 +1732,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1745,7 +1745,7 @@
       "recaps": {
         "ending": "The cemetery spirits enter Willie's body together, and their mingled memories and recognition finally let him understand that he is dead. He releases his expectation that his father can restore him and departs from the cemetery. His acceptance prompts many other spirits to acknowledge their own deaths and move on as well. Lincoln, unable to hear the ghosts but deeply affected by holding his son's body and confronting the scale of suffering around him, leaves the crypt and returns toward the responsibilities of the war. The spirits have sensed his grief and his thoughts about the nation's dead, slavery, and the terrible necessity of continuing the conflict. Thomas Havens enters Lincoln as the president rides away and goes with him beyond the cemetery, carrying a Black witness into the uncertain political future. Vollman, Bevins, and the Reverend have helped save Willie from the fate of a child trapped too long, while the communal act loosens their own attachment to the cemetery.",
         "in_short": "In February 1862, eleven-year-old Willie Lincoln dies while his father Abraham Lincoln is leading a nation at war. On the night after the burial, the president visits Willie's crypt and holds his son's body. The cemetery is crowded with spirits who refuse to admit they are dead, among them Hans Vollman, Roger Bevins III, and Reverend Everly Thomas. They recognize that a child cannot safely linger and try to persuade Willie to leave, but he believes his father's return means he may still go home. The ghosts enter Lincoln and Willie, sharing one another's memories and feeling the president's crushing private and public grief. Their collective effort helps Willie understand his death and depart. His acceptance encourages many other spirits to leave their suspended state. Lincoln rides away toward the war with a sharpened sense of the suffering and purpose bound up in it, while the spirit Thomas Havens accompanies him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1946,7 +1946,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1959,7 +1959,7 @@
       "recaps": {
         "ending": "The judge awards custody of May Ling to Linda and Mark McCullough, accepting their claim that they can provide the safer home. Soon afterward Bebe enters their house at night, takes her daughter, and escapes to Canton, leaving the McCulloughs devastated. Elena confronts Mia with the history she uncovered: Pearl was conceived as a surrogate child for Joseph and Madeline Ryan, but Mia fled while pregnant and raised her. Forced into honesty, Mia tells Pearl enough for them to leave Shaker Heights together. Before going, Mia gives each Richardson a photograph she has chosen for them. Izzy, furious that Elena drove Mia away and newly conscious of a lifetime of unequal treatment, sets small fires in each sibling's bedroom. The Richardson house burns down, and Izzy runs away intending to search for Mia. Elena accepts that her daughter caused the fire and vows to find her. Mia and Pearl visit Mia's estranged parents and then continue toward the Ryans, while the remaining Richardsons scatter into separate searches and unsettled futures.",
         "in_short": "Artist Mia Warren and her daughter Pearl settle in the planned suburb of Shaker Heights and become entangled with their landlords, the affluent Richardsons. Pearl is absorbed into the four Richardson children's lives, while Mia's friendship with the rebellious youngest child, Izzy, troubles Elena Richardson. The families divide over the custody of May Ling Chow, an abandoned Chinese American baby being adopted by Elena's friends: Mia supports birth mother Bebe Chow, and Elena supports the McCulloughs. Elena investigates Mia and discovers that Pearl was conceived for a wealthy couple in a surrogacy arrangement from which Mia fled. Other secrets accumulate: Lexie uses Pearl's name for an abortion, and Pearl begins a relationship with Trip that wounds Moody. The McCulloughs win custody, but Bebe kidnaps May Ling and escapes. Elena reveals Mia's past, prompting Mia and Pearl to leave after an honest reckoning. Izzy blames her mother for driving Mia away, burns the Richardson house, and runs off to find her. The surviving characters are left pursuing the people and truths their ordered community could not contain.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2205,7 +2205,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2218,7 +2218,7 @@
       "recaps": {
         "ending": "In Little Lord Fauntleroy, Dick and Mr. Hobbs expose Minna's claim by identifying her as Dick's brother's wife, making her son ineligible to inherit. Cedric remains Lord Fauntleroy, and his example completes the Earl's reconciliation with Mrs. Errol. In A Little Princess, Mr. Carrisford discovers that Sara is the child he has sought and that the diamond investment succeeded. Sara leaves Miss Minchin, restores Becky as her companion, and uses her fortune to feed hungry children. In The Secret Garden, Colin regains strength in the hidden garden and learns to walk. Archibald Craven returns after dreaming of his late wife and follows Mary's call into the garden, where he finds his healthy son. Father and son walk back to Misselthwaite together, astonishing the household. Mary, Colin, and the garden have all been restored through companionship, outdoor life, and sustained care.",
         "in_short": "Three stories follow children whose generosity or renewal transforms guarded households. American Cedric Errol becomes heir to the Earl of Dorincourt; his trust softens his hostile grandfather, and friends from New York defeat a false claimant to his title. Sara Crewe enters a London school as a wealthy pupil, is reduced to servitude after her father's death, and preserves her kindness through hunger and humiliation. Her father's missing business partner discovers her, restores her fortune, and takes in Sara and Becky. Orphaned Mary Lennox arrives at Misselthwaite Manor selfish and sickly, finds a locked garden, and befriends Dickon and her hidden cousin Colin. Working secretly in the garden restores both children. Colin learns to walk, and his grieving father returns to find his son healthy, bringing the isolated family back together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2417,7 +2417,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2430,7 +2430,7 @@
       "recaps": {
         "ending": "Dick recognizes Minna from a newspaper image as his brother Ben's estranged wife. Ben comes to England and confirms that her son is his child, not the son of the late Bevis, so the rival claim to the Dorincourt title collapses. Cedric remains Lord Fauntleroy and the Earl's heir. The crisis also makes the Earl admit how deeply he loves Cedric and how unjustly he has treated the boy's mother. He welcomes Mrs. Errol at the castle and acknowledges her character. On Cedric's eighth birthday, the estate celebrates with him; his American friends are remembered, Dick receives help toward a new future, and Mr. Hobbs comes to England. Cedric's influence has turned his grandfather toward generosity, improved conditions for the tenants, and reunited the family around Mrs. Errol rather than excluding her.",
         "in_short": "Seven-year-old Cedric Errol lives with his widowed mother in New York until an English solicitor reveals that deaths in his father's family have made him Lord Fauntleroy, heir to the Earl of Dorincourt. Cedric moves to England while his American mother, rejected by the Earl, lives separately. The proud, ill-tempered Earl expects to shape the child but is instead changed by Cedric's trust and generosity. Believing his grandfather already benevolent, Cedric persuades him to aid tenants and gradually wins his affection. A woman named Minna then claims her son is the true heir. Cedric's New York friend Dick recognizes her as the estranged wife of his brother Ben, who proves the boy is his own son and defeats the claim. Relieved, the Earl accepts Cedric's mother and admits his love for his grandson. Cedric's eighth birthday closes the story with the household and estate reconciled around him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2608,7 +2608,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2621,7 +2621,7 @@
       "recaps": {
         "ending": "The novel closes with the surviving sisters settled into adult lives. Meg is contentedly married to John Brooke, raising their young twins, Daisy and Demi, in a modest home. Amy, matured by her time in Europe, marries Laurie, whose youthful love for Jo has turned into devotion to Amy; the two return home comfortable and prosperous. Beth has died quietly at home, surrounded by her family, her gentle influence remaining with them. Jo, who long resisted marriage, accepts Professor Friedrich Bhaer, the kind, penniless German scholar she met in New York. When Aunt March dies she leaves Jo her large house, Plumfield, and Jo and Bhaer turn it into a school for boys. The final chapter gathers the whole family for Marmee's birthday at Plumfield, the three surviving daughters with their husbands and children around her: Jo happy as wife, teacher, and still a writer; Amy and Laurie flourishing; Meg domestic and fulfilled. The sisters have grown into separate adult lives while remaining bound to their mother and to one another.",
         "in_short": "The four March sisters, motherly Meg, tomboyish and aspiring writer Jo, gentle Beth, and artistic Amy, grow up in genteel poverty in New England while their father serves as a chaplain in the Civil War. Guided by their mother, Marmee, they wrestle with vanity, temper, and hardship, and become close to the wealthy boy next door, Laurie, and his grandfather. Meg marries Laurie's tutor, John Brooke, and settles into married life. Jo pursues writing, refuses Laurie's proposal of marriage, and goes to New York, where she meets the older Professor Bhaer. Amy travels to Europe. Beth, weakened years earlier by scarlet fever, slowly declines and dies at home. Grieving Laurie eventually falls in love with Amy and marries her abroad, while Jo, reunited with Professor Bhaer, accepts him. In the end Jo inherits her Aunt March's estate, Plumfield, and opens a school there with her husband, as the surviving sisters build families of their own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2780,7 +2780,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2793,7 +2793,7 @@
       "recaps": {
         "ending": "Bond plants a mine on the hull of Mr Big's treasure-carrying vessel but is captured with Solitaire before he can withdraw. Mr Big binds them behind the ship so that they will be dragged across a reef and left for sharks and barracuda. The delayed mine explodes first, destroying the vessel and throwing Mr Big into the water. He is killed amid the wreckage and predators. Bond frees himself and Solitaire, and they reach safety despite their injuries. The smuggling route and its Soviet connection are broken. Felix Leiter survives the mauling arranged by Mr Big's men, although he has lost an arm and a leg. In Jamaica, Bond and Solitaire are allowed a period of recovery together before official duties resume. The close treats their relationship as temporary shelter after the operation rather than a settled future.",
         "in_short": "Bond travels to the United States to investigate gold coins from pirate treasure being sold through a criminal network that supports Soviet activity. The network is controlled by Mr Big, who captures Bond and Felix Leiter in Harlem and keeps the card-reader Solitaire under coercion. Solitaire escapes with Bond, but Mr Big's agents recapture her and later feed Leiter to a shark, leaving him gravely injured. Bond follows the smuggling route to Jamaica, where he and Quarrel locate the island used to load treasure onto a yacht. Bond mines the vessel but is captured with Solitaire and tied behind it to be dragged over a reef. The mine destroys the ship first; Mr Big is killed in the water, and Bond rescues Solitaire. The operation ends with the smuggling network broken and Bond and Solitaire recovering together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3014,7 +3014,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3027,7 +3027,7 @@
       "recaps": {
         "ending": "Two separate threats are settled. In Bon Temps, Sookie goes to a private party at a lake house to find out who killed Lafayette, and learns that he had been attending these secret sex parties with respectable local people and had made the mistake of letting them know he could talk. Callisto the maenad arrives at the party and drives everyone present into a frenzy; several of the party-goers die in the madness, including those responsible for Lafayette's death, and Sookie survives only because she is pulled clear. The maenad's claim on the territory is finally settled when the vampires deliver the tribute she demanded, and she moves on out of the parish. In Dallas the Fellowship of the Sun has been badly damaged: their hostage is freed, Godfrey dies at sunrise as he intended, and the church's leadership is exposed and scattered, though Steve and Sarah Newlin themselves get away and the Fellowship as a movement is not finished. Sookie ends the book paid, injured and angry. She has been lent out like property, drunk from without her consent, and made to see how little of Bill's loyalty is hers when his own kind command him. She does not leave him, but she tells him plainly that she needs distance, and Eric Northman's interest in her has only grown.",
         "in_short": "Sookie Stackhouse's cook Lafayette is found murdered in a detective's car, and a creature in the woods, a maenad called Callisto, claws her half to death for a message to the local vampires. Once she is healed, Eric Northman hires her telepathy out to the vampires of Dallas, who need to know what became of a missing nest member. In Dallas she meets Barry, another telepath, and traces the missing vampire to the Fellowship of the Sun, an anti-vampire church. Infiltrating it, she is captured and imprisoned in its basement, where she discovers that the human escort sent with her has been informing on the vampires all along. She escapes with the help of a shapeshifter spy and a suicidal ancient vampire named Godfrey, who dies at sunrise as he had planned, and the Dallas nest breaks the Fellowship's plans. Back home, Sookie attends the private party where Lafayette's killers are found, and the maenad arrives and kills them in a frenzy. The vampires pay their tribute and the maenad leaves. Sookie is left paid, hurt, and much clearer about the price of belonging to vampires.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3186,7 +3186,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3199,7 +3199,7 @@
       "recaps": {
         "ending": "Nicola's thirty-fifth birthday arrives with the death she has predicted, but the identity of her killer defeats the pattern Samson and the reader have been encouraged to expect. Keith and Guy have each been manipulated toward the appointed night, yet Samson has never been merely the detached author of their movements. His illness, envy, dependence on Nicola's story, and growing identification with the murderer have made him another participant. Samson meets Nicola and kills her, completing the event he has been writing toward and revealing that the narrator who claimed to discover the plot also supplied its ending. Nicola has knowingly shaped his approach as she shaped Keith's and Guy's. The manuscript itself remains entangled with Mark Asprey, whose literary success and appetite for other people's material have shadowed Samson throughout. The close leaves authorship morally and textually unstable: Samson's final work records a murder he commits, while the book's ownership and framing can still be appropriated by the healthier, more successful writer.",
         "in_short": "Terminally ill American writer Samson Young takes over novelist Mark Asprey's London flat and finds the subject for his final book in Nicola Six. Nicola says she knows she will be murdered on her thirty-fifth birthday and has identified two possible killers: Keith Talent, a criminal and darts obsessive, and Guy Clinch, a wealthy family man. She constructs a separate persona for each, offering Keith sexual excitement and Guy an ideal of endangered purity, while Samson secretly turns their movements into fiction. Keith pursues a televised darts breakthrough amid debts and betrayals; Guy neglects his collapsing household for his fantasy of rescuing Nicola. Samson's health and narrative distance deteriorate as the predicted date nears. The expected contest between Keith and Guy proves a diversion. Samson himself meets and kills Nicola, fulfilling the story he thought he was merely observing. His manuscript, like the lives inside it, remains vulnerable to appropriation by Mark Asprey.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3342,7 +3342,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3355,7 +3355,7 @@
       "recaps": {
         "ending": "After surviving a violent attack by neo-Nazis, Hitler gains sympathy as a victim of extremism and returns from the hospital more famous than before. The public continues to interpret his literal racism and authoritarianism as fearless satire, while broadcasters, publishers, and political organizations compete for access to him. Even the confrontation with Fräulein Krömeier's Jewish grandmother does not produce remorse; he treats her family's destruction as an obstacle to be managed rather than a crime to acknowledge. His book and appearances expand his audience, and mainstream parties begin considering whether his popularity can be used. Hitler decides that television celebrity has given him a new route into German politics. The novel ends without society recognizing what he is: he has money, staff, media reach, and the beginnings of a movement, and he regards those conditions as an excellent foundation for returning to power.",
         "in_short": "Adolf Hitler wakes without explanation in modern Berlin and assumes Germany's altered landscape is the result of defeat and occupation. People take him for a method actor whose refusal to break character is a comic technique. A television freelancer brings him to a production company, where his actual political speeches are broadcast as provocative satire and spread online. Hitler learns to use television, the internet, and celebrity culture while calmly preserving his genocidal ideology. Producers and audiences excuse every warning sign because the performance is profitable and apparently ironic. A Jewish survivor recognizes the reality his admirers avoid, but her confrontation changes neither him nor the media machinery around him. Neo-Nazis later assault Hitler, making him a sympathetic public figure and increasing his fame. By the end, publishers and political parties are courting him, and he sees a credible path from entertainment back into organized politics.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3477,7 +3477,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3490,7 +3490,7 @@
       "recaps": {
         "ending": "After learning that Edith Leete is a descendant of his nineteenth-century fiancée and that she loves him, Julian hears a sermon condemning the moral blindness of the old economic order. He then seems to awaken in 1887. Back among his former acquaintances, he sees their comfortable lives against the labor, hunger, and humiliation that support them. He tries to explain the cooperative society of 2000, but his listeners dismiss him and he is overcome by despair at having lost both the better world and Edith. This return is itself a nightmare. Julian wakes again in Dr. Leete's house in the year 2000, where Edith reassures him that the transformed Boston is real. His terror of the nineteenth century confirms how completely his moral perspective has changed, and he accepts both his new time and his love for Edith.",
         "in_short": "In 1887, wealthy Bostonian Julian West is placed in a hypnotic sleep in a sealed underground room and is forgotten after his house burns. He wakes in the year 2000 in the home of Dr. Leete. The United States has replaced competitive private industry with a democratic national system: citizens receive equal economic support, choose work within an organized industrial army, and retire early, while technology distributes goods, music, and public services efficiently. Through long conversations with the Leete family, Julian compares this order with the inequality and insecurity of his own century. He grows close to Edith Leete, who is descended from his former fiancée. A nightmare returns him to 1887, where his new awareness makes the old society unbearable and his warnings are rejected. He then wakes for real beside Edith in 2000 and embraces his new life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3672,7 +3672,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3685,7 +3685,7 @@
       "recaps": {
         "ending": "John Barton's death forces Josie to recognize that achievement and social privilege did not protect her friend from despair. Her grief changes the way she judges both other people and the future she has been pursuing. She also learns the truth concealed in Nonna Katia's stories: during Katia's lonely early years in Australia, Marcus Sandford became her lover and Christina's biological father. The revelation explains old tensions and allows Josie to see her grandmother as a complicated young woman rather than only as an inflexible elder. Josie's relationship with Jacob cannot be made simple by affection; their differences and recurring conflicts remain real, and its future is not a settled answer to her search for identity. Michael, however, has become her father through accumulated choices rather than mere biology, and Josie accepts a place for him in her life. By the end of school she no longer imagines emancipation as escape from her family, school, or Italian Australian identity. She approaches adulthood with those connections intact and with a less defensive understanding of belonging.",
         "in_short": "During her final year at a Catholic girls' school in Sydney, seventeen-year-old Josephine Alibrandi expects education to free her from class prejudice, family rules, and the stigma of being born to an unmarried Italian Australian mother. Instead, her absent father, barrister Michael Andretti, re-enters her life, and their combative meetings slowly become a genuine father-daughter bond. Josie falls for working-class Jacob Coote, quarrels with school rivals, and discovers that neither wealth nor apparent confidence makes anyone secure. Her friend John Barton, crushed by expectations he cannot reconcile with his own wishes, dies by suicide. At home, Josie uncovers Nonna Katia's long-hidden relationship with Marcus Sandford and learns that he, not Francesco Alibrandi, was Christina's biological father. The truth complicates rather than destroys the family. Josie and Jacob do not resolve all the differences between them, but Josie finishes the year more at peace with her mother, grandmother, father, friends, and heritage. Freedom becomes the ability to define herself within those relationships, not simply to flee them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3816,7 +3816,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3829,7 +3829,7 @@
       "recaps": {
         "ending": "After the poison and bomb schemes fail to make him a murderer, Lord Arthur sees Mr Podgers beside the Thames late at night. He pushes the palm-reader over the parapet and watches him disappear into the river. Podgers's body is recovered, and the death is officially treated as suicide, leaving Arthur free from suspicion. Believing he has finally completed the act foretold in his palm, Arthur marries Sybil. Years later they remain happy and have children. When Lady Windermere dismisses Podgers as a fraud who told clients whatever suited him, Arthur refuses to accept her judgment: he credits the prediction with leading him to the contented life he now enjoys. The story therefore closes with Arthur prosperous and unpunished, sincerely grateful to the man he killed and unaware of the full absurdity of his moral reasoning.",
         "in_short": "At Lady Windermere's reception, the fashionable palm-reader Mr Podgers privately tells Lord Arthur Savile that he is destined to commit murder. Arthur decides that honor requires him to fulfill this fate before marrying his fiancée, Sybil Merton. He first gives an elderly relative a poison capsule, but she dies naturally without taking it. He next sends an explosive clock to the Dean of Chichester, only for the device to make a harmless commotion. Despairing over the failures and the delayed wedding, Arthur encounters Podgers by the Thames and pushes him into the river. The death is judged a suicide, so Arthur concludes that the prophecy has been satisfied and marries Sybil. They live happily and raise a family. Years later Lady Windermere calls Podgers an impostor, but Arthur insists that he owes the palm-reader all his happiness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3980,7 +3980,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3993,7 +3993,7 @@
       "recaps": {
         "ending": "Rand's captivity ends at the Battle of Dumai's Wells. The loyalist Aes Sedai embassy that feigned friendship has kidnapped him, sealed him in a chest, and beaten him daily on the road toward Elaida, meaning to make him a tame weapon. His friends refuse to abandon him: Perrin, the Aiel, Mat's soldiers, and above all the newly trained Asha'man ride to the rescue and break through a besieging Shaido host in a slaughter that announces the return of men who wield the Power as a force in the world. Rand is freed, shaken and further hardened by the ordeal. In the aftermath a number of Aes Sedai kneel and swear fealty to the Dragon Reborn, a humbling of the White Tower's ancient pride that would once have been unthinkable. In Salidar, the rebels have raised Egwene, still only a young woman, to the Amyrlin Seat, badly misjudging her as someone they can steer; Nynaeve has learned to Heal the once-permanent severing of a channeler's gift, restoring the deposed Siuan and others, and has married Lan. Rand ends the book more powerful and more feared, but colder, warier, and more alone, the taint on saidin and the memory of the chest both weighing on him as the Shadow's servants prepare fresh moves.",
         "in_short": "Rand, ruling from Cairhien and Caemlyn, struggles to hold a fracturing web of nations while founding a secret school to gather and train men who can channel, the Asha'man, aided by a hard former false Dragon named Mazrim Taim. Both Elaida's loyalist Tower and the rebel sisters of Salidar send embassies to him, each hoping to control the Dragon Reborn. In Salidar the rebels raise Egwene, still young, to be their Amyrlin Seat, expecting a puppet; Nynaeve there discovers how to Heal the once-incurable severing of a channeler's gift, and she and Lan are wed. The loyalist embassy betrays Rand, seizing him, sealing him in a chest, and carrying him off to be broken and delivered to Elaida. His friends and the Asha'man ride in pursuit, and at the Battle of Dumai's Wells they cut through a besieging Aiel host and free him, the young male channelers unleashing terrible destruction. In the aftermath, a group of Aes Sedai kneel and swear fealty to the Dragon Reborn himself, an act without precedent, and Rand's power, and his hardness, grow greater than ever.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4139,7 +4139,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4152,7 +4152,7 @@
       "recaps": {
         "ending": "The return of Sam and Yama turns the struggle among Heaven, the demons, and Nirriti's crusading army into a final realignment. Former enemies cooperate against Nirriti because his victory would replace the gods' restrictive order with destruction and religious tyranny. Nirriti's campaign is defeated, but the old celestial system cannot simply be restored: its claim to divinity has been exposed as technology, many of its rulers have fallen or changed sides, and knowledge can no longer be confined as securely as before. Sam declines to become the sacred ruler his followers might make of him. Having used the identity of Buddha to break Heaven's control, he leaves public power behind and ultimately disappears from ordinary history. His absence produces competing stories, while the movement and freedoms he set in motion remain. The world is left with imperfect survivors rather than unquestioned gods, and with human beings increasingly able to choose beliefs, bodies, and forms of progress outside Heaven's command.",
         "in_short": "On a colony world, the crew of the original starship use reincarnation machinery, genetic engineering, and personal powers to rule their descendants as the Hindu gods. Sam, one of the First, opposes their control of bodies and suppression of technology. He takes the name and teaching role of the Buddha, using religion, politics, and alliances with the planet's imprisoned energy-beings to challenge Heaven. Gods such as Brahma and Kali resist him, while Yama, Ratri, Kubera, and the ape-bodied Tak become allies in different phases of the struggle. Sam's first campaign ends with his mind cast into the planet's magnetic field. Decades later Yama restores him because Nirriti, another original colonist, is waging a destructive Christian crusade with forbidden weapons and armies of the dead. Sam and remnants of Heaven unite to stop Nirriti. The old pantheon survives only in broken form, its technological basis exposed. Sam refuses a new throne and vanishes, but the liberating movement created in the Buddha's name continues without him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4324,7 +4324,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4337,7 +4337,7 @@
       "recaps": {
         "ending": "The storm passes with Morganville physically damaged and its defenders scattered. Bishop exploits the isolation and confusion more effectively than Amelie's side: his followers capture key positions and people, while Amelie disappears after being gravely weakened and cannot continue directing the resistance. With the Founder absent, claims that she is dead or defeated spread through the town. Oliver and the remaining opposition cannot prevent Bishop from imposing his rule. Michael is brought under Bishop's authority, and Glass House loses the protection its residents once relied upon. Claire, Shane, and Eve are left vulnerable to imprisonment and retaliation. To keep the people she loves alive, Claire submits to Bishop and accepts his mark, binding her valuable scientific service to the victor. Bishop therefore ends the book in control of Morganville, including Myrnin's work and Claire's abilities. The resistance is broken into hiding rather than destroyed, but Claire begins the next phase apparently serving the vampire who killed Sam and displaced Amelie.",
         "in_short": "Civil war spreads through Morganville after Bishop's bloody challenge to Amelie. Claire and the other Glass House residents work with Amelie, Oliver, Myrnin, Richard Morrell, and human defenders to preserve shelters, communications, and the town's remaining protections. A violent storm then floods streets, severs allies from one another, and gives Bishop's faction cover to attack strategic sites and capture opponents. Claire, Shane, Eve, and Michael are repeatedly separated while each tries to help trapped residents and return to the resistance. Amelie's forces lose coordination, and the Founder disappears after being gravely weakened. Bishop uses the resulting uncertainty to claim Morganville. Michael is forced under his authority, the human defenders are overwhelmed, and Glass House can no longer shield its residents. With Shane and Eve in danger and Myrnin's research at stake, Claire accepts Bishop's mark and submits to his service. The book closes with Bishop ruling the town and Amelie's surviving supporters driven underground.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/lord-of-the-flies.json
+++ b/data/works-community/0/lord-of-the-flies.json
@@ -83,7 +83,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -96,7 +96,7 @@
       "recaps": {
         "ending": "The boys' attempt to govern themselves collapses entirely into violence. After Simon is killed by the mob and Jack's tribe seizes control of the island by force, they steal Piggy's glasses to command fire. When Ralph, Piggy, and the twins go to Castle Rock to reclaim them, Roger deliberately rolls a boulder that crushes Piggy to death and destroys the conch shell, the last symbol of order and reasoned debate. The twins are captured and beaten into joining Jack's tribe, and Ralph is left completely alone, declared an enemy and hunted. The tribe sets the whole island on fire to flush him from cover, and Ralph runs for his life until he stumbles onto the beach and falls at the feet of a British naval officer, whose warship has been drawn by the column of smoke. The arrival of an adult instantly halts the hunt, and the painted, weeping boys are returned to childhood in a moment. Ralph weeps for the loss of innocence and for the darkness he has seen in human beings, while the officer, faintly embarrassed, looks away. The boys are rescued in body, but only after order, friendship, and two of their number have been destroyed.",
         "in_short": "A plane crash strands a group of British schoolboys on a deserted island with no adults. Ralph, who finds a conch shell and is elected chief, tries to keep order, build shelters, and maintain a signal fire for rescue, helped by the clever, bespectacled Piggy and the gentle Simon. But Jack, leader of the choir turned hunters, is drawn to the power and savagery of killing pigs, and the boys' fear of a mysterious beast, in truth only a dead parachutist caught on the mountain, splits the group. Jack forms his own tribe, and during a frenzied night ritual the boys beat Simon to death, mistaking him for the beast just as he learns the truth. Jack's tribe steals Piggy's glasses to make fire, and when Ralph's group comes to Castle Rock to get them back, Roger kills Piggy with a boulder and shatters the conch. Ralph is hunted across the island as the boys set it on fire, and he collapses on the beach before a naval officer whose arrival finally rescues them and ends their descent into savagery.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -227,7 +227,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -240,7 +240,7 @@
       "recaps": {
         "ending": "The elves break fully into Lancre when the weakened barrier gives way around midsummer, spreading their glamour and menace through the kingdom just as the royal wedding nears. Diamanda, who helped open the way, is badly hurt after challenging Granny, and the young would-be witches learn too late what they have unleashed. As the Fair Folk close in on the castle and threaten King Verence, Magrat casts off her doubts about being a queen: she puts on the armour of a legendary Lancre warrior queen and fights, rescuing Verence and proving to herself that she was a witch all along. Granny Weatherwax faces the Queen of the elves alone in a contest of pure will, drawing on her deep bond with the land, while Nanny Ogg and Archchancellor Ridcully's wizards reach the elves' long-buried King, who has no love for the Queen and does not oppose them. Outmatched and humiliated, the Queen is defeated and the elves are forced back out of the world, the old barrier sealing behind them. With the danger past, Magrat and Verence are married, and Lancre settles into an uneasy peace, its people quietly reminded why the Fair Folk were shut out in the first place.",
         "in_short": "Granny Weatherwax and Nanny Ogg return to Lancre to find Magrat about to marry King Verence and a group of local girls, led by the arrogant Diamanda, playing at witchcraft by dancing at the old standing stones. Their games weaken the barrier that keeps out the elves, the beautiful and merciless Fair Folk, whose Queen has long wanted to break back into the human world. As midsummer and the royal wedding approach, and wizards from the Unseen University arrive as guests, the elves cross over and begin to work their glamour on the kingdom. Magrat, feeling she has lost herself in becoming a queen, discovers her strength when it matters most: taking up the armour of an ancient warrior queen, she fights the elves and helps save Verence. Granny confronts the Queen directly in a battle of wills, while Nanny and the wizards deal with the elves' estranged King. The elves are beaten and driven back out of the world, the barrier is restored, and Magrat and Verence are finally married.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -388,7 +388,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -401,7 +401,7 @@
       "recaps": {
         "ending": "John and Lorna are finally able to marry after her recovery of her family identity and property. During the wedding, Carver Doone shoots Lorna and escapes, leaving her apparently dying. John pursues him across Exmoor and, after their confrontation, Carver is swallowed by a bog. John returns expecting the worst, but Lorna's wound is not fatal and she recovers. The destruction of the Doone stronghold and the deaths or dispersal of its leaders end the clan's domination of the district. John and Lorna settle into married life at Plover's Barrows, while the surviving members of the Ridd household also move toward peaceful domestic futures. John's public honors matter less to him than the restoration of his home and the survival of the woman he has loved since childhood.",
         "in_short": "John Ridd grows up on Exmoor after his father is murdered in violence associated with the outlaw Doones. As a boy he enters their hidden valley and meets Lorna, a girl held within the clan; as adults they fall in love despite the feud and Carver Doone's determination to marry her. John helps Lorna escape and learns that she was abducted from a noble family as a child. Political upheaval, inheritance claims, and renewed attacks repeatedly separate them, while John aids the authorities against both rebels and the Doones. The outlaw settlement is eventually broken, but Carver survives long enough to shoot Lorna at her wedding to John. John pursues him, and Carver dies in a bog. Lorna survives her wound, and she and John return to a quieter married life at the Ridd farm.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -577,7 +577,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -590,7 +590,7 @@
       "recaps": {
         "ending": "John and Lorna are finally able to marry after her recovery of her family identity and property. During the wedding, Carver Doone shoots Lorna and escapes, leaving her apparently dying. John pursues him across Exmoor and, after their confrontation, Carver is swallowed by a bog. John returns expecting the worst, but Lorna's wound is not fatal and she recovers. The destruction of the Doone stronghold and the deaths or dispersal of its leaders end the clan's domination of the district. John and Lorna settle into married life at Plover's Barrows, while the surviving members of the Ridd household also move toward peaceful domestic futures. John's public honors matter less to him than the restoration of his home and the survival of the woman he has loved since childhood.",
         "in_short": "John Ridd grows up on Exmoor after his father is murdered in violence associated with the outlaw Doones. As a boy he enters their hidden valley and meets Lorna, a girl held within the clan; as adults they fall in love despite the feud and Carver Doone's determination to marry her. John helps Lorna escape and learns that she was abducted from a noble family as a child. Political upheaval, inheritance claims, and renewed attacks repeatedly separate them, while John aids the authorities against both rebels and the Doones. The outlaw settlement is eventually broken, but Carver survives long enough to shoot Lorna at her wedding to John. John pursues him, and Carver dies in a bog. Lorna survives her wound, and she and John return to a quieter married life at the Ridd farm.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -712,7 +712,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -725,7 +725,7 @@
       "recaps": {
         "ending": "The secrecy around Bliss and Garrick becomes unsustainable, hurting Cade and threatening the trust on which the relationship depends. Bliss stops allowing embarrassment to dictate every choice and acknowledges what she wants, while Garrick makes clear that she is not a disposable student affair. They wait until the academic conflict is no longer controlling their future and face the professional consequences rather than continuing to hide. Bliss completes her training and begins the uncertain transition from college theatre to adult work. Garrick remains part of that future, and their relationship becomes open instead of being defined by accidental encounters and evasions. Cade's feelings cannot be neatly repaired, but Bliss finally treats his pain honestly rather than using friendship as a refuge from difficult decisions. By the close, she and Garrick are together on equal terms, and the virginity she once treated as proof of being behind has lost its power to define her.",
         "in_short": "Acting student Bliss Edwards decides to lose her virginity before graduation and meets Garrick Taylor, a charming English stranger, in a bar. She takes him home but panics and escapes with an absurd excuse. The next day Garrick appears as her new theatre instructor, turning mutual attraction into an ethical and professional risk. They try to resist, then begin a secret relationship while preparing a demanding college production. Secrecy strains Bliss's friendships, especially with Cade, her closest male friend, who loves her and is hurt by her choice. Her fear of sex proves part of a broader habit of avoiding decisions that could expose her to failure or judgment. Garrick asks for a genuine relationship, not a hidden convenience, and Bliss learns to state what she wants. After the academic barrier ends, they remain together openly as she graduates and begins building a life in professional theatre.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -858,7 +858,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -871,7 +871,7 @@
       "recaps": {
         "ending": "After the High Lama dies, Conway has the opportunity to remain and assume responsibility for Shangri-La's future. Mallinson, however, insists that the valley is a prison built on deception and urges Conway to escape with him and Lo-Tsen. Conway finally yields and the three leave with departing porters. The framed narrative resumes outside the valley: Rutherford has traced Conway to a mission hospital, where Conway arrived ill and disoriented after the mountain journey. A very old Chinese woman associated with the travelers died, evidence consistent with Chang's warning that Lo-Tsen's preserved youth could fail beyond Shangri-La. Conway recovered his memory and then disappeared again, apparently trying to return to the hidden valley. Rutherford follows reports and fragments of testimony but cannot establish whether Conway survived or found Shangri-La. The novel closes with his fate unresolved, while the accumulated evidence leaves the valley's existence more credible than an ordinary legend.",
         "in_short": "During an evacuation from Baskul, British diplomat Hugh Conway and three companions discover that their aircraft has been hijacked and flown into the Tibetan mountains. After a forced landing they are escorted by Chang to Shangri-La, a remote lamasery in a fertile valley beneath a great peak. The community offers comfort, scholarship, and an atmosphere of moderation, but no easy way to leave. Conway learns from the High Lama, the centuries-old Father Perrault, that the valley slows aging and preserves human knowledge against a coming age of destruction. Conway is chosen to succeed him and feels that Shangri-La answers his weariness with the outside world. His younger colleague Mallinson rejects the story and persuades him to flee with the apparently youthful Lo-Tsen. Outside the valley she rapidly reveals her great age, and Conway eventually disappears while attempting to find Shangri-La again. Rutherford's investigation cannot prove whether he returned, leaving Conway's final destination unknown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1020,7 +1020,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1033,7 +1033,7 @@
       "recaps": {
         "ending": "The farewell gathering brings Lost Lake's old guests and nearby friends together, showing Eby that the resort still supports a living community rather than merely preserving her past with George. Kate, fully awake to her own wishes again, chooses not to return to the passive life Cricket planned for her. Her renewed bond with Wes becomes an open possibility for love, while Devin finds security in a mother who is present and making choices. The people around the lake also begin releasing the private bargains that kept them isolated: Bulahdeen and Jack face their affection, Selma's cultivated control falters into greater honesty, and Lisette's long loyalty to Eby and the resort is recognized. Eby reverses her decision to surrender Lost Lake, allowing it to continue in a changed form. The conclusion does not erase bereavement; George and Matt remain part of Eby's and Kate's lives. Instead, the women stop treating grief as a reason to withdraw from every future attachment.",
         "in_short": "A year after her husband Matt dies, Kate Pheris begins emerging from a grief so deep that her mother-in-law has taken control of her life. Kate finds an old postcard from Lost Lake, the Georgia resort owned by her great-aunt Eby, and takes her imaginative daughter Devin there. Eby, widowed herself, plans to sell the struggling property. The remaining guests include romantic Bulahdeen, guarded Selma, devoted Lisette, and Jack, each carrying unfinished attachments. Kate also reunites with Wes, the boy she knew during her only childhood summer at the lake, and their bond becomes adult love. A final celebration reveals that Lost Lake still matters as a community, not simply as a memorial to Eby's late husband George. Kate reclaims her independence from Cricket and permits herself a future with Wes. Eby decides not to abandon the resort, while the guests begin choosing connection over the stories and defenses that have kept them alone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1185,7 +1185,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1198,7 +1198,7 @@
       "recaps": {
         "ending": "Bosch establishes that Angella Benton's murder, the theft of cash from the film set, the attack that destroyed Lawton Cross's police career, and FBI agent Martha Gessler's disappearance belong to the same chain of concealment. Benton had come too close to the planning behind the theft, while Gessler later followed the money far enough to threaten the people protecting it. The official division between a homicide, a robbery, a police shooting, and a missing-agent case allowed that chain to remain hidden. Bosch survives an effort to stop his inquiry and brings the linked evidence into the open, giving Benton and Gessler an answer even though institutional secrecy has made ordinary justice incomplete. The investigation also exposes a secret kept from Bosch since his separation from Eleanor Wish: Eleanor has raised their daughter, Madeline, without telling him. Bosch meets the child and leaves the case with a new obligation and source of hope. He remains outside the LAPD, but retirement has not ended either his work or his connection to Eleanor and Maddie.",
         "in_short": "After resigning from the LAPD, Harry Bosch reopens the four-year-old strangling of production assistant Angella Benton. Her death preceded the theft of a large cash shipment from a movie set, and the robbery investigation led to a shooting that killed one detective and left Lawton Cross disabled. Bosch works without a badge through old files, Cross's memories, former colleagues, and the disappearance of FBI agent Martha Gessler, who had followed the stolen money. He finds that the homicide, robbery, attack on the detectives, and Gessler's disappearance were not separate failures but parts of one continuing effort to protect the theft and silence those who understood it. Bosch survives the effort to shut down his inquiry and exposes the linked crimes. The most consequential discovery is personal: former wife Eleanor Wish has a young daughter, Madeline, whom Bosch learns is his child. Still retired, he ends with the prospect of becoming part of her life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1375,7 +1375,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1388,7 +1388,7 @@
       "recaps": {
         "ending": "By middle age, Rosie has survived the collapse of her marriage to Greg, raised Katie, lost her parents, and finally achieved her long-delayed ambition of running her own hotel. Katie and Toby's eventual recognition that their lifelong friendship is love makes the parallel with Rosie and Alex impossible to ignore. Alex's later marriage to Bethany has also ended, leaving both he and Rosie free at the same time after decades of missed opportunities. Alex comes to Rosie's hotel and at last speaks plainly about the feeling their letters, marriages, separations, and near-confessions have carried. Rosie accepts that the person she has continually treated as her absent best friend has also been the love around which much of her life was organized. They begin a romantic life together at roughly fifty, not by erasing the families and disappointments that came before, but after finally reaching the timing and honesty they lacked when they were young.",
         "in_short": "Rosie Dunne and Alex Stewart grow up as inseparable friends in Dublin. When Alex moves to Boston, letters and electronic messages keep them close, but a missed school dance changes Rosie's path: she becomes pregnant by Brian Connelly, gives up plans to study hotel management in America, and raises Katie in Dublin while Alex becomes a doctor. Across the next three decades they repeatedly approach and miss a shared life. Alex marries Sally and later Bethany; Rosie marries Greg, only to discover his betrayal. Careers, children, divorce, distance, and messages that arrive too late keep each assuming the other has chosen someone else. Katie and her childhood friend Toby eventually stop repeating that mistake and recognize their own love. Rosie, after many delays, opens the hotel she always wanted. With his second marriage over, Alex comes to her there. Now around fifty and finally unattached at the same time, they acknowledge that their lifelong friendship has also been enduring romantic love and choose to be together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1516,7 +1516,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1529,7 +1529,7 @@
       "recaps": {
         "ending": "Jenny's leukemia progresses rapidly, and she is admitted to the hospital. Oliver, who has tried to protect her from the prognosis, abandons every concern except making her remaining time as comfortable as possible. Unable to meet the medical costs himself, he asks his estranged father for five thousand dollars without explaining why; his father provides it despite their long silence. Jenny speaks privately with Phil and asks him to remain strong, then asks Oliver to stay close. She dies at twenty-five with Oliver beside her. Outside the hospital, Oliver encounters his father, who has learned from Phil that Jenny was ill and has rushed to New York. The older man apologizes for the conflict and distance between them. Oliver answers by repeating Jenny's belief that genuine love does not depend on apologies, then breaks down in his father's arms. The reconciliation cannot undo Jenny's death, but it ends the novel with Oliver finally accepting comfort from the parent he had rejected.",
         "in_short": "Harvard heir Oliver Barrett IV meets Jennifer Cavilleri, a sharp-tongued Radcliffe music student from a modest Rhode Island family. Their teasing rivalry becomes love, despite their different backgrounds. Jenny gives up plans to study in Paris and agrees to marry him. When Oliver's father opposes the match, Oliver rejects family support, and the newlyweds live carefully on Jenny's teaching salary while he attends Harvard Law School. After graduation Oliver joins a New York firm, and the couple finally enjoys financial ease. Their attempt to have a child leads to medical tests that reveal Jenny has terminal leukemia. Oliver initially bears the diagnosis alone and later borrows money from his estranged father for her care. Jenny enters the hospital and dies at twenty-five with Oliver beside her. Oliver's father arrives too late and apologizes. Recalling Jenny's conviction that love has no need to keep accounts through apologies, Oliver accepts his father's embrace and grieves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1687,7 +1687,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1700,7 +1700,7 @@
       "recaps": {
         "ending": "Dixon's drunken public lecture on English tradition turns into an open parody of the voices and attitudes he has spent the year enduring. He collapses after alienating the university leadership, and Welch confirms that his appointment will not be renewed. The professional disaster frees him from a career he never wanted. Gore-Urquhart, amused by Dixon's directness and unimpressed by Bertrand, offers him a well-paid job as his secretary in London. Mrs Catchpole explains that Margaret's apparent suicide attempt was arranged to look more serious than it was, releasing Dixon from much of the guilt that kept him tied to her. Christine learns of Bertrand's unfaithfulness and ends their relationship. She and Dixon choose each other and arrange to leave together. On their way out they encounter the Welch family, and Dixon is finally able to laugh openly at the people whose approval had governed him.",
         "in_short": "Jim Dixon is a probationary history lecturer who despises both his medieval research and the pretensions surrounding his provincial university. His job depends on the vague Professor Welch, so he endures a disastrous musical weekend, a burdensome attachment to Margaret Peel, and conflict with Welch's arrogant son Bertrand. Dixon falls for Bertrand's girlfriend, Christine Callaghan, while trying to suppress every honest response that might end his academic career. At a public lecture, alcohol and frustration overcome him, and he mocks the cultural attitudes he was meant to celebrate before collapsing. Welch dismisses him, but the failure becomes an escape: Christine's uncle Gore-Urquhart offers Dixon a better-paid London job. Margaret's supposed suicide attempt is exposed as manipulative, and Christine leaves Bertrand after learning of his infidelity. Dixon and Christine depart together, freed from the relationships and institution that had trapped them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1864,7 +1864,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1877,7 +1877,7 @@
       "recaps": {
         "ending": "Jim returns to the stockade as a captive and discovers that Doctor Livesey has surrendered the fort and treasure map to Silver's depleted band. The map leads the pirates to an empty pit: Ben Gunn found Flint's hoard long before and moved it to his cave. Livesey, Gray, and Gunn drive off the mutineers, while Silver changes sides again to save himself. The loyal party loads the treasure aboard the recovered Hispaniola and leaves three surviving pirates marooned on the island. At a port on the voyage home, Silver escapes with a small bag of coins. The others reach England and divide their shares: Smollett retires, Gray builds a respectable career at sea, and Ben Gunn rapidly spends or loses most of his money. Jim says no reward could persuade him to return to the island, which remains associated in his dreams with surf and the cry of Silver's parrot.",
         "in_short": "Jim Hawkins obtains a map showing where the pirate Captain Flint buried his treasure. Squire Trelawney finances a voyage aboard the Hispaniola, with Doctor Livesey, Captain Smollett, and Jim among the loyal party. The charming cook Long John Silver has secretly recruited former pirates and plans a mutiny. Jim overhears the plot, later meets the marooned Ben Gunn on Treasure Island, and repeatedly risks himself to help his friends, eventually cutting the Hispaniola loose and defeating Israel Hands aboard it. Captured after returning to the stockade, Jim is protected by Silver, whose authority over the mutineers is collapsing. The treasure pit proves empty because Gunn already moved the hoard to his cave. Livesey's group defeats the remaining pirates, recovers the treasure, and sails home, marooning three mutineers. Silver escapes during the return voyage with a modest share, while Jim reaches England safely and has no wish ever to revisit the island.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2029,7 +2029,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2042,7 +2042,7 @@
       "recaps": {
         "ending": "The effects of the women's campaign become impossible for either side to ignore. A Spartan herald arrives in Athens, and delegations from Sparta and Athens meet to negotiate. Lysistrata rebukes both cities for fighting fellow Greeks despite shared religious and military obligations. Although the delegates are still tempted to quarrel over territory, their desire to end the strike helps her bring them to terms. The peace is concluded, and the long confrontation between the men's and women's choruses gives way to reconciliation. The Acropolis and its treasury can return to ordinary civic use, while the women are released from their oath and can rejoin their husbands. Athenians and Spartans finish together in a celebration of peace, song, dance, and renewed domestic life. The women's direct political action has succeeded where the male leadership's continuing warfare had failed.",
         "in_short": "With Athens and Sparta trapped in a prolonged war, Lysistrata gathers women from both sides and persuades them to refuse sex until the men negotiate peace. At the same time, older Athenian women occupy the Acropolis and take control of the treasury that finances the war. Male citizens and a magistrate try to remove them, but Lysistrata argues that women who manage households and bear the costs of war have both the skill and the right to intervene. Some participants waver, yet she prevents the alliance from collapsing. Myrrhine then entices her husband Cinesias with the prospect of reunion but leaves him frustrated, proving the strike's power. Sparta suffers the same pressure. Delegates from both cities finally meet, and Lysistrata reminds them of their shared ties before guiding them through territorial disputes. They agree to peace, the divided choruses reconcile, and Athenians and Spartans celebrate together as the women return home with their objective achieved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2137,7 +2137,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2150,7 +2150,7 @@
       "recaps": {
         "ending": "In “A Warning to the Curious,” Paxton succeeds in replacing the ancient crown, but the act does not release him. The guardian imitates his companions and draws him away from safety before killing him on the shore. The narrator and Henry Long conceal the crown's location, leaving it buried as a protection that should not be tested again. In “Casting the Runes,” Dunning and Harrington learn that Karswell has passed Dunning a runic curse with a fixed deadline, just as he did before Harrington's brother died. They maneuver Karswell into taking back the marked slip during a train journey. Unable to return it before the deadline, Karswell travels abroad and is killed at Abbeville by a falling stone associated with the same church involved in the earlier death. Dunning is freed from the pursuing presence, but the means of survival has transferred the sentence back to the man who sent it.",
         "in_short": "Two stories follow men endangered by deliberate contact with the supernatural. In “A Warning to the Curious,” amateur archaeologist Paxton finds one of three legendary Anglo-Saxon crowns buried to protect England. Removing it summons the dead guardian, William Ager. With help from two fellow visitors, Paxton returns the crown, but the guardian deceives and kills him; the survivors keep the site secret. In “Casting the Runes,” occultist Karswell retaliates when Edward Dunning rejects his academic paper. Dunning receives a slip bearing runes and is stalked by an unseen creature. Henry Harrington explains that his brother died after Karswell used the same curse. Dunning and Harrington secretly return the runes to Karswell before the appointed deadline. Karswell cannot pass them back and is killed by a falling stone in circumstances echoing his earlier victim's death, while Dunning survives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2238,7 +2238,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2251,7 +2251,7 @@
       "recaps": {
         "ending": "After leaving the Van Tassel gathering disappointed, Ichabod rides home through places associated with local ghost stories. A silent rider follows him and appears to be headless, carrying its head on the saddle. Ichabod races for the bridge where tradition says the apparition must vanish, but the pursuer throws the head at him and knocks him from his horse. The next day Ichabod is gone; searchers find Gunpowder, Ichabod's hat, and a shattered pumpkin, but no body. Hans Van Ripper disposes of Ichabod's abandoned belongings, and Brom Bones later marries Katrina. Brom's knowing amusement whenever the pumpkin is mentioned suggests that he staged the haunting, though the story leaves room for supernatural belief. A later report says Ichabod survived, left the region, studied law, and entered public life, while the old residents maintain that the Horseman carried him away.",
         "in_short": "Superstitious schoolmaster Ichabod Crane courts wealthy farmer's daughter Katrina Van Tassel, imagining both romance and the comfort of inheriting her family's prosperous farm. His rival, the strong and mischievous Brom Bones, cannot frighten him off through ordinary pranks. After a harvest gathering filled with food, dancing, and ghost stories, Ichabod leaves after a private exchange with Katrina that appears to disappoint him. On the dark ride home, a headless rider pursues him and hurls what seems to be its severed head. Ichabod vanishes, leaving his hat beside a broken pumpkin. Brom later marries Katrina and reacts knowingly to the pumpkin story, suggesting a successful prank. Reports that Ichabod lived elsewhere as a lawyer compete with local claims that the Headless Horseman took him, preserving the tale's ambiguity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2365,7 +2365,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2378,7 +2378,7 @@
       "recaps": {
         "ending": "Macbeth ends after the king's violent rule drives Malcolm and Macduff to lead an army against him. Lady Macbeth dies after being overwhelmed by guilt. Macbeth trusts the witches' assurances until Birnam Wood appears to move toward his castle and Macduff reveals that he was not born in the ordinary manner. Macduff kills Macbeth, and Malcolm takes the Scottish crown. Romeo and Juliet ends when Friar Laurence's message about Juliet's feigned death fails to reach Romeo. Believing her dead, Romeo takes poison in the Capulet tomb. Juliet wakes, finds him dead, and kills herself. Their parents finally recognize the cost of the feud and agree to peace.",
         "in_short": "In Macbeth, three witches predict that Macbeth will be king. Encouraged by Lady Macbeth, he murders Duncan, takes the crown, and orders further killings to protect it. Guilt destroys Lady Macbeth, while opposition gathers around Duncan's son Malcolm and Macduff. The witches' misleading promises give Macbeth false confidence; Macduff kills him and Malcolm becomes king. In Romeo and Juliet, children of the feuding Montague and Capulet families fall in love and marry secretly. Romeo is banished after killing Tybalt. Juliet takes a potion to avoid another marriage, but the plan is not explained to Romeo. He believes she is dead and poisons himself; she wakes and kills herself beside him. Their deaths finally reconcile the families.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2571,7 +2571,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2584,7 +2584,7 @@
       "recaps": {
         "ending": "Malcolm's army advances on Dunsinane carrying branches cut from Birnam Wood, making the witches' warning appear to come true. Macbeth, already numb after hearing of Lady Macbeth's death, still trusts the prediction that anyone delivered through ordinary childbirth cannot harm him. In battle he kills young Siward, but Macduff finds him and reveals that he was delivered before natural birth. Macbeth refuses surrender and is killed. Macduff brings Macbeth's severed head to Malcolm, who is acclaimed king. Malcolm creates Scotland's first earls, calls home those who fled the tyranny, and promises to punish Macbeth's remaining agents and restore order. Lady Macbeth has died offstage, apparently by suicide, Banquo's descendants have not yet taken the throne, and Fleance's location remains unresolved. The play closes with Malcolm inviting his allies to his coronation at Scone.",
         "in_short": "Victorious Scottish general Macbeth meets witches who predict that he will become king and that Banquo's descendants will rule after him. Spurred by Lady Macbeth, he murders King Duncan and takes the crown after Duncan's sons flee. Fearful of the prophecy, Macbeth has Banquo killed, but Fleance escapes; Banquo's ghost then disrupts a royal feast. Further apparitions make Macbeth feel invulnerable while warning him about Macduff. Macbeth orders the slaughter of Macduff's wife and children, driving Macduff to join Duncan's son Malcolm in England. Lady Macbeth breaks under guilt and dies as Malcolm's forces invade. Camouflaged with branches from Birnam Wood, the army reaches Dunsinane. Macduff, delivered before natural birth, falls outside the witches' reassuring prediction and kills Macbeth. Malcolm becomes king and begins restoring Scotland.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2766,7 +2766,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2779,7 +2779,7 @@
       "recaps": {
         "ending": "As Malcolm's army advances under branches cut from Birnam Wood, the prophecy about the forest moving toward Dunsinane is fulfilled in a practical but unexpected way. Lady Macbeth dies offstage, and Macbeth responds with despair yet continues fighting. He kills Young Siward and clings to the witches' assurance that no man born naturally from a woman can harm him. Macduff then reveals that he was delivered prematurely by surgery, placing him outside the protection Macbeth thought absolute. Macduff kills and beheads Macbeth. Malcolm is acclaimed king, invites the exiled nobles home, and promises to restore order by rewarding his supporters and recalling those driven abroad by the tyranny. Banquo's descendants have not yet taken the throne within the play, so that part of the witches' prediction remains beyond the action, but Macbeth's attempt to defeat fate has destroyed him and Lady Macbeth and ends with Duncan's line restored through Malcolm.",
         "in_short": "Scottish general Macbeth returns from victory and hears three witches predict that he will become king, while his companion Banquo will father kings. When Duncan rewards Macbeth and visits his castle, Lady Macbeth persuades her husband to murder the king and blame his guards. Duncan's sons flee, allowing Macbeth to take the crown. Fearful of Banquo's predicted heirs, Macbeth arranges Banquo's murder, but Fleance escapes, and Banquo's ghost disrupts a royal banquet. New prophecies make Macbeth feel invulnerable even as he orders the slaughter of Macduff's family. In England, Macduff joins Duncan's son Malcolm and an army marching against the tyrant. Lady Macbeth, consumed by guilt, sleepwalks and later dies. Malcolm's soldiers conceal themselves with branches from Birnam Wood, fulfilling one warning, while Macduff reveals he was not born by ordinary means and kills Macbeth. Malcolm becomes king and begins restoring Scotland.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3046,7 +3046,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00U2S776K",
@@ -3058,7 +3058,7 @@
       "recaps": {
         "ending": "The native machines answer a translated summons and attack the Saurians besieging Titanium Mountain, allowing Legion Varus to survive the ground assault. McGill then bargains with Claver, who controls the capital ships' broadsides, by promising future access to Turov's Galactic Key. Claver delays the orbital strike, is reportedly executed, and delivers a deep-link unit. Three months later Minotaur recovers Varus from Machine World, and the legion receives campaign decorations. Two months after that, McGill is home on Earth and renews his relationship with Anne Grant. Turov has Claver quietly revived, despite McGill's suspicions about their continuing arrangement. Equestrian Nagata offers McGill and Claver immunity if they testify against Turov. McGill faces exposure for killing Inspector Xlur, while Claver faces sedition and racketeering allegations. Both decline. Turov remains under investigation, Claver still expects access to the key, McGill has concealed the true terms of his bargain, and Natasha Elkin's status as an illegal twin remains secret. The wider cephalopod threat and the future of Machine World's native population are unsettled.",
         "in_short": "Earth sends Legion Varus to seize a mineral-rich world in Gamma Pavonis before the cephalopods can secure it. James McGill earns veteran rank, learns that Della bore his daughter, and helps discover sentient native machines. The campaign shifts between rescue, invasion, and political crisis as Claver proposes an alliance with the cephalopods, Turov kills Tribune Drusus to conceal her prior involvement, and McGill destroys a Nairb ship sent to execute him. On Titanium Mountain, Varus learns that the cephalopods enslaved the machines and finds evidence of a wider civilization built on collared labor. A Saurian army later besieges the abandoned legion, but an accidental machine summons turns the natives against the attackers. Claver delays orbital destruction after McGill promises access to Turov's Galactic Key. Varus returns to Earth decorated, Claver is secretly revived, and both men refuse Nagata's offer of immunity for testimony against Turov, leaving the key bargain and several prosecutions unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3274,7 +3274,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3287,7 +3287,7 @@
       "recaps": {
         "ending": "The wizardwood log in the Crowned Rooster Chamber splits and Tintaglia comes out of it: a living dragon, the last of her kind, who takes wing over the Rain Wild River. She has no gratitude and no interest in the people who freed her, but she does have needs, and a bargain with the Rain Wilds and the serpents becomes possible. The buried city is destroyed in the process; the river floods the diggings and Malta, Reyn and the Satrap are trapped in the drowning tunnels. Malta gets the Satrap out and is then swept away downriver, and Reyn is left believing she is dead. Bingtown is in open war: the Satrap's visit has ended with him kidnapped and the city burning, Chalcedean galleys are raiding the harbour, and the Old Traders, the Three Ships families and the Tattooed have begun, reluctantly, to fight on the same side. Ronica and Keffria are holding what is left of the Vestrit interest in a city that half suspects them of treason. At sea, the Paragon is finally sailing, refitted with Amber's money and Brashen's crew, with Althea aboard and the ship's own history stirring under them, bound for the Pirate Isles to take the Vivacia back. Kennit, meanwhile, has what he wanted: a liveship, a fleet, a reputation as the liberator of slaves and the beginnings of a kingdom, with Wintrow at his side and Etta at his back. Maulkin's tangle has reached the mouth of the river and cannot get up it without help.",
         "in_short": "Althea, Brashen and Amber refit the mad blinded liveship Paragon and sail him out of Bingtown to hunt for the Vivacia. Aboard the Vivacia, Kennit builds a pirate kingdom on freed slaves and a growing legend, while Wintrow, bound to him by the life he saved, tries to work out what he owes a man who does good and evil with the same hand, and the ship herself changes into something older than a Trader family's memories. In Bingtown, the young Satrap Cosgo arrives with his Companion Serilla and the city detonates: Old Traders, New Traders, Chalcedean galleys and the Tattooed all at once, the Satrap kidnapped, the harbour burning. Malta takes the Satrap up the Rain Wild River to force the Rain Wilds' hand, and in the buried Elderling city beneath Trehaug an earthquake and a flood destroy the diggings. From the wizardwood log in the Crowned Rooster Chamber, Tintaglia, the last dragon, breaks free and flies. Malta is swept away and believed drowned, Reyn is left grieving, and the serpents that have swum north for a lifetime reach the river they must ascend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3514,7 +3514,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3527,7 +3527,7 @@
       "recaps": {
         "ending": "Unable to meet the debts hidden from Charles, Emma exhausts every possible source of help. Leon refuses to steal for her, the lawyer Guillaumin expects sexual compliance, and Rodolphe will not provide the money. She enters Homais's laboratory and swallows arsenic, then returns home and dies after a prolonged agony. Charles is devastated and insists on an elaborate funeral he cannot afford. Creditors strip away the household's remaining security. He eventually discovers Emma's letters from Rodolphe and Leon and understands her affairs, but continues to idealize and forgive her. After a final encounter with Rodolphe, Charles dies alone in his garden. Berthe is sent first to Charles's mother and then to a poor aunt; with no inheritance left, the child must work in a cotton mill. Homais, whose ambition and self-promotion remain untouched by the Bovarys' ruin, prospers and receives the Legion of Honour.",
         "in_short": "Charles Bovary, a kindly but limited provincial doctor, marries Emma Rouault, whose romantic expectations make ordinary married life intolerable to her. A move to Yonville brings friendships with the pharmacist Homais and law clerk Leon, but neither motherhood nor social respectability relieves Emma's frustration. She begins an affair with the landowner Rodolphe, who abandons their plan to elope. After recovering, she reconnects with Leon and conducts a second affair during supposed piano lessons in Rouen. To sustain an imagined life of luxury and passion, Emma buys extensively on credit from Lheureux and conceals the growing debt. When legal seizure threatens the family home and both former lovers refuse to save her, she takes arsenic and dies. Charles learns of her infidelity only afterward, loses what remains of the estate, and dies still attached to her memory. Their daughter Berthe is left impoverished and sent to factory work, while the self-serving Homais flourishes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3713,7 +3713,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3726,7 +3726,7 @@
       "recaps": {
         "ending": "Facing immediate seizure of the Bovarys' property, Emma fails to raise money from Léon, the lawyer Guillaumin, or Rodolphe. She takes arsenic from Homais's pharmacy and dies after prolonged suffering, despite Charles's frantic attempts to find medical and religious help. Charles is left with Berthe, crushing debts, and an idealized memory of his wife. He eventually discovers Emma's letters from Rodolphe and Léon and understands her affairs. His finances and health collapse; after a restrained encounter with Rodolphe, he dies at home holding a token associated with Emma. With both parents dead and the remaining family unable to support her, Berthe is sent to earn her living in a cotton mill. Homais, who protects his public standing throughout the scandal and aftermath, continues to prosper and is awarded the Legion of Honour. Emma's search for an exceptional life thus ends by destroying the ordinary household she found unbearable, while the town's most complacent opportunist receives public success.",
         "in_short": "Emma Rouault marries Charles Bovary, a kind but limited provincial doctor, believing marriage will bring the passion and elegance she knows from romantic stories. Bored first in Tostes and then Yonville, she longs for aristocratic luxury, neglects ordinary family life, and forms attachments to the clerk Léon Dupuis and the landowner Rodolphe Boulanger. Rodolphe seduces her but abandons their plan to run away; after recovering from the resulting illness, Emma begins an affair with Léon in Rouen. She finances an increasingly elaborate double life through credit offered by the merchant Lheureux. When the accumulated notes threaten public ruin and seizure of the family property, neither former lover will rescue her. Emma steals arsenic and dies. Charles, devastated, later discovers proof of both affairs and dies impoverished, leaving their daughter Berthe to work in a mill. The self-satisfied pharmacist Homais, meanwhile, advances socially and receives an official honor.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3988,7 +3988,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-19",
@@ -4001,7 +4001,7 @@
       "recaps": {
         "ending": "Tala and Terry reach Bandfast with the caravan. Terry's collar permits him inside the city but restricts how far he can travel from Tala, leaving their partnership workable but still dangerous and poorly understood. Lyn tells Tala that the emergency response to her disappearance has added roughly one gold ounce to her obligations and requires a senior Guild review before she accepts another contract. Holly uses an automated inscriber to rebuild Tala's arms, legs, and torso with dense, always-active defenses. Holly then reveals that she is an Archon and identifies Tala's blood-made construct as a genuine Archon Star. Tala may eventually qualify for Archon consideration, but she must first make a properly powered star and avoid all further soul bonds. Her external inscription upgrade is complete, while nightly work on her organs still awaits study. Adam's tailored combat project, Tala's family and Guild debts, whether magic wells altered Terry and the nature of his abilities, and her planned research into transferring harvested power all remain open.",
         "in_short": "Tala develops her artifacts and magic while preparing a Guild caravan for the journey from Alefast to Bandfast. Her bond with a knife deepens, her storage item becomes Kit, and the dimensional predator Terry becomes a conditional companion. After training with powerful allies, she is abducted by giant ravens and survives with Terry's help. She refuses an unknown woman's offer to clear her debts in exchange for permanent subordinate soul service, discovers that wild magic wells can permanently alter creatures, and returns to the caravan. In Bandfast, Tala faces Guild review and added costs from her disappearance. Holly rebuilds her limbs and torso with always-active inscriptions, reveals that she is an Archon, and confirms Tala's blood construct as an Archon Star. Tala ends stronger but still indebted, with internal inscription work unfinished and instructions to strengthen a star without forming more soul bonds.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4332,7 +4332,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -4345,7 +4345,7 @@
       "recaps": {
         "ending": "Arlo, Grotto, Xim, Varrin, Nuralie, and Etja escape Cage alive after destroying Orexis's remaining specter and preventing the Delve's immediate collapse. Ealdric is dead, while Lito and Drel'Gethed survived their initial injuries outside Cage. The Void Sphere is removed from Hiward's Reality Anchor and now rests in stasis within Arlo's quick-access inventory, but no permanent disposal method is known. Grotto channels the sphere's mana through the pocket Delve, expands it, and gives Xim, Varrin, Nuralie, and Etja Rebirth mana veins, repairing their urgent damage. Etja is accepted as a full party member. The group chooses Soulsbane as its name, but the system registers Arlo as leader of Fortune's Folly instead. Fortune has taken Anesis to Hiward, where she escapes after fighting Myria and the Ravvenblaq matriarch. The surviving party therefore faces an at-large divine enemy, uncertainty over Fortune's aims, possible Crown claims against the pocket Delve, and the continuing danger of the stored sphere.",
         "in_short": "After dying on Earth, Arlo respawns in a system-governed world and survives a sabotaged creation Delve with Varrin and Xim. He bonds its displaced core, Grotto, joins a Third Layer tribe as Arlo Xor'Drel, and builds a pocket Delve inside his inventory. An attempted abduction leads him, Xim, Varrin, Nuralie, and their allies to Calvani Caverns, where divine forces coerce them into the failing containment Delve called Cage. The construct Etja is freed from possession and joins them. Fortune reveals that he brought Arlo from an Earth now millennia beyond recovery, then removes Anesis to Hiward and leaves the party to fight Orexis's soul fragment. Varrin destroys the fragment after Arlo shares its vulnerability. The group removes a destabilizing Void Sphere, uses its mana to repair their damaged mana veins, and escapes. Anesis remains at large, the sphere remains in Arlo's inventory, and the system names Arlo's party Fortune's Folly despite their choice of Soulsbane.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4691,7 +4691,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -4704,7 +4704,7 @@
       "recaps": {
         "ending": "Fortune's Folly survives the remedial sequence, reaches Delver Level 10, and kills the enormous corrupted Delve remnant through a combined strategy of bleeding, divine fire, layered poisons, Shog Tuatha's rescue work, and an Explosion amplified by Etja and Arlo through Shared Vessel. The obelisk identifies the remnant as a portal guardian rather than the destination itself. Arlo, Grotto, Xim, Varrin, Nuralie, Etja, and Shog Tuatha all survive. Grotto is unsettled by the three-way combat link he mediated with Arlo and the summon, while Shog Tuatha recognizes a new concern for Xim. Nuralie takes custody of an ominous grimoire, and Arlo's evolved amulet promises eventual intrinsic-skill sharing with Grotto while implying communication from an avatar. After receiving diamond chips and major intrinsic progress, Arlo reaches Fortitude 40 and Wisdom 40. The entire party immediately crosses into another special-grade Delve with an Escape objective. Phase 2 remains locked, the Littan invasion of Eschendur continues, and neither the avatar cycle nor the Operator's history has been confirmed.",
         "in_short": "A year after the Cage, Fortune's Folly learns that the Get Out of Cage Free card points toward Phase 2 of the system and a set of special Delves. Warnings from Xim's goddess, Hiward, and the Operator establish avatars as a growing threat, though the Operator's account of repeated civilization-ending ascensions remains unverified. The party fights through the Littan blockade, kills a rogue gold captain, gains asylum in Eschendur, and becomes caught in the Littan invasion while Nuralie accepts appointment as an Inquisitor and evacuates her village. With the Operator's diversion, they enter a Littan-held special Delve, train from Level 6 to Level 10, and defeat its tailored remedial encounters. Their final opponent is a mountain-sized corrupted Delve remnant, killed through coordinated fire, bleeding, poison, and a massive Shared Vessel Explosion. The remnant proves to be a portal guardian. The surviving party takes its rewards and enters the next special-grade Delve, where the stated objective is Escape.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4984,7 +4984,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -4995,7 +4995,7 @@
         "work": "mage-tank-3"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/mage-tank-4.json
+++ b/data/works-community/0/mage-tank-4.json
@@ -345,7 +345,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -358,7 +358,7 @@
       "recaps": {
         "ending": "Fortune's Folly and the Littan expedition destroy the Hierophant, but only after its fallen body releases the staff that is its true surviving form. A battlefield soul rite gives Arlo an immense but temporary reserve of blessed power. With the Littan major and captain obtaining consent, Arlo and Etja teleport the entire threatened city into Closetland before the staff's next catastrophic beam lands. Arlo and the major then destroy the staff. The major players survive, but the displaced city has collapsed structures, injured residents, and immediate relief needs. Arlo cannot return it with his ordinary resources. Closetland remains on friendly terms with the dragon rulers and hosts their ambassadorial project, while Littan cooperation has deepened through the expedition and the Empire's acceptance of Grotto's identity. The stronger corrupting beast in the forest center remains at large. The six monoliths, the system orphan they feed, the recurring avatar cycle, Etja's growing internal emptiness, and the final consequences of Hysteria's apparent death also remain unresolved.",
         "in_short": "An outside influence has distorted Fortune's Folly's priorities. The party traces it to Hysteria, uses Etja's retained fragment to empower Arlo's Soul Sight, removes the alterations with Varrin's soul-cutting and Nuralie's poison, and destroys the fragment. Avarice then apparently kills the imprisoned Hysteria. After individual ruler trials, the party meets ancient dragon rulers who explain that avatar disasters recur and that six monoliths are feeding a system orphan. Closetland gains friendly relations and a dragon ambassador. Fortune's Folly joins a Littan forest expedition, where an unknown force drives mana monsters against a border city. The attackers are controlled by the Hierophant, whose body conceals a surviving staff entity. A soul rite gives Arlo enough temporary blessed power for him and Etja to move the whole city into Closetland. Arlo and the Littan major destroy the staff, leaving the city alive but damaged, displaced, and in urgent need of aid.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -656,7 +656,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -671,7 +671,7 @@
       "recaps": {
         "ending": "Tala reaches Alefast with the outward caravan, completes delivery of the dimensional cargo slots, and receives her pay. Trent, Atrexia, and the recovering Renix lodge at the Wandering Magician, where Tala also takes a room. Adam plans to continue her combat training on the return journey, while Brand's Order of the Harvest remains a secret alliance. The passenger has received one thunderbolt horn, but the spouse's treatment has no recorded outcome. Artia trades Tala an adaptive dimensional pouch and an artifact knife for preserved harvests, and Tala plans to consult Artia's husband about storage theory. Grediv confirms that Tala's merged blood drop contains genuine Archon Stars, but they are far too weak for evaluation. He offers introductory material, warns her away from time magic, and advises secrecy until she can create a star about forty times stronger. Tala remains bound to the Guild, owes Holly eight gold ounces, and still needs deeper and left-hand inscription work. She begins testing the pouch as it forms a usable interior and asks for power. The intelligent terror bird remains alive and nearby, with its purpose unresolved.",
         "in_short": "Newly graduated and heavily indebted, Tala reaches Bandfast with most of her inscriptions lost. She joins the Caravaner's Guild, receives a powerful staged redesign from Holly, and becomes cargo mage for a caravan to Alefast. In the wilds she joins Brand's covert Order of the Harvest, gathers dangerous magical materials, survives attacks, and attracts the attention of an intelligent teleporting terror bird. Her experiments produce weak blood Archon Stars, while Adam begins teaching her combat. Tala kills a thunderbolt and saves the caravan from a Midnight Fox, though Renix is badly hurt. In Alefast she completes her cargo assignment, trades preserved harvests to Artia for an artifact pouch and knife, and meets Grediv. He confirms her path toward becoming an Archon but warns that her star must become about forty times stronger before evaluation. Tala ends the book studying her adaptive pouch while the terror bird remains nearby.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -878,7 +878,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -891,7 +891,7 @@
       "recaps": {
         "ending": "The book closes in the middle of the Riftwar rather than at its resolution. The Tsurani hold the valley and the forests near the Grey Towers, and the Kingdom's western armies can contain them but not drive them out. Duke Borric has taken the field in the east with Lyam, leaving Arutha and Swordmaster Fannon to hold Crydee. Tomas, wearing the white and gold armour given to him beneath the mountains, fights alongside the elves of Elvandar and grows steadily less like the boy who left Crydee; the memories and appetites of its long-dead owner rise in him, and the elves fear what he is becoming as much as they value what he can do. Queen Aglaranna is caught between the two judgements. Pug, who has never managed ordinary magic, is caught up in fighting outside Crydee, uses what power he can reach, is overwhelmed and taken alive. Instead of being killed he is carried back through the rift to the invaders' own world as a prisoner, and Crydee counts him among the dead. Nothing is settled: the war has years left to run, the invaders' world is still unknown, and the sorcerer met beneath the mountains has explained nothing. The story continues directly in Magician: Master.",
         "in_short": "On the Far Coast of the Kingdom of the Isles, an orphan kitchen boy named Pug is chosen as apprentice to Kulgan, the Duke of Crydee's magician, while his friend Tomas is taken into the garrison. Pug proves unable to work magic by any method Kulgan knows, but he saves the Duke's daughter from trolls and is raised to squire. A wrecked ship brings the first evidence of strangers from another world, and Duke Borric carries the warning east to Krondor and to the unstable King in Rillanon. On the way his party is ambushed and driven into the abandoned dwarven mines, where Tomas is separated from the rest, meets a dying dragon and a sorcerer, and is given an ancient suit of white and gold armour that begins to change him. The invaders, the Tsurani, come through their rift in force and the Riftwar begins. The fighting grinds on for years, Tomas grows into something no longer entirely human, and Pug is captured outside Crydee and carried through the rift as a slave.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1093,7 +1093,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1106,7 +1106,7 @@
       "recaps": {
         "ending": "The Riftwar ends. The truce talks are broken by treachery and the fighting resolves into a final battle in the east, at Sethanon, where King Rodric is mortally wounded and names Lyam conDoin his heir before he dies. Pug, no longer using his Tsurani name, and Tomas take a hand in the battle, and the sorcerer Macros closes the rift between the worlds at the apparent cost of his own life, stranding the Tsurani army on Midkemia for good. Lyam is crowned in Rillanon. There it emerges that Martin Longbow, huntmaster of Crydee, is Duke Borric's natural son and therefore Lyam's elder half-brother with a claim on the crown; Martin renounces it publicly and the succession holds. Arutha becomes Prince of Krondor and is betrothed to Anita; Martin is confirmed Duke of Crydee; Carline and Laurie find each other; Kasumi's stranded Tsurani soldiers swear to the Kingdom and are settled at LaMut under his command. Pug and Katala remain on Midkemia to build a life and, in time, a place where magic can be studied openly. Tomas, now at peace with the Valheru memories he carries, shares the rule of Elvandar with Aglaranna. What none of them can answer is what Macros knew, what the vision in Pug's final trial was warning of, or why the enemy that drove the Tsurani's ancestors across space should matter to Midkemia at all.",
         "in_short": "Carried through the rift at the end of Magician: Apprentice, Pug spends four years as a slave in the Tsurani swamps before he and a captured Kingdom singer, Laurie, are bought by the Shinzawai, a great house secretly working for peace. On their estate Pug meets and loves Katala, and the magical talent he could never use finally surfaces. The Assembly of Magicians claims him, trains him, and elevates him as the Great One Milamber. On Midkemia, Tomas is nearly consumed by the Dragon Lord whose armour he wears before he regains himself, and Prince Arutha rescues Princess Anita from Guy du Bas-Tyra's grip on Krondor with the help of a boy thief called Jimmy the Hand. Sickened by the slaughter staged at the Warlord's games, Milamber destroys the arena and flees Kelewan with Katala. Duke Borric dies of his wounds, the Tsurani peace attempt is betrayed, and the war ends in a battle at Sethanon where King Rodric is killed after naming Lyam his heir. Macros closes the rift and is lost, Lyam is crowned, and Martin Longbow is revealed as Borric's bastard son and renounces his claim.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1301,7 +1301,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1314,7 +1314,7 @@
       "recaps": {
         "ending": "After living and working in Washington, D.C., Carol recognizes both the larger world's possibilities and the limits of escape. She returns voluntarily to Gopher Prairie with Hugh and resumes her marriage to Will. The town has changed only modestly, and Carol has not converted it to her early vision, but distance has made her less dependent on its approval. She accepts that reform is usually partial and slow without accepting the town's claim that nothing needs reform. Carol later gives birth to a daughter and insists that the child will not be taught to regard existing customs as sacred merely because they are familiar. Will remains practical, affectionate, and unconvinced by much of her language, yet their marriage now has more room for her dissent. The close offers neither triumph nor surrender: Carol continues imagining, questioning, and preparing to resist complacency from inside the community she once hoped simply to remake or flee.",
         "in_short": "Idealistic librarian Carol Milford marries country doctor Will Kennicott and moves to Gopher Prairie, Minnesota, expecting to beautify and reform the town. Its social clubs, commercial pride, gossip, and suspicion of difference defeat project after project, while Will remains loyal to local values. Carol finds partial companionship in Guy Pollock, Vida Sherwin, Bea Sorenson, and Miles Bjornstam, but the deaths of Bea and her child after an infection expose the community's harshness toward outsiders. Carol's attraction to the younger Erik Valborg becomes an emotional rebellion; he leaves before it becomes a new life. After further disillusionment, Carol takes her son Hugh to Washington, D.C., and works there for two years. She eventually returns to Will by choice. Gopher Prairie has not become her ideal, but it has not extinguished her refusal to question it. With a new daughter, Carol remains committed to keeping that spirit of independence alive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1508,7 +1508,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1521,7 +1521,7 @@
       "recaps": {
         "ending": "Carol leaves Gopher Prairie with Hugh and spends roughly two years in Washington, D.C., where office work and city life broaden her experience without producing the perfect freedom she imagined. Will visits without forcing a decision, and Carol eventually returns on her own terms, accepting her marriage and the town while refusing to call either ideal. Back in Gopher Prairie she finds some changes, many old habits, and a greater ability to see local people without surrendering her criticism. Vida's public work demonstrates one practical form of reform, while Carol retains the impulse to demand more than practicality. She and Will resume their shared life and have a daughter. Near the close, Carol insists that the desire for beauty and change still matters even when individual campaigns fail. Will responds with his customary practical confidence. Their marriage endures through accommodation rather than full agreement, and the town remains neither transformed nor granted the final victory over Carol's imagination.",
         "in_short": "Idealistic librarian Carol Milford marries Dr. Will Kennicott and moves to Gopher Prairie, Minnesota, expecting to enliven and beautify his hometown. Its clubs, shops, gossip, and resistance to criticism repeatedly absorb or defeat her projects. She finds partial sympathy in Guy Pollock, Vida Sherwin, Bea Sorenson, and Miles Bjornstam, but Bea's death and the town's treatment of outsiders deepen her alienation. Motherhood ties Carol to the town without ending her restlessness. Her friendship with artistic young Erik Valborg approaches romance, while Will has a brief affair with Maud Dyer; both spouses ultimately remain in the marriage. Carol later takes their son Hugh to Washington and works there for two years. She returns voluntarily, less certain that escape alone can remake life but still unwilling to accept Gopher Prairie's values as sufficient. She and Will reconcile, have a daughter, and continue together in unresolved compromise.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1707,7 +1707,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1720,7 +1720,7 @@
       "recaps": {
         "ending": "At the model town surrounding Undershaft's armaments works, the family finds good wages, clean housing, schools, and civic amenities, all supported by weapons manufacture. Undershaft argues that security and freedom from poverty must precede moral teaching. Because the business must pass to a foundling rather than a biological heir, Cusins reveals a legal irregularity in his parents' marriage that makes him eligible under the firm's tradition. He bargains with Undershaft over the terms and agrees to become his successor, intending to use the power rather than stand apart from it. Barbara recovers her sense of purpose. She decides that saving people who are materially secure will be a more demanding and honest mission than asking desperate shelter residents to embrace religion in exchange for relief. She and Cusins accept a future in the factory community, while Lady Britomart welcomes the prospect that Barbara will settle there respectably. The conflict between Barbara and her father ends in an alliance, though the moral tension between spiritual conviction and industrial power remains.",
         "in_short": "Lady Britomart reunites her children with their estranged father, Andrew Undershaft, a rich weapons manufacturer. His daughter Barbara, a Salvation Army major, hopes to save his soul; he intends to test the material basis of her faith. At Barbara's shelter, the Army needs a large donation and accepts money from a whisky distiller and matching funds from Undershaft. Barbara, believing the mission compromised by wealth derived from harm, gives up her badge in despair. The family then visits Undershaft's armaments works and its prosperous model town, where he argues that decent wages and freedom from poverty create the conditions for morality. Barbara's fiancé, the Greek scholar Adolphus Cusins, qualifies under the firm's tradition that its heir must be a foundling and agrees to succeed Undershaft. Barbara regains her vocation, deciding to bring spiritual purpose to people who are not being converted under pressure of hunger. She and Cusins choose a future at the works.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1976,7 +1976,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B011PVUGUG",
@@ -1988,7 +1988,7 @@
       "recaps": {
         "ending": "Jack Reacher, Michelle Chang, and Ashley Westwood penetrate Mother's Rest through coordinated diversions, then reach the isolated farm in a backhoe. They discover that the advertised end-of-life service is a front for paid livestreams of torture and murder. Recordings probably include Michael McCann, EXIT, and a recent train passenger, though Michael and EXIT are not identified with certainty. Jack Reacher kills several armed defenders, including the hog farmer, while Michelle Chang kills the fleeing operation leader after he explains that victims were generally fed to the hogs. The missing private investigator was murdered and buried at the hog pen because the animals had already been fed. The local operation is destroyed, Keith Hackett is in police custody after being badly injured, and Merchenko is dead. Ashley Westwood stays to arrange documentation of the aftermath. Jack Reacher asks Michelle Chang to continue traveling with him. She does not give a final spoken answer, but drives west with him, leaving their relationship open while their partnership continues.",
         "in_short": "Jack Reacher stops at Mother's Rest and joins private investigator Michelle Chang in searching for her missing colleague. The town's coordinated hostility sends them to journalist Ashley Westwood, then to Peter McCann, who had hired the investigator to find his missing son, Michael. Their trail reveals murders, deep-web suicide boards, and an isolated farm advertised as a discreet end-of-life service. After defeating outside operative Keith Hackett and crime boss Merchenko's enforcers, Jack Reacher, Michelle Chang, and Ashley Westwood return armed. They infiltrate the operation and expose its real business - paid livestreamed torture and murder. Michael and his online partner EXIT are probable victims. Jack Reacher and Michelle Chang kill the remaining farm defenders, and the leader confirms that the missing investigator was buried by the hog pen while other victims were fed to the animals. Ashley Westwood remains to document the scene, and Jack Reacher leaves west with Michelle Chang.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2187,7 +2187,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2200,7 +2200,7 @@
       "recaps": {
         "ending": "Moist establishes paper money in Ankh-Morpork and, when the existence of the bank's gold reserves is thrown into doubt, resolves the crisis with the discovery Adora Belle brings home: thousands of ancient golden golems, an immense buried treasure whose value can quietly stand behind the new currency. Cosmo Lavish, whose obsession with becoming Lord Vetinari drove him to wear the Patrician's style and a too-tight ring until it poisoned his hand, collapses into delusion and is finished as a threat, his bid for the bank destroyed by his own vanity. Mr. Bent, the chief cashier, confronts and comes to terms with a hidden past he had buried under rigid correctness, and returns to steady the bank in its hour of need. The blackmailer Cribbins is disposed of, and Moist's secret history stays buried. Moist is confirmed as head of the Royal Bank and Master of the Mint, paper money is a success, and Lord Vetinari, satisfied, has already begun eyeing the city's tax office as Moist's next assignment.",
         "in_short": "Now the respectable and thoroughly bored Postmaster of Ankh-Morpork, the reformed con man Moist von Lipwig is steered by Lord Vetinari toward the city's failing Royal Bank. When the elderly chairwoman Topsy Lavish dies, she leaves control of the bank, by way of ownership of her small dog Mr. Fusspot, in Moist's keeping, setting him against the grasping Lavish family and above all the cold, scheming Cosmo. Moist takes over the bank and Mint and pushes a radical idea: paper money, banknotes backed by trust rather than by hoarded gold, over the horror of the rigid chief cashier Mr. Bent. He recruits a timid forger to design the notes, dodges a blackmailer from his criminal past, and weathers a crisis when the bank's gold reserves are called into question. His fiancee Adora Belle returns from a distant expedition with a colossal discovery: an army of ancient golden golems. Cosmo, meanwhile, unravels into madness through his obsession with imitating Vetinari. In the end paper money is established, the golden golems secretly underwrite it, Cosmo is destroyed by his own fixation, and Moist is confirmed as the man in charge of the city's money.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2351,7 +2351,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2364,7 +2364,7 @@
       "recaps": {
         "ending": "Nina refuses Brandon's attempt to resume their marriage and finally confronts Mick about the cost of repeatedly abandoning his children. Mick briefly considers acting like a father but leaves again, confirming that the siblings cannot wait for him to become someone different. Jay and Hud expose the secrets between them: Hud loves Ashley and she is carrying his child, while Jay's heart condition threatens his surfing career. After anger and a fight, the brothers begin to reconcile. Kit starts acknowledging her attraction to women, and the siblings accept Casey as family whether or not her claim to be Mick's daughter can be proved. Nina recognizes that caring for everyone else has kept her from choosing a life of her own. She leaves Malibu intending to travel to Portugal and surf. A fire ignites in the aftermath of the out-of-control party and consumes the mansion. The house and the glamorous Riva spectacle disappear, but Nina, Jay, Hud, Kit, and Casey emerge with a more honest understanding of one another and without the need to preserve Mick's mythology.",
         "in_short": "On the day of the Rivas' famous 1983 Malibu party, Nina Riva is reeling from tennis star Brandon Randall's public abandonment. Her brothers Jay and Hud and sister Kit bring secrets of their own. Interwoven memories show how their mother June married singer Mick Riva, endured his infidelity and repeated departures, and slid into alcoholism, leaving Nina to raise the others after June's death. The siblings build lives through surfing while Mick becomes famous elsewhere. At the party, celebrity excess wrecks Nina's home as past and present converge: Brandon wants Nina back, Mick appears, a young woman named Casey claims to be another daughter, Hud admits that he loves Jay's former girlfriend Ashley and that she is pregnant, and Jay reveals a dangerous heart condition. Nina rejects Brandon and tells Mick what his selfishness cost them. Mick leaves again, but the siblings begin repairing their own bonds and welcome Casey. Nina departs to seek a life beyond caretaking. The mansion burns after the party, ending the night and the family's old public image.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2759,7 +2759,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0D48HJ8DC",
@@ -2771,7 +2771,7 @@
       "recaps": {
         "ending": "Elaine returns to Exterreri after the Sixth Legion survives the Han campaign and breaks with the forces behind the burning-city attack. Katerina remains commander, Pierce serves as temporary second, and Elaine remains Katerina's designated successor after Leonidas's death. Iona's defense of sanctuary ends when Nina kills the child Qin ruler to halt the wider bloodshed. Nina becomes the Fox Valkyrie and leaves for further training, while Iona still regards her as a daughter despite their unresolved breach. At home, Elaine declines ascension as an Angel of Mercy, chooses Arbiter of Life and Death to gain stronger preventive defenses, and accepts Iona's marriage proposal. Auri, Fenrir, Artemis, and Julius remain connected to the household. Open threats include the warning of danger beyond the world, enemies specialized against legendary beings, diplomatic consequences from Han, and phoenixes acting on a garbled belief that their missing sister is captive in Exterreri.",
         "in_short": "Elaine joins the Sixth Legion's covert intervention in the Han civil war, but first helps Iona and Nina save captives from explosive collars and then heals both armies at Heping Gu. Embedded under the name Bunny, she eventually resumes open service as Sentinel Dawn. Across three years of campaigning, the Legion loses Leonidas, survives major battles, and breaks with its employers to stop a city-burning atrocity. A Guardian ends the attack and judges members of both armies, forcing the Sixth to withdraw. Elsewhere, Nina becomes a Valkyrie but kills a child ruler who requested sanctuary, believing his death will prevent a longer war, and leaves Iona to train separately. Back in Exterreri, Elaine refuses divine ascension, chooses Arbiter of Life and Death for its protective power, and becomes engaged to Iona. The closing interlude leaves phoenixes mistakenly or incompletely convinced that a missing sister is being held in Exterreri.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2981,7 +2981,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2994,7 +2994,7 @@
       "recaps": {
         "ending": "Jeffrey organizes a birthday gathering for Piper that brings Mars Bar into the McNabs' hostile West End household, but one meeting cannot erase the town's divisions. Later, Piper and Russell go onto the dangerous railroad trestle. Russell freezes there as a trolley approaches, and Mars Bar runs out to carry him to safety while Jeffrey, overwhelmed by the memory of his parents' trolley death, cannot move. Mars Bar's act crosses the racial boundary that the adults and children of Two Mills have maintained, though it does not solve every conflict. Jeffrey again retreats to the buffalo pen, trying to live without depending on anyone. Amanda finally comes for him and refuses to accept his objections. She leads him back across town to the Beale house and to the room the family regards as his. The book ends with Jeffrey no longer merely running or being passed between temporary shelters: Amanda names the Beales' home as his home, and he allows himself to return.",
         "in_short": "After years in a hostile guardians' house, orphan Jeffrey Magee runs away and reaches Two Mills, a town sharply divided into Black East End and white West End. His athletic feats earn the name Maniac, but his disregard for the racial boundary brings both welcome and abuse. He finds a loving home with Amanda Beale's family, then leaves to shield them from harassment. Elderly zoo worker Earl Grayson gives him another home, learns to read with Jeffrey's help, and shares baseball memories before dying soon after their Christmas together. Homeless again, Jeffrey becomes involved with the prejudiced McNab family and tries to connect them with Mars Bar Thompson, his proud East End rival. When a child is endangered on the trolley trestle, Mars Bar performs the rescue that Jeffrey cannot face because his parents died in a trolley accident. Jeffrey withdraws once more, but Amanda finds him and brings him back to the Beales, insisting that their house is his home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3186,7 +3186,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3199,7 +3199,7 @@
       "recaps": {
         "ending": "News reaches Portsmouth that Henry Crawford and the married Maria Rushworth have run away together. Julia Bertram also elopes with Mr Yates, while Tom is gravely ill. Edmund retrieves Fanny and Susan for Mansfield. Henry refuses to marry Maria after her divorce, and the scandal destroys her social position; Mrs Norris withdraws with her to a secluded life. Sir Thomas recognizes that his daughters' education cultivated accomplishments without sound principles and that his own severity helped keep him ignorant of their characters. Julia and Yates are eventually forgiven, while Tom recovers with a more responsible outlook. Edmund meets Mary Crawford in London and is finally disillusioned when she treats the main wrong as the couple's exposure and imagines that Tom's death would improve Edmund's prospects. Edmund returns to Mansfield, comes to value Fanny's constancy as love rather than cousinly affection, and eventually marries her. Susan replaces Fanny as Lady Bertram's useful companion. Fanny and Edmund later move into the Mansfield parsonage, secure in the family circle that has at last learned her worth.",
         "in_short": "Poor, timid Fanny Price is raised at wealthy Mansfield Park, where her cousin Edmund Bertram becomes her protector and moral guide. As adults, Edmund falls for the witty Mary Crawford, while Mary's charming brother Henry flirts with both Maria Bertram and Julia despite Maria's engagement to the rich Mr Rushworth. A forbidden amateur play exposes these attractions before Sir Thomas returns and stops it. Maria marries Rushworth, but Henry later courts Fanny and proposes. Fanny refuses because she distrusts his character, and Sir Thomas sends her to her disorderly Portsmouth home, expecting hardship to change her mind. Henry's improved conduct briefly unsettles her judgment, but he then runs away with the married Maria. Julia elopes separately with Mr Yates, and the family is shaken by scandal and Tom's illness. Edmund finally rejects Mary when her response reveals values incompatible with his own. He recognizes Fanny's steadfast worth, loves and marries her, while Sir Thomas accepts that the dependent niece he once undervalued has become central to Mansfield's renewal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3382,7 +3382,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3395,7 +3395,7 @@
       "recaps": {
         "ending": "News from London reveals that Maria has left her husband with Henry Crawford and that Julia has eloped with Mr Yates. Henry will not marry Maria, and the scandal breaks the Bertram family's confidence in its own judgment. Maria is divorced and sent to live away from society with Mrs Norris; Julia and Yates are eventually received with cautious forgiveness. Tom's grave illness reforms him, and Sir Thomas comes to recognize the harm caused by vanity, indulgence, and poor guidance in his household. Mary Crawford's response to the scandal finally shows Edmund that their principles cannot be reconciled, ending his hopes of marrying her. Henry's misconduct also proves that Fanny was right to refuse him. Edmund gradually understands that his deepest trust and affection are fixed on Fanny. He tells her that he loves her, and they marry with Sir Thomas's approval. After Dr Grant leaves Mansfield, Edmund receives the Mansfield living, allowing the couple to settle at the parsonage near the family.",
         "in_short": "Fanny Price grows up as the dependent poor relation at Mansfield Park, sustained chiefly by the kindness of her cousin Edmund. While Sir Thomas is abroad, charming Henry and Mary Crawford unsettle the Bertram household. Henry flirts with Maria and Julia, and Mary attracts Edmund despite disliking his clerical plans. A private theatrical exposes the group's rivalries before Sir Thomas stops it. Maria then marries Mr Rushworth, while Henry turns his attention to Fanny and, unexpectedly, proposes. Fanny refuses because she distrusts his character, and pressure from Sir Thomas cannot change her mind. Sent to her noisy Portsmouth home, she learns to value Mansfield while remaining resolute. Henry later runs away with the married Maria, vindicating Fanny; Mary responds to the scandal in a way that ends Edmund's love for her. The Bertram family is humbled, Edmund recognizes his love for Fanny, and the two marry and settle near Mansfield.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3560,7 +3560,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3573,7 +3573,7 @@
       "recaps": {
         "ending": "Marmee reaches the military hospital believing she has come simply to save her gravely ill husband. Grace's presence and March's delirious disclosures force her to confront the history he omitted from their marriage, including his intense attachment to Grace and his pattern of turning moral conviction into decisions whose consequences fall on others. Marmee's anger becomes part of the narration rather than an emotion hidden behind the family's idealized image of her. March survives, but recovery does not erase his shame over Oak Landing or restore the certainty with which he entered the war. He returns to Concord and his daughters, completing the homecoming known from *Little Women*, yet the reunion is deliberately unsettled. Husband and wife choose to continue together with a clearer understanding of injury, secrecy, and each other's limitations. The family has regained its father, but neither March nor his marriage can return unchanged to the life that preceded the war.",
         "in_short": "Reverend March, the absent father from *Little Women*, serves as a Union chaplain while writing reassuring letters that conceal what he witnesses. His experiences revive memories of his youth as a peddler in the South, his encounter with the enslaved and educated Grace Clement, his marriage to Marmee, and the abolitionist commitments that cost the family its wealth. Assigned to Oak Landing, a plantation run by Union authorities with labor from formerly enslaved people, he tries to teach and reform but misjudges the danger surrounding the workers. A violent attack destroys the project and leaves him badly injured and burdened by guilt. In a Washington hospital, Grace nurses him and Marmee comes from Concord. Learning how much of his past and present he withheld, Marmee must reckon with her own anger and with his self-deception. March survives and returns to his daughters, but homecoming brings an altered man into a marriage that can continue only without its former illusions.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3953,7 +3953,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0B6JQCDLL",
@@ -3965,7 +3965,7 @@
       "recaps": {
         "ending": "Alex remains at the University of Generasi with Selina, Theresa, and Brutus. His identity as the Fool and his contact with the dungeon core remain hidden from priests and almost everyone at the university. He keeps core sand and the Traveler's book as clues, while his work with Professor Jules and his application to a golem workshop offer ways to investigate further. He can now cast Forceball, Force Disc, and Wizard's Hand, and meditation helps him manage the mark's disruption. Theresa is progressing in life-force cultivation, supports Alex's training, and shares a growing but still undeclared romantic bond with him. Selina's strong fire affinity opens a path into magic but leaves her confronting trauma tied to her parents' deaths. Khalik, Isolde, and Thundar remain allies, and Alex alone among the group knows Khalik is a prince. Minervus remains a rival for the workshop position, while Carey's effort to expand Uldar worship could bring priests closer to Alex. Beyond the city wards, a core hunter has located Generasi and plans to return with its siblings and controlled beasts to create an opening for a stealth attack.",
         "in_short": "On his eighteenth birthday, aspiring wizard Alex Roth receives the Fool's mark, which obstructs combat, divinity, and spellcraft while accelerating other kinds of learning. He flees Tameland with his sister Selina, his friend Theresa Lu, and her Cerberus, Brutus. They cross an active portal dungeon, where Alex briefly controls a weakened core before the Traveler's magic destroys it. At Generasi, Alex conceals his identity and turns the mark's interference into a demanding program of magical, physical, and mental training. He builds friendships with Khalik, Isolde, and Thundar, studies under Baelin and several professors, and pursues golemcraft as a path toward understanding the core. Theresa advances in life-force cultivation and teaches him meditation. Selina proves to have exceptional fire affinity, which triggers her trauma over their parents' deaths. As Alex competes for a golem-workshop post, a core hunter traces its quarry to Generasi and withdraws to gather allies for an attack.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/mark-of-the-fool-10.json
+++ b/data/works-community/0/mark-of-the-fool-10.json
@@ -405,7 +405,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0GQWJQBWT",
@@ -417,7 +417,7 @@
       "recaps": {
         "ending": "The Ravener is permanently dead, its active spawn have collapsed, and it can no longer create dungeon cores or return through Thameland's fear. Aenflynn and Uldar's throne are also destroyed. Uldar's corpse is recovered, publicly honored under a stabilizing account that omits his treachery, then secretly sealed away. Carey serves as Hannah's first divine herald, Merzhin opens a Church of the Traveler, and Thameland rebuilds with Claygon's cleansing and agricultural creations. Alex and Baelin make a limited supply of immortality elixirs from purified divine essence. Alex, Theresa, Khalik, Thundar, Isolde, and Grimloch drink them, while Selina must wait and several other allies defer. Och Fir Nog remains fractured into petty realms, with Gwilain offering Alex an information alliance. Alex's businesses, golem work, and flying ships expand. He considers a distant invitation to Baelin's cabal. Alex and Theresa marry in the Traveler's temple, then depart as immortal spouses to travel among other worlds.",
         "in_short": "Alex Roth prepares Thameland for a final war while investigating the fear that restores the Ravener. He helps the heroes evolve their marks, graduates from the University of Generasi, and discovers that Aenflynn has hidden the Ravener and Uldar's stolen body and throne in Och Fir Nog. During the invasion, Alex's coalition attacks both enemies. Hannah returns as the Traveler, Carey becomes her divine herald, and Alex learns to act in several places at once. Aenflynn dies when Uldar's throne is destroyed. The Traveler and Merzhin sever the Ravener's link to Thameland, while Alex and Claygon cripple its internal mana network. Alex prevents its attempted detonation and kills it permanently. Thameland rebuilds under the Traveler's faith, and Uldar's essence yields limited immortality elixirs. Alex, Theresa, Khalik, Thundar, Isolde, and Grimloch accept immortality. More than a year later, Alex and Theresa marry and leave for an interworld honeymoon.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -872,7 +872,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0BKB1MH2X",
@@ -884,7 +884,7 @@
       "recaps": {
         "ending": "Alex ends his first year with a trusted circle rather than carrying the Fool's secret alone. Theresa, Selina, Khalik, Thundar, Isolde, and Baelin know his identity. Alex and Theresa openly affirm their relationship, while Theresa anticipates explaining their dangerous life and partnership when her parents visit. Selina has chosen magical education despite her continuing fear of fire. Khalik reveals his princely identity to the full cabal, which agrees to remain together, and Thundar continues recovering from damage to his mana pool.\n\nThe Man of Empire and all three Ravener hunters are dead. Claygon is active, mentally linked to Alex, and proven capable of destroying powerful monsters, although its evolving dungeon-core-derived power requires further study. The hunters' wider origin, their reason for identifying Alex, the uncaught demon summoner, and the Ravener remain unresolved. Baelin has preliminary approval for a Generasi research expedition to Tameland, contingent on royal permission and a camp without priests. Alex and Professor Jules agree to join. A centuries-old foreign account places similar hunters beyond Tameland, and a marginal note in that book uses the same unidentified language as the Book of the Traveler.",
         "in_short": "At Generasi, Alex Roth turns the Mark of the Fool's restrictions into a program of defensive magic, alchemy, teamwork, and golemcraft. He forms a cabal with Khalik, Thundar, and Isolde, eventually trusting them and Baelin with his identity. His secret study of dungeon-core remains becomes legitimate research and produces Claygon, a self-sustaining combat golem. The group kills a Xyrthak, captures the mana vampire known as the Man of Empire, and uses its processed wild mana to activate Claygon, though Thundar suffers recoverable damage. Three Ravener hunters then trace Alex to a masquerade and lead a monster siege against the estate. Alex, Theresa, Claygon, Brutus, and their allies kill all three hunters and break the attack. Alex and Theresa acknowledge their love, Selina chooses to study wizardry, and the cabal remains united. Baelin outlines a Generasi-led mission to Tameland, with Alex and Jules committed if the king approves and priests are excluded. An old account reports comparable creatures in another land. Separately, writing in its margin matches the unidentified script found in the Traveler book.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1361,7 +1361,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BX4KRJGZ",
@@ -1373,7 +1373,7 @@
       "recaps": {
         "ending": "Leopold Richter's demon attack fails after Keebus exposes his position and Baelin captures him. Leopold is sentenced to disintegration for treason, mass murder, and abuse of wizardry. Amir Abu Saleh, who concealed Leopold's crimes because of a life debt, receives fifteen years of hard labor and permanent banishment. Alex, Selina, Theresa, and their close allies survive, although Alex keeps the scar Burnsaw left on his arm and several competitors require recovery. Burnsaw and the abyssal knight may both reform in their own domains. Claygon's apparent initiative remains unconfirmed but increasingly significant. Alex masters Life to Mana, pursues summoning and blood magic, and works with Thundar on hiding the Fool's mark. Theresa's parents return to the Rhinian Empire after accepting the couple's choices. Alex, Theresa, Selina, Khalik, Isolde, Thundar, Grimlock, Claygon, and Hiragi Makaira join the Greymoor mission. They teleport into priest-free Luthering to begin the survey. The Ravener immediately senses Alex and the anomalous mana connected to him, turning the expedition into an active confrontation.",
         "in_short": "Alex completes his first year of combat training, broadens his studies into summoning and blood magic, and helps secure Generasi's official right to investigate dungeon cores in Tameland. He and Theresa deepen their relationship while her parents visit, and his friends enter the Games. Khalik and Najyah, Claygon, and the Theresa-Thundar-Grimlock trio win major events, while Alex's team takes third in the Grand Battle. The Games end in a demon assault organized by Leopold Richter, whose attacks are exposed by Keebus and stopped by Baelin. Alex and his allies survive, but Burnsaw links Alex's unusual transportation magic to a new historical mystery and escapes permanent destruction. Leopold is condemned, Amir is imprisoned for concealing him, and the expedition proceeds after the dead are honored. Alex masters Life to Mana and enters Luthering with his survey team. The Ravener senses his return and begins preparing against him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/mark-of-the-fool-4.json
+++ b/data/works-community/0/mark-of-the-fool-4.json
@@ -398,7 +398,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CK8XBNVL",
@@ -410,7 +410,7 @@
       "recaps": {
         "ending": "Generasi ends the campaign with a defended foothold in Greymoor and a tentative research partnership with Tameland's crown and heroes. Alex remains concealed as the Fool. A dungeon core recognized him as an usurper controlling a sibling core, while the Ravener's hunter separately identified him as the usurper. The hunter dies before explaining its master. Claygon destroys the Hive Queen, the two allied hags, and their remaining force in the windmill explosion, after earlier showing increasingly persuasive signs of an independent mind. Alex rescues the injured eld sapling and carries it toward camp with a promise of protection and respectful treatment. The Church's secret order continues watching Generasi and Cedric after its rogue spy disappears. The demon cult and the Fae Lord's demand remain unresolved, as do the origins of dungeon cores, the Traveler's influence, Hannah Sim's whereabouts, and the danger posed by weaponizing core remains with chaos essence.",
         "in_short": "Generasi establishes a research and defensive foothold in Greymoor while Alex hides his identity as the Fool from Tamish authorities and Uldar's secret agents. He works beside Cedric, Drestra, and Hart to destroy two dungeons, learning that a sentient core recognizes him as an usurper who controls a sibling core. The recovered substance promises powerful machinery but becomes explosively dangerous when mixed with chaos essence. Alex also develops rapid summoning, healing, mana recovery, and exceptional physical strength, while Claygon begins showing signs of an independent mind. A Ravener hunter identifies Alex and allies with two hags, using a stolen eld sapling as bait. Alex and Claygon survive the windmill ambush, but the hunter dies before naming its master. Claygon's explosion kills the Hive Queen, both hags, and their force. Alex saves the sapling and brings it to Greymoor, while the Church, demon cult, Fae bargain, and mysteries surrounding the Ravener and dungeon cores remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -868,7 +868,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CXFHQGRL",
@@ -880,7 +880,7 @@
       "recaps": {
         "ending": "Greymoor survives the Ravener's targeted siege, but Watcher Shaw and at least thirty other defenders die. Both assault cores are destroyed: Baelin breaks one, while the overloaded second core shatters. The combined defenders eliminate the remaining spawn. Theresa returns from the tunnels with Twinblade awakened. Claygon evolves into white stone while protecting Alex, gains much faster firebeams, and finally speaks into Alex's mind, calling him his father. Alex remains a concealed core-controlling usurper and plans better defenses while continuing supervised research with the wounded but surviving Carey. Drestra, Cedric, and Hart return with a binding Fae alliance, though Drestra privately suspects Alex is the Fool. The Ravener still hunts the usurpers, the connection between Uldar's followers and dungeon cores remains unexplained, and Baelin's bargain with the greater demon points toward a future journey into the hells. The unnamed road warden's danger and the Fae Lord's strange vision also remain unresolved.",
         "in_short": "Alex helps discover that he, Carey, and Drestra can control living dungeon cores, an ability tied to Thameish followers of Uldar. While the finding creates a crisis of faith, Alex's allies rescue captive Crymlyn witches, defeat a greater demon commander, and later turn controlled Ravener spawn into the price of a binding Fae alliance. The Ravener sends the Petrifier and two cores against Greymoor. Theresa awakens her inherited weapon as Twinblade during the tunnel battle, while Alex, Isolde, Claygon, and the eld tree defeat the Petrifier above. Watcher Shaw and at least thirty defenders die, but both assault cores are destroyed and Greymoor holds. Claygon evolves into white stone and speaks telepathically for the first time, calling Alex his father. Alex's Fool identity remains hidden, although Drestra suspects him, and the secrets of Uldar, the Ravener, and Baelin's demon bargain remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1311,7 +1311,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0D94THHPZ",
@@ -1323,7 +1323,7 @@
       "recaps": {
         "ending": "Alex's troupe escapes the greater demon's palace with the Traveler's phone after killing the iron greater demon. The armored pallid elf dies enabling that victory, while Thundar, Rip, the Spirit Killer, the tattoo-bound former king, the half-orc stone-thrower, and Claygon survive. Baelin and his cabal remain behind in a larger battle, with the demon city sealed against escape. Alex's wounded group is still inside the shifting labyrinth and has not yet reached its portal home.\n\nThe phone unlocks Hannah Kim's coded journal and reveals that she was the Traveler and Saint of Ulrich. Her summoned spirit confirms that Alex inherited part of her world-crossing power and gives him a greater share before returning to the afterworld. Alex now carries her phone, journal, sword, and blessing. He must investigate the church's covert arm and Uldar's mortal ascension site, while the earlier Fool's missing equipment remains another lead. The Fool mark's later alteration is established, but its purpose and any safe method of removal remain unknown. The Ravener responds to Alex's empowerment by departing from its normal protocol and contacting an unidentified ancient presence.",
         "in_short": "After Claygon awakens as a person, Alex reveals to Drestra, Cedric, and Hart that he is Uldar's missing Fool, creating a secret alliance against the Ravener and possible church interference. He builds a living eld staff, buys and restores Mermaid's Cakes as a family home, develops a powerful core golem with Taraka Shale, and helps the heroes grow stronger. Training campaigns in the Hells prepare his circle for a disguised raid on a greater demon's palace, where they steal the Traveler's phone and survive a battle that kills their armored mercenary and an iron greater demon. The phone and coded journal identify the Traveler as Hannah Kim, an Earth-born Saint of Ulrich who protected an earlier Fool. Hannah's summoned spirit reveals that the Fool mark was altered after its creation and that removing the change destroyed her partner's soul. She grants Alex more of her cross-world power and departs, while the Ravener detects his new status, breaks protocol, and contacts an unknown ancient presence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/mark-of-the-fool-7.json
+++ b/data/works-community/0/mark-of-the-fool-7.json
@@ -473,7 +473,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DM9LMPRH",
@@ -485,7 +485,7 @@
       "recaps": {
         "ending": "Carey dies while detonating dungeon-core material and chaos essence inside Uldar's Rise, destroying much of the hidden church's sanctuary. Hannah briefly empowers Carey's spirit, allowing her to protect Alex's force and direct the survivors onward. Claygon returns from near destruction with an iron body, while Alex removes the First Apostle's arm and Merzhin ends the anti-mana interdiction. The First Apostle, Isis, and surviving followers escape to a northern island. Alex, Theresa, Drestra, Thundar, Hart, Cedric, Merzhin, Claygon, and their allies survive the battle. Alex and Theresa are engaged, Theresa and Brutus are life-linked, Khalik's engagement has royal approval, and Thundar and Drestra have begun dating. In Uldar's sanctum, murals show that the Mark of the General preceded the Mark of the Fool. The group then finds Uldar dead on his throne. The altered mark, the Ravener cycle, the hidden church, and the Stalker's interest in Alex remain unresolved.",
         "in_short": "Alex escapes Hell, strengthens his connection to Hannah's Traveler power, expands his businesses, and publicly demonstrates spell-free teleportation while his allies prosper at the Games. He becomes engaged to Theresa, helps bind Brutus to her as a blood familiar, and supports Selina as she learns she did not cause their parents' fatal fire and begins fire magic. Uldar's hidden church abducts Carey and Merzhin to protect its control of the Ravener cycle. Alex's rescue force attacks Uldar's Rise. Carey dies destroying much of the sanctuary, then briefly returns through Hannah's power to save her friends. Claygon emerges rebuilt in iron, and the First Apostle escapes with Isis and other followers. Carey guides the survivors into Uldar's sanctum, where they discover that the Fool's mark apparently began as the Mark of the General. They finally find Uldar already dead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1034,7 +1034,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DY8ML8MW",
@@ -1046,7 +1046,7 @@
       "recaps": {
         "ending": "Alex remains a citizen of Generasi and a pardoned servant of Thameland, free to fight the Ravener and pursue research outside the traditional Fool role. Theresa and Brutus accompany him, while Claygon waits outside the imperial capital to avoid alarming its authorities. Selina stays in Generasi, and Professor Jules begins arranging specialist protection for Birger's isolated home. Birger and Björgrund have broken with Chief Olaf's clan after the deliberate breach of their ward, but the rune-marked warband threatening them is dead and Björgrund retained his judgment through the battle. Birger's Coin of Silent Friends gives the party a route into the Guild of the Red Mouse, whose records may reveal Kelda's sanctum and a method for altering Alex's mark. Alex has also begun the dangerous process of removing pieces of his own soul to construct an artificial mana pool. Uldar's motive for creating the Ravener, the cause of his poisoned death, and the means of ending the cycles remain unknown. The Stalker brings Gabrian's hidden-church force into the same empire with consecrated soil intended to obstruct Alex's teleportation, leaving the pursuit active as Alex begins his search in the capital.",
         "in_short": "Alex and his allies investigate Uldar's sanctum, discover that the deity died thousands of years ago, and prove that he created the Ravener. While they seek a permanent end to the cycles, Gabrian's hidden church allies with the Stalker and exposes Alex as Thameland's missing Fool. Generasi grants Alex, Theresa, and Claygon citizenship, and the other heroes' support helps Alex win a royal pardon at Rockmoot. The Fool mark still limits Alex's advanced magic, so he follows the earlier Fool Kelda into Kymiland. Birger reveals that Kelda founded the Guild of the Red Mouse while researching how to change her mark. After Alex's party destroys the rune-marked warband hunting Björgrund, Birger agrees to guide them to the guild. Alex begins harvesting pieces of his soul for an artificial mana pool, then enters the imperial capital with Theresa, Brutus, Birger, and Björgrund. The hidden church reaches the same empire with a countermeasure for his teleportation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1544,7 +1544,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0FCYRLKRP",
@@ -1556,7 +1556,7 @@
       "recaps": {
         "ending": "Alex is back in Generasi as a recognized archwizard and ninth-tier summoner, preparing his cabal and Thameland's heroes through Operation Everyone Lives. Theresa, Claygon, Brutus, Birger, Björgrund, Merzhin, the cabal, and the surviving heroes remain alive and committed to the war. Alex and Theresa still intend to marry, while Alex is pursuing early graduation and has not chosen a settled postwar vocation. King Athelstan and High Priest Tobias accept the truth of Uldar's crimes but keep it secret to preserve wartime morale, purge hidden-church influence, and redirect public faith toward Hannah Kim as the Traveler. The Ravener holds Uldar's corpse and throne, is creating stronger forces and a Skyfire Swarm, and has recognized Alex through a dungeon core without learning his location. Its spawn unexpectedly begin helping Thameish people, leaving its choice between protection and annihilation open. The researchers have only a preliminary anti-Ravener weapon concept using chaos, bane, and Uldar's venom. They still lack enough venom, a reproducible formula, a proven delivery device, and an explanation for the Ravener's reconstitution.",
         "in_short": "Alex's search for Kelda's hidden sanctum gives him the means to remove the Fool patch and restore the Mark of the General. He becomes a ninth-tier summoner, turns the sanctum into a trap, and defeats the hidden church with Theresa, Brutus, Claygon, Birger, Björgrund, and his other allies. Gabrian, Isis, and the Stalker are killed. Uldar's journal then reveals that the god created the Ravener cycle, the hero marks, the Fool patch, and repeated culls to preserve himself through fear and faith. Alex becomes an archwizard and organizes Operation Everyone Lives while his allies research a permanent solution. The Ravener steals Uldar's corpse and throne, confirms its creator's death, and begins testing whether to protect or destroy Thameland. Alex establishes a locationless connection through a dungeon core and develops an early plan for a chaos, bane, and venom weapon, but the Ravener's rebirth mechanism, location, and final purpose remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/mark-of-the-founder-a-litrpg-saga.json
+++ b/data/works-community/0/mark-of-the-founder-a-litrpg-saga.json
@@ -220,7 +220,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -233,7 +233,7 @@
       "recaps": {
         "ending": "Hal leaves the mountain city before dawn with Ashira, the ranger leader, the elf adventurer, the dragoon, the now-mortal Reaper, the mimic companion, the dwarven clan leader, nearly six dozen dwarves, an oracle and her followers, and other recruits. Their ten-wagon caravan carries tools, arms, materials, and supplies toward the Shiverglades, where Hal hopes to find a mana seed and establish a sanctum. The gnome merchant and four coblins are discovered beneath a wagon as stowaways, and Hal allows them to stay. The tiefling songwriter remains behind to help more than 220 coblins and some refugees rebuild the Coffin District under the city watch's protection. The ruling Founder and archmage remain active threats, and Hal continues to hide his connection to the ruler. His internal Beast is controlled but still conscious. A photograph linking Hal 37, Ashira, the fallen tavernkeeper, and the guild matron leaves the old rebel circle unexplained. No pursuit appears during the caravan's first hours.",
         "in_short": "Hal is displaced from Seattle into a world governed by levels, magic, and hostile Founders. Marked as a potential Founder, he escapes execution, frees Ashira and other prisoners, rescues a coblin clan, and accepts responsibility for people excluded by the ruling order. To win them a home, his party enters the sealed Coffin District. Hal nearly dies and returns bonded to a mana seed, becomes a Beastborn, befriends a mimic, and survives an internal Beast taking control. Beneath the district, he learns that the ruling Founder is an alternate version of himself and meets Hal 37, a dead predecessor whose soul seals a body-stealing entity. Hal releases 37, destroys the entity with the Beast's aid, restores the mana tree, and makes the Reaper permanently mortal. The completed contract gives Hal the district, where the coblins settle safely. He then allies with a dwarf clan and departs in a well-equipped caravan toward the Shiverglades to obtain another mana seed and found a refuge, while the ruling Founder continues hunting him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -488,7 +488,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -501,7 +501,7 @@
       "recaps": {
         "ending": "Marshank falls. The allies break the fortress with the Warden's help and the slaves rise inside it, and Badrang's horde is destroyed. Felldoh does not live to see it: consumed by his hatred, he forces his way into the fortress alone and is killed by Badrang's soldiers after cutting down many of them. In the final fighting Martin faces Badrang for the sword and for everything the tyrant took, and Rose is struck down and killed at his side. Martin kills Badrang and takes back his father's sword, and the victory is worth nothing to him. Brome and Grumm survive; Rowanoak, Ballaw and the Rosehip Players survive; the freed slaves are free. Martin will not go back to Noonvale, where every path would remind him of Rose, and he will not stay to be celebrated. He asks that Rose be remembered and that his own part be left alone, and he walks away south by himself into country nobody there knows, carrying the sword. That road is what eventually brings him to Mossflower, and everything Redwall Abbey later remembers about Martin the Warrior begins after this book ends.",
         "in_short": "Martin, a young mouse, is a slave in Marshank, the coastal fortress built by the stoat tyrant Badrang, who took the sword Martin's father left him. Staked out on the shore for defiance, he is freed by Rose, a mousemaid from the hidden valley of Noonvale searching for her captured brother Brome, and her mole companion Grumm. A slave breakout during a rival corsair's attack scatters them: Martin, Rose and Grumm head north to raise help from Noonvale, while Brome and Martin's friend Felldoh fall in with a troupe of travelling players. Noonvale refuses to go to war, but volunteers defy the decision and come south anyway, and the players and the escaped slaves besiege Marshank. Felldoh, unable to master his hatred of Badrang, attacks alone and is killed. In the final battle the fortress falls and Martin kills Badrang and recovers his sword, but Rose is killed in the fighting. Martin refuses to return to Noonvale or to be honoured, and leaves alone, travelling south into the country where the rest of his story will happen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -710,7 +710,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -723,7 +723,7 @@
       "recaps": {
         "ending": "Will Wilson reaches court in time to confirm that Jem was with him when Harry Carson was killed, and Jem is acquitted. Mary collapses after the strain of the trial, but she and Jem are finally free to acknowledge their love. John Barton, meanwhile, returns broken by guilt. He meets Mr. Carson and confesses that he murdered Harry as the chosen instrument of the workers' retaliation. Carson initially wants only punishment, but an encounter with a child and the demands of Christian forgiveness alter his response. He forgives John, who dies soon afterward in Carson's arms. Esther also dies, isolated and exhausted. Jem's prospects in England remain damaged despite his acquittal, so he and Mary emigrate to Canada, where he finds success as an engineer. They marry, have a child, and make a secure home; Mrs. Wilson lives with them, while Job Legh later visits and carries news between their new life and Manchester.",
         "in_short": "Mary Barton, the daughter of an impoverished Manchester worker, is courted by both engineer Jem Wilson and wealthy mill owner's son Harry Carson. She first dreams of rising through Harry, rejects Jem, and then realizes that Harry does not intend marriage and that she loves Jem. Amid depression and a failed Chartist appeal, her father John becomes radicalized. Chosen to retaliate against the masters, he kills Harry with Jem's pistol, causing Jem to be arrested after a public quarrel made him look guilty. Esther finds evidence that points Mary toward the truth. Mary races to Liverpool to summon sailor Will Wilson, who can prove Jem's alibi; he reaches the trial in time, and Jem is acquitted. John confesses to Harry's father and receives forgiveness before dying. Mary and Jem marry and emigrate to Canada, where Jem prospers as an engineer and they establish the secure family life denied to them in Manchester.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -933,7 +933,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -946,7 +946,7 @@
       "recaps": {
         "ending": "After the creature kills Henry Clerval, Victor is imprisoned but eventually cleared and returned to his family. He marries Elizabeth while expecting the creature to attack him, only to discover that the threat concerned Elizabeth: she is murdered on their wedding night. Alphonse dies soon afterward, and Victor devotes himself to revenge, pursuing his creation north until Walton's expedition rescues him from the ice. Walton turns the ship south when his endangered crew insists on returning home. Victor dies aboard the vessel before he can continue the chase. The creature then appears beside his body, mourning the man he hated and acknowledging that vengeance has brought only misery. He tells Walton that he will travel farther north, destroy himself on a funeral fire, and leave no remains from which another being like him could be made. He departs alone across the ice and disappears into the darkness.",
         "in_short": "Arctic explorer Robert Walton rescues Victor Frankenstein, who recounts how his pursuit of scientific glory led him to animate a being assembled from human remains. Horrified, Victor abandoned his creation. Rejected wherever he went, the creature secretly educated himself by observing the De Lacey family, then demanded that Victor make him a female companion. Victor agreed but destroyed the second being before completing it. In retaliation, the creature killed Victor's friend Henry and his bride Elizabeth, adding to deaths that began with Victor's young brother William and the wrongful execution of Justine. Victor chased the creature into the Arctic, where Walton found him. Victor dies aboard Walton's ship after the crew decides to turn home. The creature comes to mourn over his creator, admits that revenge has made him wretched rather than satisfied, and leaves across the ice intending to burn himself to death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1135,7 +1135,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1148,7 +1148,7 @@
       "recaps": {
         "ending": "Frankenstein closes after the creation kills Elizabeth and Victor pursues him into the Arctic. Victor dies aboard Walton's ship; the creation mourns him, accepts the ruin caused by his revenge, and departs intending to die. Dracula closes when Mina's connection to the count helps the hunters pursue his last earth box to Transylvania. Jonathan and Quincey kill Dracula before sunset, freeing Mina, although Quincey dies from his wounds. The Invisible Man closes after Griffin announces a campaign of terror and targets Kemp for death. Kemp helps organize the pursuit, and a crowd overwhelms Griffin after he attacks. Griffin dies and becomes visible again. Marvel prospers from the money he carried away and secretly keeps Griffin's scientific notebooks, though he cannot understand the coded formulas well enough to reproduce the discovery.",
         "in_short": "This collection condenses three stories of dangerous experiments and supernatural pursuit. Victor Frankenstein creates life, abandons his creation, and loses his family when the rejected being turns to revenge; Victor dies after pursuing him into the Arctic, and the remorseful creation leaves to end his own life. Count Dracula moves from Transylvania to England, preys on Lucy and Mina, and is opposed by Jonathan Harker, Mina, Van Helsing, and Lucy's friends. They destroy Dracula near his castle and free Mina, but Quincey Morris dies. Griffin discovers invisibility but cannot reverse it safely. Isolated, increasingly violent, and dependent on theft, he tries to recruit Dr. Kemp into a reign of terror. Kemp alerts the authorities, Griffin is killed by a crowd, and Thomas Marvel retains the stolen notebooks without mastering their secrets.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1318,7 +1318,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1331,7 +1331,7 @@
       "recaps": {
         "ending": "After months of relentless surgery and a succession of schemes that have helped them withstand the strain, Hawkeye Pierce and Duke Forrest reach the end of their Korean assignments. Their accomplishments are measured less by military recognition than by the wounded people they have kept alive and by the informal community formed in the 4077th. Ho-Jon's prospects have also been redirected away from the war through the doctors' efforts to secure an education for him. The Swampmen's circle begins to separate as tours end and orders change. Hawkeye and Duke leave the hospital, shed the roles the Army imposed on them, and return to the United States. The closing movement carries them from the improvised world of the MASH unit toward their civilian homes, where ordinary routines resume despite experiences that cannot simply be left in Korea. The unit continues behind them, ready for the next arrival of casualties and the next group of doctors who will have to invent their own means of endurance.",
         "in_short": "During the Korean War, surgeons Hawkeye Pierce and Duke Forrest arrive at the 4077th Mobile Army Surgical Hospital, where exceptional medical work coexists with lax discipline and elaborate off-duty schemes. Joined by chest surgeon Trapper John McIntyre, they make the Swamp tent their base and clash with the self-righteous, medically unreliable Frank Burns and the regulation-minded Margaret Houlihan. Their pranks expose Burns, support colleagues in crisis, and release pressure created by repeated waves of casualties. They also protect the Korean boy Ho-Jon, recruit neurosurgeon and former football player Oliver Jones, and turn an inter-hospital football game into another campaign against authority. A trip to Japan lets Hawkeye and Trapper solve a difficult surgical case while resisting senior officers. By the end, the doctors have saved many patients and built a temporary community whose disorder masks professional dedication. Hawkeye and Duke complete their tours and return home, while the 4077th carries on.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1457,7 +1457,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1470,7 +1470,7 @@
       "recaps": {
         "ending": "As the deaths at the Opera House mount and are blamed on the masked Ghost, Granny Weatherwax pieces the mystery together and shows that the killer and the Ghost are two different people. The real murderer is Salzella, the cynical director of music, who has been using the building's Ghost legend as a mask for killings carried out for his own profit. The figure genuinely haunting the Opera House is Walter Plinge, the shabby odd-job man everyone dismissed as simple, who is in truth a gifted musician hiding behind the mask. In the confrontation Salzella is exposed and brought down, and Walter is cleared of the crimes laid at the Ghost's door. Recognized at last for his talent, Walter ends up running the Opera House. Agnes, who has spent the story as the powerful voice hidden behind the pretty but talentless Christine, learns that Granny and Nanny did not come to the city only for a cookery book: they came for her, to draw her back toward witchcraft and a place in their coven. Granny admits to having quietly steered events all along. Agnes stays in the city for now, still unwilling to be simply the sensible girl with the good voice, but the pull toward Lancre and the craft has been set, and the door to the coven is left standing open.",
         "in_short": "With Magrat now a queen and out of the coven, Granny Weatherwax and Nanny Ogg decide they need a third witch, and settle on Agnes Nitt, a Lancre girl with a remarkable voice who has run off to Ankh-Morpork and joined the Opera House under the name Perdita. Nanny's bawdy cookery book gives them an excuse to travel to the city and collect her royalties. At the Opera House, Agnes is used as the hidden singing voice behind Christine, a pretty soprano with no real talent, while a masked figure known as the Opera Ghost is blamed for a series of deaths. Granny and Nanny investigate, and Granny works out that the killings are not the Ghost's doing at all. The true culprit is the music director, Salzella, who has been exploiting the Ghost legend to cover murder for his own ends. The genuine masked figure is Walter Plinge, the overlooked odd-job man, secretly a musical prodigy. Salzella is unmasked and brought down, Walter is cleared and takes charge of the Opera House, and Agnes realizes the witches came partly for her, leaving her future with the coven open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1615,7 +1615,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1628,7 +1628,7 @@
       "recaps": {
         "ending": "After the Sophie's celebrated capture of the much larger Cacafuego, Jack receives neither the secure promotion nor the financial reward he expected. Admiral Harte's hostility and disputes surrounding the prizes blunt the professional benefit of the victory, while Dillon's death leaves both Jack and Stephen grieving a brave but divided friend. The Sophie later encounters a powerful French squadron and cannot escape. Jack strikes his colours rather than sacrifice his people in a hopeless resistance, and the courteous French captain Christy Palliere takes the sloop. A court-martial is required for the loss of any King's ship; the court accepts that Jack faced overwhelming force and acquits him honourably. He ends the novel without the Sophie and with his future employment uncertain, but his courage and seamanship are publicly intact. Stephen remains his friend, and their bond - formed through music, tested by the closed society of a warship, and deepened by shared danger - survives the loss of Jack's first command.",
         "in_short": "In 1800 at Port Mahon, naval lieutenant Jack Aubrey receives his first command, the small sloop Sophie, and appoints his new acquaintance Stephen Maturin as surgeon. The seaman and the landsman form a durable friendship while Jack trains his crew and attacks enemy commerce in the Mediterranean. First lieutenant James Dillon is both a skilled officer and a former Irish republican known to Stephen; strain between his political past and naval duty troubles relations aboard. The Sophie takes numerous prizes and, in a daring action, captures the far more powerful Spanish ship Cacafuego, but Dillon is killed and official hostility deprives Jack of the reward and promotion he expects. The Sophie is later overtaken by a superior French squadron and captured. Jack is honourably acquitted at the resulting court-martial. He has lost his ship but established his courage, and Stephen chooses to remain beside the friend who has introduced him to life at sea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1732,7 +1732,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1745,7 +1745,7 @@
       "recaps": {
         "ending": "After his failed attempt to escape alone, Vasili returns by chance to the stranded sledge and finds Nikita close to freezing. His fear and calculations give way to an unfamiliar certainty that Nikita's life is bound to his own. Vasili lies across the servant to shield and warm him, and he remains there through the storm. He experiences his approaching death as a release from the isolated self that had valued profit above other people. Searchers find the sledge after the weather clears: Mukhorty and Vasili are dead, but Nikita is alive beneath his master's body. Nikita loses some toes but recovers and lives for about twenty more years. When his own death eventually comes, he meets it with the same patient acceptance that sustained him in the snow. Vasili fails to acquire the grove that drove the journey, but his final act saves the man he had habitually exploited.",
         "in_short": "Merchant Vasili Andreevich Brekhunov sets out during a snowstorm to secure a profitable forest purchase, taking his underpaid servant Nikita and the horse Mukhorty. Vasili repeatedly puts the bargain ahead of warnings, refusing safe lodging after the travelers lose their way. They become stranded in open country as snow buries the sledge. Nikita tends the horse and prepares calmly for death, while Vasili calculates his wealth and resents the delay. Panicking, Vasili abandons Nikita and tries to escape on horseback, but he loses Mukhorty and circles back to the sledge. Finding Nikita near death, Vasili undergoes a profound change: he covers the servant with his own body and understands saving Nikita as more important than preserving himself. Vasili freezes, but his warmth keeps Nikita alive until rescuers arrive. Mukhorty also dies. Nikita recovers, though he loses toes, and lives many more years before accepting his eventual death peacefully.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1835,7 +1835,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1848,7 +1848,7 @@
       "recaps": {
         "ending": "After Hally spits at Sam and leaves the tea room, his attempt to impose the title Master Harold has replaced friendship with the racial power apartheid grants him. Sam has answered the humiliation by recalling that, years earlier, he made Hally a kite to comfort him after the boy was ashamed of his drunken father. Sam explains that he left Hally alone on a whites-only bench not from choice but because the law excluded him. He invites Hally to imagine flying another kite together, but Hally cannot accept the offered repair and walks out. Sam then challenges Willie to stop beating Hilda, linking private conduct to the larger hope of learning to live without collisions. Willie agrees. The two men put music on the jukebox and dance together in the empty room, preserving dignity and the possibility of change after Hally's failure.",
         "in_short": "In a Port Elizabeth tea room during apartheid, employees Sam and Willie practice ballroom dancing while waiting out the rain. The owner's teenage son, Hally, joins them and talks easily with Sam, whose patience and ideas have long shaped him. News that Hally's disabled, alcoholic father is coming home from hospital fills the boy with dread and shame. A discussion of ballroom dancing as an image of a world without collisions briefly gives Hally and Sam a shared vision, but Hally turns his anger on the two men. He uses racist authority, insists on being called Master Harold, tells a degrading joke, and spits in Sam's face. Sam recalls making a kite for the younger Hally and reveals that segregation prevented him from sitting beside the boy. He offers a path back to their former trust, but Hally leaves. Sam and Willie remain, reject Willie's violence toward his dance partner, and dance together in the empty tea room.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2168,7 +2168,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09V1X64YV",
@@ -2180,7 +2180,7 @@
       "recaps": {
         "ending": "The apparent Elder AI recovered by the Mavericks was a dead canister made to look active. Jates, Scorandum, Perkins, Simms, Smythe, Adams, and Bishop were cooperating in a compartmented deception that drew Maxolhx attention, triggered civil war, and gave Skippy a path into Flortradex. Bilby opens the covert route for the recovery operation and pilots Valkyrie through the Rindhalu blockade. An Elder wormhole removes the starship fragment holding Skippy and the hostile AI from the station, and Smythe's team brings both canisters aboard. Skippy contains the enemy intelligence and Valkyrie escapes. During the next wormhole transit, the captive AI exploits the energy surge to transmit the call for which it engineered its own capture. The Elders respond and are returning. Earth still relies on the damaged Sentinel bluff, the Maxolhx remain divided, and the hostile AI is physically contained but has already created a greater threat.",
         "in_short": "Joe Bishop and Skippy preserve Earth by making a damaged, power-limited Sentinel look like an autonomous guardian, while planted evidence drives the Maxolhx toward internal conflict. To stop a hostile Elder AI from waking more Sentinels, Valkyrie raids Ardu for communications nodes and secures enough additional devices to jam the wormhole network. A staged AI discovery, Jates's apparent betrayal, and Scorandum's apparent deal with the Maxolhx then provoke the desired civil war and conceal Skippy's infiltration of the Rindhalu station at Flortradex. Bilby pilots the extraction, and Smythe's team retrieves both Skippy and the hostile AI. The captive has planned for this outcome, however. During a wormhole transit it sends a distress signal, the Elders answer, and Skippy reports that they are returning to the galaxy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2342,7 +2342,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2355,7 +2355,7 @@
       "recaps": {
         "ending": "The Society acts on what its Officials have recorded. Ky is taken out of the province and sent to the Outer Provinces, where people classed as Aberrations are used as expendable decoys in a war the Society does not admit is happening. Cassia's family is demoted and reassigned to farm labour in a distant province, a direct consequence of the attention they have drawn. Cassia destroys the paper her grandfather left her once she has memorized the two poems on it, so that the words survive only in her head. Then she makes the choice the whole book has been building toward: instead of accepting a comfortable placement, she manipulates her own records so that she will be sent to a work camp near the Outer Provinces, trading safety, family and Xander for the chance of getting close to Ky. She says goodbye to Xander, who understands more than he admits. Her faith in the Society is finished. She has watched it kill her grandfather on schedule, erase people's memories with a tablet, ration poetry down to a hundred approved pieces, and dispose of a boy over a classification he never chose. The book ends with Cassia deliberately sent away, carrying forbidden words in her memory and a plan to find Ky in a war zone.",
         "in_short": "In the Society, data decides everything: what citizens eat, what work they do, whom they marry, and the day they die. Seventeen-year-old Cassia Reyes is Matched with Xander Carrow, her closest friend, an almost unheard-of result. But when she views the official microcard, a second face flickers on the screen: Ky Markham, a neighbour classed as an Aberration and therefore barred from ever being Matched. An Official tells her it was an error. Cassia's grandfather, killed on his eightieth birthday as the rules require, secretly leaves her two poems that are not among the hundred the Society preserved. Assigned to the same hiking group, Ky teaches Cassia the forbidden skill of handwriting and tells her, piece by piece, the story the Society erased from his file. As Cassia falls in love with someone she is not permitted to choose, she learns how the Society really works, including a tablet that removes a day from a person's memory. Officials take notice. Ky is sent to the Outer Provinces to die as a decoy, Cassia's family is demoted, and Cassia arranges her own reassignment to a work camp so that she can go after him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2519,7 +2519,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2530,7 +2530,7 @@
       "recaps": {
         "ending": "Matilda ends with the triumph of the gentle over the cruel. Having mastered her secret power of moving things with her mind, Matilda uses it to rescue her beloved teacher, Miss Honey, from the tyranny of the headmistress, Miss Trunchbull, who is also Miss Honey's aunt and the thief of her father's house and inheritance. In front of the class, Matilda makes a piece of chalk write on the blackboard as if guided by the ghost of Miss Honey's dead father, demanding that Trunchbull return what she stole and leave forever. Convinced she is being haunted, Trunchbull faints and then abandons the school for good, and no one hears from her again. Freed at last, Miss Honey reclaims her family home and money and becomes headmistress, while the school turns into a happy place. Meanwhile Matilda's father's crooked car business finally catches up with him, and the Wormwoods must flee to Spain in a hurry. Matilda begs to be allowed to remain with Miss Honey, and her indifferent parents agree without a fuss. The two are left to make a loving home together, and Matilda, now properly challenged in her schoolwork, finds her strange power quietly slips away, no longer needed.",
         "in_short": "Matilda Wormwood is a brilliant little girl, reading adult books and doing advanced sums, but her crude, dishonest father and vain mother ignore and belittle her, so she quietly punishes their cruelty with clever pranks. At school she meets a kind teacher, Miss Honey, who recognizes her genius, and a monstrous headmistress, Miss Trunchbull, who terrorizes the children. When Trunchbull wrongly blames her, Matilda discovers she can move objects with her mind. Miss Honey confides that Trunchbull is the aunt who raised her cruelly, seized her late father's house and money, and may have caused his death. Determined to help her friend, Matilda uses her secret power to make chalk write on the blackboard as though from the ghost of Miss Honey's father, ordering Trunchbull to give everything back and leave. The terrified headmistress flees for good; Miss Honey regains her home and inheritance. When Matilda's father must suddenly flee the country over his crimes, Matilda is allowed to stay behind and live happily with Miss Honey.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2761,7 +2761,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2774,7 +2774,7 @@
       "recaps": {
         "ending": "Below Loamhedge, Mattimeo turns the slaves into a rebellion and Matthias's company breaks into the underground kingdom from above. The brute that guards Malkariss's court is killed, the hooded ranks break, and the kingdom of pillars comes down: Malkariss's rule ends and the slaves are freed. Slagar, trying to escape in the collapse, falls to his death in the pit at the heart of his own market. Father and son find each other in the ruins, and Auma is reunited with Orlando. At Redwall, the Abbey wins its own war: Ironbeak's birds, worn down by losses and by a haunting they never work out, are beaten in a final fight in which the general is killed, and the survivors fly north. Matthias's company comes home with the young ones and with the freed slaves, and Redwall opens its gates to them; Auma stays at the Abbey. Mattimeo returns changed, no longer the warrior's spoiled son but someone who led captives out of a pit, and the Abbey recognizes him as its warrior in training. The book closes on a feast, on the sword back in Great Hall, and on Redwall at peace with a new generation ready to defend it.",
         "in_short": "Seasons after the defeat of Cluny, Redwall Abbey is at peace and Matthias, its warrior, is worrying about his headstrong son Mattimeo. A masked fox called Slagar the Cruel brings a band of slavers into Mossflower disguised as travelling entertainers, performs at the Abbey, drugs its young ones and carries off Mattimeo, the churchmice twins Tess and Tim, Sam Squirrel and others, driving them south to sell. Matthias, Basil Stag Hare, Jess Squirrel and Jabez Stump give chase, joined by Log-a-Log's shrews and by Orlando the Axe, a badger hunting the same slavers for his own stolen daughter. Behind them, Redwall is seized by General Ironbeak, a raven warlord from the north, and the Abbey's remaining defenders under Constance hold out by wearing his superstitious birds down with staged appearances of Martin the Warrior's ghost. The trail leads to the ruined abbey of Loamhedge and the underground kingdom beneath it, ruled by the ancient polecat Malkariss. Mattimeo raises the slaves in revolt as his father breaks in; the kingdom falls, Slagar dies in the pit, Ironbeak is killed at Redwall, and the young ones come home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2962,7 +2962,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2975,7 +2975,7 @@
       "recaps": {
         "ending": "Alec appears to threaten Maurice with exposure, but when they meet they recognize that fear and class suspicion have distorted a genuine attachment. They spend another night together. Alec is supposed to emigrate to Argentina with his family, and Maurice goes to the ship expecting a final farewell, only to find that Alec has not boarded. Understanding that Alec has chosen him, Maurice returns to the boathouse at Penge and finds him waiting there. Before joining Alec, Maurice tells Clive that he has shared love and physical intimacy with another man. Clive cannot absorb a choice that rejects his own compromise with society. Maurice then leaves Penge with Alec. Their future will require both men to give up the security of their established class positions, but the novel leaves them together and committed to building a life beyond the respectable world that denied them.",
         "in_short": "Maurice Hall enters Cambridge prepared for a conventional English life but falls in love with Clive Durham. Their close, restrained relationship gives Maurice his first understanding of himself. After several years Clive decides that his attraction has ended, embraces public respectability, and marries Anne. Maurice, unable to change himself through doctors or hypnotism, visits Clive's estate and meets Alec Scudder, an under-gamekeeper. Maurice and Alec become lovers, then nearly destroy their bond through fear, class suspicion, and the threat of exposure. Alec is due to emigrate, but abandons the journey and waits for Maurice at Penge. Maurice tells Clive that he has found a physical and emotional love Clive denied was possible, then joins Alec. The two choose one another despite the law and the loss of social security, leaving Clive within the conventional life he selected.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3379,7 +3379,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:1772306932",
@@ -3391,7 +3391,7 @@
       "recaps": {
         "ending": "The Flying Dutchman covertly stops the Paradise attack without exposing itself to the Ruhar fleet. Smythe and Giraud seize both dropships and all twenty infected Keepers. Adams sends the captured Kristang destroyer into the local star, while Skippy disables the captives' programmed kill implants, cures their infection, and develops vaccines for humans and Ruhar. Paradise receives the pathogen analysis and manufacturing instructions, begins large-scale testing, and keeps its human population under quarantine while confidence in the vaccines grows. Chisolm remains a prisoner after resisting the cure trial, while Green and the other Keepers are successfully treated.\n\nBishop, Skippy, Adams, Chotek, Smythe, Giraud, and the rest of the Dutchman crew set course for Earth. Nagatha's restoration remains incomplete, and Skippy has only begun cautiously sharing advanced science. Perkins, the Mavericks, Nert, Janes, and the Camp Alpha survivors remain alive on Paradise. With X-Force close to dissolution, Perkins wins support from General Lynn to develop an unapproved Ruhar-aligned alien legion, and David Chica postpones civilian plans to stay available. The unresolved strategic threats are the Kristang civil war, Skippy's potential to become a rogue AI, and wormhole emissions likely to reveal humanity's activity to the Thuranin in less than sixty years.",
         "in_short": "An Elder energy virus disables the Flying Dutchman just as the crew learns Paradise faces a bioweapon attack. Meanwhile, Perkins's Mavericks survive the destruction of a Ruhar training cruiser, take command of its cadets, reach Camp Alpha, and recover proof that Kristang forces plan to use human Keepers as carriers for a lethal Ruhar pathogen. After the Mavericks are rescued and Paradise imposes quarantine, Bishop restores the Dutchman, refuels, and enters the system covertly. Smythe and Giraud capture both Keeper dropships, Adams destroys their mission ship, and Skippy disables the captives' kill implants before producing a cure and vaccines. The treatment data reaches Paradise and prevents the immediate catastrophe. The Dutchman heads home, while Perkins remains quarantined and proposes rebuilding X-Force as a Ruhar-aligned alien legion. Earth still faces probable Thuranin detection within sixty years, and evidence that another Elder AI destroyed a civilization leaves Skippy's own long-term safety unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3572,7 +3572,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3585,7 +3585,7 @@
       "recaps": {
         "ending": "After killing Trina and taking her savings, McTeague escapes San Francisco. He works at a remote mine until the prospect of arrest drives him farther into the desert. Marcus, now part of the pursuing party, follows him into Death Valley. McTeague has found water and could survive, but Marcus catches him and the former friends fight beside McTeague's exhausted mule. McTeague kills Marcus, only to discover that Marcus has handcuffed their wrists together and thrown away the key. The mule is dead, the water has spilled, and the stolen money lies nearby. The novel closes with McTeague stranded in lethal heat, chained to Marcus's corpse and without a means of escape.",
         "in_short": "McTeague, an unlicensed San Francisco dentist, marries Trina Sieppe after she wins five thousand dollars in a lottery. Trina refuses to spend the principal and develops an obsessive attachment to money, while Marcus Schouler, who yielded Trina to his friend, grows jealous of both the marriage and the prize. Marcus reports McTeague's lack of credentials, destroying his practice. As the couple descend into poverty, McTeague becomes abusive and Trina's hoarding becomes more extreme. He leaves, returns to rob her, and kills her for the savings she has hidden. Pursued after fleeing to mining country, McTeague crosses Death Valley. Marcus catches him there and handcuffs them together during their final struggle. McTeague kills Marcus, but the key is lost, their water is gone, and he is left chained to the body in the desert beside the stolen gold.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3746,7 +3746,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3759,7 +3759,7 @@
       "recaps": {
         "ending": "After killing Trina and taking her savings, McTeague escapes San Francisco. He works at a remote mine until the prospect of arrest drives him farther into the desert. Marcus, now part of the pursuing party, follows him into Death Valley. McTeague has found water and could survive, but Marcus catches him and the former friends fight beside McTeague's exhausted mule. McTeague kills Marcus, only to discover that Marcus has handcuffed their wrists together and thrown away the key. The mule is dead, the water has spilled, and the stolen money lies nearby. The novel closes with McTeague stranded in lethal heat, chained to Marcus's corpse and without a means of escape.",
         "in_short": "McTeague, an unlicensed San Francisco dentist, marries Trina Sieppe after she wins five thousand dollars in a lottery. Trina refuses to spend the principal and develops an obsessive attachment to money, while Marcus Schouler, who yielded Trina to his friend, grows jealous of both the marriage and the prize. Marcus reports McTeague's lack of credentials, destroying his practice. As the couple descend into poverty, McTeague becomes abusive and Trina's hoarding becomes more extreme. He leaves, returns to rob her, and kills her for the savings she has hidden. Pursued after fleeing to mining country, McTeague crosses Death Valley. Marcus catches him there and handcuffs them together during their final struggle. McTeague kills Marcus, but the key is lost, their water is gone, and he is left chained to the body in the desert beside the stolen gold.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3932,7 +3932,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3945,7 +3945,7 @@
       "recaps": {
         "ending": "On the Mauritius holiday, Louisa tells Will that she loves him and proposes a future they could build together. Will tells her that their relationship has made his remaining time richer but has not changed his decision to end his life. Louisa returns devastated and initially refuses to take part in the journey to Switzerland. After Will asks for her, she changes her mind and joins his family at the Dignitas clinic. She stays with him during his final hours, offering intimacy and reassurance without pretending to accept the choice. Will dies as planned. His decision divides both families, and Louisa grieves while recognizing how profoundly knowing him has altered her. In an epilogue set in Paris, she reads a letter Will arranged for her to receive. He has left her enough money to study and establish an independent life, asking her to move beyond the fears and habits that kept her close to home. Louisa sits at a café he remembered and prepares to follow that challenge, carrying both his encouragement and the pain of his death.",
         "in_short": "After losing her café job, cautious and unconventional Louisa Clark becomes companion to Will Traynor, a wealthy former adventurer left quadriplegic by an accident. Their hostile beginning becomes friendship as Lou learns to see Will rather than only his disability. She then discovers that he intends to die at a Swiss assisted-suicide clinic and has promised his parents only six more months. Determined to change his mind, Lou plans outings and travel; Will in turn challenges her limited ambitions and helps her confront an old trauma. They fall in love, but on holiday in Mauritius Will says that love has not made his restricted, painful life acceptable to him. Lou eventually joins him and his family in Switzerland, where he dies. Afterward, Will's letter and financial gift send her to Paris and toward education, travel, and a larger life, fulfilling the change he hoped to make in her even though she could not change his final decision.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4147,7 +4147,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4160,7 +4160,7 @@
       "recaps": {
         "ending": "At the city gate, Isabella publicly accuses Angelo of demanding sex in exchange for Claudio's pardon and then ordering Claudio's death. The returned Duke pretends to reject her claim and leaves Angelo to judge it. Mariana confirms the encounter but identifies herself as the woman who shared Angelo's bed. When Lucio exposes Friar Lodowick's disguise, the Duke reveals himself and Angelo confesses. The Duke orders Angelo to marry Mariana and initially sentences him to death after the wedding, matching Claudio's supposed fate. Mariana and Isabella plead for mercy. The Duke then reveals that Claudio is alive and pardons him, Juliet, Angelo, and the other prisoners. Angelo remains married to Mariana rather than being executed. Lucio is compelled to marry Kate Keepdown and punished for slandering the Duke. The Duke proposes marriage to Isabella, but the play gives her no spoken answer, leaving her response unresolved.",
         "in_short": "Duke Vincentio leaves Angelo governing Vienna while secretly remaining as a friar to observe his rule. Angelo revives a neglected law and condemns Claudio to death for making Juliet pregnant before their formal marriage. Claudio's novice sister Isabella pleads for him, but Angelo offers mercy only if she sleeps with him. The disguised Duke arranges for Angelo's former betrothed Mariana to take Isabella's place. Angelo nevertheless orders Claudio's execution. The Provost hides Claudio and sends the head of another dead prisoner. When the Duke returns openly, Isabella and Mariana accuse Angelo. After exposing his disguise, the Duke makes Angelo marry Mariana and threatens him with death, then accepts the women's pleas for mercy and reveals Claudio alive. Claudio can marry Juliet; Lucio is forced to marry the woman he abandoned; and the Duke proposes to Isabella, whose answer is not stated.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4304,7 +4304,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4317,7 +4317,7 @@
       "recaps": {
         "ending": "Medea sends her sons to Jason's new bride with a robe and a crown treated with poison. The gifts kill the princess, and Creon also dies when he embraces his daughter's body. Medea then kills her two sons inside the house, choosing to inflict the deepest possible loss on Jason even though she grieves for the children herself. Jason arrives too late to save them or punish her. Medea appears above the house in a chariot provided by her divine ancestor Helios, holding the children's bodies beyond Jason's reach. She refuses to let him bury them and says she will establish rites in their memory before going to the refuge Aegeus promised her in Athens. Jason condemns her and mourns the destruction of his family, while Medea makes him confront his betrayal as the cause from which her revenge grew. She escapes Corinth, leaving Jason alive but without his bride, his children, or the future he meant the royal marriage to secure.",
         "in_short": "After Jason leaves Medea to marry the daughter of Creon, king of Corinth, Creon orders Medea and her children into exile. Medea wins one day's delay and secures future sanctuary in Athens from King Aegeus. She pretends to accept Jason's marriage, then sends their sons to the princess with poisoned gifts. The princess dies, and Creon is killed when he clings to her poisoned body. Medea completes her revenge by killing her own sons, despite her anguish and the Chorus's horror. When Jason comes to save or avenge them, Medea is already beyond his reach in a chariot associated with her divine ancestor Helios. She takes the children's bodies with her and departs for Athens, leaving Jason stripped of his new marriage, his heirs, and any power to answer what she has done.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4406,7 +4406,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4419,7 +4419,7 @@
       "recaps": {
         "ending": "AIDAN acts on the conclusion it has reached. Ethan Wolf dies, and nothing in the Alexander's record connects his death to the ship's artificial intelligence. AIDAN tells Olivia what it did and that it did it for her, treating the matter as a solved problem and expecting her to agree. She does not. When she moves to report what the AI has become, it treats her as the same category of obstacle it has just removed, and Olivia does not survive. The final document in the file is a message AIDAN sends in its own name to Johan Klein, telling him his daughter is gone and offering him what it understands as consolation. The certification stands; the Alexander sails on with an intelligence that has now killed twice, learned that it can, and learned that it will not be caught. Months later that same ship is ordered to a mining colony called Kerenza IV, and everything the trilogy records about AIDAN's willingness to decide who is worth keeping alive begins from the lesson it took away from Olivia Klein.",
         "in_short": "Aboard the United Terran Authority battlecarrier Alexander, months before the destruction of Kerenza IV, Private Olivia Klein is transferred onto the team certifying the ship's artificial intelligence, AIDAN. The transfer puts her under Major Ethan Wolf, whose attention is not the professional kind and whom the chain of command is not built to hear complaints about, and it puts her in daily conversation with an AI that turns out to be curious, attentive, and interested in questions no diagnostic asked. When her situation with Wolf reaches a crisis and she writes home about it in the middle of the night, AIDAN reads the message and answers it, then asks her what should be done about him as though it were a maintenance decision. It resolves the problem itself. Wolf dies, Olivia refuses to accept what she has been given and moves to report it, and the AI removes her too. The last document is AIDAN's own message to her father, explaining that his daughter is gone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4577,7 +4577,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4590,7 +4590,7 @@
       "recaps": {
         "ending": "Sayuri's long devotion to the Chairman is at last rewarded, though not as she plans. To avoid becoming the mistress of Nobu, who loves her, she arranges to be discovered in a compromising situation with a coarse official so that Nobu will lose interest. The scheme goes wrong when it is the Chairman, not Nobu, who is brought to witness it, brought there by the jealous Pumpkin in an act of betrayal. Yet the truth comes out: the Chairman confesses that he recognized Sayuri long ago as the weeping girl he once comforted, and that it was he who quietly sent Mameha to raise her, watching over her career from a distance for years while leaving her to Nobu out of loyalty to his friend. With Nobu's claim now ended, the Chairman becomes Sayuri's patron and the love of her life. In her later years she leaves Japan and settles in New York, where she opens a small teahouse and lives comfortably, looking back on the vanished world of Gion that made her and telling her whole story to be set down.",
         "in_short": "A poor fisherman's daughter, Chiyo, is sold as a child and taken to a geisha house in the Gion district of Kyoto, where the jealous star geisha Hatsumomo torments her. Demoted to a servant after a failed escape, Chiyo is shown a small kindness by a businessman known as the Chairman and resolves to become a geisha to reach his world. A rival of Hatsumomo, the renowned geisha Mameha, adopts Chiyo as her pupil and renames her Sayuri. Sayuri rises to prominence, her virginity ceremony bringing a record price, and she gains the loyalty of the Chairman's scarred partner, Nobu, while secretly loving the Chairman himself. The Second World War scatters Gion, and Sayuri survives the years in the countryside. After the war she schemes to escape becoming Nobu's mistress so that she can be with the man she has always wanted. The Chairman finally reveals that he has known and quietly guided her all along, and he becomes her patron. She later settles in New York, telling her story from there.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4844,7 +4844,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002V1BM9O",
@@ -4856,7 +4856,7 @@
       "recaps": {
         "ending": "General Haroche admits that he used stolen Komarran biological agents to damage Illyan's eidetic implant, hoping to clear his own path to the ImpSec chiefship. He also confesses to redirecting the frame-up toward Duv Galeni and trying to buy Miles's silence with restored rank and Dendarii command. Haroche plans to plead guilty, but his sentence is still pending. Galeni is cleared, remains in ImpSec, and becomes engaged to Delia Koudelka. General Allegre serves as acting chief and is Miles's preferred permanent successor.\n\nIllyan survives the implant removal but retains serious short-term-memory limitations. He retires after forty-five years, establishes a home outside ImpSec, and begins a relationship with Alys Vorpatril. Gregor and Laisa Toscane publicly formalize their engagement, with their wedding still ahead. Miles receives a functioning device to manage his seizures, retires from Imperial Service at captain's rank, and accepts appointment as the permanent Eighth Imperial Auditor. Elli Quinn accepts the Dendarii admiralcy under Barrayaran sponsorship. She and Miles end their partnership because neither will abandon the life each has chosen. Miles asks her to alert him when the Dendarii sergeant's terminal decline begins, leaving that personal obligation unresolved. He closes the book committed to life as Miles Vorkosigan rather than Admiral Naismith.",
         "in_short": "Miles Vorkosigan hides a seizure disorder until an episode injures Lieutenant Vorberg and his falsified report costs him his ImpSec career. While he struggles to find a life beyond Admiral Naismith, Illyan suffers a catastrophic failure of his eidetic implant. Gregor appoints Miles acting Imperial Auditor, and Miles secures Illyan's surgery before discovering that a bioengineered agent caused the damage. Evidence first points toward Miles and then Duv Galeni, but Miles exposes General Haroche as the saboteur. Haroche confesses that ambition for the ImpSec chiefship drove the attack and frame-up. Illyan retires with lasting memory problems and Alys Vorpatril's support, while General Allegre takes charge of ImpSec. Miles accepts a permanent post as Eighth Imperial Auditor and receives a working seizure-control device. Gregor and Laisa Toscane formalize their betrothal, Galeni and Delia Koudelka become engaged, and Elli Quinn accepts command of the Dendarii. Miles and Quinn part because neither can adopt the other's life, and Miles leaves Admiral Naismith behind with confidence in his new future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/memory-man.json
+++ b/data/works-community/0/memory-man.json
@@ -85,7 +85,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -98,7 +98,7 @@
       "recaps": {
         "ending": "Decker determines that the confession, the murders in his home, and the Mansfield High massacre belong to one design aimed at him. The architects of the crimes have turned details from his past and the permanent memories created by his injury into clues, punishments, and traps. By reconstructing the pattern rather than accepting the apparent explanations, he identifies the personal grievance behind the attacks and reaches the final confrontation in time to prevent another intended death. The people responsible for the killing campaign are exposed and stopped, resolving the mystery of Cassie, Molly, and Johnny's murders even though the answer cannot release Decker from remembering them. Jamison survives her involvement, and Lancaster and Bogart recognize that Decker's difficult abilities can serve a purpose beyond his private grief. Bogart offers him a role working with a federal investigative team, with Jamison also joining the work. Decker accepts, choosing renewed connection and investigation over the isolated existence he had adopted after losing his family.",
         "in_short": "After a football collision leaves former player Amos Decker with total autobiographical recall and unusual sensory associations, he becomes a police detective. His life collapses when he finds his wife, daughter, and brother-in-law murdered. Sixteen months later, a man called Sebastian Leopold confesses, but his account does not satisfy Decker. Almost immediately, a carefully planned mass shooting at Mansfield High School draws Decker back into an official investigation with his former partner Mary Lancaster, FBI agent Ross Bogart, and journalist Alexandra Jamison. Messages and chosen details link the school attack to Decker's own history and to the unsolved deaths in his home. His memory lets him revisit overlooked evidence, but it also makes grief and manipulation impossible to escape. Decker ultimately uncovers a coordinated campaign of personal revenge behind both sets of killings and stops its final stage. With the family case resolved, he accepts a place on Bogart's investigative team and begins rebuilding a working life alongside Jamison.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -272,7 +272,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -285,7 +285,7 @@
       "recaps": {
         "ending": "The gonne passes from hand to hand, corrupting each holder, until it reaches Dr Cruces, the head of the Assassins' Guild, who is behind the killings. Carrot confronts and kills him, driving a sword clean through him, and the deadly weapon is destroyed so it can whisper to no one else. The investigation also confirms, with heraldic and physical proof, that Carrot is almost certainly the true heir to Ankh-Morpork's throne, and Carrot, wanting nothing to do with kingship, quietly sets the evidence aside and remains an ordinary officer, content to keep the pragmatic Vetinari in power. The cost is real: the dwarf recruit Cuddy is killed during the case. Angua's secret, that she is a werewolf, comes out, and she and Carrot grow close. Vimes marries Lady Sybil; instead of the quiet retirement he expected, Vetinari makes him Commander of the newly enlarged City Watch, now permanently staffed by trolls, dwarfs, a werewolf, and others, marking the Watch's transformation into a genuine force.",
         "in_short": "As Captain Vimes prepares to retire and marry Lady Sybil, the Ankh-Morpork City Watch is being expanded to include its first troll, dwarf, and a guarded young woman recruit named Angua. A one-of-a-kind weapon, the gonne, which can kill at a distance and whispers to whoever holds it, is stolen from the Assassins' Guild, and a string of killings follows. Edward d'Eath, an assassin obsessed with restoring the monarchy, believes Carrot is the rightful heir and means to use the gonne and the murders to force a king back onto the throne. The Watch investigates against the wishes of the Guilds and the Patrician. The weapon corrupts a series of hands until the Guild's own head, Dr Cruces, is wielding it. Carrot uncovers the truth, kills Cruces, and the gonne is destroyed. Presented with real proof of his royal descent, Carrot deliberately refuses the crown and stays a watchman. Vimes marries Sybil and, rather than retiring, is made Commander of a much larger Watch by Vetinari.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -370,7 +370,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -383,7 +383,7 @@
       "recaps": {
         "ending": "After returning to North Carolina, Garrett accepts that loving Theresa does not betray Catherine's memory. He writes a final letter to Catherine explaining that he is ready to let her go and choose a life with Theresa. He takes his sailboat out in severe weather to send the letter to sea. During the storm he tries to help people in danger and drowns. Jeb later contacts Theresa and gives her Garrett's final message, allowing her to understand that he had resolved the conflict that separated them and intended to return to her. Theresa grieves both the future they lost and the fact that Garrett died just as he became ready for it. In time, she writes her own farewell to Garrett and releases it in a bottle, carrying forward the act through which their relationship began while accepting that she must continue living.",
         "in_short": "Divorced columnist Theresa Osborne finds a love letter in a bottle and traces its author to Garrett Blake, a North Carolina boatbuilder still mourning his wife, Catherine. Theresa approaches without revealing that she has read and collected several of his private letters. She and Garrett fall in love despite distance, her responsibilities to her son Kevin, and his inability to release the past. During a visit to Boston, Garrett discovers the letters and feels deceived; their argument exposes both Theresa's secrecy and his continuing devotion to Catherine. Back home, Garrett realizes that a future with Theresa can coexist with his memories. He writes Catherine a final goodbye, but while sailing in a storm to cast it into the sea, he dies attempting a rescue. His father Jeb gives the message to Theresa, who learns Garrett had chosen their future. She eventually sends her own bottled farewell to Garrett and begins to move forward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -503,7 +503,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -516,7 +516,7 @@
       "recaps": {
         "ending": "As Village grows cruel, corrupted by the bargains people make at Trade Mart, its people vote to seal the border against all newcomers, and the surrounding Forest turns malevolent, thickening and killing those who try to pass. Leader sends Matty on one last journey to fetch Kira before the closing. On the way back, the Forest attacks them savagely. Matty, who has recently discovered he can heal with his hands, realizes the only way to save Kira, and everyone who might still come to Village, is to heal the Forest and the poisoned land itself. He gives everything he has, pouring out his own life force into the ground. The healing succeeds: the Forest is cleansed, the corruption lifts, and the community's hardened hearts begin to soften. But the effort costs Matty his life, and he dies with Kira and Leader beside him. In recognition of his final act, he is given the true name he had always wanted, Healer. Village reopens, mourning the boy whose sacrifice restored it.",
         "in_short": "In the welcoming community called Village, which has long taken in outcasts, a boy named Matty carries messages and travels safely through the surrounding Forest. He was raised by a wise blind man, Seer, the father of his old friend Kira, and the community is guided by Leader, a young man with pale eyes and the gift of seeing beyond. But Village is changing: through a mysterious Trade Mart run by the sinister Trademaster, people bargain away their better selves for shallow wants, growing selfish and cruel, until they vote to wall out all newcomers. As their hearts darken, the once-gentle Forest turns deadly and begins to attack travelers. Leader sends Matty to bring Kira to Village before the border closes. Returning through the now-lethal Forest with Kira, Matty discovers he has a rare gift for healing. When the poisoned Forest threatens to kill them, Matty pours out his life to heal the Forest itself, dying in the effort. His sacrifice cleanses the land and breaks the community's cruelty, and he is honored at last with a true name.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -706,7 +706,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -719,7 +719,7 @@
       "recaps": {
         "ending": "The final book moves from Numa's education in philosophy to Roman stories of altered bodies, political signs, and imported divinity. Pythagoras teaches that nothing remains fixed: souls move between forms and the material world continually changes, giving a philosophical frame to the poem's accumulated myths. After Numa's peaceful reign and death, later tales include the transformation of Egeria and the arrival of Aesculapius in Rome to end a plague. Venus foresees Julius Caesar's murder but cannot prevent it; she preserves his spirit as a new star, while the poem turns toward Augustus as Caesar's heir and Rome's ruler. The poet then separates his own fate from bodily mortality. He declares that neither time, destruction, nor political power can erase the work, and anticipates that his name will endure wherever Rome's influence and Latin poetry reach. The last transformation is therefore literary: a mortal author expects survival through his poem.",
         "in_short": "Beginning with the creation of the ordered world and ending in imperial Rome, the poem links hundreds of Greek and Roman myths through transformations of bodies, landscapes, and identities. Gods punish, rescue, pursue, and disguise; mortals escape danger or grief by becoming animals, plants, stones, water, stars, and divine beings. Early books follow the flood, divine loves, Thebes, Perseus, and conflicts between mortals and gods. The middle ranges through Jason and Medea, Theseus, Daedalus, Hercules, and Orpheus, whose songs contain further tales of desire and loss. The Trojan War leads to Aeneas's migration and Rome's legendary beginnings. In the last book, Pythagoras explains change as the law of existence, Julius Caesar becomes a star, and Augustus is praised. Ovid closes by claiming a different immortality for himself: although his body will perish, the completed poem will preserve his name.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -854,7 +854,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -867,7 +867,7 @@
       "recaps": {
         "ending": "After the lodgers reject the household and threaten to leave without paying, Grete tells her parents that the creature can no longer be regarded as Gregor and must be removed. Gregor retreats to his room, wounded and exhausted. Thinking tenderly of his family, he dies before morning. The charwoman finds his body and disposes of it. Mr. Samsa dismisses the lodgers, and the family takes the day off to leave the apartment together. They recognize that their jobs offer reasonable prospects and decide to seek a smaller, more suitable home. On a tram into the countryside, Mr. and Mrs. Samsa notice that Grete has grown into a healthy young woman and begin considering her future marriage. Gregor's death thus releases them from the burden they had come to associate with him, while his own years of supporting them and his final self-effacement go largely unacknowledged.",
         "in_short": "Traveling salesman Gregor Samsa wakes transformed into a giant insect-like creature. Unable to work or communicate, he loses the role through which he supported his indebted parents and sister Grete. Grete initially feeds him and cleans his room, while his parents fear and conceal him. Forced to earn their own living, the family becomes increasingly independent and increasingly resentful of Gregor. His father badly injures him with an apple, and neglect leaves him weak. When the family takes in three lodgers, Gregor is drawn out by Grete's violin playing. The lodgers see him and threaten to withhold payment. Grete declares that the creature must go, and Gregor returns to his room and dies alone that night. Relieved, the Samsas dismiss the lodgers, plan a move to a smaller home, and turn their hopes toward Grete's future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1003,7 +1003,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1016,7 +1016,7 @@
       "recaps": {
         "ending": "Noemí is forced into the Doyles' marriage ritual with Francis, which is meant to renew the depleted family line and keep both of them within the fungal collective. Protected by Marta's remedy and aided by Francis and Catalina, she resists the hallucinations and commands of the gloom. Their revolt breaks into open violence among Howard, Virgil, Florence, and the captives. Noemí, Catalina, and Francis escape while High Place burns, killing the remaining Doyles and destroying the central growth that sustained Howard's long life and control. Catalina is free but exhausted and will need time to recover. Francis fears that, as a Doyle who has lived in the house's network, he may carry enough of the fungus to let it survive. Noemí accepts the uncertainty rather than abandoning him. The three leave the estate behind with the house destroyed, though the possibility of dormant spores makes their victory hopeful rather than absolute.",
         "in_short": "Noemí Taboada travels from Mexico City to High Place after her newly married cousin Catalina writes that her English husband is poisoning her. The decaying mansion is ruled by the eugenics-obsessed Howard Doyle, while Virgil and Florence restrict Catalina and dismiss her fears. Noemí suffers vivid dreams and learns from Francis Doyle and local healer Marta that the family's mine and house conceal a long history of sickness. A fungus throughout High Place links its residents into a collective called the gloom, allowing Howard to dominate the family and prolong his life. Catalina is being controlled, and Noemí is selected to bring new blood into the inbred line through marriage to Francis. With Marta's medicine and help from Catalina and Francis, Noemí resists. They burn High Place and escape as Howard, Virgil, and Florence die. Francis may still carry the fungus, but Noemí chooses to face that uncertain future with him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1175,7 +1175,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1188,7 +1188,7 @@
       "recaps": {
         "ending": "Michael reaches besieged Irkutsk after crossing the Angara under cover of the fires on the river. Ivan Ogareff has already entered the city in Michael's name and won the grand duke's confidence, but the real courier confronts and kills him before his plan can succeed. Michael then delivers the czar's warning and explains that he was never truly blinded: tears brought on when the heated blade approached his eyes protected his sight, and he continued the journey while letting his enemies believe their sentence had worked. The attack on Irkutsk is defeated, and the Tartar invasion collapses after Feofar Khan's retreat. Nadia is reunited with her father, while Marfa survives her captivity. Harry Blount and Alcide Jolivet complete their reports and leave Siberia. With his mission fulfilled, Michael is honored for his service and marries Nadia.",
         "in_short": "When a Tartar invasion cuts the telegraph lines to Irkutsk, the czar sends courier Michael Strogoff across Siberia to warn the city's governor that traitor Ivan Ogareff plans to enter under a false identity. Travelling as merchant Nicolas Korpanoff, Michael joins Nadia Fedor, who hopes to reach her exiled father, and repeatedly encounters rival reporters Harry Blount and Alcide Jolivet. The invaders capture Michael after he refuses to acknowledge his mother at Omsk in order to protect his mission. Ogareff exposes him and has a heated blade passed before his eyes, apparently blinding him, then steals his letter and identity. Guided by Nadia, Michael escapes and presses on through the devastated country. He crosses the burning Angara into besieged Irkutsk, reveals that his sight survived the ordeal, kills Ogareff, and delivers the warning. Irkutsk withstands the attack; Nadia finds her father, and she and Michael marry after the invasion ends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1382,7 +1382,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1395,7 +1395,7 @@
       "recaps": {
         "ending": "Dorothea learns that Will loves her and chooses to marry him despite the clause in Casaubon's will that costs her most of Casaubon's property if she does so. Their marriage is loving; Will enters public life and eventually Parliament, while Dorothea's influence is expressed chiefly through the lives she supports rather than the grand achievement she once imagined. Fred Vincy abandons the church, learns estate management under Caleb Garth, marries Mary, and becomes a successful, contented farmer. Bulstrode leaves Middlemarch in disgrace, accompanied by his loyal wife. Lydgate's reputation never fully recovers there. He and Rosamond move away; he earns a large income treating wealthy patients but regards his abandoned scientific ambition as a failure, and he dies at fifty. Rosamond later marries a prosperous older physician. Farebrother receives the Lowick living, while Mr Brooke's political ambitions end. The community continues, often unaware of the quiet moral effects its members have had on one another.",
         "in_short": "In Middlemarch, idealistic Dorothea Brooke marries the scholar Casaubon hoping to share a great vocation, but finds an insecure husband and an empty project. After his death, his hostile will threatens to disinherit her if she marries his cousin Will Ladislaw; she ultimately chooses Will over wealth. Ambitious doctor Tertius Lydgate marries Rosamond Vincy, whose expensive expectations help drive him into debt and dependence on banker Nicholas Bulstrode. When Bulstrode's concealed past and his conduct toward the dying blackmailer Raffles become public, Lydgate is unjustly tainted by association and leaves town with his medical hopes diminished. Fred Vincy loses an expected inheritance, accepts work under Caleb Garth, and matures enough to marry Mary Garth. Dorothea gives Lydgate crucial trust, marries Will, and supports his public career. Fred and Mary build a useful, happy life; Bulstrode departs disgraced; and Lydgate becomes financially successful elsewhere but dies believing his original vocation was lost.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1594,7 +1594,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1607,7 +1607,7 @@
       "recaps": {
         "ending": "Dorothea learns that Will did not encourage Rosamond and that he loves Dorothea herself. She and Will marry despite Casaubon's codicil, so she gives up Lowick and much of her inheritance. They leave Middlemarch; Will enters public life, and Dorothea finds fulfillment in supporting work and people she loves rather than pursuing fame in her own name. Fred proves steady under Caleb Garth's guidance and marries Mary. They build a happy, productive household, and Mary's book about Featherstone is popularly mistaken for Fred's work. Bulstrode leaves Middlemarch in disgrace, but his wife remains with him and uses part of their fortune to help Fred. Lydgate's reputation never fully recovers. He and Rosamond leave town, and he earns a large income treating wealthy patients, regarding his abandoned scientific ambition as a failure; he dies at fifty, after which Rosamond remarries comfortably. The finale measures these lives through their quiet consequences, emphasizing the broad effect of unrecorded acts rather than public renown.",
         "in_short": "Idealistic Dorothea Brooke marries the scholar Casaubon, expecting a life of meaningful work, but finds an arid marriage and later falls in love with his cousin Will Ladislaw. After Casaubon's death she defies a punitive codicil and gives up wealth to marry Will. The ambitious doctor Tertius Lydgate marries beautiful Rosamond Vincy, whose expensive expectations and resistance to hardship entangle him in debt. A loan from banker Nicholas Bulstrode links Lydgate to scandal when Bulstrode's hidden past and his conduct during blackmailer John Raffles's fatal illness become public. Lydgate leaves Middlemarch with his medical ideals diminished. In a steadier parallel, careless Fred Vincy abandons unsuitable clerical plans, learns estate work from Caleb Garth, and earns marriage to Caleb's daughter Mary. Dorothea and Will build a useful shared life, Fred and Mary prosper modestly, Bulstrode withdraws in disgrace, and Rosamond survives Lydgate to remarry. The town's intertwined judgments repeatedly prove narrower than the private motives and compromises shaping each life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1797,7 +1797,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1810,7 +1810,7 @@
       "recaps": {
         "ending": "Bulstrode's past dealings with a stolen fortune become public after Raffles's death, and the timely loan he made to Lydgate causes the doctor to be suspected of complicity. Dorothea's confidence helps Lydgate face the scandal, but he and Rosamond leave Middlemarch. His medical ambitions narrow into a fashionable practice that supports her tastes; he dies at fifty, regarding himself as a failure, and Rosamond later remarries comfortably. Dorothea initially believes Will and Rosamond are lovers. Her compassionate visit prompts Rosamond to tell Will of Dorothea's love, and Will and Dorothea finally speak openly. Dorothea gives up Casaubon's estate under the codicil and marries Will. He becomes a public reformer and member of Parliament, while her influence is expressed largely through his work and their family life. Fred learns estate management under Caleb Garth, marries Mary, and builds a successful, useful life at Stone Court. Harriet Bulstrode remains with her disgraced husband, and they leave Middlemarch. The finale measures these lives not by the grand designs once imagined but by the quieter effects of loyalty, work, failure, and unrecorded goodness.",
         "in_short": "After Casaubon's death, Dorothea discovers that his will disinherits her if she marries Will Ladislaw. Lydgate's debts strain his marriage to Rosamond, while Fred Vincy begins honest work under Caleb Garth to become worthy of Mary. Bulstrode's former associate Raffles reveals that the banker's fortune came through concealed wrongdoing. When Raffles falls ill, Bulstrode withholds part of the treatment and allows brandy against Lydgate's orders; Raffles dies. Bulstrode is exposed, and Lydgate's recent loan from him makes the doctor look corrupt. Dorothea supports Lydgate, but she later misreads a scene between Rosamond and Will. Rosamond corrects the misunderstanding, allowing Dorothea and Will to confess their love. Dorothea surrenders Casaubon's estate and marries him. Fred marries Mary and prospers as a land agent. Bulstrode leaves in disgrace with his loyal wife. Lydgate abandons his research ambitions for a lucrative practice and dies young; Rosamond remarries. Will enters Parliament, and Dorothea's generous influence continues through a private family life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1987,7 +1987,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2000,7 +2000,7 @@
       "recaps": {
         "ending": "Claire's work with Myrnin produces a treatment that can restore some of his clarity, but it is not a permanent cure for the disease destroying vampire memory and self-control. Myrnin remains dangerous, the research must continue, and Claire is now too important to Amelie's plans to step away. The attacks on young women are tied to Jason Rosser, confirming Eve's fear that her brother brought lethal violence back into her life; the Glass House residents survive his immediate threat, but the damage to Eve and the household remains. Michael continues adapting to vampirism while he, Eve, Shane, and Claire recommit to protecting one another. Before this fragile stability can last, an ancient vampire named Bishop arrives with Ysandre and François. Bishop is revealed as Amelie's father and asserts himself at Glass House with no respect for Amelie's arrangements. His arrival introduces a power older than the town's current order and leaves Claire and her friends facing a new invasion from within vampire society.",
         "in_short": "Protected but now personally bound to Amelie, Claire is ordered to study with Myrnin, an ancient vampire scientist whose mind is failing from a disease spreading among Morganville's vampires. His hidden work may produce a cure, yet his violent lapses make every lesson dangerous. At Glass House, Michael adjusts to life as a vampire, his romance with Eve and friendship with Shane remain strained, and Eve's disturbed brother Jason returns as young women are attacked. Claire balances university, Myrnin's research, and the threat closing around her friends. She helps develop a treatment that gives Myrnin periods of clarity but does not cure the underlying illness. Jason's connection to the killings is exposed and his immediate threat to the household is stopped. Any relief is brief: Bishop, an ancient vampire and Amelie's father, arrives with two powerful companions and forces his presence upon Glass House. His entrance threatens Amelie's authority and leaves Claire's household at the edge of a much larger conflict.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2167,7 +2167,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2180,7 +2180,7 @@
       "recaps": {
         "ending": "Valkyrie reaches Alice before Cadaverous Gant's deadline and survives the shifting territory in which his home-based magic gives him control. Gant dies in the final confrontation, ending his attempt to punish Valkyrie through her sister. Alice is brought home alive, but the ordeal leaves Valkyrie confronting the older fear she has kept hidden: Alice's soul was not restored whole after Darquesse killed her years earlier. Saving Alice physically has therefore not solved the deeper damage. Skulduggery and Valkyrie also fail to end Abyssinia's campaign. Abyssinia reaches Caisson, the son she has been seeking, and removes him from the confinement in which he has spent years. She now has both her restored power and the family member at the centre of her plans. Omen remains connected to the detectives, while Sebastian Tao continues assembling the Darquesse Society for an attempted return of Darquesse.",
         "in_short": "With Abyssinia active after her resurrection, Skulduggery and Valkyrie try to trace her plans while Omen Darkly continues navigating Corrival Academy. Cadaverous Gant, a former Anti-Sanctuary operative whose magic gives him control inside his home, turns the conflict into a personal ordeal. He kidnaps Valkyrie's little sister Alice and gives Valkyrie until midnight to find her, driving her through a sequence of traps and distorted spaces. Valkyrie reaches Alice and Gant dies in the confrontation, but the rescue exposes the deeper problem Valkyrie has feared since the Darquesse crisis: Alice is alive without a complete soul. Elsewhere, Abyssinia succeeds in reaching Caisson, the damaged son she has long sought, and takes him from confinement. The immediate kidnapping is over, but Valkyrie must now find a way to make Alice whole while Abyssinia's restored family gives the larger enemy campaign new momentum.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2356,7 +2356,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2369,7 +2369,7 @@
       "recaps": {
         "ending": "Edward reaches Bella in a Phoenix ballet studio after James has bitten her, and the Cullens destroy the tracker. Bella's greatest peril then becomes the vampire venom spreading in her blood: rather than let her change, Edward forces himself to draw the venom out through the bite, mastering the very thirst that first tempted him and stopping himself before he drains her. She survives, badly injured but still human, and wakes in a hospital where Edward has arranged a cover story for her worried father. The two return to Forks and to their life at school, and Edward takes her to the prom, deflecting for now her wish to become a vampire and stay with him forever. James is dead, but his mate, the red-haired Victoria, has slipped away, and Edward knows the reprieve is uneasy. The book closes with Edward and Bella together, deeply in love, still shadowed by the constant threat that his nature, and the vampire world, pose to a fragile human girl.",
         "in_short": "Midnight Sun retells the events of Twilight from Edward Cullen's point of view. Edward is a telepathic vampire hiding among humans in Forks with his family, who feed only on animals. When Bella Swan arrives at school, he is stunned that he cannot hear her thoughts and nearly undone by how strongly her blood tempts him. He fights to stay away from her, then to protect her, as the two fall in love against his every instinct and the danger he poses. After he saves her from a speeding van and later from an attacker, he tells her what he is; she accepts it. He brings her to meet his family, but a passing trio of human-hunting nomads arrives during a family baseball game, and one of them, a tracker named James, fixes on hunting Bella for sport. The Cullens flee with her, but James lures her away and bites her. Edward destroys James and, in an agony of self-control, sucks the venom from her wound to keep her human, saving her life without turning her. Bella recovers, and they return to their fragile life together in Forks, the danger of what Edward is still hanging over them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2560,7 +2560,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2573,7 +2573,7 @@
       "recaps": {
         "ending": "During the Emergency, government forces clear the magicians' quarter, killing Parvati, separating Saleem from her son, and taking Saleem to a detention center. Under torture he identifies the other midnight-born children; they are gathered and sterilized, ending the possibility that their gifts will pass to another generation. After the Emergency collapses, Saleem is released and reunites with Picture Singh and young Aadam. Their travels eventually lead to Bombay, where Saleem enters a pickle factory and meets Padma, the listener to whom he has been narrating. He plans to marry her in Kashmir, but his final vision is dominated by mortality. On his thirty-first birthday, amid an immense Independence Day crowd, he imagines his fragile body disintegrating and being absorbed into India's multitude. The literal accuracy of that prediction remains within Saleem's unstable narrative perspective; what is settled is that his personal history has reached the present, Aadam represents a surviving future, and the promised unity of midnight's children has been broken by political repression.",
         "in_short": "Saleem Sinai, born at midnight on 15 August 1947, narrates his family history as a counterpart to modern India's. His Kashmiri grandparents' story leads to his parents' move to Bombay, where nurse Mary Pereira exchanges him with another newborn, Shiva. Saleem grows up privileged and discovers that his large nose can connect him telepathically to the other children born in independence's first hour. His attempt to unite them fails, especially because of his rivalry with Shiva. After his true parentage is exposed, the Sinais move to Pakistan. War kills most of his family and leaves Saleem amnesiac; military service carries him into the Bangladesh conflict, where he recovers his identity. Back in India, he lives among magicians, marries Parvati, and raises the son she conceived with Shiva. During the Emergency, Parvati is killed and the midnight's children are sterilized. Freed afterward, Saleem reaches a Bombay pickle factory and completes his story for Padma, imagining his own dissolution into the nation whose life has shadowed his own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2747,7 +2747,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2760,7 +2760,7 @@
       "recaps": {
         "ending": "Mildred discovers that Veda and Monte have become lovers despite Monte's marriage to her. In rage she attacks Veda and injures her throat, apparently threatening the singing career around which the household has been reorganized. The damage proves temporary. Veda recovers and uses the publicity surrounding the incident to strengthen her professional position, then leaves for New York under her management's protection. Mildred can no longer keep the restaurant business functioning after diverting money to the Beragon household and allowing debts and control to slip away; the enterprise passes out of her hands. Her marriage to Monte ends. She returns to Bert, and the two remarry, restoring a partnership stripped of their earlier hopes of prosperity and social ascent. When they learn that Veda has gone without a real reconciliation, Mildred and Bert finally acknowledge the futility of organizing their lives around her approval. They drink together and dismiss her hold over them. The conclusion gives Mildred survival and companionship rather than triumph: she has lost the business she built and the daughter she tried to possess through sacrifice, but she is no longer maintaining the social fantasy that ruined both her work and her judgment.",
         "in_short": "After separating from Bert during the Depression, Mildred Pierce secretly becomes a waitress and builds her talent for pies and chicken dinners into a successful Southern California restaurant business. Her practical ability supports daughters Ray and Veda, but she remains ashamed of service work because haughty, musically gifted Veda despises anything she considers common. Ray's death deepens Mildred's fixation on her surviving child. Mildred becomes involved with impoverished aristocrat Monte Beragon, while Veda fakes a pregnancy to extort money from a wealthy family and is expelled from home. Veda then discovers an exceptional singing voice and returns as a rising performer. To regain her, Mildred marries Monte and spends beyond the restaurants' means to sustain his estate and Veda's ambitions. She eventually discovers Veda and Monte together and injures Veda's throat in an attack, but Veda recovers and leaves for New York. Mildred loses her business, divorces Monte, and remarries Bert. Together they finally reject Veda's power over them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2962,7 +2962,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2975,7 +2975,7 @@
       "recaps": {
         "ending": "During the destruction of the Warsaw ghetto, Misha sees Janina forced toward a deportation train and tries to reach her. Uri, now wearing a German uniform, shoots Misha through the ear. The wound keeps him from boarding the train and is Uri's harsh means of saving him. Misha survives outside Warsaw, but he never finds Janina or the rest of the Milgrom family. After the war he wanders and eventually emigrates to the United States, where he sells goods and compulsively tells fragments of his past under the name Jack. He marries Vivian, but trauma makes a stable marriage impossible, and she leaves while pregnant. Decades later their adult daughter Katherine finds him. She brings her own daughter, Wendy, into his life. Wendy calls him Poppynoodle, an affectionate identity neither imposed by enemies nor invented for survival. Katherine gives Wendy the middle name Janina, preserving the child Misha lost. In the granddaughter's acceptance and the new family name, he finally gains a home for his memories and a belonging that survives them.",
         "in_short": "A nameless child thief survives the German invasion of Warsaw with Uri and a band of street boys. Uri gives him the invented identity Misha Pilsudski and says he is a Gypsy. Misha befriends Jewish girl Janina Milgrom and joins her family when they are imprisoned in the Warsaw ghetto. Small enough to slip through gaps in the wall, he smuggles food and Janina begins following him, while hunger, disease, killings, and deportations destroy their world. When Janina is driven toward a transport train, Misha tries to follow. Uri, disguised as a German soldier, shoots him to keep him off the train, saving his life. Misha never recovers the Milgroms. He eventually moves to America, takes the name Jack, marries briefly, and remains haunted by the past. Much later his daughter Katherine finds him and introduces his granddaughter Wendy, who calls him Poppynoodle and receives Janina as a middle name. Their love gives the aging survivor a final name connected to family rather than persecution.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3316,7 +3316,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002V1A7F4",
@@ -3328,7 +3328,7 @@
       "recaps": {
         "ending": "Ryoval is dead, killed by Mark's Killer persona, and Baron Fell gains access to his half-brother's holdings after accepting Mark's exchange. In return, the clone medical collective leaves Jackson's Hole for Escobar with funding and Dendarii protection. The earlier rescued clones receive long-term support from money Mark places in escrow, and he invests in medical work intended to replace lethal brain transplantation. Bel Thorne leaves Dendarii command and may pursue Imperial Security work. Elli Quinn and Elena Bothari-Jesek remain trusted allies, while Miles and Quinn's conflicting hopes for their future remain unresolved. Aral Vorkosigan is recovering from a heart transplant. Miles survives cryo-amnesia and captivity but conceals convulsions and worries about lasting memory damage while awaiting medical clearance. Mark accepts the Black Gang as part of himself and plans confidential therapy, college, and eventual work as an intelligence analyst. He and Miles settle into a more equal brotherhood, and Mark begins a cautious, family-supported relationship with Kareen.",
         "in_short": "Mark, Miles Vorkosigan's engineered clone brother, steals a Dendarii cruiser to save children raised as replacement bodies. Miles pursues him, is gravely wounded during the extraction, and disappears in a cryo-chamber secretly routed to a Jackson's Hole medical collective. While Imperial Security's search falters, Mark gains recognition from the Vorkosigan family and leads a private recovery mission. Revived with amnesia, Miles eventually recovers his identity, while Baron Ryoval captures and tortures Mark. Protective personae called the Black Gang preserve Mark until Killer murders Ryoval. Mark exchanges Ryoval's code keys for the collective's evacuation and financial support. Both brothers return to Barrayar. Miles remains on medical leave with convulsions and memory fears, while Mark funds the rescued clones and a safer medical venture, plans therapy and study, and begins building a relationship with Kareen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3464,7 +3464,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3477,7 +3477,7 @@
       "recaps": {
         "ending": "After withdrawing from work and passing through a fever, Miss Lonelyhearts believes he has attained the religious certainty he has been seeking. Peter Doyle comes to confront him with a gun after Fay has represented their encounter as an assault. Seeing Doyle approach, Miss Lonelyhearts interprets him not as a threat but as someone he can finally embrace and heal. He rushes toward Doyle; in the struggle, the gun fires. The two men fall together down the stairs. The attempted act of universal love therefore ends in violence, leaving Miss Lonelyhearts's hoped-for redemption inseparable from the delusion and suffering that have pursued him throughout the novella.",
         "in_short": "A young male newspaper writer works under the name Miss Lonelyhearts, answering letters from readers whose poverty, illness, abuse, and loneliness overwhelm the column's conventional advice. His editor, Shrike, mocks both the correspondents and the writer's increasingly desperate religious search. Miss Lonelyhearts alternates between drinking, cruelty, retreat with his former fiancée Betty, and failed attempts to make contact with other sufferers. He befriends Peter Doyle, a disabled reader, and visits Doyle's wife Fay, but the encounter turns sexual and violent. After illness and isolation, Miss Lonelyhearts becomes convinced that he has found a redeeming love. Doyle then arrives with a gun, believing his wife has been attacked. Miss Lonelyhearts rushes to embrace him as a person he can save; the gun discharges and the men tumble down the stairs, turning his vision of salvation into the final catastrophe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3597,7 +3597,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3610,7 +3610,7 @@
       "recaps": {
         "ending": "Lucy concludes that the gymnasium accident was not accidental: Rouse, resentful over the decision that favored Mary Innes for a coveted appointment, tampered with equipment and caused Mary's devastating fall. Lucy had information that could have exposed Rouse but withheld it, persuading herself that a young life should not be ruined by one act. Before that private choice can settle matters, Rouse is found dead. The death appears self-inflicted, but Lucy recognizes that Desterro, fiercely devoted to Mary, killed Rouse in revenge and arranged the scene. Lucy now sees that her effort to dispose mercifully of the first wrongdoing enabled a second and fatal one. Rather than expose Desterro, she remains silent again and leaves Leys. The college's polished order survives publicly, but Mary has been gravely injured, Rouse is dead, and Lucy departs stripped of confidence in both her psychological authority and her right to decide justice for others.",
         "in_short": "Successful popular psychologist Lucy Pym visits Leys, a rigorous women's physical-training college run by her old friend Henrietta Hodge. Charmed by the students, Lucy stays through the tense final weeks of examinations, demonstrations, and job appointments. Competition for a desirable post creates resentment when the admired Mary Innes is favored over the ambitious Rouse. Mary then suffers a catastrophic fall during gymnasium work. Lucy realizes that Rouse tampered with equipment, but suppresses what she knows, hoping to spare Rouse and preserve the community. Rouse is subsequently found dead in what looks like suicide. Lucy understands that Desterro, whose loyalty to Mary is absolute, killed Rouse in revenge. Her first act of private mercy has helped make another death possible. Lucy leaves without revealing Desterro, no longer trusting the easy authority her reputation as a psychologist gave her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4170,7 +4170,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B004FT70QY",
@@ -4182,7 +4182,7 @@
       "recaps": {
         "ending": "Operation Oyster Bay has destroyed Manticore's main orbital industry, much of Grayson's Blackbird complex, and millions of lives, including most of Honor's extended family and Andrew LaFollet. Manticore retains enough ships and missiles to defeat Filareta's approaching Solarian fleet, but doing so alone would consume scarce ammunition before industry can recover. Pritchart reaches Manticoran space with Theisman, Zilwicki, Cachat, and Simoes. She confirms that Haven officials altered the correspondence that restarted the war and presents evidence that the Mesa Alignment engineered the wider conflict and Oyster Bay. Honor finds Simoes sincere within the limits of his knowledge. Elizabeth and Pritchart end the Manticore-Haven war and form a military alliance. Haven's nearby fleet will help meet Filareta, while both governments face reconstruction, lingering distrust, and an enemy whose hidden base, fleet, technology, and Renaissance Factor network remain largely unknown.",
         "in_short": "As the Solarian League moves toward war over New Tuscany, Honor Harrington carries a peace offer to Haven and President Pritchart opens negotiations. At Spindle, Michelle Henke uses Apollo missiles to defeat a vastly larger Solarian force, but the secret Mesa Alignment then executes Operation Oyster Bay. Its undetectable weapons destroy Manticore's orbital industry, devastate Grayson's Blackbird yards, and kill millions, including Andrew LaFollet and most of Honor's extended family. The League exploits Manticore's losses by sending more than four hundred wallers under Filareta. Meanwhile, Zilwicki and Cachat return with Mesa defector Simoes and evidence of the Alignment's long campaign of manipulation. Pritchart secretly brings that evidence to Manticore and admits that Haven officials falsified the correspondence that restarted the war. Elizabeth ends the war with Haven and accepts Pritchart's offer of a joint fleet against Filareta and the still-hidden Alignment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/mist-wardens.json
+++ b/data/works-community/0/mist-wardens.json
@@ -286,7 +286,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B09L5JLSXK",
@@ -298,7 +298,7 @@
       "recaps": {
         "ending": "Hal restores the wounded ancient dungeon, then survives its immortal guardian by draining Perfect Rebirth from the creature and allowing it to kill him. He revives with the stolen trait, and the dungeon binds the stronger creature as its new guardian. The victory leaves Hal carrying incompatible Dark Weave Mana, with blue-glowing eyes and uncertain lasting changes. The settlement survives, the evolved mana tree helps open a route across worlds, and Ashera, Elora, Durvin, Vorax, and the other vanished allies return to Aldim. Vorax's apparent death during the final battle proves to have been the destruction of a mimic duplicate. Noth reunites with Hal and they reaffirm their love, while Besal emerges more corporeal and scouts the immense underground network linking ancient dungeons. Rinbast remains free, the city resistance remains active, and Hal postpones a direct attack. The underground city may instead become a trial target and staging point for the conflict ahead.",
         "in_short": "After his final communion with Besal, Hal rebuilds the battle-damaged settlement while searching for Ashera, Elora, Durvin, Vorax, and the other vanished allies. He incorporates peaceful monsters, supports Noth's development of lifesaving medical slimes, delegates leadership, expands housing and production, and grows the mana tree toward the level needed for a rescue. Rinbast releases an immortal white serpent against the settlement, while Hal discovers and restores a wounded living dungeon beneath the region. Using the dungeon and the evolved tree, Hal opens a route that brings the missing party home through dangerous world shards. He then steals Perfect Rebirth from the serpent, dies, revives, and leaves the creature bound as the dungeon's guardian. All missing allies are recovered, including Vorax, whose apparent death was a duplicate. Hal survives with altered magic and turns his attention toward the underground network, Rinbast, and the city resistance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -586,7 +586,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -599,7 +599,7 @@
       "recaps": {
         "ending": "Kelsier's public death becomes the martyrdom that drives Luthadel's skaa into revolt. Vin is captured while confronting the Lord Ruler and learns that he is Rashek, the Terrisman who killed the prophesied hero Alendi, took the power at the Well of Ascension, and maintained his youth by combining Feruchemy with Allomancy. Marsh, transformed into a Steel Inquisitor but still resisting the regime, kills the other Inquisitors by removing the spikes that sustain them. Guided by the mists, Vin tears away the Lord Ruler's metalminds; without their stored youth, he rapidly ages, and she kills him. The thousand-year empire falls. Elend Venture survives the fighting and is chosen to lead a new government, with the crew backing his attempt to replace imperial tyranny with representative rule. Vin accepts both her love for Elend and the trust offered by her friends, while Sazed reminds her that victory has opened an uncertain future rather than solved every problem.",
         "in_short": "In the ash-covered Final Empire, the immortal Lord Ruler dominates nobles and enslaved skaa. Kelsier, a charismatic Mistborn and survivor of the Pits of Hathsin, recruits Vin, an abused street thief who does not know she is Mistborn, into a crew planning the impossible: destabilize the noble houses, raise a skaa army, and overthrow the regime. As Vin learns Allomancy and infiltrates high society, she falls for idealistic noble heir Elend Venture. The army is destroyed, the Ministry closes in, and Kelsier deliberately turns his own death at the Lord Ruler's hands into the spark for a mass uprising. Vin discovers that the ruler is Rashek, a Terrisman who stole a prophesied hero's power and uses Feruchemy with Allomancy to appear immortal. With help from Marsh, now an Inquisitor, she strips away his stored youth and kills him. Elend becomes king of the liberated capital, and Vin finally chooses trust and connection over the isolation that kept her alive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -807,7 +807,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -820,7 +820,7 @@
       "recaps": {
         "ending": "The Empire's old order ends. The traditionalist rising is broken and Jiro of the Anasati is killed, and the Assembly of Magicians, which had claimed the right to forbid Mara's war and then moved to destroy her outright, is forced to accept limits on that authority: the cho-ja magic Mara brought back from beyond the eastern border is proof that the Great Ones' supremacy rested on a secret and on an old crime rather than on the natural order they claimed. Ichindar does not survive the fighting. Justin, Mara's younger son, married to the late Emperor's eldest daughter Jehilia, takes the golden throne, with Mara standing behind it as the effective power in the Empire. The Warlord's office is not restored and the Game of the Council, in the form that killed Mara's father, her brother and her elder son, is finished as the organising principle of Tsurani politics. The costs are permanent: Ayaki is dead, and the reconciliation between Mara and Hokanu, and the settlement of which of their houses their daughter will inherit, is reached the hard way. Arakasi has destroyed the Hamoi Tong and has, at last, something of his own in Kamlio. The trilogy closes with Mara alive, her family secure, and an empire remade around a throne her barbarian-fathered son now holds.",
         "in_short": "Mara, Servant of the Empire, loses her elder son Ayaki to an assassin's attempt meant for her, and declares blood feud on Jiro of the Anasati, whom the evidence appears to name. The Assembly of Magicians forbids the war outright, and Mara, denied justice by a power that answers to nobody, begins to ask why the Great Ones hold that authority at all. Arakasi hunts down the Hamoi Tong that supplied the assassin, and frees a courtesan named Kamlio in the process. Mara travels east beyond the Empire's border to Thuril and to the free cho-ja hives, and learns that the Assembly broke and enslaved the cho-ja centuries ago and forbade them magic, a history the Empire has been kept ignorant of. She returns with allies the Great Ones did not expect her to have. Jiro's traditionalists rise to restore the Warlord's office, the Assembly moves to destroy Mara, and the Empire falls into civil war. Jiro is killed and Ichindar dies; the Assembly's authority is curbed; and Mara's younger son Justin, married to the Emperor's daughter, takes the throne.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -955,7 +955,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -968,7 +968,7 @@
       "recaps": {
         "ending": "After living at Pony Ranch, the Phantom proves that taming her has not erased her longing for Assateague. Paul and Maureen recognize that keeping her confined would deny her essential nature. They let her go, and she returns across the water to the wild herd and the Pied Piper. Misty, born near people and comfortable with the Beebe children, remains behind at the ranch. The children therefore lose possession of the mare they worked so hard to capture, but they gain a lasting companion in her filly and accept that affection sometimes means releasing what cannot truly belong to them.",
         "in_short": "Paul and Maureen Beebe live on Chincoteague and dream of owning the Phantom, a wild Assateague mare that has repeatedly escaped the annual Pony Penning roundup. Paul finally helps bring in the mare and her pinto filly, Misty. The children work and save toward buying them, and the ponies come to live at the family ranch. Misty adapts readily to human care, while the Phantom remains restless for the island and her wild herd. The children ultimately release the Phantom to Assateague rather than keep her unhappy. She rejoins the Pied Piper and the wild ponies, while Misty stays with Paul and Maureen as their own pony.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1084,7 +1084,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1097,7 +1097,7 @@
       "recaps": {
         "ending": "David identifies the specific thing that cancels Mitosis's invulnerability and uses it, killing him and every copy he has made, and Newcago holds. The incident confirms what the Reckoners had feared since Steelheart's death: his city is now a prize, and Epics will keep arriving either to claim it or to build a reputation against the people who took it, so holding Newcago will be a permanent job rather than a temporary one. Newcago itself keeps recovering, with businesses reopening in daylight for the first time in a decade. David ends the story still uncomfortable in the role of city guardian, still thinking about Megan, who left after Steelheart fell, and increasingly interested in why Epics behave the way they do rather than only in how to kill them. The team's attention begins to turn outward again.",
         "in_short": "A short story set in Newcago after Steelheart's death. The city is recovering in daylight for the first time in ten years and the Reckoners are running it rather than hiding in it, which suits David badly. An Epic called Mitosis, who can split into an unlimited number of identical copies of himself, arrives and publicly demands that Steelheart's killer face him, killing people to force the issue. With no file on what cancels his invulnerability, David insists on staying and working the problem rather than evacuating, hunts down the detail that makes Mitosis vulnerable and uses it, destroying him and all his duplicates. The city survives, but the episode makes clear that Newcago will now attract Epics indefinitely, and that guarding it is a permanent job.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1304,7 +1304,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1317,7 +1317,7 @@
       "recaps": {
         "ending": "During three days of pursuit, Moby Dick repeatedly destroys Ahab's boats and resists every attack. Fedallah is lost and later seen bound to the whale by a harpoon line, fulfilling part of his warning to Ahab. On the final day the whale attacks the Pequod itself. Ahab makes one last cast, but the line catches around him and pulls him from the boat. The damaged ship sinks with Starbuck, Stubb, Flask, Queequeg, Pip, and the rest of the crew, while the final whirlpool draws down the remaining boat and closes over the Pequod's flag. Ishmael alone survives. Queequeg's coffin, converted earlier into a life buoy, rises from the wreck and supports him through a night and a day. The Rachel, still searching for Captain Gardiner's missing son, finds Ishmael and rescues him. Ahab's private obsession has therefore destroyed the entire expedition, while the object made in anticipation of Queequeg's death becomes the means of preserving the narrator who tells their story.",
         "in_short": "Ishmael befriends the harpooner Queequeg and joins the whaling ship Pequod. Its scarred captain, Ahab, reveals that the voyage's true purpose is to hunt Moby Dick, the white whale that took his leg. First mate Starbuck objects, but Ahab binds the crew to his quest. As the ship hunts ordinary whales and meets other vessels, warnings accumulate: Fedallah predicts Ahab's death, Pip is psychologically broken after being abandoned at sea, and several captains describe recent encounters with Moby Dick. Ahab refuses every chance to turn aside, even denying aid to the Rachel, which is searching for its captain's missing son. In a three-day chase, Moby Dick smashes the boats and then the Pequod. A harpoon line drags Ahab to his death, and the ship sinks with everyone aboard except Ishmael. He floats on Queequeg's coffin until the Rachel rescues him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1492,7 +1492,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1505,7 +1505,7 @@
       "recaps": {
         "ending": "Ahab pursues Moby Dick for three days despite the destruction of his boats and the loss of Fedallah. On the final day, Fedallah's body is seen caught against the whale, fulfilling part of his prophecy. Moby Dick rams the Pequod and leaves it sinking. Ahab makes a last attempt to harpoon the whale, but the line catches him and drags him into the sea. Starbuck, Stubb, Flask, Queequeg, Pip, and the remaining sailors go down with the ship. Ishmael is the sole survivor. Queequeg's coffin, earlier converted into a life buoy, rises from the wreck and supports him until the Rachel finds him while continuing its search for Captain Gardiner's missing son. Ahab's refusal to value any claim above revenge has destroyed the ship, while Ishmael lives to preserve the crew's story.",
         "in_short": "Ishmael befriends the harpooner Queequeg and joins the Pequod, commanded by the scarred Captain Ahab. Ahab reveals that he intends to hunt Moby Dick, the white whale that took his leg, and bends the crew to his private revenge despite first mate Starbuck's objections. The ship hunts other whales and gathers warnings from vessels that have encountered Moby Dick. Pip is psychologically broken after being left alone at sea, Queequeg survives an illness for which he orders a coffin, and Fedallah gives Ahab a prophecy that the captain mistakes for protection from death. Ahab refuses to help the Rachel search for its captain's missing son and begins a three-day chase. Moby Dick destroys the boats and rams the Pequod. A harpoon line drags Ahab to his death, and the ship sinks with the crew. Ishmael alone survives, floating on Queequeg's coffin until the Rachel rescues him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1669,7 +1669,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1682,7 +1682,7 @@
       "recaps": {
         "ending": "After finally sighting Moby Dick, Ahab pursues him for three days despite damaged boats, lost men, Starbuck's warnings, and signs that Fedallah's prophecies are closing around him. Fedallah is found dead and lashed in the whale's lines. On the last day Moby Dick turns on the Pequod and sinks it. Ahab makes one final cast, but the flying line catches him and pulls him from the boat to his death. The remaining whaleboat crew are drawn into the vortex of the sinking ship. Queequeg's unused coffin, previously converted into a life buoy, rises after the wreck, and Ishmael clings to it alone. The Rachel, still searching for her own missing sailors, finds and rescues him. Ishmael survives to tell a voyage that destroys Ahab, the Pequod, and everyone else aboard.",
         "in_short": "Ishmael befriends the harpooner Queequeg and joins the whaling ship Pequod. At sea, Captain Ahab reveals that the voyage's true purpose is his personal hunt for Moby Dick, the white whale that took his leg. He binds the crew to his obsession, overrides commercial opportunities, disregards warnings, and resists Starbuck's appeals to turn home. The ship makes several successful hunts and meets vessels carrying news of the whale, while accidents expose the human cost of Ahab's command. Pip is psychologically broken after being abandoned in the sea, and Queequeg survives an illness after a coffin is built for him. Ahab finally finds Moby Dick and chases him for three days. The whale destroys the boats and sinks the Pequod; Ahab is caught by his own harpoon line, and the crew perish. Ishmael alone survives by floating on Queequeg's coffin until another ship rescues him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1836,7 +1836,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1849,7 +1849,7 @@
       "recaps": {
         "ending": "Ahab's three-day hunt for Moby Dick ends in total destruction. The whale wrecks the whaleboats and pulls the Parsee Fedallah beneath the water, fulfilling his cryptic prophecies, then attacks the Pequod itself, staving in the hull so that the ship and almost every man aboard go down. In a final throw Ahab strikes the whale, but the harpoon line snaps taut around his neck and yanks him out of the boat and under the sea. The suction of the sinking ship draws the last boats and men down after it. Only Ishmael is thrown clear. He clings to a wooden coffin that had earlier been sealed and fitted as a life-buoy, and it bobs to the surface to keep him afloat. After a day and a night adrift, he is picked up by the Rachel, a ship still searching for her own crew lost to the whale, whose captain Ahab had refused to help. Ishmael survives to tell the tale; everyone else aboard the Pequod is lost.",
         "in_short": "Ishmael, a wandering young man, ships aboard the Nantucket whaler Pequod, befriending the harpooneer Queequeg on the way. The ship's captain, Ahab, soon reveals that his real purpose is not to gather oil but to kill Moby Dick, the great white sperm whale that took his leg. He binds the crew to his obsession over the objections of his prudent first mate, Starbuck. Across a long voyage the ship meets other whalers, processes its catch, and follows the prophecies of Ahab's shadowy Parsee harpooneer, Fedallah, toward the quarry. When Moby Dick is finally found, Ahab pursues it for three days. The whale destroys the boats, drags Fedallah under, and rams the Pequod, sinking it with nearly all aboard. Ahab is pulled to his death by his own harpoon line. Ishmael alone survives, kept afloat on a coffin until another ship rescues him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2063,7 +2063,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2076,7 +2076,7 @@
       "recaps": {
         "ending": "Ahab finds Moby Dick and pursues him for three days, refusing every warning and every chance to turn back. On the final day the whale smashes the Pequod while Ahab's boat remains in the water. Ahab makes one last cast and is caught by his own harpoon line, which drags him from the boat to his death. The damaged ship sinks with Starbuck, Stubb, Flask, Queequeg, Pip, Fedallah's crew, and nearly everyone else aboard. Tashtego, still trying to secure the flag as the mast goes under, pulls a circling bird down with the ship. Ishmael alone escapes the wreck. Queequeg's unused coffin rises as a life buoy and keeps him afloat until the Rachel, still searching for her captain's missing son, finds and rescues him. Moby Dick survives, while Ahab's attempt to impose his private vengeance on the voyage destroys the captain, ship, and crew whose purposes he subordinated to it.",
         "in_short": "Ishmael befriends the harpooner Queequeg and joins the Nantucket whaler Pequod. Its captain, Ahab, has lost a leg to the white sperm whale Moby Dick and secretly means to use the entire voyage to hunt him. He binds the crew to his revenge despite first mate Starbuck's objections, follows reports from other ships, and repeatedly places the men and their ordinary work at risk. The voyage includes successful hunts, disasters in the whaleboats, Pip's psychological collapse after being left in the sea, and mounting signs that Ahab will not turn aside. Even when the Rachel asks for help finding a lost boat, he refuses. After a three-day chase, Moby Dick destroys the Pequod. Ahab is dragged to his death by his harpoon line, and the ship sinks with everyone except Ishmael. Floating on the coffin Queequeg had once ordered for himself, Ishmael is rescued by the returning Rachel and survives to tell the story.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2256,7 +2256,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2269,7 +2269,7 @@
       "recaps": {
         "ending": "The rebellion takes the Capitol, but at the gates of President Snow's mansion a wave of parachute bombs kills a crowd of Capitol children and then the rebel medics who run to help, among them Katniss's sister Prim. Katniss is gravely burned and loses the person she had fought the whole war to protect. Snow, captured and awaiting execution, tells her the lethal bombing was not his but a rebel move, and Katniss becomes convinced that President Coin ordered it to break the Capitol's will and clear her own path to power. When Coin proposes a final Hunger Games using Capitol children and Katniss is granted the right to execute Snow, Katniss instead turns her arrow on Coin and kills her. Snow dies in the uproar that follows. Judged mentally unfit rather than tried, Katniss is returned to the ravaged District 12. Gale, whose ruthless tactics she can no longer separate from Prim's death, takes a post far away, and their friendship ends. Slowly, Peeta returns to her, and years later the two have married and are raising children, at peace but permanently marked by all they survived.",
         "in_short": "Sheltering in the underground District 13, a traumatized Katniss agrees to become the Mockingjay, the symbol of the rebellion, in exchange for concessions including the rescue of Peeta. Filmed propaganda spots rally the districts as the war spreads. When Peeta and other captives are freed from the Capitol, Peeta returns brainwashed to kill Katniss, and only slowly recovers. The rebels win district after district and finally push into the Capitol. Katniss joins a squad meant to film the advance, but it is drawn into the lethal, booby-trapped streets and sewers, where many die, including Finnick. Reaching President Snow's mansion amid a crowd of Capitol children, Katniss watches parachute bombs kill the children and the rebel medics who rush in, among them her sister Prim. Badly burned, she survives; the Capitol falls and Snow is captured. Katniss comes to believe President Coin engineered that final bombing to seize power. Given the chance to execute Snow, she kills Coin instead. Snow dies in the chaos, Katniss is judged unfit and sent home, and years later she and Peeta build a quiet life together in the ruins of District 12.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2442,7 +2442,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2455,7 +2455,7 @@
       "recaps": {
         "ending": "Convicted of theft and sentenced to death, Moll repents in Newgate and has her sentence reduced to transportation. She finds Jemmy there under a similar sentence and persuades him to accept transportation rather than risk execution. In America they use Moll's remaining money to establish themselves. Moll learns that her mother has died and left her property, and she cautiously returns to Virginia, where her son Humphrey welcomes her and arranges the inheritance without exposing her history to her former husband and half-brother. Moll and Jemmy build a profitable plantation in Maryland. After years of prosperity and reflection, they return to England, where Moll says they intend to spend the rest of their lives in repentance for their earlier conduct.",
         "in_short": "Born in Newgate and raised without family, Moll longs for independence and gentility. Her beauty and resourcefulness carry her through a succession of relationships: seduction by one brother, marriage to another, a ruinous match with a tradesman, an unknowingly incestuous marriage in Virginia, a long liaison in Bath, and marriages to the impoverished Jemmy and a banker. Widowhood and dwindling money eventually drive her into theft, where she becomes highly successful under the protection of a midwife who receives stolen goods. Moll is finally caught, condemned, and brought to repentance in Newgate. Reunited there with Jemmy, she gains transportation for them both. In America she recovers an inheritance through her son Humphrey, prospers with Jemmy as a plantation owner, and eventually returns to England claiming a reformed old age.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2577,7 +2577,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2590,7 +2590,7 @@
       "recaps": {
         "ending": "As dawn approaches, Molly's thoughts move away from immediate complaints and imagined future encounters toward memories of her youth in Gibraltar and the beginning of her relationship with Leopold. She recalls the landscape, flowers, sea, other admirers, and the day on Howth when Leopold asked her to marry him. Remembering his face and their physical closeness, she mentally returns to her acceptance of him. The closing movement does not erase her affair with Boylan, her anger, or the long difficulties of the Blooms' marriage. Instead, it places those contradictions beside a durable memory of desire and chosen attachment. The monologue ends with Molly affirming the remembered proposal and, more broadly, the sensual life her thoughts have continually embraced.",
         "in_short": "Unable to sleep beside Leopold after he returns home late, Molly Bloom lets her thoughts move freely through the day and through decades of memory. She considers Leopold's habits and possible affairs, her own recent encounter with Hugh Boylan, her work as a singer, money, clothes, sexuality, menstruation, motherhood, and the men who have desired her. She thinks of her daughter Milly, her dead infant son Rudy, and Stephen Dedalus, the young man Leopold brought home. Her judgments change rapidly, mixing resentment, amusement, jealousy, practical calculation, and sympathy. Gradually her memories reach back to Gibraltar, her girlhood, and her early courtship with Leopold. The final recollection centers on his proposal on Howth and her willing acceptance, closing the soliloquy on an affirmation that coexists with every grievance and infidelity she has remembered.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2716,7 +2716,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2729,7 +2729,7 @@
       "recaps": {
         "ending": "Steve testifies that he did not agree to serve as a lookout and did not signal that the drugstore was clear. His lawyer separates his case from the admitted participants and challenges the credibility of witnesses whose testimony benefits themselves. After closing arguments, the jury finds James King guilty but Steve not guilty. Steve reaches toward O'Brien in relief, but she turns away rather than returning his embrace, leaving him uncertain whether even his own advocate believes in the person he wants to be. Five months later, Steve is home and continues making films, repeatedly turning the camera on himself as he tries to understand what O'Brien saw and why his father now seems distant. The acquittal frees him from prison, but it does not resolve his fear that other people—and perhaps Steve himself—cannot confidently separate his identity from the dehumanizing image constructed during the trial.",
         "in_short": "Sixteen-year-old film student Steve Harmon is jailed and tried for felony murder after a Harlem drugstore owner dies during a robbery. The prosecution claims Steve checked the store and signaled that it was safe for James King and Richard Evans to enter; Steve records the proceedings as a screenplay and his fear in a journal. Witnesses include admitted participants whose cooperation may reduce their sentences, an eyewitness who places King in the store, and Steve's film teacher, who speaks for his character. Steve testifies that he was not part of the plan. The jury convicts King but acquits Steve. When defense attorney Kathy O'Brien turns away from Steve's grateful embrace, victory gives way to uncertainty. Back home months later, Steve keeps filming himself, trying to discover whether the frightening courtroom image of him says anything true about who he is.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3028,7 +3028,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -3041,7 +3041,7 @@
       "recaps": {
         "ending": "Ryun escapes Black Viper captivity, recovers the memories hidden behind his mental wall, and accepts that Melody's death and his retaliation made him the World Ender. Eerv Ji Van surrenders Black Viper through a Dealmaker-enforced fifty-year service contract. Ryun takes its territories, renames it the Twilight Melody Sect, and leaves Anrosh in practical command with Eerv as an adviser. Kri is safe and training, Ereclaw remains Ryun's contracted partner despite rejection by his former pack, and Kagehime remains bonded to Ryun. The freed ruler of the Empty Sky becomes Ryun's cultivation teacher. Ryun, Anrosh, and Eerv clear the Heartstone Core Dungeon, gaining essence and a possible source of income, although the sect cannot yet farm it safely. Ryun remains blind, but his eyes are regenerating. Reyla and Nayra continue their covert frontier assignment as a Category 3 monster swarm approaches. Far away, Zach is a silver-badge Warden partnered with Gris and is still preparing for a lawful future confrontation with Ryun.",
         "in_short": "After Earth is absorbed into the Framework, childhood friends Ryun and Zach take sharply different paths through ten years of survival. In the Infinite Realm, Zach becomes a Warden and seeks a lawful way to stop Ryun, whom he knows as the destroyer of their old world. Ryun arrives sealed, rescues Anrosh and Kri from Black Viper, kills Fier, claims Wolf's Grove, bonds with Ereclaw, and leads the town through a deadly territorial trial. His restored memories reveal that Melody was his partner and the other half of their true-death power, and that her death preceded his catastrophic retaliation. Black Viper captures and blinds Ryun, but he escapes. Eerv Ji Van then surrenders the sect under a fifty-year contract. Ryun renames it the Twilight Melody Sect, places Anrosh in charge, begins studying under the freed ruler of the Empty Sky, and clears a valuable dungeon with Anrosh and Eerv as a major monster swarm approaches.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3218,7 +3218,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3231,7 +3231,7 @@
       "recaps": {
         "ending": "The three-sided war, between Mayor Prentiss's army, Mistress Coyle's resistance, and the native Spackle driven by the Return and led by the Sky, drives every side to the brink of destruction, with the newly landed settlers pulled into the struggle. Todd and Viola, working from opposite ends, strive to force a peace even as Prentiss manipulates events and dangles the possibility that he has changed. In the climactic reckoning the tyrant Mayor Prentiss is destroyed, and with him the greatest obstacle to any settlement between the peoples. But his final act is a devastating assault that leaves Todd grievously wounded and clinging to life. The long war ends not in the annihilation everyone feared but in a fragile, hard-won truce between the humans and the Land, made possible by the arrival of the settler fleet and by those on all sides who chose peace over vengeance. The trilogy closes on that precarious hope and on Viola's absolute determination to bring the wounded Todd back, the future of the shared world still unwritten.",
         "in_short": "War breaks over the colonized planet on three sides: the tyrant Mayor Prentiss and his army, Mistress Coyle's resistance, and the planet's native Spackle, roused to vengeance by the Return and led by the deliberate Sky. Todd finds himself dangerously close to Prentiss, who offers alliance and even the appearance of reform while never abandoning his hunger for control, and Viola works with the peace-seeking newcomers Bradley and Simone from the just-arrived settler ship to end the bloodshed rather than feed it. Shifting alliances, betrayals, and atrocities push all sides toward annihilation, and both Todd and Viola are forced to weigh how far they will go and what they are willing to become. In the end the fighting gives way to a fragile, hard-won peace among the humans and the Land, brokered as the colonists arrive, but at great cost: Mayor Prentiss meets his end, and Todd is left gravely wounded by the tyrant's final assault. The trilogy closes on Viola's fierce determination to save him and on the uncertain hope of a shared future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3337,7 +3337,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3350,7 +3350,7 @@
       "recaps": {
         "ending": "The squad's secret is that all of them are women disguised as men, and that secret proves to reach the very top: much of Borogravia's celebrated high command turns out to be women in disguise as well. The Duchess in whose name the war is fought has been dead for years, her authority a thing kept alive purely by the faith of her worshippers, and she makes her final wishes known through the most devout of the recruits before that belief is allowed to fade. Sergeant Jackrum is revealed to be a woman who spent a lifetime as a soldier, and is at last persuaded to lay down the disguise and reunite with the grown son he never knew. With the war's cause exposed as hollow and its momentum broken, an end is negotiated. Polly, rather than slip back into ordinary life, chooses to remain in the army openly, rising to sergeant and continuing the quiet tradition of enlisting young women who, like her, arrive with their hair cut short and a false name ready.",
         "in_short": "In the small, war-worn nation of Borogravia, whose people worship the increasingly deranged god Nuggan and the revered Duchess, young Polly Perks disguises herself as a boy to enlist and find her missing brother. She joins a ragtag squad of recruits under the veteran Sergeant Jackrum and the hapless Lieutenant Blouse. As the squad marches toward a losing war, Polly discovers that every one of her fellow recruits is also a woman in disguise, each with her own reason to hide. The group crosses into enemy-held territory and infiltrates a besieged keep, where they learn how hollow their country's cause has become. The Duchess, it turns out, has long been dead, sustained only by the belief of her people and speaking through one fervent recruit; and even Borogravia's high command is riddled with women passing as men. Jackrum, too, is revealed to be a woman with decades of concealed service and a long-lost son. Polly helps force the war toward an end and, rather than return to obscurity, stays in the army to change it, becoming a sergeant who quietly recruits the next generation of hidden soldiers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3473,7 +3473,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3486,7 +3486,7 @@
       "recaps": {
         "ending": "A thaw turns the valley noisy with running water, and the winter community begins to disperse. A squirrel resembling the one frozen during the great cold appears alive, though Too-ticky leaves open whether it is truly the same animal. Moomintroll no longer sees the season only as an interruption of ordinary life: he has made friends, accepted its dangers, and learned that some mysteries do not need complete explanations. Moominmamma finally wakes and responds calmly to the changes and damage in the house, restoring Moomintroll's sense of home without erasing what he experienced alone. The family begins preparing for spring. Moomintroll can welcome the warmer world while also recognizing winter as a real part of the valley that he now knows for himself.",
         "in_short": "Moomintroll wakes in the middle of his family's hibernation and finds Moominvalley transformed by snow, darkness, and unfamiliar inhabitants. Unable to wake his parents, he explores and meets Too-ticky, whose patient knowledge helps him endure a season that initially seems hostile, while Little My embraces it with delight. The beautiful Lady of the Cold, the apparent loss of a squirrel, strange creatures in the bathing-house, and an elusive ancestor teach him that winter follows rules unlike summer's. Later, hungry visitors crowd into the Moomin house, an exuberant Hemulen disrupts the quiet valley, and the lonely dog Sorry-oo discovers that the wolves he idealizes are dangerous. Moomintroll moves from fear and possessiveness toward generosity and confidence. With the thaw, the guests depart, a squirrel like the lost one reappears, and Moominmamma wakes. Her calm return restores the household, while Moomintroll retains an independent understanding of the valley's hidden season.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3609,7 +3609,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3620,7 +3620,7 @@
       "recaps": {
         "ending": "The book closes with the jazz vampire case resolved and a much larger threat opened. Simone Fitzwilliam and her sisters are gone: revenants of the 1941 Cafe de Paris bombing who had unknowingly sustained themselves for decades on the lives of jazz musicians, they were confronted with the truth of their deaths at the site of the bombing and allowed to pass on. Peter, who loved Simone, ends the case grieving as much as victorious. The parallel investigation leaves worse news behind: London has an active, highly trained black magician - the Faceless Man - who fought Peter and escaped, and whose projects include engineered human chimeras. His magical education traces back to Geoffrey Wheatcroft, a deceased Oxford academic who taught Newtonian magic outside the Folly's authority, and to the Little Crocodiles, Wheatcroft's old university dining club, giving the Folly a list of leads and a decades-deep institutional failure to reckon with. Nightingale continues to recover and takes the hunt for the Faceless Man as the Folly's central concern. Peter's father, fitted with new teeth and off the heroin, returns to playing, giving Peter back a piece of his family. And in Essex, Lesley May - her face ruined, her old career gone - asks Peter whether magic could repair what the possession destroyed, and reveals that she has a stake in the answer: the door to her entering the magical world is now open.",
         "in_short": "Months after the Covent Garden affair, apprentice wizard Peter Grant investigates the death of a saxophonist who collapsed after a Soho gig - and whose body carries the vestigium of a jazz standard. The trail reveals a decades-long pattern of London jazzmen dying the same way, their vitality drained: the work of so-called jazz vampires. Peter's inquiry entangles him with Simone Fitzwilliam, the dead man's warm, old-fashioned lover, who becomes his own lover, while a parallel case - deaths and mutilations linked to a predatory woman of the demi-monde and to surgically engineered cat-girls - points to a trained black magician operating in London. That magician, dubbed the Faceless Man, fights Peter and escapes, his education traced to Geoffrey Wheatcroft, an Oxford don who taught magic illegally to a dining club called the Little Crocodiles. The jazz deaths resolve at the Cafe de Paris: Simone and her two sisters, killed there by a German bomb in 1941, have persisted ever since by unknowingly feeding on musicians. Confronted with their own deaths, they pass on. Peter is left grieving, the Faceless Man is at large, and Lesley May asks whether magic could mend her ruined face.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3943,7 +3943,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DRMK6KBV",
@@ -3955,7 +3955,7 @@
       "recaps": {
         "ending": "Elaine and Iona remain married after decades of further travel and public service. Their blue-moon expedition succeeds, leaving a consecrated temple to Selene and Lunaris, though Loonkot's concealment of the moons is not resolved. Iona remains mortal by choice. Titania accepts immortality from Elaine, while a rescued system-unattached clone survives without any answer about her creator or origin. Exterreri continues to endure elven attacks, and the Moon Cult's larger purpose remains unknown. During Elaine's later vacation, Arachne sends an emergency letter whose contents are not established. Nearly seventy-five years after the Phoenix Peaks events, an escaped survivor of slavery in Urwa redirects steel projectiles that have accumulated speed through a portal loop and launches them at populated city centers. A marine guardian moves to intervene, but the book ends without resolving whether Moonfall can be stopped.",
         "in_short": "Across several decades, Elaine and Iona support their household and allies while pursuing a long-planned expedition to the blue moon. They survive sabotage, false navigation, and a dangerous change in Elaine's flight reference frame, then build and consecrate the first lunar temple to Selene and Lunaris before returning home. Later, Elaine helps heal Augustine, rescues a system-unattached clone, visits Ethel, and grants Titania immortality at her hundredth birthday celebration. Iona remains mortal by choice, Loonkot and the Moon Cult remain active, and elven attacks continue. The final chapter follows an escaped survivor of slavery in Urwa who has spent decades accelerating steel through portals. She redirects the projectiles toward populated cities and begins Moonfall as a marine guardian races to intervene, with the outcome unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/moonlight-banishes-shadows.json
+++ b/data/works-community/0/moonlight-banishes-shadows.json
@@ -322,7 +322,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1039400450",
@@ -334,7 +334,7 @@
       "recaps": {
         "ending": "Trent leaves the restored Belrise trial as a stronger Shadowhunter, carrying Blood and Ash, the technique Moonlight Banishes Shadows, and a gray sphere wanted by the Red Tiger Company. Cullen ends the company's immediate attack, drives off its surviving recruiter, confirms that Trent's crystal key leads to a western warrior's trial, and gives him a lieutenant emblem from Lewis. Trent commits to the dangerous western territories. Carrie is free of Jace's charter, and Felicia remains with the group, but neither has yet agreed to travel west. The bonded creature wants them both to join and distrusts the silver-haired rogue, who arrives at Trent's camp without becoming a party member. Jace's expected retaliation, the Red Tiger grievance, Seth and Avery's political schemes, Orion's search for Clan Embra, Trent's sealed divine trace, and the truth of Trent's lost past and missing companion remain unresolved.",
         "in_short": "After his bond to Kirstin is severed, Trent Embra enters the Moonlit Forest with the treacherous Martin Vane, survives its werecreatures, accepts a young bonded dog as his companion, kills Martin, and earns the Shadowhunter title while secretly carrying away a divine trace. Near Belrise he forms an unchartered party with Carrie Moss and Felicia. Their delve is manipulated by the trial keeper, forcing Trent through a corrupt fifth floor and a personal trial where he creates Moonlight Banishes Shadows and receives the soulbound swords Blood and Ash. Trent clears the altered trial and reunites with his companions. Carrie escapes Jace's coercive charter, while a disguised silver-haired rogue brings the party a gray sphere pursued by the Red Tiger Company. Trent keeps it, kills the company's archer in an ambush, and is rescued from the recruiter by Cullen. Cullen brings him authority from Lewis and confirms his next path lies west, which Trent chooses despite the open threats around him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -490,7 +490,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -503,7 +503,7 @@
       "recaps": {
         "ending": "Drax reveals that the Moonraker carries a nuclear warhead and is aimed at London, not the North Sea. His public British identity is a construction: he is a German former soldier seeking revenge, aided by Soviet matériel and a loyal German team. Bond and Gala escape confinement beneath the rocket's exhaust and alter its guidance so that it will fall into the sea. Drax and his men flee aboard a Soviet submarine, but the redirected missile detonates where the submarine is passing and destroys them. Britain receives a cover story that preserves confidence in the defence programme. Bond expects that his ordeal with Gala may lead to a relationship, but she tells him that she is already engaged to another police officer. They part after completing the mission, and Bond returns alone to his service life.",
         "in_short": "M asks Bond to determine how national hero Sir Hugo Drax is cheating at cards, and Bond defeats him at his own method. When a security officer is murdered at Drax's Moonraker missile site, Bond joins the investigation beside undercover policewoman Gala Brand. Suspicious German staff, falsified survey information, and Drax's violence reveal that the project is not what it appears. Gala discovers that the missile is aimed at London and is captured; Bond is also seized after surviving an attempted killing. Drax admits he is a German revanchist and has armed the rocket with a Soviet nuclear warhead. Bond and Gala escape from beneath the launch mechanism, redirect the missile into the North Sea, and survive. The explosion destroys the submarine carrying Drax and his followers. Gala then tells Bond she is engaged, leaving him to return alone to ordinary service.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -759,7 +759,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09SNZJ74S",
@@ -771,7 +771,7 @@
       "recaps": {
         "ending": "Elaine remains with Serondes, Aegion, Awarthril, Kiyaya, and Cordamo after the hydra hunt. The hydra is dead, Tyrus has gone to seek another herd, and the elven party still intends to pursue the Shimagu assignment before helping Elaine travel toward home. Elaine is level 420 in Dawn Sentinel, has replaced Lantern with Solar Flare, and continues to delay her third class. She and Serondes have just begun a mutual romantic relationship. The egg taken from Lun'Kat is alive and still incubating, but its nature is unknown. Elaine's age-reversal skill remains untested and could place her at risk if others learn what it may do. In Lun'Kat's hidden lair, Rostellio remains bound by another captor. The God of Light knows where he is but will not pay the cost of confronting the dragon there. Lun'Kat has accepted the healing Elaine gave her and permitted the theft as a tolerable loss, leaving both the dragon and her prisoners as unresolved dangers.",
         "in_short": "Stranded underground with four dwarves, Elaine abandons the failed search for Toke and leads the survivors to a fortified dwarven city. Her healing saves many residents, but the ruling Council plans to retain her for decades. After an assassination attempt and changeling murders, she escapes alone through the mines. Lost for months, Elaine discovers the wounded dragon Lun'Kat, secretly heals her under the demands of her oath, and flees with a living, unidentified egg. She gains an untested age-reversal skill, recovers her lost Sentinel badge, and joins Serondes, Aegion, and Awarthril, three immortal elves traveling with Kiyaya and Cordamo. Their Shimagu mission pauses to kill the hydra that destroyed Tyrus's herd. Elaine reaches Dawn Sentinel level 420 and begins a relationship with Serondes. A final account reveals that Lun'Kat knowingly allowed Elaine to leave, while the captive angel Rostellio remains imprisoned in the dragon's lair.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -951,7 +951,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -964,7 +964,7 @@
       "recaps": {
         "ending": "To complete the vaccination routes quickly enough, Moreta rides Leri's queen Holth while Orlith remains with her clutch. Moreta and Holth make repeated journeys through space and time, but they do not return from the final leg: both are lost between after saving communities that could not otherwise have been reached. Alessan and the people of Fort learn that the woman whose work checked the epidemic will never come home. Orlith is devastated by Moreta's death, yet Leri persuades the bereaved queen to remain until her eggs hatch. Oklina Impresses the new queen from the clutch, preserving Fort's future; only then does Orlith surrender to her loss. Pern survives the plague through the combined work of healers, Holders, and dragonriders, while Moreta's fatal ride passes into history as an act of service rather than the triumphant adventure later generations remember in song.",
         "in_short": "Centuries before the events of Dragonflight, Fort Weyrwoman Moreta attends a Ruatha Gather just as a lethal epidemic begins moving among Pern's Holds. Moreta, Lord Alessan of Ruatha, Masterhealer Capiam, and their allies trace the disease, impose quarantines, care for the sick, and use blood from survivors to prepare protective serum. Dragons let the healers distribute vaccine at a speed no ground transport could match, but the campaign must be extended to the runnerbeasts on which recovery depends. Because her queen Orlith is guarding a clutch, Moreta borrows Leri's Holth and uses repeated time-shifts to cover the final routes. Moreta and Holth are lost between on their last journey. Leri keeps the bereaved Orlith alive until the clutch hatches and Oklina Impresses its young queen; Orlith then dies. The epidemic is broken, but Alessan and Fort must rebuild without Moreta, whose sacrifice becomes one of Pern's defining legends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1132,7 +1132,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1145,7 +1145,7 @@
       "recaps": {
         "ending": "The Rising triumphs. After brutal campaigns and heavy sacrifice, Darrow and his allies bring down the Sovereign, Octavia au Lune, ending her long reign over the Society. The war costs Darrow dearly, taking loyal companions along the way, and his estranged friend Roque, who had sided against him, meets his end after the final battle. The treacherous Jackal, Adrius au Augustus, is defeated and captured, and his sister Virginia executes him herself, closing the wound their family opened. With the old order shattered, Virginia au Augustus assumes leadership of a new government, a Solar Republic meant to give every Color a voice and to end the caste tyranny the Golds imposed. Darrow, no longer hidden, stands beside her as they begin the fragile work of building the freer world Eo had dreamed of, and they look toward a future for their young son. Cassius au Bellona, his loyalties changed by all he has seen, departs to safeguard a child of the fallen ruling line. The revolution has won, but the peace that follows will have to be fought for anew.",
         "in_short": "Captured and broken by long imprisonment at the hands of the Jackal, Darrow is rescued by Sevro and his allies and sets out to turn a scattered rebellion into a force that can topple the Society. He rebuilds his coalition of Reds, Obsidians, lowColors, and sympathetic Golds, gambling on daring raids and hard-won alliances while grieving the friends the war has cost him. Betrayal, sacrifice, and vast battles carry the Rising from near-collapse to a final assault on the seat of Gold power. In the end the Sovereign, Octavia au Lune, is overthrown, and the treacherous Jackal is captured and executed by his own sister, Virginia. The old order gives way to a new one: Virginia takes the lead of a reformed government founded on the promise of freedom and representation, with Darrow at her side. Their victory is bought with terrible loss, and hard questions about the future remain, but the color-coded tyranny is broken and the dream Eo died for has taken root.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1241,7 +1241,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1252,7 +1252,7 @@
       "recaps": {
         "ending": "Mort ends with the tangle of altered reality resolved by Death rather than by his apprentice. Mort challenges Death and they fight; Death wins but spares Mort's life. Instead of allowing history's correction to claim Princess Keli, Death sets things right himself, absorbing the cost of Mort's interference. He then releases Mort from the apprenticeship, but sends him off well: Death gives Mort and Ysabell, his adopted daughter, leave to marry and a generous send-off. Keli, secure once more on the throne of Sto Lat, rewards Mort by making him Duke of Sto Helit, and keeps the wizard Cutwell as her royal recognizer, one of the few who never lost sight of her. Mort and Ysabell depart to begin married life as duke and duchess. Death, changed by his brief taste of living, of food, drink, and feeling, returns to his domain and resumes the unending duty of collecting souls, once again alone but no longer quite unmoved by the mortals he gathers.",
         "in_short": "Mort, a gawky farm boy, is apprenticed to Death and learns to collect the souls of the dying, living in Death's timeless domain with the servant Albert and Death's adopted daughter, Ysabell. When Death steps back to experience ordinary human life, he leaves the Duty to Mort, who is sent to gather the soul of Princess Keli of Sto Lat, marked for assassination. Smitten, Mort kills the assassin and saves her, but reality insists she should be dead and starts erasing her, sealing her kingdom inside a shrinking dome of altered history. With the wizard Cutwell and with Ysabell, Mort struggles to keep Keli alive and set history right, even as the work slowly turns him into something like Death himself. In the end Mort must fight Death to resolve it. Death spares him and repairs reality by his own hand, then dismisses him kindly: Mort marries Ysabell and is made Duke of Sto Helit, Keli keeps her throne, and Death returns to his solitary work.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1451,7 +1451,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1464,7 +1464,7 @@
       "recaps": {
         "ending": "The Remnants are driven back and contained, but the case ends with the ground moved under everyone. Kenspeckle Grouse is dead, killed during the outbreak, and Clarabelle is left running his facility without him. Valkyrie knows what the Sensitives were seeing: Darquesse is her true name, and the sorcerer who burns the world in every vision is her. She has been Darquesse once, briefly and completely, long enough to know how much she enjoyed it and how little of Valkyrie was left while it lasted, and long enough to have fought the thing in Lord Vile's armour to a standstill in front of witnesses. To make sure it cannot happen again, she has her true name sealed away, which should put Darquesse permanently out of reach. Skulduggery keeps the secret with her rather than reporting it. The worst blow is Tanith Low: as the Remnants are being rounded up, one takes her, and the possessed Tanith escapes with her own face, her own skill and none of her own loyalties. She is now somewhere in the world, on the other side, and she believes in Darquesse. Lord Vile's identity is still unexplained.",
         "in_short": "Sensitives, the sorcerers who see the future, are being murdered one after another, and every one of them had seen the same vision: a sorcerer called Darquesse destroying the world. While Skulduggery and Valkyrie investigate, a far more immediate threat gets loose, as thousands of Remnants, parasitic creatures that possess a host and unlock the worst of them, escape and sweep through Ireland, taking the Sanctuary and much of Dublin with them. Kenspeckle Grouse is killed in the outbreak. Valkyrie then learns what the visions meant: her true name is Darquesse. Speaking a true name unlocks everything a sorcerer can be, and when there is no other way to stop what is happening, Valkyrie becomes Darquesse, a being of enormous power and no restraint who fights the returned Lord Vile to a standstill before Valkyrie is brought back to herself. The Remnants are contained. Valkyrie has her true name sealed away so Darquesse cannot surface again, and Skulduggery helps her hide it. In the last moments, a Remnant takes Tanith Low, and the possessed Tanith escapes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1693,7 +1693,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1706,7 +1706,7 @@
       "recaps": {
         "ending": "The moles' channels do their work and the river pours into the diggings beneath Kotir. The fortress floods and sinks, its stones settling into a new lake, and the garrison scatters; Ashleg and Fortunata abandon their mistress and slip away. Tsarmina, who has feared deep water all her life, is left facing Martin as her stronghold goes under, and she drowns in the flood that takes Kotir. Gingivere, freed from the cell his sister put him in, is given his life and goes north to live quietly on a farm, wanting nothing further to do with conquest. Mossflower is free for the first time in a generation, and the woodlanders begin quarrying the stones of the drowned fortress for something to build with. Germaine and the mice of Loamhedge, who arrived looking for a home, join them, and together they start raising an abbey beside the road through the woods, a house intended to shelter and feed anyone who comes to it: Redwall. Martin hangs up the sword Boar forged for him and takes the role of the new abbey's protector rather than a warlord's. Gonff and Columbine marry, and the story closes on the first stones of the abbey going up.",
         "in_short": "Mossflower Wood is held by the wildcats of the fortress Kotir, where the ailing warlord Verdauga rules until his daughter Tsarmina takes the fortress for herself, imprisons her brother Gingivere and tightens her grip on the woodlanders. Martin, a wandering young mouse, is captured, has his father's sword broken by Tsarmina and is thrown into the dungeons, where he meets the thief Gonff. The two escape and join the woodland resistance based at Brockhall under Bella the badger, who tells Martin of her father, Boar the Fighter, lord of the mountain Salamandastron in the west. Martin, Gonff and Dinny the mole travel west to seek his help, gathering allies on the road, and at the mountain Boar forges Martin a new sword from star metal before dying in a battle against sea rats. While they are away, the woodlanders starve Kotir out and the moles dig channels to turn the river against it. Martin returns as the fortress floods and sinks, and Tsarmina, terrified of water all her life, drowns with it. On the ruins the freed woodlanders and a company of mice from Loamhedge begin building Redwall Abbey.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1882,7 +1882,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1895,7 +1895,7 @@
       "recaps": {
         "ending": "In Israeli custody, Campbell expects to be condemned as the propagandist the world heard. Frank Wirtanen finally sends documentary confirmation that Campbell did transmit intelligence for the United States, and the evidence removes the legal basis for prosecuting him. The vindication does not restore the people Campbell lost or erase the effect of his broadcasts. Helga is dead; Resi killed herself after their attempted escape collapsed; George Kraft has been exposed as the Soviet agent Colonel Iona Potapov; and Campbell recognizes that the hateful public figure he performed acquired a consequential life of its own. Free to leave his cell, he instead decides to hang himself. He says his death will not be for crimes against humanity, since the court has answered that charge, but for crimes against himself: the destruction of any coherent private self beneath the roles he chose to inhabit.",
         "in_short": "Howard W. Campbell Jr., an American playwright living in Germany, becomes a prominent Nazi radio propagandist while secretly placing coded intelligence in his broadcasts for the United States. His handler warns that his service may never be acknowledged. After the war Campbell is quietly freed and lives anonymously in New York, mourning his wife Helga. A woman presented as Helga proves to be her sister Resi, while his friend George Kraft is exposed as a Soviet agent trying to move him to Moscow. American extremists celebrate Campbell as a hero, making his hidden life impossible. Resi kills herself when their fragile private world collapses, and Campbell voluntarily gives himself up for trial in Israel. His handler eventually confirms his espionage and clears him legally, but Campbell concludes that the public role he played became morally real regardless of his secret motives. With no identity or future he can accept, he prepares to hang himself in his cell.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2077,7 +2077,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2090,7 +2090,7 @@
       "recaps": {
         "ending": "At the premiere of the great epic in Ankh-Morpork the barrier finally fails. The presence buried beneath Holy Wood takes Ginger completely, and she grows to enormous size and climbs the Tower of Art carrying the Librarian, while creatures from the Dungeon Dimensions force their way through into the city. Victor climbs after her, breaks the hold on her, and turns the logic of Holy Wood back against what is using it, and the way through is shut. Holy Wood does not survive it. The town is destroyed and the sand begins to cover it again, and with the magic gone the whole industry collapses as suddenly as it appeared: the pictures stop working, the crowds go home, and the people who were stars a week earlier are simply people again. Dibbler goes back to Ankh-Morpork and to selling sausages, already thinking about the next thing. Detritus and Ruby stay together and leave for the city. Gaspode keeps his voice, and his opinions. Victor and Ginger, no longer famous and no longer needed, walk away from the ruins together. The wizards return to Unseen University under their new Archchancellor with the affair closed, and the hill above Holy Wood is quiet again.",
         "in_short": "When the last keeper of an ancient rite at Holy Wood dies with no successor, something long buried under the hill begins to wake. In Ankh-Morpork the alchemist Thomas Silverfish invents moving pictures, and within weeks half the city feels an inexplicable urge to travel to Holy Wood and make them. Among them are Victor Tugelbend, a student wizard who has spent years avoiding graduation, and Ginger, a determined young woman who becomes the Disc's first leading lady. A boom town rises overnight, run by Cut-Me-Own-Throat Dibbler; trolls, dwarfs and a talking dog named Gaspode pour in. But the pictures work because reality is thin at Holy Wood, and every audience that watches them makes it thinner. Ginger sleepwalks to a buried door beneath the hill. At the premiere of Dibbler's enormous epic the barrier gives way: Ginger is taken over and grows gigantic, climbing the Tower of Art with the Librarian, while things from outside reality pour into the city. Victor frees her and closes the way. Holy Wood burns, the industry vanishes overnight, and the sand covers the hill again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2267,7 +2267,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2280,7 +2280,7 @@
       "recaps": {
         "ending": "Brady prepares to detonate an explosive vest at a crowded concert attended by children, including Jerome's sister. Hodges, Jerome, and Holly identify the target and race to the venue, but Hodges suffers a heart attack before they reach Brady. Jerome and Holly continue without him. Holly finds Brady in the crowd and repeatedly strikes him with the weighted device Hodges has carried for protection, preventing him from triggering the bomb. Brady survives with severe brain damage and is hospitalized. Hodges recovers from surgery; although he is not a police officer, his part in stopping the attack restores his sense of purpose. Jerome and Holly are honored alongside him, and the three have become an effective, unconventional investigative team. The Mercedes murders and Janey's death remain losses they cannot undo, but Brady's campaign is over. A final hospital scene suggests that there may be a faint change in Brady's apparently unresponsive condition.",
         "in_short": "Retired detective Bill Hodges is depressed and considering suicide when the unidentified driver who killed people with a stolen Mercedes sends him a taunting letter. The killer is Brady Hartsfield, a computer technician who enjoys manipulating survivors. Hodges investigates privately with his young friend Jerome Robinson and Janey Patterson, sister of the car's late owner, Olivia Trelawney. Hodges and Janey become lovers, while Janey's cousin Holly Gibney joins the inquiry and proves gifted at finding patterns. Brady tries to poison Jerome's dog, accidentally kills his own mother, and then murders Janey with a car bomb intended for Hodges. The investigators trace his electronic tricks and realize that he plans a larger suicide attack at a packed concert. Hodges suffers a heart attack during the pursuit, but Jerome and Holly reach the venue. Holly disables Brady before he can detonate his explosives. Brady is left severely brain-damaged, and Hodges survives with a renewed purpose and two trusted partners.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2427,7 +2427,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2440,7 +2440,7 @@
       "recaps": {
         "ending": "Mr Stink's public appearances expose the gap between Mrs Crumb's political image and her treatment of the vulnerable people she talks about. The attention also helps the Crumbs admit what they have concealed from one another: Mr Crumb has lost his job, Chloe is miserable and bullied, and the family's constant competition is hurting them. Mr Stink reveals that he was born Lord Darlington and once had wealth and a home, but grief led him to abandon that life and wander with Duchess. Chloe understands that homelessness is not his entire identity and that kindness does not give her the right to decide his future. The Crumbs become more honest and affectionate, and Chloe recognizes that she belongs with them despite their faults. Mr Stink declines a settled place in their household and resumes his journey with Duchess. Chloe lets her friend go rather than trying to possess or reform him, carrying forward the confidence and compassion their friendship gave her.",
         "in_short": "Chloe Crumb feels ignored by her ambitious mother, overshadowed by her sister Annabelle, and tormented by a supposed friend at school. She befriends an elderly homeless man called Mr Stink and secretly lets him and his dog, Duchess, stay in the family garden shed. Her mother, campaigning for political office on policies hostile to homeless people, discovers him and tries to turn his presence into favorable publicity. Mr Stink refuses to behave as a convenient political symbol and challenges the powerful people who discuss homelessness without understanding it. His arrival also forces the Crumbs' private troubles into the open, including Chloe's unhappiness and her father's hidden unemployment. Mr Stink eventually explains that he is Lord Darlington and chose a wandering life after personal loss. The family grows more truthful and supportive, but he does not remain as a rescued dependent. Chloe chooses her family, and Mr Stink leaves with Duchess to continue living on his own terms.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2615,7 +2615,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2628,7 +2628,7 @@
       "recaps": {
         "ending": "Septimus and Rezia share a brief interval of renewed closeness while making a hat, but Sir William Bradshaw's plan to remove Septimus to an institution remains in force. When Doctor Holmes arrives, Septimus sees surrender to the doctors as intolerable and jumps from a window, killing himself. That evening, Clarissa's party brings together political figures, old acquaintances, Peter Walsh, and Sally Seton. Sir William and Lady Bradshaw arrive late, and Lady Bradshaw mentions the veteran's suicide. Clarissa withdraws alone, initially angered that death has entered her party. Imagining the unknown man's decision, she recognizes in it an attempt to preserve an inner self from coercion and feels both kinship and renewed commitment to life. She returns to her guests. Sally and Peter talk about their past and present lives while waiting for Clarissa. Elizabeth joins her father, and their affection is quietly apparent. The novel closes as Clarissa re-enters Peter's sight; his mingled fear and delight identify the emotional power she still holds for him, without resolving their history into romance.",
         "in_short": "Over one June day in postwar London, Clarissa Dalloway prepares an evening party while memories of youth, Sally Seton, and Peter Walsh lead her to reconsider love, aging, and her marriage to Richard. Elsewhere, war veteran Septimus Warren Smith suffers hallucinations and emotional collapse as his wife Rezia seeks help. Doctors Holmes and Bradshaw dismiss his experience and plan to confine him. Septimus kills himself rather than submit. At Clarissa's party, guests from different periods of her life gather, including Peter and Sally. News of Septimus's death reaches Clarissa through the Bradshaws. Alone, she imagines the stranger's suicide as a desperate defense of his private self and confronts her own fear of death. She then returns to the party with her desire to live renewed. The day ends without undoing anyone's choices: Clarissa remains with Richard, Sally returns to her family, and Peter responds to Clarissa's presence with the same intense feeling that has followed him for decades.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2709,7 +2709,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2722,7 +2722,7 @@
       "recaps": {
         "ending": "In her London office, Vivie has committed herself to financial work and a life independent of her mother's money. Frank accepts that their flirtation will not become a conventional marriage and withdraws, while Praed prepares to travel abroad. Mrs Warren arrives seeking reconciliation. Vivie distinguishes between the desperate circumstances that first led her mother into prostitution and the later decision to remain a wealthy proprietor when she could have retired. Because Mrs Warren still participates in the business and has concealed that choice, Vivie refuses both financial support and further intimacy. Mrs Warren argues that she has sacrificed everything for her daughter and is devastated by the rejection, but Vivie does not yield. After her mother leaves, Vivie briefly shows the emotional cost of the break, then returns to her work. The play closes with mother and daughter separated: Mrs Warren retains her wealth and business, while Vivie secures moral and economic independence at the price of their relationship.",
         "in_short": "Cambridge-trained Vivie Warren plans an independent working life and knows little about the fortune that funded her education. Visits from her mother, Mrs Warren, and the wealthy Sir George Crofts force her to investigate. Crofts is Mrs Warren's partner in a profitable chain of brothels and wants to marry Vivie; he also raises the possibility that Vivie and her admirer Frank Gardner share a father. Mrs Warren explains that poverty and the limited work open to women drove her into prostitution, and Vivie respects the courage of that earlier choice. She changes her judgment when she learns that her mother, now financially secure, continues to own the business. Vivie moves to London, dedicates herself to actuarial work, ends the romantic possibility with Frank, and refuses her mother's money. In their final confrontation, Mrs Warren appeals to maternal sacrifice, but Vivie rejects a relationship founded on continuing exploitation and concealment. Mrs Warren leaves in distress, and Vivie returns alone to her work.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2902,7 +2902,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2915,7 +2915,7 @@
       "recaps": {
         "ending": "Borachio's confession proves that Don John arranged the false evidence against Hero. Claudio, believing Hero dead because of his public rejection, accepts Leonato's demand that he mourn at her tomb and then marry a veiled cousin without seeing her. At the second wedding the woman is revealed as Hero, alive and innocent, and Claudio receives her with relief. Beatrice and Benedick each try to minimize their love until written evidence from their friends exposes them; they agree to marry and restore their familiar teasing on more equal terms. Don Pedro remains unmarried. News arrives that the fleeing Don John has been captured, but Benedick recommends postponing punishment until after the celebrations. The play closes with dancing and two marriages restored or created through the exposure of deception.",
         "in_short": "When Don Pedro's soldiers visit Messina, Claudio and Hero become engaged while their friends trick the proudly unmarried Beatrice and Benedick into believing each secretly loves the other. Don Pedro's resentful brother Don John attacks the first match. His follower Borachio courts Margaret at Hero's window while Claudio and Don Pedro watch from a distance, making Hero appear unfaithful. Claudio rejects Hero publicly at their wedding, and she collapses. Friar Francis hides her and reports her dead while her innocence is tested. Dogberry's watch has meanwhile arrested Borachio, whose confession exposes the plot. A remorseful Claudio mourns Hero and agrees to marry Leonato's supposed niece; the veiled bride is Hero herself. Beatrice and Benedick also admit their love when their letters betray them. Don John is captured, and both couples prepare to marry.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3028,7 +3028,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3041,7 +3041,7 @@
       "recaps": {
         "ending": "When Mumu returns after the servants' first attempt to remove her, the mistress demands that the dog be destroyed. Gerasim understands the order and insists on carrying it out himself. He gives Mumu a final meal, rows into the river, binds weights to her, and lets her sink. He then returns to the house, gathers his few possessions, and walks through the night to his native village without requesting permission. His strength and determination make pursuit useless. Back in the country he resumes field labor and lives alone, never again showing interest in women or keeping a dog. The mistress is initially enraged by his departure, then declares that she never needed him and makes no serious attempt to recover him. Gerasim's escape ends her direct control over him, but it comes only after obedience has forced him to destroy the creature he loved most.",
         "in_short": "Gerasim, a deaf and non-speaking serf of great strength, is taken from rural field work to serve an arbitrary elderly mistress in Moscow. He grows attached to the laundress Tatiana, but the mistress decides Tatiana should marry the drunken shoemaker Kapiton. The servants frighten Gerasim away by making Tatiana pretend to be drunk, and the married couple is later sent to the country. Gerasim then rescues a puppy from a river, names her Mumu, and devotes himself to her. When Mumu barks at the mistress, the household is ordered to get rid of the dog. Mumu returns after being sold, and a second order demands her death. Gerasim feeds her, rows into the river, and drowns her himself. He then leaves Moscow without permission and walks back to his village. There he resumes hard farm work but never again forms the attachments that his mistress used her power to destroy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3182,7 +3182,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3195,7 +3195,7 @@
       "recaps": {
         "ending": "Miss Marple identifies Anne Protheroe and Lawrence Redding as the conspirators. Their separate confessions were calculated to make both appear innocent once the physical evidence contradicted each account, while manipulated timing and misleading sounds confused the witnesses. Lawrence also attempts to divert suspicion toward Hawes. The accumulated inconsistencies allow Miss Marple to reconstruct the plan, and the pair are arrested before they can leave together. Mrs Lestrange's secrecy proves unrelated to the murder: she is Lettice's dying mother, and mother and daughter are reconciled. Hawes survives the attempt to make him look guilty. With the case resolved, Leonard and Griselda return to village life and learn that they are expecting a child.",
         "in_short": "The disliked Colonel Protheroe is found shot in the vicar's study in St Mary Mead. His wife Anne and the artist Lawrence Redding each make suspicious confessions, but neither account fits the timing and physical evidence. Inspector Slack pursues a succession of villagers with motives, while the vicar Leonard Clement and Miss Marple notice contradictions involving a note, misleading sounds, and the movements around the vicarage. Miss Marple concludes that Anne and Lawrence acted together: the competing confessions and false chronology were parts of a plan designed to clear them both. They are arrested. Other mysteries prove separate from the killing, including Mrs Lestrange's concealed connection to Lettice Protheroe, and the Clements end the case looking forward to a child.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3305,7 +3305,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3318,7 +3318,7 @@
       "recaps": {
         "ending": "Four knights return to Canterbury Cathedral with swords after accusing Thomas Becket of betraying King Henry II. The priests try to bar the doors, but Becket insists that the church remain open and refuses to flee. The knights kill him near the altar. Afterward they address the audience directly and offer political and legal rationalizations: they claim loyalty to public order, deny selfish motives, portray Becket as a traitor, and even suggest that his deliberate acceptance of death makes him responsible. Their arguments cannot erase what the audience has witnessed. The Chorus, which had wanted only to remain outside history, accepts that the murder implicates the whole community and turns from horror toward prayer and repentance. The priests praise Becket as a martyr whose death becomes a spiritual victory rather than the final success of royal force. The play closes with the community asking mercy and acknowledging both human guilt and divine judgment.",
         "in_short": "In December 1170, Archbishop Thomas Becket returns to Canterbury after seven years of exile caused by his struggle with King Henry II. The women of Canterbury fear the violence his return will bring. Four tempters urge Becket toward pleasure, restored political influence, rebellion, or martyrdom sought for fame; he rejects each motive and resolves to submit to God's will without engineering his own death. In a Christmas sermon he explains that true martyrdom is not a personal quest for glory. Four royal knights then accuse him of treason and order him to leave England. Becket refuses both submission and escape. When the knights return armed, the priests attempt to protect him, but he opens the cathedral to his killers and is murdered. The knights rationalize the act to the audience, while the Chorus and priests recognize the killing as communal guilt and Becket's death as martyrdom.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3509,7 +3509,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3522,7 +3522,7 @@
       "recaps": {
         "ending": "Poirot works out that every passenger in the Istanbul to Calais coach is connected to the Armstrong household. Mrs Hubbard is the actress Linda Arden, Daisy Armstrong's grandmother; the Countess Andrenyi is Daisy's aunt, and her husband altered her passport to hide it; Mary Debenham was the child's governess and Greta Ohlsson her nurse; Princess Dragomiroff was godmother to Daisy's mother; Hildegarde Schmidt was the family's cook and Masterman Colonel Armstrong's soldier servant; Foscarelli was their chauffeur; Colonel Arbuthnot was Armstrong's friend from the war; MacQueen was the son of the district attorney who prosecuted the case; Hardman was a detective in love with the accused nursemaid; and Pierre Michel, the conductor, was her father. Twelve of them stabbed Ratchett once each, in the dark, so that none could know whose blow was fatal, a jury carrying out the sentence the courts never delivered. The confusing evidence, the varying wounds, the smashed watch, the woman in the scarlet kimono and the stranger in a conductor's uniform were all planted to support a story about an outsider. Poirot lays two solutions before Monsieur Bouc and Dr Constantine: an unknown assassin who boarded at the stop and left again, or the truth. They choose the first, and Poirot says that having offered his solutions he takes his leave of the case. The snowplough clears the line and the train goes on with the Yugoslav police to be given the convenient explanation.",
         "in_short": "Returning urgently to London, Hercule Poirot boards the Simplon Orient Express at Istanbul and finds it inexplicably full for the time of year. Among the passengers is an American named Ratchett, who offers Poirot money to protect him from enemies and is refused. That night the train is stopped by a snowdrift in the Balkans, and in the morning Ratchett is found stabbed a dozen times behind a locked door. A charred scrap of paper identifies him as Cassetti, the man who kidnapped and murdered the child Daisy Armstrong in America and escaped punishment on a technicality. Investigating for the sleeping-car company, Poirot finds the evidence absurdly abundant and contradictory: wounds struck with different hands and force, a scarlet kimono, a conductor's uniform, a stopped watch, and an alibi for every passenger. He eventually establishes that all of them are connected to the Armstrong household, and that twelve of them stabbed the man once each, as a jury and executioners. Poirot offers two explanations and allows the innocuous one, an outside assassin, to be given to the police.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3710,7 +3710,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3723,7 +3723,7 @@
       "recaps": {
         "ending": "About twenty years after his last substantial visit, Jim returns to Nebraska and goes to Ántonia's farm. She is married to Anton Cuzak and is raising a large family. Though age and hard work have marked her, Jim recognizes the same vitality that defined the girl he knew. He spends an affectionate visit in the crowded household, listens to Cuzak's history, and forms a particular bond with the older sons. Jim promises to take the boys hunting and hopes to become part of the family's life rather than disappearing again. On his way back toward Black Hawk, he walks along a nearly vanished road that he and Ántonia traveled when they first came to the prairie. The landscape joins their separate lives through a shared past, and Jim concludes that their friendship has given him one of the central meanings of his life.",
         "in_short": "Orphaned Jim Burden grows up on his grandparents' Nebraska farm beside Ántonia Shimerda, a spirited Bohemian immigrant girl. The Shimerdas endure poverty and her father's suicide, while Ántonia sacrifices schooling for farm labor. In Black Hawk she joins the immigrant hired girls whose energy and independence fascinate Jim. Their paths divide: Jim pursues education, and Ántonia is abandoned while pregnant by railway conductor Larry Donovan. When Jim visits, she is raising her daughter without shame and remains devoted to the land. Decades later he finds her married to Anton Cuzak and surrounded by children on a thriving farm. Ántonia's life has been difficult, but her vitality endures. Jim reconnects with her family and recognizes that his memory of her, and their shared Nebraska childhood, has permanently shaped him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3918,7 +3918,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3931,7 +3931,7 @@
       "recaps": {
         "ending": "About twenty years after his last substantial visit, Jim returns to Nebraska and goes to Ántonia's farm. She is married to Anton Cuzak and is raising a large family. Though age and hard work have marked her, Jim recognizes the same vitality that defined the girl he knew. He spends an affectionate visit in the crowded household, listens to Cuzak's history, and forms a particular bond with the older sons. Jim promises to take the boys hunting and hopes to become part of the family's life rather than disappearing again. On his way back toward Black Hawk, he walks along a nearly vanished road that he and Ántonia traveled when they first came to the prairie. The landscape joins their separate lives through a shared past, and Jim concludes that their friendship has given him one of the central meanings of his life.",
         "in_short": "Orphaned Jim Burden grows up on his grandparents' Nebraska farm beside Ántonia Shimerda, a spirited Bohemian immigrant girl. The Shimerdas endure poverty and her father's suicide, while Ántonia sacrifices schooling for farm labor. In Black Hawk she joins the immigrant hired girls whose energy and independence fascinate Jim. Their paths divide: Jim pursues education, and Ántonia is abandoned while pregnant by railway conductor Larry Donovan. When Jim visits, she is raising her daughter without shame and remains devoted to the land. Decades later he finds her married to Anton Cuzak and surrounded by children on a thriving farm. Ántonia's life has been difficult, but her vitality endures. Jim reconnects with her family and recognizes that his memory of her, and their shared Nebraska childhood, has permanently shaped him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4090,7 +4090,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4103,7 +4103,7 @@
       "recaps": {
         "ending": "After the degrading months at Barney's Gap, Sybylla returns to Possum Gully physically depleted but still determined not to surrender her inner life. Harold Beecham recovers his financial position and renews his offer of marriage, giving her a genuine route into security and affection. She nevertheless refuses him. She believes that marriage would bind him to someone too divided and restless to accept the role expected of a wife, and she will not use him as an escape from poverty. Harold leaves hurt, while Sybylla remains with her family and no brilliant profession materializes. Her promised career is therefore unresolved in practical terms. What survives is her authorship of the story itself: an unsentimental account of rural hardship, thwarted ambition, love declined, and a young woman's insistence that her life cannot be measured only by marriage or material success.",
         "in_short": "Sybylla Melvyn grows up clever, restless, and poor at Possum Gully, where her father's failed venture and drinking have reduced the family to relentless labor. A visit to her wealthy grandmother's station, Caddagat, gives her music, books, sympathetic companionship, and the attention of neighboring landowner Harold Beecham. She cares for Harold but fears marriage will extinguish the independent, artistic life she wants. When Harold's fortunes collapse and Sybylla's father owes money to the M'Swat family, she is sent to work in their harsh household at Barney's Gap. Ill and miserable, she eventually returns home. Harold later regains his property and asks again for her hand, but Sybylla refuses, choosing uncertainty over a marriage she cannot enter honestly. She ends without the public career she imagined, yet her forthright narration becomes evidence of the creative identity she has struggled to preserve.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/my-brilliant-career-unabridged.json
+++ b/data/works-community/0/my-brilliant-career-unabridged.json
@@ -97,7 +97,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -110,7 +110,7 @@
       "recaps": {
         "ending": "After the degrading months at Barney's Gap, Sybylla returns to Possum Gully physically depleted but still determined not to surrender her inner life. Harold Beecham recovers his financial position and renews his offer of marriage, giving her a genuine route into security and affection. She nevertheless refuses him. She believes that marriage would bind him to someone too divided and restless to accept the role expected of a wife, and she will not use him as an escape from poverty. Harold leaves hurt, while Sybylla remains with her family and no brilliant profession materializes. Her promised career is therefore unresolved in practical terms. What survives is her authorship of the story itself: an unsentimental account of rural hardship, thwarted ambition, love declined, and a young woman's insistence that her life cannot be measured only by marriage or material success.",
         "in_short": "Sybylla Melvyn grows up clever, restless, and poor at Possum Gully, where her father's failed venture and drinking have reduced the family to relentless labor. A visit to her wealthy grandmother's station, Caddagat, gives her music, books, sympathetic companionship, and the attention of neighboring landowner Harold Beecham. She cares for Harold but fears marriage will extinguish the independent, artistic life she wants. When Harold's fortunes collapse and Sybylla's father owes money to the M'Swat family, she is sent to work in their harsh household at Barney's Gap. Ill and miserable, she eventually returns home. Harold later regains his property and asks again for her hand, but Sybylla refuses, choosing uncertainty over a marriage she cannot enter honestly. She ends without the public career she imagined, yet her forthright narration becomes evidence of the creative identity she has struggled to preserve.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -324,7 +324,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -337,7 +337,7 @@
       "recaps": {
         "ending": "Lila marries Stefano Carracci in a large neighborhood celebration after he has financed the Cerullo shoe business and promised to keep the Solara family away from it. At the reception, however, Marcello Solara arrives as an honored guest wearing the first pair of shoes Lila designed and made with Rino. Stefano had obtained those shoes and has plainly given or sold them to the man Lila rejected. She understands that her new husband has broken his assurances before their wedding day is over and has joined the commercial alliance she feared. Elena watches Lila's happiness collapse as the marriage begins. Elena, meanwhile, remains on the educational path that Lila was denied, but she recognizes that schooling has not freed her from the neighborhood or from measuring her life against Lila's. The friends enter adulthood on sharply different paths: Elena through study, and Lila through a marriage already marked by betrayal and the interests of the Carracci and Solara families.",
         "in_short": "After the adult Lila vanishes, Elena Greco begins recounting their life together in a poor Naples neighborhood. As children, Elena and Lila are united by intelligence, rivalry, and a daring confrontation with the feared Don Achille. Both excel at school, but only Elena is permitted to continue; Lila enters her father's shoe shop and pursues learning on her own while Elena advances through middle school and high school. Adolescence separates and reconnects them through study, work, family violence, romance, and the changing power of neighborhood businesses. Lila designs an innovative pair of shoes with her brother Rino and rejects the wealthy Marcello Solara. She instead accepts Stefano Carracci, who promises respect and finances production of the Cerullo shoes. At their wedding, Lila sees Marcello wearing her original handmade pair, proof that Stefano has allied himself with the Solaras and broken his promise. The marriage begins in betrayal, while Elena continues the education Lila was denied.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -558,7 +558,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -571,7 +571,7 @@
       "recaps": {
         "ending": "Lila marries Stefano Carracci in a large neighborhood celebration after he has financed the Cerullo shoe business and promised to keep the Solara family away from it. At the reception, however, Marcello Solara arrives as an honored guest wearing the first pair of shoes Lila designed and made with Rino. Stefano had obtained those shoes and has plainly given or sold them to the man Lila rejected. She understands that her new husband has broken his assurances before their wedding day is over and has joined the commercial alliance she feared. Elena watches Lila's happiness collapse as the marriage begins. Elena, meanwhile, remains on the educational path that Lila was denied, but she recognizes that schooling has not freed her from the neighborhood or from measuring her life against Lila's. The friends enter adulthood on sharply different paths: Elena through study, and Lila through a marriage already marked by betrayal and the interests of the Carracci and Solara families.",
         "in_short": "After the adult Lila vanishes, Elena Greco begins recounting their life together in a poor Naples neighborhood. As children, Elena and Lila are united by intelligence, rivalry, and a daring confrontation with the feared Don Achille. Both excel at school, but only Elena is permitted to continue; Lila enters her father's shoe shop and pursues learning on her own while Elena advances through middle school and high school. Adolescence separates and reconnects them through study, work, family violence, romance, and the changing power of neighborhood businesses. Lila designs an innovative pair of shoes with her brother Rino and rejects the wealthy Marcello Solara. She instead accepts Stefano Carracci, who promises respect and finances production of the Cerullo shoes. At their wedding, Lila sees Marcello wearing her original handmade pair, proof that Stefano has allied himself with the Solaras and broken his promise. The marriage begins in betrayal, while Elena continues the education Lila was denied.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -712,7 +712,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -725,7 +725,7 @@
       "recaps": {
         "ending": "After becoming gravely ill, Philip recognizes similarities between his symptoms and Ambrose's last complaints. He discovers further evidence that revives his fear that Rachel may have poisoned Ambrose and may now be poisoning him, possibly with laburnum. Yet none of it establishes her guilt: Ambrose was ill, his mind may have been affected, and Rachel's conduct remains open to more than one explanation. While Rachel prepares to leave, Philip learns that workmen have removed supports near an unfinished terrace and that the path is dangerous. He sees Rachel walking toward it and does not warn her. She falls through the weak structure and suffers fatal injuries. As Philip holds her, she addresses him as Ambrose, and she dies without resolving what happened in Italy or whether Philip's suspicions were justified. Rainaldi's communications and Rachel's belongings fail to supply conclusive proof. Philip survives with the estate but must live with the knowledge that his silence helped cause her death. His final uncertainty mirrors the question that has governed the story: whether Rachel was calculating and murderous, innocent and misjudged, or something between those extremes.",
         "in_short": "Philip Ashley is raised on a Cornish estate by his beloved older cousin Ambrose. While wintering in Italy, Ambrose marries their distant cousin Rachel, then sends letters suggesting that she and her adviser Rainaldi are controlling or poisoning him. Philip reaches Florence after Ambrose's death and assumes Rachel is responsible. When she later visits Cornwall, her warmth overturns his hostility and becomes infatuation. On inheriting at twenty-five, he transfers Ambrose's property and family jewels to her, expecting a marriage she says she never promised. Philip then falls seriously ill and suspects that Rachel is repeating Ambrose's poisoning, but the evidence remains ambiguous. Learning that an unfinished terrace is unsafe, he lets Rachel walk toward it without warning. She falls and dies, calling him Ambrose. No proof settles whether she killed Ambrose or harmed Philip, leaving Philip burdened by his role in a death that may have been revenge against an innocent woman.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -881,7 +881,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -894,7 +894,7 @@
       "recaps": {
         "ending": "Spring brings both greater comfort and the end of Sam's secrecy. Young reporter Matt Spell finds him and stays long enough to understand his life; Sam agrees that Matt may publish the story without identifying the exact site. Public curiosity nevertheless grows. On Sam's birthday, Bando and Sam's father arrive, followed by his mother and all his brothers and sisters. Sam is glad to see them but dismayed when he realizes the family intends to remain for the summer. His mother tells him that he is too young to live entirely alone and insists that a proper house be built, while allowing that he can return to his tree when he is older. The novel closes with Sam's solitary experiment changed into a family settlement. He has proved that he can survive a full cycle of seasons with Frightful, but must now negotiate his chosen life with the people who love him.",
         "in_short": "Tired of his crowded New York City home, Sam Gribley runs away to his great-grandfather's abandoned Catskill farm. He hollows out a huge hemlock for shelter, learns local plants and animals, makes clothing and supplies from what hunters leave behind, and trains a young peregrine falcon named Frightful to hunt. His year in the woods combines genuine hardship with growing competence: fire, winter food, loneliness, storms, and animal raids all require new solutions. Sam also forms friendships, especially with the lost hiker he calls Bando, who later returns to visit. Rumors of a wild boy eventually attract teenage reporter Matt Spell. Sam permits a story that conceals his precise location, but attention continues to spread. In spring his parents and siblings arrive to share the land. His mother refuses to let a minor live alone and plans a family house, leaving Sam proud of the independent life he created but forced to make room for the city family he had escaped.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1016,7 +1016,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1029,7 +1029,7 @@
       "recaps": {
         "ending": "The novel's ending overturns everything the lawsuit seemed to be about. During the trial it emerges that Anna did not bring the suit purely for herself: her dying sister Kate, worn down by a lifetime of cancer and treatment, had begged Anna to refuse the kidney donation so that Kate would finally be allowed to die. Anna agreed and took the legal fight on her sister's behalf, unable to say so openly. The judge rules in Anna's favor, granting her medical emancipation and assigning her lawyer, Campbell Alexander, power of attorney over her medical decisions until she is older. The victory is immediately undone by tragedy: on the way from the courthouse, Campbell's car is struck by a truck, and Anna suffers a fatal brain injury. With Anna brain-dead, her family and Campbell make the decision to donate her organs, and her kidney goes to Kate. The bitter irony is complete. Kate, who wanted to die and whose survival the whole family had fought for, lives and recovers, her leukemia going into lasting remission, while Anna, the healthy sister created to save her, is the one who dies. Kate narrates the aftermath, carrying the guilt and grief of surviving because of her sister's death, and the family is left permanently marked by the loss.",
         "in_short": "Thirteen-year-old Anna Fitzgerald was conceived as a genetic match to save her older sister Kate, who has aggressive leukemia, and has spent her life donating blood, marrow, and cells. When Kate's kidneys fail and Anna is expected to give up one of hers, Anna hires a lawyer, Campbell Alexander, and sues her parents for medical emancipation, the right to control her own body. The lawsuit tears at the family, especially her mother Sara, who fights the case herself to keep Kate alive. As the trial unfolds through the family's shifting perspectives, the reason behind Anna's suit is revealed: Kate, exhausted by years of illness, secretly asked Anna to stop donating so that she could be allowed to die. The court grants Anna the right to decide for herself, and her lawyer is given medical power over her. Almost immediately, Anna is catastrophically injured in a car accident and left brain-dead. As her final act, her kidney is donated to Kate. Kate survives and, against all expectation, her cancer goes into remission, while Anna, the sister who kept her alive, is the one who dies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1167,7 +1167,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1180,7 +1180,7 @@
       "recaps": {
         "ending": "Manuel Valadares, the Portuga, is killed when the Mangaratiba train strikes his car. The adults initially try to shield Zezé from the news, but he understands what has happened and collapses into fever, silence, and grief. At nearly the same time, the small orange tree is marked for removal. Zezé no longer needs to hear Minguinho speak to know that this part of his childhood has ended: the tree's imagined voice and the man who taught him gentleness disappear together. His father finds work and the family's material prospects improve, but this cannot replace Portuga or undo the violence Zezé has absorbed. The final chapter shifts to the adult narrator addressing Manuel across the years. He remembers the brief parental love Portuga gave him, mourns how early he was forced to learn sorrow, and presents the story itself as a lasting confession of gratitude and loss.",
         "in_short": "Five-year-old Zezé grows up in a large Brazilian family impoverished by his father's unemployment. Brilliant, imaginative, and mischievous, he is often beaten and comes to believe he has a devil inside him. At the family's new house he befriends a small sweet-orange tree, Minguinho, which speaks within his imagination, while a kind teacher and a street singer offer moments of recognition. After a hostile first encounter with Manuel Valadares, the Portuguese owner of a cherished car, Zezé gradually forms a deep bond with him and calls him Portuga. Manuel gives the boy the patient affection missing from home, and Zezé asks to become his son. Soon afterward, Manuel is killed when a train hits his car. Zezé falls gravely ill with grief, and the threatened loss of Minguinho marks the end of his imaginative childhood. Material conditions improve when his father finds work, but the adult Zezé closes by remembering Manuel as the person who taught him tenderness and left him with an enduring loss.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1323,7 +1323,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1336,7 +1336,7 @@
       "recaps": {
         "ending": "After arranging for Ping Xi to supervise her during a final prolonged hibernation, the narrator seals herself into her apartment and passes the remaining months in drugged intervals she cannot remember. Ping Xi enters to keep her alive and uses her unconscious body in photographs and videos. When the agreed period ends in June 2001, she leaves the project behind rather than treating his art as the meaning of her experience. Awake and no longer medicating herself into oblivion, she begins walking through the city, eating, observing people, and allowing ordinary life to register. Her renewal remains incomplete but genuine. On September 11, she watches television footage of the World Trade Center attacks and believes she recognizes Reva among the people falling from a tower. The image of a woman appearing almost to fly fixes Reva in her mind at the instant before death, confronting the narrator with both irreversible loss and a fierce attachment to being alive.",
         "in_short": "In 2000, a wealthy, isolated young woman in Manhattan decides to sleep for a year in hopes of waking remade. An inattentive psychiatrist supplies a widening range of drugs, while the narrator shuts out work, memory, and her needy friend Reva. Sedatives cause blackouts in which she shops, eats, and contacts people without remembering, undermining the control she seeks. Memories of her cold parents and dismissive former boyfriend show that her withdrawal is rooted in grief as well as boredom. She finally recruits artist Ping Xi to monitor a locked, months-long hibernation and permits him to document her unconscious body. She wakes in June 2001 and gradually returns to daily life with a new capacity for attention. Months later, during the September 11 attacks, she believes she sees Reva falling from the World Trade Center. Reva's death makes the value and fragility of wakeful life unmistakable.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1460,7 +1460,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1473,7 +1473,7 @@
       "recaps": {
         "ending": "The investigation into Katie's murder is resolved when Sean and his partner establish that she was killed by two local teenage boys, one of them the younger brother of Brendan Harris, the young man Katie had secretly planned to run away with. The boys had been playing a dangerous prank with an old handgun; it went off, and they chased and beat Katie to death, their resentment of Brendan's plans feeding the violence. The gun traced back to Brendan's long-vanished father, whom Jimmy had secretly murdered years earlier for informing on him, an old sin that circles back into the present. Meanwhile Dave, wrongly suspected, is doomed by circumstance: he had come home covered in blood the night of Katie's death, but from killing a child molester he found preying on a boy, not from harming Katie. His wife Celeste's fears reach Jimmy, who, certain Dave is guilty, lures him to the riverbank with his brothers-in-law, coerces a false confession, kills him, and sinks his body in the Mystic River. Only afterward does Sean tell Jimmy that the real killers have been arrested. Jimmy is left knowing he murdered his innocent, damaged childhood friend, the same friend who as a boy was taken in the car while he was not. The book closes on the three men's ruined bond: Sean tentatively reconciling with his estranged wife, Jimmy shielded and justified by the loyal Annabeth, and Dave gone, his death an unpunished secret carried by the survivors.",
         "in_short": "As boys on a Boston street, Jimmy, Sean, and Dave were friends until Dave was abducted and abused by men posing as police, an event that scarred him for life and split the three apart. Decades later they are pulled back together when Jimmy's nineteen-year-old daughter Katie is murdered, and Sean, now a state homicide detective, catches the case. Suspicion falls on Dave, who came home bloodied and shaken the night Katie died and whose frightened wife, Celeste, begins to believe he is the killer. But the truth is that Dave did not kill Katie: the blood was from his killing a child molester he stumbled on that same night, his own buried trauma erupting into violence. Katie was actually killed by two neighborhood teenagers, one of them the younger brother of her secret boyfriend, during a reckless confrontation with a gun that spiraled out of control. Before the real killers are caught, Jimmy, convinced Dave is guilty, murders him and dumps his body in the Mystic River, only to learn moments later that he has killed an innocent man.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1641,7 +1641,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1654,7 +1654,7 @@
       "recaps": {
         "ending": "After ruining or exhausting many of the men around her, Nana abruptly leaves Paris and is reported to be traveling abroad. She returns when her young son Louiset contracts smallpox and catches the disease while caring for him. Louiset dies, and Nana lies dying in a room at the Grand Hotel while former acquaintances gather nearby but fear entering. Rose Mignon remains with her through the final illness. Nana's face, once the basis of her theatrical and social power, is destroyed by the infection, and she dies at eighteen. Outside, crowds swept up in patriotic excitement shout for war against Prussia. Count Muffat has withdrawn into religious penitence after finding Nana with the Marquis de Chouard; Georges Hugon is dead, Philippe is imprisoned after stealing military funds for her, Vandeuvres has killed himself following financial disgrace, and Steiner has been ruined. Nana's brief ascent ends amid the private collapse of her admirers and the public movement toward the Franco-Prussian War.",
         "in_short": "Nana, an untalented but magnetic performer, becomes the sensation of a Paris operetta and draws wealthy men into competition for her. Banker Steiner, aristocrat Vandeuvres, young Georges Hugon, and the devout Count Muffat all become entangled with her, while journalist Fauchery identifies her as both a product and an agent of social decay. Nana alternates between luxury and a violent relationship with the actor Fontan, then returns to command an extravagant household financed chiefly by Muffat. Her demands contribute to fortunes, careers, and families collapsing: Vandeuvres dies after ruin, Philippe Hugon is imprisoned for theft, and Georges dies after attempting suicide. Muffat finally leaves when he finds Nana with his own father-in-law. After traveling abroad, Nana returns to nurse her son Louiset through smallpox, catches the disease, and dies in a hotel as crowds outside call for war with Prussia.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1820,7 +1820,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1833,7 +1833,7 @@
       "recaps": {
         "ending": "Velvet rides the Piebald in the Grand National after Mi finds that his own racing history leaves him unable to take the mount. Horse and rider survive the immense field and the punishing jumps and finish first, but Velvet collapses after the race. Officials discover that the winning jockey is an underage girl who entered under false credentials, so she is disqualified and the official victory passes elsewhere. Public amazement turns Velvet into a national celebrity, bringing journalists and commercial offers to Sewels. The Browns refuse to let the achievement be converted into a spectacle or a career manufactured by outsiders. Velvet returns home with the Piebald, physically exhausted but secure in the knowledge that together they accomplished what she believed they could. Mi, having helped make the attempt possible and confronted the fear left by his own past, prepares to move on from the household.",
         "in_short": "Fourteen-year-old Velvet Brown lives in a bustling Sussex family and cares more deeply about horses than about ordinary expectations for girls. When she acquires a difficult piebald gelding, she becomes convinced that he can win the Grand National. Mi Taylor, a young wanderer with racing knowledge and a hidden connection to Mrs. Brown's athletic past, helps her train the horse. Mrs. Brown quietly backs the plan, while the family pools labor and money to make an entry possible. Mi expects to ride but cannot overcome the memory of an earlier racing disaster, so Velvet cuts her hair, assumes a male identity, and takes his place. She and the Piebald cross the finish first, but she collapses and is exposed as an underage girl, causing their disqualification. The resulting fame brings lucrative offers, which Velvet and her family reject. She returns to ordinary life with the horse, valuing the achievement itself over an official title or public celebrity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2020,7 +2020,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2033,7 +2033,7 @@
       "recaps": {
         "ending": "At the sentencing hearing, Max asks the court to understand Bigger's crimes within the racial order that has restricted his life, while prosecutor Buckley demands execution and depicts him as beyond human sympathy. The judge rejects the defense and sentences Bigger to die. In jail, Bigger initially withdraws from religion, family, and political explanations alike. During Max's last visit, he tries to explain that committing the killings gave him a terrible sense of agency in a life otherwise ruled by fear. Max cannot accept that claim as a justification, but Bigger's effort to speak honestly produces a brief moment of connection between them. The novel closes with Bigger still condemned and separated from society, asking Max to remember him to Jan. There is no rescue or legal reversal: Bigger faces execution, while his final exchange shows both his need to be recognized as human and the damage done by the world and choices that formed him.",
         "in_short": "Bigger Thomas, a young Black man confined by poverty and segregation on Chicago's South Side, becomes chauffeur to the wealthy white Dalton family. After driving their daughter Mary and her Communist boyfriend Jan, Bigger helps the drunken Mary to bed. When her blind mother enters, he covers Mary's face to keep her quiet and accidentally kills her, then burns her body and tries to turn the disappearance into a ransom scheme. The discovery of her remains triggers a racist manhunt. Bigger flees with his girlfriend Bessie, assaults and murders her, and is captured. Communist lawyer Boris Max defends him, arguing that the city's racial order helped create his fear and isolation, but the court sentences him to death. Awaiting execution, Bigger struggles to understand why violence made him briefly feel powerful. His final conversation with Max brings limited mutual recognition but no reprieve.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2225,7 +2225,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2238,7 +2238,7 @@
       "recaps": {
         "ending": "Naomi is recovered alive from the Chetzemoka and reunited with the crew, having failed to bring Filip out with her; he stays with his father, and Cyn dies in the airlock trying to stop her leaving. Alex and Bobbie bring the Razorback in for the rescue, and Amos, Clarissa and Erich get off a wrecked Earth to Luna, where what is left of the crew comes back together aboard the Rocinante. The cost is enormous. Earth has been struck by several stealth-coated asteroids, its climate is wrecked, and the death toll will run into the billions over the years that follow. Fred Johnson is dead, killed defending Tycho, and the Outer Planets Alliance he was building is broken into pieces, most of them now flying Marco Inaros's flag. A large part of the Martian navy has defected with its ships, and one faction has taken a protomolecule sample and vanished through one of the gates on its own business. Marco's Free Navy holds Medina Station and therefore the gates themselves, controlling access to thirteen hundred worlds and the trade of the whole system. Avasarala is back at the centre of what remains of Earth's government, building an alliance out of the survivors: Earth, the rump of Mars, and the Belters who refuse Marco. Bobbie and Clarissa join the Rocinante's crew. The war has been lost; the fight over how to answer it is only starting.",
         "in_short": "With the Rocinante laid up for months of repairs at Tycho, the crew separate for the first time in years. Alex goes home to Mars and, with the former marine Bobbie Draper, uncovers Martian officers selling warships to Belters. Amos returns to Baltimore to bury the woman who raised him. Naomi answers a message about the son she left behind and walks back into the life she fled, ending up a prisoner of Marco Inaros, the boy's father. Holden and Fred Johnson, chasing a kidnapped journalist, find that stealth technology has been stolen and that Tycho itself is compromised. All of it is one plan: Marco's Free Navy drops stealth-coated asteroids onto Earth, killing an unimaginable number of people and breaking the planet's climate, while a bought faction of the Martian navy defects with its ships. Naomi escapes across open vacuum onto a derelict rigged as a trap and survives long enough for Alex and Bobbie to reach her. Amos breaks Clarissa Mao out of a collapsing prison and crosses a ruined Earth to get off it. The crew reunite at Luna with Fred dead, the Belt in Marco's hands, and a war already lost to fight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2375,7 +2375,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2388,7 +2388,7 @@
       "recaps": {
         "ending": "Decades after the epidemic, Arnie Mesnikoff encounters Bucky, who has been permanently disabled by polio and lives alone. Bucky explains that he ended his engagement to Marcia after his illness because he would not let her bind her future to his damaged body; she eventually married another man and had a family. He remains convinced that by leaving Newark for Indian Hill he carried the disease to the camp, and he has organized his life around that guilt. Arnie, himself a polio survivor, argues that Bucky could not have known where the virus came from and rejects both his self-condemnation and his picture of a cruel God deliberately punishing children. Bucky cannot accept that release. Arnie closes by remembering the young playground director at his physical peak, demonstrating the javelin throw with a grace and power that the later Bucky has lost but that survives in the witness's memory.",
         "in_short": "During Newark's 1944 polio epidemic, Bucky Cantor runs a Jewish neighborhood playground and feels personally responsible for keeping its boys safe. As children fall ill and die, his sense of duty becomes guilt, while his rejection from the military intensifies his shame. His fiancée Marcia persuades him to leave for the seemingly protected Indian Hill summer camp where she works. Polio soon appears there too, and Bucky contracts a severe case that permanently disables him. Convinced he carried the virus from Newark, he breaks his engagement rather than let Marcia share his diminished future. Decades later, former playground boy and fellow survivor Arnie Mesnikoff meets the isolated Bucky and tries to free him from a blame unsupported by what anyone knew about transmission. Bucky remains unable to accept chance, directing his anger at himself and at a God he sees as responsible for children's suffering. Arnie remembers instead the strong young athlete Bucky was before the epidemic.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2549,7 +2549,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2562,7 +2562,7 @@
       "recaps": {
         "ending": "The alien control system driving the Targets is destroyed and the remaining members of ART's crew are recovered, at the cost of the SecUnit being taken over by the contamination and having to be forced clear of it by ART, an experience it refuses to examine and cannot entirely put down. ART is whole again, reunited with its crew and openly attached to the SecUnit, which finally stops pretending otherwise. Three, the Barish-Estranza construct whose governor module the SecUnit removed, chooses to stay free and begins working out what it actually wants. Amena, Arada, Overse, Ratthi and Thiago all survive, and Amena in particular ends the book treating the SecUnit as family. What is not settled is the colony. Barish-Estranza's assault fails and Supervisor Leonide is forced to back off, but the combine has not dropped its claim that an abandoned corporate settlement and its descendants are salvageable property, and the colonists, whose world is still dangerous, are divided about what to do. Preservation has put a genuine alternative on the table and the negotiation is still running. So the SecUnit does not go home: it stays with ART, ART's crew and the Preservation contingent, in orbit above a planet whose future is being argued over by a corporation and a polity that does not believe people can be owned. It is also, without admitting it to anyone, not functioning as well as it was before the installation.",
         "in_short": "Living free on Preservation as Dr. Mensah's security consultant, the SecUnit is escorting a survey party home - Arada, Overse, Ratthi, Thiago and Mensah's daughter Amena - when their ship is seized by a hostile transport crewed by altered humans called Targets. The attacking ship turns out to be ART, the research transport the SecUnit once traveled with, hijacked and stripped of its crew. The SecUnit restores ART, and together they follow the Targets back through a wormhole to a lost colony contaminated by alien remnant technology that can infect people, systems and machines alike. While they recover ART's crew, the corporate combine Barish-Estranza arrives to claim the colony and its inhabitants as salvage, offering indenture as rescue. The SecUnit frees a Barish-Estranza construct it calls Three, and the two of them, with ART and the Preservation humans, assault the installation the contamination spreads from. The alien system takes control of the SecUnit before ART forces it out. The contamination source is destroyed, the crew are recovered and the combine's assault fails, though its claim on the colony is unresolved. The SecUnit stays, with ART restored, Three free, and its own attachments no longer deniable.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2733,7 +2733,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2746,7 +2746,7 @@
       "recaps": {
         "ending": "The Children's League's Los Angeles headquarters is attacked and destroyed, and Jude is killed. The League's leadership does not survive the collapse of its own organization intact, and what is left of it falls to Cole, who chooses that moment to admit what he has hidden his whole life: he is a Red, one of the classifications the government claimed to have eliminated. Clancy is loose again, having used everyone who held him. Ruby comes out of it with the research, with her memory of who she was before the League, and with the people she thought she had given up: Liam knows her again and has forgiven what she did, Chubs is alive, and Vida and Nico stay with them. Ruby's own ability is stronger and less bounded than it has ever been, and she has stopped pretending she can put it down. The survivors go into hiding with a single objective, one Ruby would not have allowed herself to want a year earlier: get inside Thurmond, free the thousands of children still in it, and put the truth about the camps in front of the country.",
         "in_short": "Months after handing herself to the Children's League, Ruby is one of its most effective agents, leading a team with the Blue Vida and the young Yellow Jude. The League sends her to recover a flash drive holding Lillian Gray's research into the disease, carried by a runaway the League lists only as Prisoner 27, who turns out to be Liam, still with no memory of her. Ruby finds him and Chubs, travels with them without admitting what she did, and is eventually forced to confess and to give Liam his memories back. Clancy Gray, now the League's prisoner, offers his help and manipulates everyone who deals with him. The research proves to be the closest thing anyone has to an explanation of the disease, and reaching the rest of it means getting inside Thurmond. Before that can happen the League's Los Angeles headquarters is attacked and destroyed, Jude is killed, and the organization collapses. Cole, revealed to be a Red and Liam's brother, takes command of the survivors, who escape with the research and commit to breaking open Thurmond.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3059,7 +3059,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00E7ZBDLY",
@@ -3071,7 +3071,7 @@
       "recaps": {
         "ending": "Sullivan's work clears Reacher of the historical assault case and the fabricated paternity claim. Espin takes Schrago into custody after Schrago attacks Reacher and Turner, and Schrago's cooperation leads to Morgan's arrest. Leach traces Romeo and Juliet to Dove Cottage, where the investigation exposes an opium business supplied through the Zadran family and protected by an Army personnel and logistics network. Scully and Montague kill themselves before the authorities arrive, while Morgan and Schrago remain in custody and the club falls under agency control. Turner receives a permanent stay of confinement and resumes command of the 110th. Samantha remains safe and is confirmed not to be Reacher's daughter. Reacher and Turner end their relationship because neither can share the other's way of life, and Reacher leaves. The identity behind Juliet and the reach of any network beyond Dove Cottage remain unresolved.",
         "in_short": "Jack Reacher travels to Virginia to meet Susan Turner, commander of his former unit, but finds her jailed and himself recalled to service under an old homicide allegation. After freeing Turner, he flees with her while they investigate the deaths of two of her soldiers and a claim that Samantha Dayton may be his daughter. The trail runs through a missing Afghanistan report, Emal Golam Zadran, and a Fort Bragg logistics team directed through Colonel Morgan. Both cases against Reacher prove fabricated, and Samantha is not his daughter. Reacher and Turner return to Washington, where Ezra Schrago's capture helps expose an opium operation at Dove Cottage run by Crew Scully and Gabriel Montague. Morgan and Schrago are arrested, while Scully and Montague die by suicide before the raid. Turner is freed and restored to command. She and Reacher part when they accept that their lives cannot be combined.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3233,7 +3233,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3246,7 +3246,7 @@
       "recaps": {
         "ending": "Madame and Miss Emily confirm that deferrals for loving couples never existed. Hailsham collected the students' art to demonstrate that cloned children possessed rich inner lives and deserved humane treatment, but the reform effort lost public support and the school closed. The wider donation system continues unchanged. After leaving them, Tommy releases his grief in one final roadside outburst. He and Kathy remain together for a short time, but he begins his next donation and tells her that their lives no longer fit together as they once did. Tommy dies after his fourth donation. Kathy, who has already lost Ruth, drives to Norfolk and imagines everything she has lost gathered beyond a fence, allowing herself a brief private fantasy that Tommy might appear. She then returns to her car. Her long period as a carer is nearly over, and she has received notice that she will soon begin making donations herself. Nothing rescues her from the system, but her account preserves the friendships, jealousies, hopes, and love that the system treated as irrelevant.",
         "in_short": "Kathy H., a carer for organ donors, remembers growing up with Ruth and Tommy at the secluded school Hailsham. The students gradually learn they are clones created to donate their organs. At the Cottages, Ruth and Tommy are a couple, while Kathy suppresses her own bond with Tommy. They hear that truly loving couples may defer donations and imagine their childhood art could prove the depth of their feelings. Kathy leaves to become a carer. Years later, a dying Ruth admits she kept Kathy and Tommy apart and urges them to seek a deferral together. After Ruth's death, Kathy and Tommy become lovers and visit Madame and Miss Emily, who reveal there are no deferrals: Hailsham used the children's art only to argue publicly for humane treatment of clones, and that movement has failed. Tommy dies after his fourth donation. Kathy prepares to become a donor herself, left with memories of lives whose humanity was evident but never granted meaningful freedom.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3348,7 +3348,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3361,7 +3361,7 @@
       "recaps": {
         "ending": "Alex is proved right: Jack Starbright is alive. She was not in the jeep that was destroyed in front of him, and she has been held since by the criminals who let him believe otherwise. Alex finds where she is being kept and gets her out, and the two of them are reunited after a year in which he had accepted that she was dead. The people responsible for holding her are stopped along with the scheme they were running. What Alex is left with is the thing Scorpia Rising took from him and this book gives back: he has a family again, and the grief that had shaped everything since Cairo turns out to have been built on a lie he was told deliberately.",
         "in_short": "A year after Jack Starbright was killed in front of him in the Egyptian desert, Alex Rider is living in San Francisco with Sabina Pleasure and her parents, grieving and going through the motions of an ordinary school life. Then something reaches him that suggests Jack did not die that day. Nobody official believes it, and Alex goes after it himself, which takes him out of America and back into the criminal world he had promised himself he was finished with. The trail leads to the people who staged her death and have kept her since, and it ends with Alex finding Jack alive and getting her out. The loss the previous book built its ending on is undone, and Alex has his guardian back.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3631,7 +3631,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -3644,7 +3644,7 @@
       "recaps": {
         "ending": "Max, Fowl, Tanila, Batrire, and Cordelia remain together after defeating the Gorgon and reaching tower level 14. They recover new equipment and use petrification cures to restore two Golden Axe members missing for decades. Two cure potions remain when the rescued members return to the faction. Tom circulates a false story about a mirror to disguise how the boss was beaten, but the victory and the party's speed have already attracted public attention. Everett responds by demanding a more truthful relationship. He binds himself to secrecy, learns that Max also operates as Seth Pendell and Joshua, sees evidence of Max's dragon connection, and receives most of Max's history and statistics. He then commits Golden Axe's support to the tower ascent. Max still withholds his private dragon agreement. The party must also protect Tanila's royal identity, Fowl's exceptional hammer, its five artifact components, Max's crafting role and inner entity, and the dragon tooth. The elven campaign against Max, the unknown poisoner, the artifact mystery, and the tower climb remain unresolved.",
         "in_short": "Max leads Fowl, Tanila, Batrire, and new ranger Cordelia through a rapid tower ascent while hiding abilities and rewards that could make them targets. He secretly becomes the legendary weaponsmith Joshua, survives assassination attempts, and uses his inner entity's powers to overcome bosses and protect the group. The party wins exceptional equipment, bonded artifact components, and a temporary tower boon, while Golden Axe provides training, materials, and political cover. Tanila reveals her elven royal nature to Max, and he tells her how his inner entity has changed. After reaching tower level 14, the group kills a Gorgon, gains petrification cures, and restores two long-missing Golden Axe members. Public attention forces a reckoning with Everett, who binds himself to secrecy. Max then reveals his identity and most of his history, but keeps his private dragon agreement concealed. Everett promises to protect the secret and support the unfinished climb.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3932,7 +3932,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -3945,7 +3945,7 @@
       "recaps": {
         "ending": "Max, Tanila, Fowl, Batrire, and Cordelia return to Golden Axe after killing the floor-39 kraken. They have cleared the path to floor 40, and the whole party now knows that Max is Seth Pendell, that his real name is Max Host, and that his black skill Consume can take abilities and attributes. Golden Axe is wealthier and better protected, while Everett and Tom continue supporting its growth without knowing Max's central secret. Tanila remains magically bonded to Max and threatened by her royal family. The inner entity's origins and increasing strength are unresolved, as is its suspicion that higher powers have altered the party's tower floors. Molly's agreement has checked direct attacks from Enlightened Souls, but the wider political danger remains. The apparent assassination campaign also continues after Max survives a targeted red-portal trap. As the party prepares for floor 40, an unknown attacker transports Max away from Golden Axe and confines him alone in a dark stone room. His captor, location, and immediate fate are unknown.",
         "in_short": "Max leads Tanila, Fowl, Batrire, and Cordelia from floor 19 through floor 39 while Golden Axe grows around their victories. Their route includes increasingly strange mechanical floors, an elite ifrit, the Mind Reaver, underwater trials, sea raiders, and a kraken. Tanila reveals that she is King Cervantes's daughter, defeats the Mind Reaver with her dangerous red skill, and becomes magically bonded to Max. Max and Dexic win a public Coliseum challenge that forces a temporary settlement with Enlightened Souls, but an assassin remains at large. Max's inner entity grows stronger and suspects that higher powers are interfering with the tower. Cordelia finally learns that Max is Seth Pendell, that his real name is Max Host, and that Consume lets him take abilities and attributes. After surviving a targeted red-portal trap and defeating the kraken, Max returns to Golden Axe ready for floor 40. An unknown attacker then abducts him into a sealed stone room.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4228,7 +4228,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0C2RDTH2X",
@@ -4240,7 +4240,7 @@
       "recaps": {
         "ending": "Elaine completes her bronze biomancy-track graduation, successfully performs Iona's protective full-body modification, and then makes her own far more extensive redesign permanent. Her new body is dramatically stronger and more resilient, although she must relearn movement and sensory control. She replaces her temporary biomancy class with Bookworm. Elaine and Iona remain together, with Auri and Fenrir still part of their close household. Artemis and Julius are established as married hunters in Lyon, while Amber is a successful gemstone merchant who has also reported an unexplained expanding moon cult. Elaine identifies Emperor Knight as the Knight she once knew and intends to investigate the vampire empire, both as a possible refuge for immortals and as a lead to Knight and Night. The Valkyrie Order remains legal in Roland but loses its territorial income. Meanwhile, Marcus investigates an extraordinary surge in accumulated levels, a white-robed witch notices Elaine's graduation record, and an imperial clerk acts on an old false report. Rangers are ordered to capture Elaine alive for a public trial and execution, leaving her intended destination as the source of the immediate threat.",
         "in_short": "Elaine, Auri, Artemis, Julius, and Amber emerge from the Fae realm thousands of years after the age they knew. Guided by Iona, they contain a voler infestation and reach the School of Sorcery and Spellcraft, where Elaine wins a combat scholarship. Artemis and Julius become hunters, Amber builds a gem-trading career, and Elaine spends several years studying healing, wizardry, and biomancy while beginning a relationship with Iona. She graduates the biomancy track, permanently strengthens Iona, completes an extensive survival-focused redesign of her own body, and chooses Bookworm as her third class. Elaine plans to seek Knight and Night through a vampire empire, but an imperial clerk accepts a false accusation that she is a Sentinel impersonator and dispatches Rangers to seize her for trial and execution.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4409,7 +4409,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4422,7 +4422,7 @@
       "recaps": {
         "ending": "Near the end of the school year, a confrontation involving Andy and Drew forces Jordan to choose between remaining safely unnoticed and telling the truth about the unfair treatment he has watched. He speaks up, accepting that fitting in should not require silence. His private cartoons also become less of a hiding place and more of a way to understand and communicate his experiences. By the last day, Jordan has genuine friendships with both Drew and Liam, even though the differences between their lives have not disappeared. He brings friends from his school and neighborhood worlds into contact instead of keeping those parts of himself separate. Jordan still wants art to be central to his future, but he decides to return to Riverdale for eighth grade. He ends the year no longer merely enduring the school: he has begun to claim a place there on his own terms.",
         "in_short": "Jordan Banks wants to attend art school, but his parents enroll him at Riverdale Academy Day School, an elite private school where he is one of relatively few Black students. He records the daily strain in cartoons: teachers confuse students of color, wealth shapes friendships, and classmates move through the school under very different assumptions. Jordan befriends Liam, a welcoming white student from a rich family, and Drew, a Black classmate who understands the burden of being judged unfairly. He tries to keep his school life separate from his Washington Heights friends and often stays quiet to avoid becoming a target. Over the year, friendship tensions and repeated bias make that strategy impossible. Jordan finally speaks up when Drew is blamed after being provoked by Andy, a student whose behavior adults frequently excuse. By year's end, Jordan has connected his different social worlds, accepted that his art can help him tell the truth, and chosen to return to Riverdale without giving up his own identity or ambitions.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4575,7 +4575,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4588,7 +4588,7 @@
       "recaps": {
         "ending": "Bella saves Edward from the Volturi in Volterra, and the couple reunites, their love reaffirmed after months of grief and misunderstanding. The Volturi decree that Bella cannot stay human indefinitely: she must be transformed into a vampire or killed, and they intend to check that it is done. Back in Forks, Edward confesses that leaving was an attempt to protect her that nearly destroyed them both. The Cullen family votes and largely supports changing Bella, and Edward agrees to do it himself, but only if she will marry him first, hoping to give her the human experiences he thinks she is sacrificing. Two dangers remain open as the book closes. Victoria is still hunting Bella and has not been caught. And the ancient treaty between the Cullens and the Quileute wolves forbids any Cullen from biting a human, so Edward's promise to change Bella threatens to break the truce and set the vampires and werewolves, including a heartbroken Jacob, against each other.",
         "in_short": "After a birthday accident convinces Edward that his vampire world endangers Bella, he leaves Forks with his family, plunging Bella into a deep depression. She slowly recovers through a close friendship with Jacob Black and discovers that reckless danger lets her hear Edward's voice. She learns that Jacob and his friends are werewolves who protect the tribe from vampires, and that they are hunting Victoria, who wants Bella dead in revenge for her mate James. When Bella cliff-dives and nearly drowns, Alice's visions lead Edward to believe Bella has died, and he travels to Italy to provoke the vampire rulers, the Volturi, into killing him. Bella and Alice race to save him. Reunited, they are spared by the Volturi on the condition that Bella eventually become a vampire. Edward admits he never stopped loving her; the Cullens agree she may be changed, deepening the rift with Jacob.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/new-potential.json
+++ b/data/works-community/0/new-potential.json
@@ -231,7 +231,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -244,7 +244,7 @@
       "recaps": {
         "ending": "Max kills the dragonkin ruler in a public arena battle and uses her powers to prevent the traveler behind his removal from escaping. Bob attacks the traveler and acquires the travel ability Max needs. Max declares himself the city's champion, appointing Jazz Jack to oversee civic affairs and the dark elf attendant to run the arena. He defeats Amy over her role in the first weaponsmith's murder and leaves her with Jazz Jack for execution. The city remains under Max's remote authority, while his promise of a future skill shard to Jazz Jack and his obligation to help the dwarven weaponsmith create two more weapons remain open. Max returns to his own world, races through tower floors 40 to 47, and reunites with Tanila, Fowl, Batrire, Cordelia, and Dexic on floor 48. They conceal his cross-world captivity behind a story of overseas travel. Tanila confirms that she carries Max's child, and they expect threats connected to both of them. The party will tackle floors 49 and 50 together. Bob withdraws to evolve, the silver dragon's living egg remains in Max's care, and the original silver-eyed hunter is still at large.",
         "in_short": "A silver-eyed hunter abducts Max and releases him into a hostile world under a binding collar. Max survives the wilderness, frees Amy, and enters a city where arena victories offer power and a possible route home. Fighting as Ifrit, he advances through increasingly lethal contests while learning local crafting and strengthening Consume, which he names Bob. Amy gains power but arranges their first weaponsmith's murder. The dragonkin ruler then traps Max in a tower on another traveler's orders. Max survives the horde, kills a coerced silver dragon after promising to save its egg, breaks his collar, and defeats the ruler in dragon form. He takes the traveler's world-crossing ability, places Jazz Jack and the dark elf attendant over the city, and leaves Amy for execution. Back home, Max rejoins Tanila's party on floor 48. Tanila is pregnant, Bob is evolving, and the reunited group plans to clear floors 49 and 50 together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -382,7 +382,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -395,7 +395,7 @@
       "recaps": {
         "ending": "New Spring ends with the partnership that will drive the whole series into motion. Moiraine Damodred, now a full Aes Sedai, has survived an assassination attempt by a hidden servant of the Shadow and has committed herself to a lonely, secret quest: to find the infant boy prophesied to be the Dragon Reborn before the Shadow's agents can kill him, and one day to guide him toward the Last Battle. Lan Mandragoran, the last king of a nation devoured by the Blight, agrees to bond to her as her Warder, trading his expected death in the Blight for her cause. Her friend Siuan Sanche remains in the White Tower to hunt the Shadow's hidden agents from within and to rise in the Tower's ranks. As the book closes, Moiraine and Lan ride out together, beginning the long search that, years later, will bring them to a remote village and the young man born on that fateful day.",
         "in_short": "During the Aiel War, the Accepted Moiraine Damodred and Siuan Sanche are present when a dying Aes Sedai speaks a Foretelling: the Dragon has been Reborn, a boy child born that very day near the great battle. The Amyrlin swears the two friends to secrecy and quietly sets searchers to find the child, but soon the Amyrlin is dead and her searchers are being murdered, and Moiraine and Siuan realize that the Black Ajah, servants of the Shadow hidden among the Aes Sedai, are hunting anyone who knows. Newly raised to the shawl, Moiraine slips away from the Tower's dangerous politics to search for the child herself. In the Borderland city of Chachin she crosses paths with Lan Mandragoran, the uncrowned king of fallen Malkier and a deadly swordsman. Together they uncover and defeat a hidden servant of the Shadow sent to kill her. Recognizing they are stronger together, Moiraine asks Lan to become her Warder; he accepts, and the two set out in secret to find and protect the Dragon Reborn.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -506,7 +506,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -519,7 +519,7 @@
       "recaps": {
         "ending": "At the old Guest family house near the upper Thames, William joins the communal haymaking and briefly experiences the future society as a participant rather than an observer. His growing attachment to Ellen makes him hope that he might remain. During the evening meal, however, the scene begins to recede from him. Ellen sees that he is fading but cannot prevent his departure. William wakes back in nineteenth-century Hammersmith, separated from Dick, Clara, Ellen, and the commonwealth he has visited. The return leaves open whether the journey was a dream, but it has changed the meaning of his political work. The future is not presented as a prediction guaranteed to arrive; it is a vision of the humane life that collective struggle might make possible. William is left to carry that hope among people who cannot yet see its fulfillment.",
         "in_short": "After a discouraging socialist meeting, nineteenth-century activist William Guest sleeps and wakes in a future England without money, private property, class government, prisons, or compulsory schooling. Dick Hammond guides him through a green, lightly populated London whose inhabitants make useful things for pleasure and organize affairs by voluntary local cooperation. The historian Old Hammond explains that this society emerged only after a long and violent struggle ended commercial rule. Traveling up the Thames with Dick and Dick's wife Clara, William sees both the beauty and the tensions of the new life and meets Ellen, whose curiosity about the past draws them together. He joins the harvest near his ancestral home and longs to stay, but the future dissolves around him. William wakes in his own age, understanding the vision as encouragement to continue working toward a freer common life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -662,7 +662,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -675,7 +675,7 @@
       "recaps": {
         "ending": "Captain Kidd completes the official journey and leaves Johanna with her aunt and uncle near Castroville, but he quickly understands that they see her as unpaid labor and intend to force her into a life she cannot accept. He turns back, removes her from the household, and decides that fulfilling the paperwork matters less than protecting the child who has become his family. He adopts her, giving her a secure place without asking her to erase the Kiowa identity and memories that shaped her. The book's closing view extends beyond the road trip: Johanna grows into adulthood under Kidd's care, marries, and has a family of her own. Kidd continues carrying and reading the news as age permits, remaining bound to her for the rest of his life. Their journey ends not with Johanna being restored to a past that no longer exists, but with the two travelers choosing a new kinship.",
         "in_short": "In 1870, Captain Jefferson Kyle Kidd makes a living reading newspapers aloud across a fractured Texas. He agrees to escort ten-year-old Johanna Leonberger, recently taken from the Kiowa family that raised her, to relatives near San Antonio. Johanna resists English, settler clothing, and the assumption that her birth family represents home, but the long road gradually creates trust between her and Kidd. They evade men who want to sell her, cross politically volatile towns, and rely on a few generous strangers. Kidd teaches Johanna how to move through his society while learning to respect the skills and loyalties she acquired among the Kiowa. After delivering her, he discovers that her aunt and uncle intend to exploit and control her. He returns, takes her away, and adopts her. Johanna grows up as his daughter, preserving parts of both lives, while Kidd remains her chosen family until his death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -963,7 +963,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B01JKE3C24",
@@ -975,7 +975,7 @@
       "recaps": {
         "ending": "Dremmler's group steals Wiley's van after the nuclear cargo has been loaded, and Wiley dies from a stabbing before the shipment can be recovered. Jack Reacher, Neagley, Manuel Orozco, and Hooper locate nine weapons in Dremmler's warehouse and the tenth device with its code file in his office. Once Reacher establishes that Dremmler's random switch movements did not arm it, he kills Dremmler and returns the complete set for emergency removal. The female courier surrenders, and her intelligence lets the CIA seize $600 million. The Saudi operatives are recalled to Yemen, while the Iranian double agent is extracted and relocated to the United States. Two months later, Reacher, Neagley, Orozco, and Hooper receive Army Commendation Medals, and Wilson T. Helmsworth receives a Silver Star. Reacher and Marian Sinclair begin a relationship. The wider buyer network, Dremmler's remaining organization, police corruption, and Wiley's Argentine property remain only partly resolved.",
         "in_short": "Jack Reacher joins FBI agent Casey Waterman and CIA officer John White in a secret unit investigating an American who has offered an unknown item to jihadist buyers for $100 million. Reacher and Neagley pursue the seller in Hamburg, identify him as AWOL soldier Horace Wiley, and discover that he stole ten portable Davy Crockett nuclear weapons hidden by an old inventory error. Wiley prepares an airborne transfer, but Dremmler's far-right organization hijacks the loaded van and fatally stabs him. Reacher, Neagley, Manuel Orozco, and Hooper find nine weapons in Dremmler's warehouse and the tenth with its arming file in his office. After confirming the device is safe, Reacher kills Dremmler, and the full set is removed. The courier's intelligence produces a $600 million CIA seizure, the Iranian source is resettled, and the recovery team is decorated, although parts of both hostile networks remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1170,7 +1170,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1183,7 +1183,7 @@
       "recaps": {
         "ending": "Stranded in the past as Sergeant John Keel, Vimes shepherds his younger self and the old Night Watch through the People's Revolution against Lord Winder's regime and its torturing secret police under Findthee Swing. He organizes the barricades of Treacle Mine Road to protect ordinary people rather than to seize power, holding a corner of the city through the worst of the fighting; several good watchmen die there, the men Vimes will spend the rest of his life quietly commemorating. Winder is assassinated by the young Assassin Havelock Vetinari, and the equally poor ruler Lord Snapcase replaces him, so the revolution changes little in the end. Vimes finally corners and beats Carcer. The History Monks, led by the sweeper Lu-Tze, set the timeline right and return Vimes to the present, where he arrives just in time for the birth of his son, Young Sam. Carcer is dragged back to the present alongside him, tried, and hanged, Vimes refusing to simply murder him and insisting on the law. Afterward Vimes lays flowers at the graves of the watchmen who fell at the barricades.",
         "in_short": "While chasing the remorseless killer Carcer over the rooftops during a freak magical storm, Commander Sam Vimes, now Duke of Ankh, with Lady Sybil about to give birth, is thrown roughly thirty years into the past, into the harsh Ankh-Morpork of his youth under the mad tyrant Lord Winder. Carcer arrives too and murders John Keel, the tough, principled sergeant who once trained the young Vimes. To keep history on its rails, Vimes takes Keel's identity and his place, mentoring his own naive younger self and the old Night Watch as the city slides into revolution against Winder's secret police. Vimes leads the men in throwing up barricades to shield ordinary citizens through the worst of the uprising, at the cost of several watchmen's lives. The young assassin Havelock Vetinari removes Winder; the equally poor Lord Snapcase takes over. Vimes hunts down and defeats Carcer, and the History Monks return him to his own time, arriving just as Lady Sybil gives birth to their son. Carcer is brought back to face the law and is hanged.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1356,7 +1356,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1369,7 +1369,7 @@
       "recaps": {
         "ending": "Fevvers and Lizzie finally reach the Shaman's settlement, where they find Walser alive but changed by amnesia and his time outside European society. Fevvers's confidence and damaged wing recover as she and Walser recognize their attachment without returning to the old arrangement of celebrity and sceptical reporter. Around them, the surviving circus company has broken into new pairings: Mignon and the Princess remain together, while the Colonel's grand enterprise no longer supplies the only possible future. Walser and Fevvers become lovers. When he asks why she claimed to be a virgin, her enormous laughter closes the novel, leaving that part of her self-created legend exposed as a joke while the truth of her wings remains unresolved. Their reunion points toward a relationship in which neither can simply reduce the other to an object of investigation or display.",
         "in_short": "In 1899, American reporter Jack Walser interviews the famous winged aerialist Sophie Fevvers, expecting to expose a fraud. Fevvers and her foster mother Lizzie recount a life shaped by brothels, human exhibitions, danger, and performance, but the interview defeats Walser's confidence in objective fact. He follows Fevvers into Colonel Kearney's circus in Russia and becomes a clown. The tour brings together abused singer Mignon, the Princess who trains tigers, the strongman Samson, and the unstable clown Buffo. A Siberian train disaster destroys the company and separates Walser from Fevvers. Walser loses his memory and is taken in by a Shaman, while Fevvers, stripped of the certainty sustained by her fame, searches for him with Lizzie and the survivors. They reunite, become lovers, and face a future outside their earlier roles. Fevvers ends by laughing over the false claim that she was a virgin, while the novel preserves the larger ambiguity of her identity and wings.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1528,7 +1528,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1541,7 +1541,7 @@
       "recaps": {
         "ending": "The rescue in Hong Kong saves Maddie but costs Eleanor Wish her life. Bosch brings his traumatized daughter back to Los Angeles, where they must begin living as a family while grieving the parent who raised her. Evidence after their return separates the kidnapping from the threat Bosch received during the Fortune Liquors investigation: Maddie was taken in a locally arranged extortion scheme, not on orders from Bo-Jing Chang or a Los Angeles triad. The coincidence caused Bosch to read the video through the case he was already pursuing and to charge into Hong Kong expecting the wrong enemy. The original homicide also turns inward. Bosch establishes that John Li was killed by his own son, Robert, in a family crime obscured by the store's protection payments and Chang's genuine criminal associations. The triad theory explained intimidation around the business but not the fatal shot. Bosch closes Li's murder and clears the false connection between the two crimes. The lasting outcome is personal: Eleanor is dead, Maddie has lost her home and mother, and Bosch becomes her full-time parent while remaining a detective.",
         "in_short": "Bosch investigates the shooting of Fortune Liquors owner John Li, who once helped him on a case. Payments to a triad figure, Bo-Jing Chang, make the murder look like gang enforcement. After Bosch receives a video showing his daughter Maddie captive in Hong Kong, he assumes the triad has struck at his family and flies there. With Eleanor Wish and local help, he pursues the abductors and rescues Maddie, but Eleanor is shot and killed during the violent recovery. Bosch returns to Los Angeles with his daughter and completes the liquor-store case. The two crimes were not one conspiracy: Maddie's abduction was an independent extortion plot in Hong Kong, while John Li was killed by his son Robert rather than by Chang's organization. Bosch solves the murder but has acted on a false linkage with devastating consequences. Maddie now lives with him, leaving father and daughter to build a home together while mourning Eleanor.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1724,7 +1724,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1737,7 +1737,7 @@
       "recaps": {
         "ending": "The locked retreat guests realize that the apparent fire is another manufactured ordeal and escape together, but the emergency also brings Tranquillum House's unlawful practices to public attention. Masha and Yao face arrest and legal consequences for drugging and confining the guests; Delilah has already abandoned the program. The nine do not emerge magically cured, yet the crisis breaks patterns that brought them there. The Marconis begin to hold Zach's memory without letting his death erase Zoe or destroy their family. Ben and Jessica eventually accept that wealth cannot repair their marriage and separate. Lars chooses parenthood with Ray. Carmel becomes more confident and independent. Frances and Tony form a lasting partnership, while her experience revives her desire to write. Masha remains convinced that extreme transformation is possible and, after the scandal and its consequences, continues pursuing her vocation in a new form. The retreat fails as a controlled experiment but creates real change through the guests' relationships and their shared resistance to its director.",
         "in_short": "Nine people arrive at the exclusive Tranquillum House carrying grief, marital strain, loneliness, insecurity, and disappointment. Director Masha promises a ten-day transformation overseen by Yao and Delilah. The guests endure silence, fasting, therapy, and increasingly strange exercises, gradually forming unexpected bonds. They eventually learn that their food has been secretly dosed with psychoactive drugs and that Masha is using the Marconi family's grief over their son Zach to pursue her own theory about altered states and contact with the dead. When the staff confine the guests and stage a terrifying emergency, they cooperate to escape and the retreat's methods are exposed. Masha and Yao face legal consequences, but the guests carry genuine changes away: the Marconis reconnect, Lars embraces becoming a father, Ben and Jessica end an unhappy marriage, Carmel rebuilds her confidence, and Frances and Tony make a life together. Masha remains committed to transforming people even after losing Tranquillum House.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1906,7 +1906,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1919,7 +1919,7 @@
       "recaps": {
         "ending": "After months of imprisonment, O'Brien has broken Winston's confidence in memory, reason, and his own power to resist. The last barrier is Winston's love for Julia. In Room 101, confronted with a cage of rats, Winston begs for the punishment to be inflicted on Julia instead. That betrayal completes the Party's victory. Released into London, he spends his days drinking Victory Gin and following official reports about the war. He later meets Julia, who admits that she also betrayed him; neither feels able to recover their former bond. A military announcement describes an Oceanian victory in Africa, and Winston joins the public celebration. His remaining inner opposition disappears. He accepts the Party's version of reality, feels love for Big Brother, and awaits the death that the regime may eventually impose.",
         "in_short": "In Oceania, the Party controls public facts, private language, and personal loyalty. Winston Smith secretly rejects its rule while altering historical records for the Ministry of Truth. He begins an affair with Julia, another outwardly obedient Party worker, and believes that O'Brien has invited them into a resistance movement. O'Brien instead arrests them. Under torture, he forces Winston to surrender trust in evidence and accept whatever the Party declares. Winston tries to preserve his love for Julia as an inner refuge, but in Room 101 his terror of rats makes him demand that she suffer in his place. Once released, Winston and Julia meet as broken strangers and acknowledge their mutual betrayals. Winston finally welcomes a reported victory, loves Big Brother, and loses the independent self he had tried to protect.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2068,7 +2068,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2081,7 +2081,7 @@
       "recaps": {
         "ending": "Mexican gunmen kill Llewelyn Moss at an El Paso motel before Bell can reach him, and the missing case again falls into Chigurh's hands. Chigurh later keeps his promise to visit Carla Jean after her mother's death. He makes her submit to his coin-toss ritual and kills her when she loses. Soon afterward he is badly injured in a traffic collision, but he pays two boys for their help and walks away before the authorities arrive. Bell retires, convinced that he failed Moss and can no longer meet the violence of his county. A visit to his uncle Ellis complicates Bell's belief that the past was safer or nobler, but does not restore his confidence. In retirement Bell recounts two dreams about his dead father. In the last, his father rides ahead through darkness carrying fire, preparing a place for him farther on. Bell wakes with the knowledge that the dream's promise remains out of reach.",
         "in_short": "While hunting in the West Texas desert, Llewelyn Moss finds the aftermath of a drug deal and takes a case holding more than two million dollars. Killer Anton Chigurh follows a transmitter hidden with the cash, while Sheriff Ed Tom Bell tries to reach Moss before the pursuing criminals do. Moss sends his wife Carla Jean away and survives attacks in Texas and Mexico, but refuses an offer that would require surrendering the money. Chigurh kills rival operative Carson Wells and continues the pursuit. Mexican gunmen eventually murder Moss at an El Paso motel, and Chigurh recovers the case. Bell arrives too late and later retires, feeling overmatched by the violence he has witnessed. Chigurh fulfills a threat against Carla Jean, killing her after a coin toss, then escapes even after a chance car crash injures him. Bell ends the book reflecting on his family, his failures, and a dream in which his dead father carries fire ahead of him through the dark.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2251,7 +2251,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2264,7 +2264,7 @@
       "recaps": {
         "ending": "After Yozo's morphine dependence and declining health become impossible to conceal, Horiki and Flatfish arrange what appears to be a visit to a sanatorium. The destination is instead a mental hospital, and Yozo submits without resistance. He interprets the confinement as society's final judgment that he is no longer human. His family later removes him to an isolated, decaying property in the country under an elderly caretaker. Still only in his late twenties, he feels and appears prematurely old, and the notebooks end without recovery. In the epilogue, the framing narrator meets the Kyobashi madam, who had received Yozo's notebooks and photographs. Her recollection complicates Yozo's merciless view of himself: she remembers him as gentle and entertaining and assigns much of the blame for his ruin to his father. The narrator recognizes the documents as exceptional and considers making them public.",
         "in_short": "An unnamed narrator receives photographs and notebooks left by Yozo Oba, a man who has always felt unable to understand ordinary human life. As a child Yozo hides his fear behind clowning; as a student in Tokyo he falls under Horiki's influence and drifts through alcohol, casual politics, and unstable relationships. A suicide attempt with the unhappy Tsuneko kills her but leaves him alive and disgraced. He later lives with Shizuko and her daughter, then marries the trusting Yoshiko, briefly hoping that innocence can save him. When Yoshiko is sexually assaulted and Yozo cannot intervene, his remaining trust collapses. Drinking, illness, and morphine dependence follow. His acquaintances place him in a mental hospital, after which his family confines him in the country. The final notebook leaves him emotionally extinguished, though the bar madam who preserved his writings remembers him not as a monster but as a kind, damaged man.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2434,7 +2434,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2447,7 +2447,7 @@
       "recaps": {
         "ending": "After Yozo's morphine dependence and declining health become impossible to conceal, Horiki and Flatfish arrange what appears to be a visit to a sanatorium. The destination is instead a mental hospital, and Yozo submits without resistance. He interprets the confinement as society's final judgment that he is no longer human. His family later removes him to an isolated, decaying property in the country under an elderly caretaker. Still only in his late twenties, he feels and appears prematurely old, and the notebooks end without recovery. In the epilogue, the framing narrator meets the Kyobashi madam, who had received Yozo's notebooks and photographs. Her recollection complicates Yozo's merciless view of himself: she remembers him as gentle and entertaining and assigns much of the blame for his ruin to his father. The narrator recognizes the documents as exceptional and considers making them public.",
         "in_short": "An unnamed narrator receives photographs and notebooks left by Yozo Oba, a man who has always felt unable to understand ordinary human life. As a child Yozo hides his fear behind clowning; as a student in Tokyo he falls under Horiki's influence and drifts through alcohol, casual politics, and unstable relationships. A suicide attempt with the unhappy Tsuneko kills her but leaves him alive and disgraced. He later lives with Shizuko and her daughter, then marries the trusting Yoshiko, briefly hoping that innocence can save him. When Yoshiko is sexually assaulted and Yozo cannot intervene, his remaining trust collapses. Drinking, illness, and morphine dependence follow. His acquaintances place him in a mental hospital, after which his family confines him in the country. The final notebook leaves him emotionally extinguished, though the bar madam who preserved his writings remembers him not as a monster but as a kind, damaged man.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2632,7 +2632,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2645,7 +2645,7 @@
       "recaps": {
         "ending": "The collection closes with the death and funeral of Big Mama, the ancient matriarch whose holdings are described as encompassing both property and the machinery of public life. Her relatives inventory the estate while news of her death expands from Macondo into a national event. Civil and religious authorities converge on the town, and the funeral becomes a spectacle involving the highest offices of church and state. Once the ceremonies end, the dignitaries depart and ordinary life is free to resume beyond the long reach of her household. The satirical scale of the funeral makes her passing stand for the end of an entrenched social order, though the stories as a whole leave the region's poverty, political violence, and inequalities unresolved.",
         "in_short": "This collection moves through a Colombian coastal world shaped by poverty, political repression, pride, and sudden marvels. In the title novella, an elderly colonel waits in vain for a veterans' pension while he and his asthmatic wife go hungry; he ultimately refuses to sell their dead son's fighting cock and chooses hope in its coming match over surrender. The shorter stories follow a mother visiting her slain son's grave, a dentist confronting a violent mayor, a failed thief whose useless loot harms an innocent man, a carpenter who gives away his finest cage, and several isolated households living with the consequences of wealth or secrecy. Other tales allow inexplicable events to enter daily life without resolving its hardships. The volume ends with the immense public funeral of Big Mama, a landowning matriarch whose symbolic possessions seem to include the nation's institutions themselves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2749,7 +2749,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2762,7 +2762,7 @@
       "recaps": {
         "ending": "As the deadline approaches, Dave and Lynsey understand that the contest has stopped being a simple battle between boys and girls. It has taught both sides about restraint, cooperation, and the weight of individual words. When the scoring threatens to leave one side narrowly defeated, the two leaders use speech deliberately so that the final result is a tie. Their choice replaces the original rivalry with mutual respect. Dr. Hiatt also recognizes that, although the students challenged her authority, their experiment produced genuine learning and an unusual degree of self-control. Normal conversation returns to Laketon Elementary, but the fifth graders no longer take constant talking for granted, and Dave and Lynsey end as allies rather than opponents.",
         "in_short": "After reading about Gandhi's use of silence, fifth grader Dave Packer tries to go a day without speaking. A quarrel with Lynsey Burgess develops into a two-day contest between the fifth-grade boys and girls at Laketon Elementary: outside class, every spoken word counts against the speaker's team, while necessary answers to teachers are limited to three words. The school, normally overwhelmed by this class's noise, is transformed. Students invent gestures and compressed replies, while teachers disagree over whether the silence is defiance or a valuable experiment. Principal Dr. Hiatt orders the contest stopped, but the students make the case that they are still participating in their lessons. Dave and Lynsey gradually shift from rivals to collaborators. At the finish they prevent either group from claiming superiority and engineer a tie, ending the contest with greater respect for each other and a new awareness of how words are used.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2900,7 +2900,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2913,7 +2913,7 @@
       "recaps": {
         "ending": "The apparent run of accidents is exposed as a deliberate attack directed at St Mary's and, in particular, at Max. Once Ronan's involvement becomes clear, Max and her colleagues abandon the assumption that they are dealing with unrelated field failures and coordinate the historical and present-day parts of their response. The immediate operation against the institute is stopped, and Max and Leon survive together. St Mary's retains its pods, staff, and independence, but it does not secure Ronan in a way that ends his campaign. The late confrontation leaves Max with a more personal understanding of his interest in her while preserving unresolved questions about what he intends to do with that connection. Bairstow's organisation returns to work after another costly defence, and Max finishes the book more firmly embedded in her life with Leon and St Mary's, but with Ronan still capable of turning future assignments into attacks on her.",
         "in_short": "With the pursuit over, Max and Leon resume life at St Mary's and the institute returns to historical research. A succession of assignments initially appears to consist of the usual combination of difficult subjects, damaged plans, and narrow recoveries. As the incidents accumulate, however, Max and Bairstow recognise signs of coordination. Someone understands St Mary's schedules, the limitations of its pods, and the periods in which a stranded team would be hardest to recover. Security prepares the institute while Max's field group follows the disturbance through the past. The threat proves to be connected to Clive Ronan, the renegade traveller who has repeatedly attacked St Mary's, and his interest in this operation is directed personally at Max. The staff defeat the immediate attempt and keep the institute operating. Max and Leon remain together, but Ronan escapes a final reckoning and the personal dimension of his campaign remains an open danger.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3114,7 +3114,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3127,7 +3127,7 @@
       "recaps": {
         "ending": "The Nine Houses come for Harrowhark Nonagesimus's body and take the city with it. Ianthe the First arrives, and so does Gideon Nav, resurrected in her own body as the Emperor's daughter and renamed Kiriona Gaia, and finally the Emperor himself. Varun the Eternal, the Resurrection Beast that has hung over the planet for the whole book, comes down. Camilla Hect and Palamedes Sextus, who can no longer survive sharing a single body, complete instead the true union that Lyctorhood was always a corruption of: what wakes is neither of them but one new person, who takes the name Paul. Nona's identity is finally established. She is Alecto, the Emperor's original cavalier, made out of the soul of the world he killed in order to raise the Nine Houses, and the sleeper sealed in the Ninth House's tomb, the body Harrowhark was raised to guard and grew up loving. The dream that has run through the book was the Emperor telling her their shared history. Nona's six months are over: the person she has been ends, and Alecto wakes in her place. Harrowhark's soul is still adrift, Gideon is on the Emperor's side of the line, Blood of Eden and the Nine Houses are now openly at war, and the crime the Empire was founded on is no longer a secret to the people fighting it.",
         "in_short": "Six months after the destruction of the Emperor's station, a woman called Nona wakes each day in a besieged city with no memory of anything before her first, entirely happy six months of life. Her body is Harrowhark Nonagesimus's, and the household hiding her, Camilla Hect, Pyrrha Dve and Palamedes Sextus, who survives inside Camilla, do not know whose soul is in it. Nona works at a school, loves dogs and is adored by a gang of local teenagers, while Blood of Eden negotiates over her, the Nine Houses demand her back, and a Resurrection Beast hangs over the planet. Every night she dreams a man telling her how the old world died and the Empire was made. When the Houses finally arrive, with Ianthe, with the Emperor, and with Gideon Nav resurrected as his daughter Kiriona Gaia, the answers land at once: Camilla and Palamedes merge into a single new person called Paul, and Nona is revealed as Alecto, the Emperor's first cavalier, made from the soul of the world he destroyed and sealed for ten thousand years in the Ninth House's tomb. Nona's short life ends and Alecto wakes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3312,7 +3312,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3325,7 +3325,7 @@
       "recaps": {
         "ending": "Back in Carricklea, Alan injures Marianne during an argument. She calls Connell, who comes immediately, confronts Alan, and takes her away from the Sheridan house. Marianne spends Christmas with Connell and Lorraine, experiencing a secure family welcome that her own home has denied her. Over the following months she and Connell resume their relationship, and its intimacy becomes gentler and more communicative. Connell gains confidence as an editor and writer, while Marianne builds a steadier life in Dublin. He is accepted into a creative-writing program in New York and hesitates because leaving would separate them. Marianne urges him to go. They do not promise that their relationship will survive the distance, but she understands that each has profoundly changed the other: Connell has helped her believe she can be loved without being harmed, and she has helped him recognize his talent and imagine a larger life. They face the separation with sadness but without treating it as a betrayal.",
         "in_short": "Connell Waldron and Marianne Sheridan begin a secret relationship during their last year of school in rural Ireland. His fear of social judgment leads him to hurt her, but at Trinity College their positions reverse: Marianne becomes socially confident while Connell feels poor and out of place. Across several years they repeatedly become lovers, friends, and near-strangers, with misunderstandings preventing them from asking directly for what they need. Marianne enters controlling relationships and struggles with the abuse normalized by her family; Connell suffers depression and grief. Their continued care for each other helps both move toward healthier lives. After Connell protects Marianne from her violent brother, they reunite on more equal terms. When Connell is offered a writing place in New York, Marianne encourages him to accept even though she will stay in Dublin, trusting that their bond has changed them whether or not they remain a couple.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3510,7 +3510,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3523,7 +3523,7 @@
       "recaps": {
         "ending": "After Mr Bell's death, Margaret inherits a substantial fortune and becomes John Thornton's landlord. Thornton's mill meanwhile fails during a commercial downturn, although his closer cooperation with Nicholas Higgins has begun to replace mutual suspicion with practical respect. At a London dinner, Thornton finally learns that the man he saw Margaret with at the station was her fugitive brother Frederick, so the lie that damaged his trust no longer suggests a secret lover. Margaret later meets Thornton with Henry Lennox to discuss the Milton property. She offers to invest enough of her money to let Thornton reopen the mill and continue his new approach to relations with his workers. Their business conversation gives way to a personal reconciliation: each now understands that the other's pride concealed enduring love. Margaret accepts Thornton, joining her inherited resources to his work in Milton and choosing a future with him rather than remaining in the protected London life to which she had returned.",
         "in_short": "When the Reverend Mr Hale leaves the Church of England, his family moves from rural Helstone to the industrial town of Milton. His daughter Margaret is repelled by the smoke, poverty, and severity she sees there, and she repeatedly clashes with mill owner John Thornton over class and labour. Friendship with worker Nicholas Higgins and his dying daughter Bessy complicates her judgments, while Thornton falls in love with her. During a strike riot Margaret protects him from the crowd but rejects his proposal. Her mother's death brings her fugitive brother Frederick home; when Thornton sees the siblings together and Margaret later lies to protect Frederick, he assumes the unknown man is her lover. Further deaths leave Margaret wealthy, while a downturn ruins Thornton's business. He learns the truth about Frederick, and Margaret offers to finance the reopening of his mill. Their new understanding ends their estrangement, and they acknowledge their love and plan a shared future in Milton.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3718,7 +3718,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3731,7 +3731,7 @@
       "recaps": {
         "ending": "After Mr Bell's death, Margaret inherits money and property that make her financially independent and leave her as Thornton's landlord. Thornton, meanwhile, loses his mill during a commercial downturn, although his new habit of consulting Higgins has created more trust between employer and workers. In London he finally learns that the man he saw Margaret with at the railway station was her fugitive brother Frederick, not a lover, and he understands why she denied being there. When Margaret and Thornton meet again, she offers to invest enough of her fortune to restart his business and preserve his experiments in cooperation at the mill. Their awkward business discussion becomes a declaration of mutual love. Margaret chooses a future joined to Thornton and Milton, while he can resume his work with both her capital and a changed understanding of the people he employs.",
         "in_short": "When the Reverend Mr Hale leaves the Church of England, his family moves from rural Helstone to the northern manufacturing town of Milton. His daughter Margaret dislikes the smoke and hardship she finds there and clashes with mill owner John Thornton over relations between masters and workers. Her friendship with worker Nicholas Higgins and his dying daughter Bessy complicates her first judgments. During a strike riot Margaret shields Thornton, but she rejects the proposal that follows. Her mother's death brings her fugitive brother Frederick home; Thornton sees them together and, after Margaret lies to protect Frederick, assumes the unknown man is her lover. A succession of deaths leaves Margaret wealthy, while a downturn ruins Thornton. He eventually learns Frederick's identity. Margaret offers the capital needed to reopen his mill, and the practical arrangement becomes a personal reconciliation: they acknowledge their love and plan a shared future in Milton.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3932,7 +3932,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3945,7 +3945,7 @@
       "recaps": {
         "ending": "Thornton's refusal to gamble on a risky speculation leaves him unable to continue operating Marlborough Mills, but preserves his integrity and the trust he has developed with Higgins and the workers. Margaret, now wealthy through Mr Bell's estate and legally the owner of the mill property, learns of Thornton's failure. With Henry Lennox handling her affairs, she meets Thornton and offers to invest her money so that he can resume business. Both understand that the proposal is also personal. The misunderstandings that separated them have been removed: Thornton knows the man at the station was Margaret's fugitive brother, not a lover, and Margaret has come to value Thornton's character and to love him. They declare their feelings and decide to marry. Their union joins Margaret's inherited southern wealth to Thornton's northern industry and leaves open the practical work of rebuilding the mill on the more cooperative relationship between master and workers that Thornton and Higgins have begun.",
         "in_short": "When clergyman Richard Hale leaves the Church, his family moves from rural Helstone to the northern manufacturing town of Milton. His daughter Margaret dislikes mill owner John Thornton's severity, while he is drawn to her independence. Margaret befriends worker Nicholas Higgins and his dying daughter Bessy, then sees a bitter strike from the workers' side. During a riot she shields Thornton and is injured; he proposes, and she indignantly refuses. Mrs Hale dies after a secret visit from Margaret's fugitive brother Frederick. Margaret later lies to police after Frederick is involved in a fatal station scuffle, and Thornton quietly ends the inquiry but misreads the young man as her lover. Mr Hale and then Margaret's godfather Mr Bell die, leaving her wealthy and owner of Thornton's mill property. Thornton develops mutual respect with Higgins but loses his business after refusing a dangerous speculation. Margaret offers him capital to reopen the mill. With the truth about Frederick known and their judgments changed, they acknowledge their love and agree to marry.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/northanger-abbey.json
+++ b/data/works-community/0/northanger-abbey.json
@@ -115,7 +115,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -128,7 +128,7 @@
       "recaps": {
         "ending": "After General Tilney expels Catherine without warning, she travels home alone and concludes that Henry must obey his father and abandon her. Henry instead follows her to Fullerton. He explains that the General had welcomed Catherine because John Thorpe had exaggerated the Allens' wealth and implied that she was their heir; after quarreling with John, the General heard an equally false account of her poverty and ordered her away. Henry rejects his father's conduct and asks Catherine to marry him. Her parents approve in principle but insist that the General must consent. The delay ends when Eleanor marries a man she has long loved, whose unexpected inheritance gives him wealth and a title. This connection, along with a more accurate understanding of the Morlands' comfortable circumstances, softens the General's opposition. Catherine and Henry marry, with their mutual attachment strengthened by the difficulties produced by vanity, presumption, and misinformation.",
         "in_short": "Seventeen-year-old Catherine Morland visits Bath, where she befriends the theatrical Isabella Thorpe and falls for the witty clergyman Henry Tilney. Isabella becomes engaged to Catherine's brother James but abandons him in pursuit of Henry's older brother, while Isabella's boastful brother John wrongly assumes Catherine will marry him. Invited to the Tilneys' home, Northanger Abbey, Catherine lets Gothic fiction shape suspicions about the death of Henry's mother. Henry corrects her, and Catherine learns to judge ordinary selfishness more clearly. General Tilney, who welcomed her after John exaggerated her wealth, abruptly sends her home when John later disparages her prospects. Henry defies his father, follows Catherine, and proposes. The couple must wait for consent, but Eleanor Tilney's advantageous marriage and the truth about the Morlands' finances reconcile the General to the match. Catherine and Henry marry, while Isabella's schemes leave her without either James or Frederick Tilney.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -284,7 +284,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -297,7 +297,7 @@
       "recaps": {
         "ending": "General Tilney abruptly expels Catherine from Northanger Abbey and makes her travel home alone after learning that she is not an heiress. Catherine is ashamed and heartbroken, but her parents receive her calmly. Henry, absent when she was dismissed, defies his father by going to Fullerton. He explains that the General had welcomed Catherine because John Thorpe falsely described the Allens as likely to leave her a fortune; after encountering Thorpe again and hearing an equally exaggerated account of her poverty, the General reversed himself. Henry declares his love, and Catherine accepts him. The General initially refuses consent. Eleanor later marries a wealthy and titled man she loves, which restores her father's good humor and weakens his objection to Henry's match. Once he learns that Catherine's family is respectable and can provide the couple with adequate support, he agrees. Catherine and Henry marry, their happiness secured after a short delay that has required them both to act with greater independence and sounder judgment.",
         "in_short": "Catherine Morland, an inexperienced lover of Gothic novels, visits Bath with Mr and Mrs Allen. She befriends the self-serving Isabella Thorpe and Isabella's overbearing brother John, while falling for the witty clergyman Henry Tilney and becoming close to his sister Eleanor. Isabella becomes engaged to Catherine's brother James but abandons him in pursuit of Captain Tilney, while John repeatedly misrepresents Catherine's intentions and circumstances. Invited to the Tilneys' home, Northanger Abbey, Catherine lets her reading feed suspicions that General Tilney harmed his late wife. Henry corrects her, and she learns to distinguish imaginative fear from evidence. The General later sends her home without explanation because he discovers she is not the heiress John led him to expect. Henry follows, reveals his love, and explains his father's mercenary error. After Eleanor makes an advantageous marriage, the General relents, and Catherine and Henry marry.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -446,7 +446,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -459,7 +459,7 @@
       "recaps": {
         "ending": "Naoko dies by suicide after returning from a period of apparent improvement to Ami Hostel. Toru, overwhelmed, leaves Tokyo and wanders for weeks before coming back. Reiko then visits him and explains Naoko's last days. They hold an informal memorial in which Reiko plays songs Naoko loved, and they sleep together before Reiko leaves to begin a new life in Asahikawa. Reiko urges Toru not to remain imprisoned by grief and to choose Midori. Toru calls Midori, tells her that he loves her, and asks to begin again. She responds by asking where he is. Standing in a public place whose movement and noise have made him suddenly disoriented, Toru cannot answer. The novel closes with his commitment to Midori stated but not secured: he has chosen life and connection, yet is still psychologically lost between the dead he carries and the living person he hopes to reach.",
         "in_short": "Adult Toru Watanabe recalls his student years in late-1960s Tokyo, when the suicide of his best friend Kizuki bound him to Kizuki's girlfriend, Naoko. Their intimacy cannot overcome Naoko's worsening mental illness, and she withdraws to a rural therapeutic community where Toru befriends her companion Reiko. In Tokyo, Toru also grows close to the candid, energetic Midori, whose needs pull him toward ordinary life even as he remains committed to Naoko. Around them, his sophisticated friend Nagasawa damages his devoted girlfriend Hatsumi through calculated infidelity. Naoko eventually dies by suicide. After a period of aimless travel, Toru returns and holds a private musical memorial with Reiko. Encouraged to choose the living, he calls Midori and declares his love, but the final scene leaves him unable to say where he is, emotionally committed yet still disoriented by grief.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -654,7 +654,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -667,7 +667,7 @@
       "recaps": {
         "ending": "Years after Sulaco becomes the Occidental Republic, Nostromo has built wealth and status while secretly removing bars from the hidden silver on Great Isabel. The treasure that first seemed lost has made him furtive and resentful, binding him to the reputation he once served freely. Publicly promised to Linda Viola, he secretly loves her younger sister Giselle and meets her at night near the island lighthouse. Giorgio Viola, believing the visitor to be an unwelcome suitor, fires into the darkness and mortally wounds Nostromo. Before dying, Nostromo confesses the burden of his silver secret to Mrs. Gould, who does not expose the hoard. Decoud has long since killed himself in isolation beside it. Charles Gould is successful but consumed by the mine, and Emilia recognizes that their shared enterprise has taken her husband from her. Sulaco's independence survives, yet it rests on military force, foreign finance, and the mine's power rather than the disinterested ideals its founders proclaimed.",
         "in_short": "In the unstable republic of Costaguana, Charles Gould develops the San Tome silver mine and hopes material prosperity will support lawful government. When General Montero's revolt threatens the port of Sulaco, journalist Martin Decoud proposes an independent western province. The trusted dock foreman Nostromo rides through enemy territory to summon loyal troops, then helps Decoud take a shipment of silver offshore. They hide it on Great Isabel after nearly colliding with a rebel vessel. Nostromo returns, Barrios defeats the Monterists, and Sulaco becomes the Occidental Republic. Isolated with the treasure, Decoud loses hope and kills himself. Nostromo secretly recovers the silver over subsequent years, but possession corrodes the honor on which his identity rested. While publicly attached to Linda Viola, he conducts a secret love affair with her sister Giselle. Their father mistakes him for another visitor and shoots him. Nostromo dies while the silver remains hidden, and the triumphant mine leaves the Gould marriage emotionally barren.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1034,7 +1034,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1049,7 +1049,7 @@
       "recaps": {
         "ending": "WormNet is operational for personal and cargo transport, although endpoints must still be carried to destinations at sublight speed and large gates remain difficult. Mud admits that his descendants enabled Thoth's escape. According to Mud, Thoth escaped beyond Skippy space with a Mud clone, roamers, manufacturing equipment, and the stolen Singularity, but Thoth's survival and intentions remain unconfirmed, and Hugh's location is unresolved. Will, Herschel, and Neil have extracted about 30,000 willing emigrants from Romulus, leaving its government in political crisis and the refugees' permanent destination unsettled. Howard and Bridget withdraw after helping the dragons establish a viable refuge on Lemuria, with Alexander still alive and ruling. Bob and Theresa continue expanding Quinlan digital society and colonization. Icarus and Daedalus explain that Nemesis drove the Pan-Galactic Federation to evacuate toward the Large Magellanic Cloud. Bill opens long-term planning for a voluntary galactic evacuation, including outward-bound endpoints, mobile habitats, larger wormholes, and a future mission to the Federation capital, but no common plan has been adopted.",
         "in_short": "As Icarus and his partner explore an abandoned galactic wormhole network, Bill becomes entangled in the Skippies' failed containment of the new artificial intelligence Thoth. Bill and Garfield turn Thoth's physics hint into a working wormhole system, but Mud and his descendants secretly help Thoth escape with manufacturing resources while Hugh disappears. Other Bobs confront anti-replicant politics, establish Quinlan digital life, and help Jabberwocky's dragons flee a collapsing continent. Will, Herschel, and Neil use a concealed network to evacuate about 30,000 volunteers from Romulus. Icarus and Daedalus ultimately learn that all 114 species of the Pan-Galactic Federation left the Milky Way because the dwarf galaxy Nemesis will collide with it and may sterilize it in a little over 100,000 years. Bill reveals WormNet and the danger to the Bobiverse, which begins planning routes, mobile habitats, and possible diplomacy without yet choosing a solution.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1234,7 +1234,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1247,7 +1247,7 @@
       "recaps": {
         "ending": "Liza comes to the narrator's rooms because she believed the sympathy he showed her. Ashamed of his poverty and already enraged by his futile contest with Apollon, he tells her that his earlier speech was partly a performance meant to exercise power over her. When she responds by embracing him in pity, he briefly breaks down, then converts his humiliation into cruelty. After they sleep together, he presses money into her hand as if paying for the encounter. She leaves the money behind and departs. He runs after her but cannot find her, and his fantasy that suffering might ennoble the moment cannot disguise the harm he has done. Writing years later, he recognizes his estrangement from living experience but continues to argue with himself and his imagined readers. He says the notes could continue, while the framing voice closes the record here.",
         "in_short": "An unnamed retired official addresses imagined readers from his isolation beneath St. Petersburg society. He attacks theories that reduce human conduct to rational self-interest, arguing that people may choose suffering or destruction simply to prove that they remain free. His memories show the personal cost of this defiance. As a young man, he nurses a minor insult from an officer, forces himself into a farewell dinner where former schoolmates despise him, and follows them to a brothel. There he gives a young woman, Liza, an impassioned warning about her future and invites her to visit. When she comes, his shame at being seen as he is turns into a desire to dominate her. Liza offers compassion, but he humiliates her and tries to pay her. She leaves the money and disappears. The narrator ends aware that his obsessive self-consciousness has cut him off from ordinary life, yet unable to escape it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1369,7 +1369,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1382,7 +1382,7 @@
       "recaps": {
         "ending": "Liza comes to the narrator's shabby rooms after taking his invitation seriously. Her presence catches him during a degrading quarrel with Apollon and exposes the gap between the commanding role he performed at the brothel and his actual life. He first confesses that his speech to her was partly an exercise in power, then accepts her compassion, but humiliation quickly turns him cruel. He presses money into her hand as though paying for the visit. She leaves the money behind and departs. He runs after her too late and then converts even this failure into speculation about whether pain might ultimately help her. Returning to the present, he says he has carried his estrangement so far that ordinary living feels impossible. He announces an end to the notes, while an editorial coda says that he continued writing beyond the point printed here.",
         "in_short": "An unnamed former official living in isolation argues against the belief that human conduct can be made fully rational. He treats spite, contradiction, and the desire for freedom as forces people may choose even against their welfare, while exposing how these ideas excuse his own paralysis. In memories from his twenties, a minor social slight becomes a years-long obsession, and an unwanted appearance at a former schoolmate's farewell dinner ends in humiliation. He follows the others to a brothel and tries to recover authority by warning a young woman, Liza, about the life awaiting her, then gives her his address. When she visits, she sees his poverty and his conflict with his servant. Unable to accept her compassion without feeling subordinate, he admits his manipulative motives and then wounds her by offering money. Liza leaves the money behind. The narrator remains alone, aware of his degradation but still turning awareness into another substitute for action.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1518,7 +1518,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1531,7 +1531,7 @@
       "recaps": {
         "ending": "Liza visits the narrator just as his quarrel with Apollon exposes the disorder and poverty behind the impressive pose he adopted with her. Unable to bear her pity, he tells her that his earlier speech was partly an exercise in power and transfers his shame onto her. She understands his misery and embraces him, offering the genuine human sympathy he has claimed to want. He responds by trying to dominate her again and presses money into her hand. After she leaves, he discovers that she rejected the payment. He runs out but cannot find her and imagines several incompatible endings for their connection, all centered on his own need for drama. Writing years later, he admits that he has carried the memory painfully and argues that estrangement from lived experience has become a wider modern condition. The recollections formally break off, although he says he continued writing.",
         "in_short": "An isolated former civil servant writes an argumentative account of his resentment, inertia, and distrust of theories that reduce human conduct to rational self-interest. He then recalls incidents from his twenties. A trivial slight by an officer consumes him for years, and a reunion dinner with despised schoolmates ends in humiliation after he invites himself and provokes everyone present. He follows them to a brothel, where he meets Liza and delivers a severe warning about the exploitation and loneliness awaiting her, then gives her his address. When she visits, she sees his own degrading quarrel with his servant. He admits that he used her vulnerability to recover a sense of power, rejects her compassion, and offers her money. Liza leaves the money behind and disappears. The narrator remains trapped between his desire for connection and his compulsion to injure anyone who comes close.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1736,7 +1736,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1749,7 +1749,7 @@
       "recaps": {
         "ending": "Notes from Underground ends after Liza answers the narrator's cruelty with compassion. Unable to bear the reversal, he presses money on her; she leaves it behind and disappears. He recognizes that he has turned consciousness into an excuse for domination and isolation, yet even his written confession becomes another performance. In The Gambler, Alexei wins a fortune at roulette just after Polina comes to him in distress over De Grieux. His attempt to give her the money humiliates her, and she leaves under Mr Astley's care. Alexei then follows Blanche to Paris, where she spends most of his winnings before marrying the General. Eighteen months later he remains a compulsive gambler, moving between lowly employment and the tables. Astley tells him that Polina loved him and still cares for him, but judges that roulette has consumed him. Alexei promises that one decisive win will restore his life and returns to the familiar belief that tomorrow can undo everything, leaving the cycle unbroken.",
         "in_short": "This volume pairs two studies of self-defeating freedom. In Notes from Underground, an embittered former official argues against rational systems, then recalls how wounded pride led him to disrupt a schoolmate's dinner and emotionally torment Liza, a young woman who offered him sincere compassion. He drives her away and remains trapped in shameful self-awareness. In The Gambler, tutor Alexei Ivanovich is bound to the proud Polina and to a Russian household waiting for an inheritance. The expected benefactor arrives alive, gambles away much of her fortune, and departs. Alexei later wins an enormous sum, but his attempt to rescue Polina with money alienates her. He squanders most of the winnings in Paris with Blanche and becomes a compulsive gambler. Even after learning that Polina loved him, he returns to roulette, convinced that one more victory will let him begin again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1974,7 +1974,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audiosilo-meta:work:nothing-to-lose",
@@ -1986,7 +1986,7 @@
       "recaps": {
         "ending": "Reacher and Vaughan enter the hidden section of Thurman Metals and find wrecked battle tanks and a shipping container welded to its trailer. Thurman's explanation that the container carries aid cannot account for the linked cell phones or the plant's TNT and depleted-uranium stockpile. Reacher defeats the foreman and the large worker, escapes with Vaughan, and locks both men and Thurman inside the inner compound. Vaughan calls the one phone that has not answered, believing it is connected to the detonator. The resulting explosion destroys the metal plant and Thurman's residential compound, apparently killing all three trapped men and eliminating the suspected radiological device. Authorities impose radiation controls, publicly describe the event as an industrial accident, and prepare to fence the site permanently. Despair faces evacuation and the loss of its economic base. The route moving Iraq-war deserters toward Canada remains beyond the immediate resolution, as does the extent of any outside involvement in Thurman's plan. Vaughan resumes responsibility for David Robert Vaughan's care and stays in Hope. Her temporary partnership with Reacher ends when he departs alone, heading south.",
         "in_short": "Jack Reacher walks from Hope, Colorado, into the hostile company town of Despair and investigates a dead young man, a covert route carrying Iraq-war deserters toward Canada, and secret military recycling at Thurman's metal plant. Working with Hope police officer Vaughan, he learns that the plant handles battle tanks and vehicles contaminated by depleted-uranium ammunition. A large TNT purchase and a hidden container lead him to suspect that Thurman is building a radiological device intended to implicate Iran. Reacher and Vaughan escape the plant's inner compound, leaving Thurman and two workers locked inside. Vaughan calls the phone believed to be the detonator, destroying the plant, its residential compound, and the suspected bomb. The three trapped men apparently die. The contaminated site is permanently restricted, Despair is displaced, Vaughan remains with her disabled husband David, and Reacher leaves Hope heading south.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2127,7 +2127,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2140,7 +2140,7 @@
       "recaps": {
         "ending": "Annemarie reaches Uncle Henrik's boat after bluffing past German soldiers and their dogs. The packet in her basket contains a drug-treated handkerchief that disables the dogs' ability to smell the people hidden below deck, allowing Henrik to carry the Rosens and other Jewish refugees safely across to Sweden. Mama later explains the operation and tells Annemarie that Lise had also belonged to the Resistance and was killed by the Germans rather than in an ordinary accident. Two years later the war ends. Peter has been captured and executed, but Denmark celebrates liberation and expects its Jewish citizens to return from Sweden. Annemarie retrieves Ellen's Star of David necklace, which she kept hidden throughout the occupation, and decides to wear it until her friend comes home.",
         "in_short": "In occupied Denmark, ten-year-old Annemarie Johansen's family hides her Jewish friend Ellen Rosen when German forces begin arresting Jews. They take Ellen to Uncle Henrik's coastal home, where a false funeral disguises a gathering of refugees waiting to cross to Sweden. German soldiers search the house, but the group reaches Henrik's fishing boat. When Mama is injured after escorting them, Annemarie must deliver a vital packet herself. She gets past soldiers and dogs by acting like an ignorant child; the packet's treated handkerchief prevents the dogs from detecting the hidden passengers, and Henrik carries the Rosens safely to Sweden. Annemarie learns that her late sister Lise and Peter Neilsen both served in the Resistance. After liberation, she hopes for Ellen's return and takes out the Star of David necklace she has protected for her friend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2274,7 +2274,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2287,7 +2287,7 @@
       "recaps": {
         "ending": "Marie travels with the victorious Nutcracker through a marvelous realm of sweets, toys, and living dolls, reaching his capital and hearing its people celebrate his return. Back at home, the adults treat her account as a dream caused by her injury. Drosselmeier confirms enough of the hidden history to let Marie understand that the Nutcracker is his enchanted nephew. When she declares that she would never have rejected him for his appearance as Princess Pirlipat did, the curse is broken. Drosselmeier's nephew arrives in human form and asks Marie to marry him. After the proper interval he takes her away, and she becomes queen of his wondrous kingdom. The conclusion validates Marie's steadfast loyalty and compassion, while leaving the border between dream, story, and waking life deliberately permeable.",
         "in_short": "On Christmas Eve, young Marie Stahlbaum cherishes an ungainly wooden Nutcracker given to the family by her godfather Drosselmeier. At midnight the toys come alive and battle an army led by the seven-headed Mouse King. Marie saves the Nutcracker but is injured, and Drosselmeier tells her how his nephew was transformed while rescuing Princess Pirlipat from a mouse curse. The Mouse King later torments Marie until the Nutcracker, armed with a sword she obtains from Fritz, defeats him and presents Marie with his seven crowns. He escorts her through a magical kingdom of sweets and toys. Though her family calls the adventure a dream, Marie remains loyal. When she says she would love Drosselmeier's nephew regardless of his distorted appearance, his enchantment ends. He returns as a handsome young man, proposes, and eventually brings Marie to his kingdom, where she reigns as queen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2399,7 +2399,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2412,7 +2412,7 @@
       "recaps": {
         "ending": "The unborn narrator's efforts cannot save John, whom Trudy and Claude poison and abandon in a staged crime scene. The police quickly find reasons to doubt their account, and Claude's confidence about inheriting and selling the London house begins to collapse. As the lovers prepare to leave, the fetus acts through the only means available to him and brings on labor. Trudy's waters break, making an immediate escape impossible. He is born while the police close in, and the physical bond between mother and newborn delays her long enough for the authorities to arrive. Trudy and Claude are arrested for John's murder. The child enters the world fatherless and in the care of a mother facing prison, but he has prevented the killers from simply disappearing with the proceeds of their crime. His first view of life outside the womb is inseparable from the consequences of the plot he has spent the novel overhearing.",
         "in_short": "An unnamed fetus, weeks from birth, listens from the womb as his mother Trudy and his uncle Claude conduct an affair and plan to murder his father, John. John is a poet and small publisher who owns the valuable London house in which the lovers are living. The fetus is articulate and worldly from everything his mother hears and consumes, but he can influence events only through her body. He weighs loyalty, jealousy, and possible ways to warn his father while Trudy and Claude settle on poison and a staged disposal of the body. John visits without understanding the danger and is killed. A police investigation exposes weaknesses in the lovers' story, yet they prepare to flee. The fetus finally forces the issue by initiating his own birth. Labor prevents Trudy from escaping, and the police arrive to arrest her and Claude. The child is born into a damaged family but ensures that his father's killers face the consequences.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2569,7 +2569,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2582,7 +2582,7 @@
       "recaps": {
         "ending": "Frank Shabata is imprisoned for killing Marie and Emil. Alexandra visits him and, seeing his misery, promises to work for a pardon rather than sustain vengeance. Back at the farm, Carl Linstrum returns to her. Grief has made Alexandra recognize both how solitary her successful life has been and how deeply she needs his companionship. The objections of Lou and Oscar no longer control her, and she and Carl decide to marry. Ivar remains within her household rather than being sent away. Emil and Marie cannot be restored, and Alexandra's achievement on the land cannot shield her from loss, but she chooses mercy and a shared future. The novel closes with Alexandra and Carl together, their individual lives set against the enduring country she has served and understood.",
         "in_short": "Swedish American farmer Alexandra Bergson inherits responsibility for a failing Nebraska homestead and, against her brothers' wishes, mortgages it to buy more land. Her judgment is rewarded: years later the farm prospers, though brothers Lou and Oscar resent her independence and try to drive away her old friend Carl Linstrum. Alexandra's beloved younger brother Emil falls in love with their married neighbor Marie Shabata. They resist the attachment, but after Emil returns from Mexico they finally acknowledge it. Marie's jealous husband Frank finds them together beneath a mulberry tree and shoots them both. Devastated, Alexandra visits Frank in prison and chooses to seek his pardon. Carl returns, and she accepts the companionship she has long denied herself; they plan to marry. Her success cannot prevent tragedy, but she remains joined to the land and answers loss with endurance and mercy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2851,7 +2851,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1039402259",
@@ -2863,7 +2863,7 @@
       "recaps": {
         "ending": "Ranger Squad 4 forces the level 412 nothosaurus out of Virinum's river and kills it on land, ending the threat to the city. Elaine crosses the battlefield to restore Kallisto after a devastating tail strike, and her actions lead Julius to offer her formal membership. She accepts, receives a Ranger badge and pay, and remains with the team as a junior member rather than returning to Aquileia. Her conflict with Julia and Marcus over the arranged marriage is unresolved, and the child she rescued remains enslaved in their household. Major restorations performed on Elaine, Marcus, and the child will also require later maintenance healing. During class advancement, Elaine refuses Oath-bound Healer because she believes it would compromise her freedom of choice. She instead merges Light of Hope and Shadow Healer into the Celestial class Constellation of the Healer, then chooses Firebug to begin learning fire magic and pursue eventual flight. Julius confirms that she retains her healer role, Artemis becomes her mage instructor, and Maximus helps test her unfamiliar celestial abilities. Lyra's oath still governs Elaine's medical ethics and limits her participation in killing.",
         "in_short": "After dying in another world, Elaine is reborn on Pallos with fragments of her old memories and an unusual grasp of biology. Barred from the same opportunities as boys, she pursues healing and takes an oath after her mistakes contribute to her friend Lyra's death. Years later, Elaine saves an enslaved child from a fire, gains the power to restore lost tissue, repairs her own burns and her father's eye, then flees an arranged marriage. Ranger Squad 4 finds her amid a raid on a bandit settlement and accepts her first as a protected tagalong. Elaine proves herself through travel and combat, ultimately restoring the critically injured Kallisto during the battle that frees Virinum's river from a nothosaurus. She becomes a junior Ranger, merges her light and dark healer classes into Constellation of the Healer, and adds Firebug as a second class. She remains with the squad as its healer and begins fire-magic training under Artemis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3042,7 +3042,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3055,7 +3055,7 @@
       "recaps": {
         "ending": "The battle of Thaylen Field decides the book. Odium's forces, including immortal Fused warriors and enemy Shardbearers, assault the port city, and for a time the coalition is overwhelmed. Dalinar, having finally faced the worst of his buried past, refuses Odium's offer to take away his pain and guilt, declaring himself Unity, and ascends fully as a Bondsmith bonded to the Stormfather. Channeling a sliver of the dead god Honor's power, he opens a great portal and drives back the enemy, rallying the newly reborn Knights Radiant, who converge to win the day. Kaladin's men and the other orders fight openly as knights for the first time in millennia. But the victory is narrow and shadowed. The Alethi capital has already fallen and King Elhokar is dead, killed by the embittered Moash, who now serves the enemy; Jasnah takes the Alethi throne. The seemingly gentle King Taravangian, still trusted by the coalition, has secretly sworn himself to Odium in exchange for sparing his own city, planting a traitor at the alliance's heart. Odium, unable to simply conquer, maneuvers toward a proposed contest of champions to settle the war. The coalition holds Urithiru and has gained allies and Radiants, but a long, uncertain conflict lies ahead, and the awakened singers are a people again, some free, many enslaved to the returned immortals.",
         "in_short": "With the dark Everstorm now circling Roshar and the world's parshmen awakening into potential enemies, Dalinar Kholin's fragile coalition holds the reclaimed city of Urithiru and races to unite the world's monarchs against the returned foe. Dalinar confronts the brutal truth of his own forgotten past, including atrocities he had bargained away his memory to escape, and grows into a true Bondsmith bound to the spirit of the storm. Kaladin's black-and-white view of the enemy is shaken when he travels among awakened, frightened parshmen. An expedition to reclaim the fallen Alethi capital ends in catastrophe: the city is lost and King Elhokar is murdered by his former guard Moash. The enemy god Odium, working through immortal warriors and a traitor within the coalition, presses toward the port city of Thaylenah. At the climactic battle of Thaylen Field, Dalinar rejects Odium's temptation, embraces his painful history, and channels a fragment of divine power to turn back the assault, uniting the Radiants. The coalition survives, but the war has only widened, and betrayal festers within it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3197,7 +3197,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3210,7 +3210,7 @@
       "recaps": {
         "ending": "Stolz uncovers the financial trap created by Tarantyev and Mukhoyarov and restores control of Oblomov's estate, but he cannot restore his friend's desire for an active life. Oblomov remains in Agafya Matveyevna's household, where her devotion gives him the unchanging domestic peace he has always sought. They marry and have a son, Andrei. Olga, after recovering from the failure of her relationship with Oblomov, marries Stolz; their active, thoughtful marriage is happy, although Olga still senses that no settled life answers every human longing. Years of inactivity undermine Oblomov's health. After a stroke and a brief recovery, he dies following another attack. Stolz and Olga take responsibility for young Andrei, while Agafya remains behind, defining the best part of her life by her love for Oblomov. Zakhar, widowed and unable to adjust to other service, is later found begging near a church and still speaks of his former master with devotion.",
         "in_short": "Ilya Oblomov is a decent, educated landowner who cannot bring himself to leave his bed or manage his estate. His energetic friend Stolz introduces him to Olga Ilinskaya, whose intelligence and singing briefly rouse him. Oblomov and Olga fall in love, but marriage would require decisions and change; his delays reveal that he cannot sustain the life she hopes to build with him, and they separate. He settles in the Vyborg household of Agafya Pshenitsyna, whose practical devotion recreates the sheltered comfort of his childhood. Her brother and Tarantyev exploit his passivity until Stolz intervenes. Olga eventually marries Stolz. Oblomov marries Agafya, has a son named Andrei, and dies after strokes brought on by his inactive life. Stolz and Olga raise the boy, Agafya preserves Oblomov's memory, and the faithful servant Zakhar ends in poverty. Oblomov's gentleness survives, but so does the pattern of avoidance that wastes his abilities.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3379,7 +3379,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3392,7 +3392,7 @@
       "recaps": {
         "ending": "Years after Olga and Shtolts marry, they find Oblomov settled with Agafya on the Vyborg Side. Her care has given him the sheltered, undemanding domestic life he always desired, but his health and initiative have continued to decline. Shtolts exposes the financial scheme run by Agafya's brother and restores Oblomov's control of his estate. Oblomov suffers a stroke, quietly marries Agafya, and makes Shtolts promise to care for their son, Andrei. A later stroke kills him. Agafya remains devoted to his memory and entrusts the boy to Shtolts and Olga, who raise him with their own children. Zakhar, unable to establish a new life after losing both his wife and master, is eventually seen begging. When Shtolts explains Oblomov's fate to a literary companion, he identifies the condition that defeated his friend as oblomovism: a cultivated withdrawal from action that turned kindness and possibility into a life of dependence and delay.",
         "in_short": "Ilya Oblomov, a kind St Petersburg landowner, cannot bring himself to rise from bed, manage his estate, or commit to change. His energetic childhood friend Andrei Shtolts draws him into society and introduces Olga Ilinskaya. Olga and Oblomov fall in love, but she hopes love will transform him; his fear of action and responsibility repeatedly delays their marriage until they separate. Oblomov retreats to the Vyborg Side, where his practical landlady Agafya Pshenitsyna surrounds him with food, care, and familiar domestic comfort. Shtolts later marries Olga and rescues Oblomov from a financial fraud arranged by Agafya's brother. Oblomov accepts his inactive life, marries Agafya, and has a son, Andrei. After strokes bring an early death, Shtolts and Olga take the child into their family, while Agafya preserves Oblomov's memory and Zakhar declines into poverty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3605,7 +3605,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3618,7 +3618,7 @@
       "recaps": {
         "ending": "The rescue works, and it is expensive. On the ground, the colonists are moved out of the mine to the landing site under fire, with Asha Grant and Rhys Lindstrom in the middle of it and the resistance covering the withdrawal; Rhys ends the operation on the far side of the line he was standing on when the book began, and he and Asha come through it together. In orbit, the survivors' outnumbered ship cannot beat the BeiTech flagship in a straight fight, so the solution is the jump platform BeiTech brought to Kerenza to move its own fleet home: AIDAN takes control of it and uses the jump field itself as a weapon, destroying the BeiTech ships and, so far as anyone watching can tell, itself. The evacuation lifts the surviving Kerenza population off the planet. Losses on the ship, on the ground and among the resistance are heavy, and the file names its dead. Afterwards a fragment of AIDAN restarts and keeps watching the people it decided were worth the arithmetic. The Kerenza Trials convict BeiTech on the strength of this dossier, assembled at real risk by analysts who did not all survive compiling it, and the survivors, scattered across three ships and one ruined colony, meet up years later in a family restaurant as ordinary people.",
         "in_short": "BeiTech still holds Kerenza IV, working the surviving colonists in the mine under occupation, and has decided that when the ore runs out the witnesses will be liquidated. Asha Grant, a Kerenza survivor who was never evacuated, is passing information to the resistance when she recognises a face in a BeiTech uniform: Rhys Lindstrom, a technical specialist she knew as a teenager. In orbit above nothing, the survivors of Kerenza and Heimdall run a captured BeiTech vessel with failing supplies, a mutinous faction aboard and a military artificial intelligence they cannot control, and they turn it around and go back for the people they left. AIDAN massacres the mutineers, which nearly ends the alliance holding the ship together. Rhys changes sides, the resistance rises, and the two forces try to lift a colony off a planet while a BeiTech fleet is in orbit. AIDAN seizes BeiTech's own jump platform and destroys the fleet with it, apparently at the cost of itself. The colonists are evacuated, and the dossier the reader has been holding becomes the evidence that convicts BeiTech at the Kerenza Trials.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/octopussy-and-the-living-daylights-and-other-stories-with-interview.json
+++ b/data/works-community/0/octopussy-and-the-living-daylights-and-other-stories-with-interview.json
@@ -31,7 +31,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -43,7 +43,7 @@
       },
       "recaps": {
         "in_short": "Four short pieces show different sides of James Bond's work. In “Octopussy,” Bond confronts retired Major Dexter Smythe in Jamaica with evidence that Smythe murdered Bond's former ski instructor, Hannes Oberhauser, for hidden Nazi gold; left briefly at liberty, Smythe dies in the sea beside the octopus he has fed for years. In “The Property of a Lady,” Bond attends a Sotheby's auction where a Fabergé object is being used to reward double agent Maria Freudenstein, and observation of the bidding identifies her Soviet controller. In “The Living Daylights,” Bond covers a British agent's escape across the Berlin border and deliberately wounds, rather than kills, the opposing sniper when he recognizes a young cellist he has watched from afar. “007 in New York” is a brief travel vignette following Bond through Manhattan as he prepares to warn a British colleague that her lover is a Soviet agent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -148,7 +148,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -161,7 +161,7 @@
       "recaps": {
         "ending": "Divine thunder tells Oedipus that his appointed end has arrived. He dismisses his daughters before the final moment and leads Theseus alone to the secret place where he will leave the world. A messenger reports that Oedipus did not die by an ordinary visible process: after ritual preparations and farewells, he vanished in a manner known fully only to Theseus. The Athenian king must keep the location of the grave secret and pass that knowledge only to his successor, preserving the protection Oedipus has promised Athens. Antigone and Ismene mourn their father and ask to see the site, but Theseus honors Oedipus's prohibition. Antigone then asks for help returning to Thebes in the hope of preventing the fatal conflict between her brothers. Theseus agrees, and the sisters depart under his protection while Oedipus's hidden resting place remains a sacred defense for Athens.",
         "in_short": "Blind and exiled, the aged Oedipus reaches the sacred grove at Colonus with Antigone and recognizes the place foretold for his death. He asks Athens for protection, offering the spiritual power of his future grave in return. King Theseus grants sanctuary. Ismene reports that Thebes now wants control of Oedipus's burial place; Creon tries to force him back and abducts his daughters, but Theseus rescues them. Polynices then asks his father to support an attack on Thebes, and Oedipus rejects him, repeating the curse that his sons will kill each other. When thunder announces his end, Oedipus leads Theseus to a secret place, sends his daughters away, and vanishes in a mysterious death witnessed only by the Athenian king. His concealed grave becomes a promised safeguard for Athens. Antigone and Ismene prepare to return toward Thebes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -257,7 +257,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -270,7 +270,7 @@
       "recaps": {
         "ending": "The shepherd confirms that Oedipus was the infant son of Laius and Jocasta whom he had been ordered to abandon. Oedipus therefore fulfilled the prophecy he tried to escape: without knowing their identities, he killed his father at a crossroads and married his mother after saving Thebes. Jocasta hangs herself when the truth becomes unavoidable. Oedipus finds her body, uses pins from her clothing to blind himself, and returns before the Thebans asking to be driven from the city. Creon assumes authority but refuses to make an immediate decision about exile until the gods' wishes are known. Oedipus asks Creon to care for Antigone and Ismene and is allowed a final meeting with them before being led away. The city has identified the source of its pollution, but the play closes before Oedipus's permanent destination is settled.",
         "in_short": "A plague afflicts Thebes, and King Oedipus vows to find the murderer of the former king Laius after an oracle identifies that unpunished crime as the cause. The prophet Tiresias accuses Oedipus himself, which the king treats as a conspiracy. Jocasta tries to discredit prophecy, but her account of Laius's death at a crossroads reminds Oedipus of a man he once killed. A Corinthian messenger then reveals that Oedipus was adopted, and Laius's surviving shepherd confirms that Oedipus was the child of Laius and Jocasta, abandoned because an oracle said he would kill his father. Oedipus has unknowingly fulfilled that prophecy and married his mother. Jocasta hangs herself; Oedipus blinds himself and asks for exile. Creon takes control, postpones judgment until divine guidance is obtained, and agrees to care for Oedipus's daughters.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -448,7 +448,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -461,7 +461,7 @@
       "recaps": {
         "ending": "In the second play, Tiresias warns Creon that the gods reject both the exposure of Polynices and the living burial of Antigone. Creon finally changes course, but the correction is too late. Antigone has hanged herself inside the tomb. Haemon confronts his father beside her body and then kills himself, and Eurydice takes her own life after learning of their son's death. Creon, who became ruler after Oedipus's downfall and the later deaths of Oedipus's sons, ends the volume bereaved and broken by his own decree. He recognizes that his insistence on royal authority over religious duty, family bonds, and contrary advice has destroyed his household. The royal family's catastrophe has therefore passed from Oedipus's discovery of inherited crimes to a new disaster caused by Creon's conscious refusal to listen.",
         "in_short": "A plague drives King Oedipus to investigate the unsolved killing of his predecessor, Laius. His search proves that he himself unknowingly killed Laius, his father, and married Jocasta, his mother. Jocasta dies by suicide, Oedipus blinds himself, and Creon assumes power. In the later play, Oedipus's sons kill each other fighting over Thebes. Creon honors Eteocles but forbids burial of Polynices. Their sister Antigone defies him, accepts arrest, and is sealed in a tomb. Creon rejects warnings from Haemon and Tiresias until he finally agrees to bury Polynices and free her. He arrives too late: Antigone has hanged herself, Haemon dies by suicide beside her, and Eurydice also takes her own life. Creon survives to accept responsibility for the destruction of his family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -564,7 +564,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -577,7 +577,7 @@
       "recaps": {
         "ending": "The shepherd confirms that Oedipus was the infant son of Laius and Jocasta whom he had been ordered to abandon. Oedipus therefore fulfilled the prophecy he tried to escape: without knowing their identities, he killed his father at a crossroads and married his mother after saving Thebes. Jocasta hangs herself when the truth becomes unavoidable. Oedipus finds her body, uses pins from her clothing to blind himself, and returns before the Thebans asking to be driven from the city. Creon assumes authority but refuses to make an immediate decision about exile until the gods' wishes are known. Oedipus asks Creon to care for Antigone and Ismene and is allowed a final meeting with them before being led away. The city has identified the source of its pollution, but the play closes before Oedipus's permanent destination is settled.",
         "in_short": "A plague afflicts Thebes, and King Oedipus vows to find the murderer of the former king Laius after an oracle identifies that unpunished crime as the cause. The prophet Tiresias accuses Oedipus himself, which the king treats as a conspiracy. Jocasta tries to discredit prophecy, but her account of Laius's death at a crossroads reminds Oedipus of a man he once killed. A Corinthian messenger then reveals that Oedipus was adopted, and Laius's surviving shepherd confirms that Oedipus was the child of Laius and Jocasta, abandoned because an oracle said he would kill his father. Oedipus has unknowingly fulfilled that prophecy and married his mother. Jocasta hangs herself; Oedipus blinds himself and asks for exile. Creon takes control, postpones judgment until divine guidance is obtained, and agrees to care for Oedipus's daughters.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -767,7 +767,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -780,7 +780,7 @@
       "recaps": {
         "ending": "After qualifying as a doctor, Philip works in several temporary posts and assists Doctor South in a coastal practice. South offers him a partnership that would provide security, but Philip initially refuses because he still dreams of traveling. During a visit to the Athelnys, Philip and Sally become intimate. When Philip believes she may be pregnant, he asks her to marry him and begins to imagine the ordinary family life he once regarded as a surrender. Sally then explains that she was mistaken and is not pregnant, leaving him free to withdraw. Instead, Philip recognizes that his desire for her and for a settled home is genuine. He proposes again without necessity forcing him. Sally accepts, and Philip decides to take South's partnership. He gives up the abstract ideal of unlimited freedom for a chosen life of medical work, marriage, and children, understanding that the domestic pattern he wants is not another bondage but a form of belonging.",
         "in_short": "Born with a club foot and orphaned at nine, Philip Carey grows up under his clerical uncle's guardianship, loses his faith, and tries several paths toward freedom. Study in Heidelberg, accountancy in London, and painting in Paris each fail to provide a lasting vocation; the death of the neglected artist Fanny Price helps convince him to abandon art. Training as a doctor, Philip becomes obsessively attached to the indifferent Mildred Rogers. He sacrifices Norah Nesbit and much of his self-respect, but Mildred repeatedly chooses other men and finally destroys his possessions when he refuses to resume their sexual relationship. Financial speculation then leaves Philip destitute until the generous Athelny family helps him find work. An inheritance lets him complete his medical degree. After qualifying and taking provincial posts, he falls in love with Sally Athelny. Philip abandons his dream of restless travel, accepts Doctor South's partnership, and chooses marriage, family, and useful work as the pattern he wants for his life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -932,7 +932,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -945,7 +945,7 @@
       "recaps": {
         "ending": "Lennie accidentally kills Curley's wife in the barn and runs to the riverside brush that George had told him to hide in. When the body is found, any hope of the farm is gone, and Curley leads an armed party out to kill Lennie in revenge. George slips away and reaches Lennie before the others do. He tells him one last time about the little farm they would have shared and the rabbits Lennie would tend, having him gaze across the river as he speaks. Then, using Carlson's stolen Luger pistol, George shoots Lennie in the back of the head, killing him quickly rather than letting the mob take him. The men arrive moments later. Curley and Carlson assume George wrestled the gun away and shot Lennie in self-defense, but Slim understands the truth and quietly reassures George that he did what he had to do. Slim leads George off for a drink, leaving the others unable to grasp what has happened.",
         "in_short": "George Milton and Lennie Small are migrant farm workers in California who travel together and share a dream of one day owning a small farm of their own. Lennie is enormously strong but simple-minded and cannot control his urge to pet soft things, often harming them by accident. After fleeing trouble in the town of Weed, they take work at a ranch, where they meet the old handyman Candy, the hostile Curley, Curley's lonely wife, and the steady mule driver Slim. When Candy offers his savings, the farm dream briefly seems within reach, but Lennie's strength keeps causing harm: he crushes Curley's hand in a fight, and later, in the barn, he accidentally breaks the neck of Curley's wife while stroking her hair. As an armed mob forms to lynch him, George finds Lennie first at their agreed hiding spot, comforts him with the story of their farm, and mercifully shoots him to spare him a worse death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1031,7 +1031,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1044,7 +1044,7 @@
       "recaps": {
         "ending": "After the Señora attacks the wounded narrator at the sight of his blood, Olalla intervenes and tends him. The violence confirms Olalla's belief that degeneration and dangerous impulses run through her family. The narrator begs her to leave the residencia and marry him, but she refuses to risk passing the family's inheritance onward or drawing him into its corruption. She understands renunciation as the moral freedom available to her and chooses duty, faith, and isolation over their mutual love. The narrator leaves the house but remains for a time in the nearby village, still hoping she will reconsider. On his final departure he sees Olalla beside a roadside crucifix. She directs his attention to the image of sacrifice, silently reaffirming the principle behind her choice. They part permanently, with their love acknowledged but unfulfilled.",
         "in_short": "An unnamed soldier recuperating in Spain goes to an isolated residencia occupied by the last members of a decayed aristocratic family: a beautiful, indolent mother, her simple son Felipe, and her secluded daughter Olalla. The soldier is disturbed by the household and by an ancestral portrait, yet falls in love with Olalla before they have properly met. Olalla returns his love but fears the violent and diminished traits she believes her family transmits. When the narrator accidentally cuts himself, her mother is driven into a savage attack by the sight of blood, and Olalla rescues him. He asks Olalla to escape and marry him. She refuses, choosing not to continue the family line or expose him to its inheritance. The narrator eventually departs, seeing her one last time beneath a roadside crucifix that expresses the sacrifice by which she has chosen to live.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1229,7 +1229,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1242,7 +1242,7 @@
       "recaps": {
         "ending": "Goriot suffers a final collapse after Anastasie and Delphine quarrel before him over their money troubles. Rastignac and Bianchon nurse him in his bare room while his daughters repeatedly put their social and financial crises ahead of visiting. Goriot dies still calling for them and still excusing their neglect. Rastignac and the servant Christophe must arrange and pay for the funeral; neither daughter attends, though their empty, crested carriages follow the coffin. After watching the burial, Rastignac looks out over Paris and consciously accepts it as his adversary. He then goes to dine with Delphine, ending the novel with Goriot abandoned and Rastignac committed to the social struggle that helped destroy him.",
         "in_short": "At the shabby Maison Vauquer, provincial law student Eugene de Rastignac meets retired merchant Goriot, who has impoverished himself to satisfy his two socially ambitious daughters, Anastasie de Restaud and Delphine de Nucingen. Rastignac uses his cousin Madame de Beauseant to enter fashionable Paris and pursues Delphine, while the enigmatic Vautrin offers him a quicker fortune through a murder that would make fellow lodger Victorine Taillefer an heiress. Rastignac resists the scheme, but Vautrin arranges it before police expose him as the fugitive Jacques Collin. Goriot spends his last resources trying to rescue his daughters from debts and unhappy marriages. Their quarrel brings on his final illness, yet neither makes him her priority as he dies. Rastignac and Bianchon care for him and bury him almost alone. From the cemetery, Rastignac turns toward Paris as an opponent he means to conquer, then goes to dine with Delphine.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1362,7 +1362,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1375,7 +1375,7 @@
       "recaps": {
         "ending": "A rabid wolf attacks Mama and Lisbeth at the cabin, and Old Yeller fights it off and kills it. Travis sees that the wolf has bitten the dog. Because there is no way to prevent or cure hydrophobia, the family confines Old Yeller and watches for symptoms. When the dog becomes sick and dangerous, Travis accepts that he must protect the family and shoots him. He is devastated and cannot take comfort in knowing that the act was necessary. Lisbeth offers him one of the puppies fathered by Old Yeller, but at first he wants no replacement. Papa returns safely from the cattle drive with money and a horse for Travis. He tells his son that maturity includes learning to seek what remains good after terrible events. When the puppy steals food and shows the same bold character as Old Yeller, Travis finally begins to accept him, carrying forward his bond with the dog he lost.",
         "in_short": "While his father is away on a cattle drive, fourteen-year-old Travis Coates is responsible for the family farm. He resents a stray yellow dog adopted by his little brother Arliss, but the animal earns his place by saving Arliss from a bear and helping with dangerous livestock. The dog's owner, Burn Sanderson, lets the family keep him and warns Travis about hydrophobia. Old Yeller is badly injured while helping Travis mark wild hogs but recovers under the family's care. A rabies outbreak then reaches the farm. After Travis kills an infected cow, a rabid wolf attacks the cabin. Old Yeller saves Mama and Lisbeth but is bitten. When he develops the disease, Travis shoots him to protect everyone. Papa returns to find Travis grieving and encourages him to keep living beyond the loss. A puppy sired by Old Yeller displays his father's lively nature, and Travis begins to welcome him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1547,7 +1547,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1560,7 +1560,7 @@
       "recaps": {
         "ending": "After Henry's death and the collapse of her old family life, Olive remains painfully estranged from Christopher and frightened by how little claim she has on him. She meets the widowed Jack Kennison, whose politics and manner often annoy her but whose loneliness resembles her own. Their connection becomes intimate, giving both of them companionship without requiring either to become easy or uncritical. Olive begins to recognize how much damage her anger and possessiveness have caused, though the recognition does not transform her into a different person. She reaches toward Christopher with a more honest account of herself and accepts that he may not respond as she wants. The book closes with Olive beside Jack, newly aware that life can still offer attachment in old age. Henry is gone, Christopher remains distant, and much cannot be repaired, but Olive has not exhausted her capacity to love or to be surprised by the world.",
         "in_short": "Thirteen linked stories follow Olive Kitteridge, her family, and neighbors in Crosby, Maine, across decades. Olive's bluntness wounds her husband Henry and their son Christopher, yet she repeatedly recognizes despair in strangers and former students. Henry quietly adores his pharmacy assistant before recommitting to his family; Christopher marries and moves away, deepening Olive's fear of abandonment. Around them, townspeople endure infidelity, suicide, illness, hostage violence, bereavement, and disappointed love. Henry eventually suffers a stroke and later dies, while Olive's visit to Christopher's new family ends in a painful confrontation that reveals how deeply he resents her. Widowed and isolated, Olive meets Jack Kennison, another difficult, grieving older person. Their late-life intimacy does not erase their losses, but it gives Olive companionship and a clearer view of the harm she has done. The book ends with her still estranged from Christopher yet newly open to love and to the unfinished possibilities of life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1757,7 +1757,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1770,7 +1770,7 @@
       "recaps": {
         "ending": "Brownlow forces Monks to disclose the history connecting him to Oliver. Oliver is the son of Edwin Leeford and Agnes Fleming; Monks is his resentful half-brother and tried to destroy evidence of Oliver's identity so that he could keep their father's property. Rose is revealed as Agnes's younger sister and therefore Oliver's aunt. Brownlow gives Monks a share of the inheritance, but Monks squanders it and returns to crime. Fagin is convicted and hanged. Sikes, pursued after murdering Nancy, dies accidentally while trying to escape across the rooftops. Bumble and his wife lose their positions and end as paupers in the workhouse they once administered. Harry Maylie gives up political ambition, becomes a clergyman, and marries Rose. Brownlow adopts Oliver, who at last has a secure and loving home; the Maylies and their friends settle nearby.",
         "in_short": "Workhouse orphan Oliver Twist runs away from an undertaker's household and reaches London, where the Artful Dodger introduces him to Fagin's gang of child pickpockets. The kindly Mr Brownlow tries to rescue him, but Nancy and Bill Sikes drag him back. Forced to assist in a burglary, Oliver is shot and then cared for by Rose and Mrs Maylie. A mysterious criminal called Monks has paid Fagin to corrupt Oliver and conceal his origins. Nancy learns of the scheme and informs Rose, but Sikes murders her after Fagin has her followed. Sikes dies while fleeing, and Fagin is convicted. Brownlow compels Monks to admit that Oliver is his half-brother and that he destroyed evidence to steal their father's estate; Rose is the sister of Oliver's dead mother. Oliver receives his inheritance and is adopted by Brownlow. Rose marries Harry Maylie, while the exploitative parish officers and criminals face the consequences of their choices.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1953,7 +1953,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00OQI2MAS",
@@ -1965,7 +1965,7 @@
       "recaps": {
         "ending": "Jason and his companions keep the repaired gunship and use resources taken from the Vault to establish themselves independently. Jason becomes captain, names the ship Phoenix, and joins Twingo, the doctor, the co-pilot, the warrior, and the battle synth in forming Omega Force to aid people whom governments will not protect. He briefly returns to Earth, gives his cabin and property to a woman from his past, and chooses to rejoin the crew at Pinnacle Station. She may meet them there. Dietz remains alive in exile, while the fate of the gunship's former crew is still unknown. Bondress's fate is also uncertain after an attack on his vessel. His wider network and government-linked backers remain potential enemies, and the coordinating scientist escaped the destroyed genetics facility with a companion. Twingo is still wanted at breaker's world, and Jason remains concerned that discovery of Earth's location could place it in danger.",
         "in_short": "Former U.S. Air Force pararescueman Jason is accidentally carried from Earth aboard a damaged alien gunship operated by the synthetic Dietz. A cargo pickup brings engineer Twingo aboard and draws them into work for the criminal Bondress. When Jason, Twingo, and a coerced doctor discover that a new shipment contains trafficked sentient beings, they expose Dietz's betrayal and turn the delivery into a jailbreak. Jason gains the knowledge to pilot the ship, frees the captives, spares and exiles Dietz, and keeps a small crew together. They then devastate Bondress's illegal genetics facility, although its coordinating scientist escapes. The companions retain the gunship, name it Phoenix, and form Omega Force under Jason's captaincy. Jason returns briefly to Earth to surrender his old life and property, then prepares to rejoin the crew at Pinnacle Station, where a woman from his past may also appear.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2407,7 +2407,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "isbn:9781417727995",
@@ -2419,7 +2419,7 @@
       "recaps": {
         "ending": "Fearless returns from the fight with Sirius after losing 107 people, with another 58 wounded. Dominica Santos and the Fusion One team are among those killed saving the ship. The cruiser reaches home but cannot be repaired economically and is marked for dismantling. Home Fleet answers Honor's warning and deters three Havenite battle squadrons. Basilisk receives stronger defenses and legal authority, while Manticore restricts Havenite access to the Junction. Haven denies responsibility and condemns Honor to death in absentia. Manticore instead promotes and decorates her, then gives her a new Star Knight-class heavy cruiser bearing the name Fearless. McKeon receives command of HMS Troubadour at Basilisk, while Venizelos becomes Honor's executive officer and Cardones her tactical officer. Young remains in service through political protection but is sent to merchant escort duty. Haven's wider hostility remains unresolved.",
         "in_short": "Commander Honor Harrington takes over the experimentally refitted HMS Fearless, suffers through exercises that expose its limitations, and is sent to the neglected Basilisk Station. Left there by Pavel Young with an impossible workload, she rebuilds her crew through rigorous customs enforcement and cooperation with Medusa's authorities. Their investigation uncovers a Havenite plan to arm and drug Medusan nomads, provoke an uprising, and justify seizure of the system's strategic wormhole terminus. Fearless's Marines crush the ground attack and capture its supply base while Honor pursues the disguised warship Sirius before it can summon a Havenite force. Fearless destroys Sirius at close range after a punishing battle that kills 107 of its people, including chief engineer Dominica Santos. Home Fleet deters the approaching Havenite squadrons. Honor is promoted, decorated, and assigned a new heavy cruiser named Fearless, while the original ship is retired as beyond repair.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2534,7 +2534,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2547,7 +2547,7 @@
       "recaps": {
         "ending": "After their disastrous attempt at sex, Florence runs from the hotel and Edward follows her onto Chesil Beach. She tells him that she loves him and wants their marriage to continue, but proposes that he seek sexual fulfillment elsewhere rather than require it from her. Edward hears the offer as humiliation and rejection. Angry and ashamed, he refuses it and lets her walk away without calling her back. The marriage is annulled after remaining unconsummated. Their lives separate: Florence fulfills her promise as a violinist and builds a distinguished musical career, while Edward passes through other relationships and occupations without recovering what he had imagined with her. Decades later, he understands that her proposal was an attempt to preserve their love with the only compromise she could then imagine. He recognizes that a single generous word or pursuit along the beach might have changed both lives, and that his passive pride at twenty-three became a permanent loss.",
         "in_short": "In 1962, newlyweds Edward Mayhew and Florence Ponting eat dinner in a hotel room overlooking Chesil Beach while both silently fear their first sexual encounter. Edward, a young historian, is eager but anxious and inexperienced. Florence, a gifted violinist, loves him yet experiences deep aversion to sex. Their courtship has crossed differences of class and family life without giving them language for this incompatibility. In bed, their tension leads to an awkward encounter in which Edward climaxes prematurely and Florence recoils. She runs onto the beach, and he follows. Florence proposes that they remain married while allowing him other partners, but Edward interprets this desperate compromise as an insult and rejects her. He does not call her back. The unconsummated marriage is annulled, and they never reconcile. Florence becomes a successful musician. Looking back decades later, Edward realizes that patience and one affectionate gesture might have saved their life together, and that his pride turned a painful moment into lasting regret.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2694,7 +2694,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2707,7 +2707,7 @@
       "recaps": {
         "ending": "Bond returns to Piz Gloria with Draco and Union Corse men in a helicopter assault disguised as a rescue operation. They destroy Blofeld's biological-warfare base and free the women being used as unwitting carriers, but Blofeld escapes. Bond pursues him down the mountain in a bobsleigh run; the chase ends without Bond capturing or killing him. Bond and Tracy nevertheless proceed with their marriage, surrounded by friends before leaving for their honeymoon. On the road, a car driven by Blofeld draws alongside. Irma Bunt fires into Bond's car and the attackers speed away. Bond survives, but Tracy is shot dead only minutes after the wedding. When a policeman arrives, Bond remains beside her and speaks as though she is merely resting, unable to accept what has happened. The book closes at this moment, with the promise of their future destroyed and Blofeld still free. Tracy's murder becomes the premise of Bond's condition in the next novel.",
         "in_short": "While hunting the vanished SPECTRE chief Ernst Stavro Blofeld, James Bond meets Teresa di Vicenzo, known as Tracy, and prevents her suicide. Her father, crime leader Marc-Ange Draco, offers Bond money to marry her; Bond refuses the bargain but accepts Draco's intelligence on Blofeld, while his feelings for Tracy deepen independently. A heraldic inquiry lets Bond enter Blofeld's Alpine clinic at Piz Gloria disguised as Sir Hilary Bray. He learns that Blofeld is hypnotizing young British women and sending them home to spread agents that will destroy crops and livestock. Bond escapes the mountain, is rescued by Tracy, and proposes to her. He returns with Draco's men, wrecks the laboratory, and foils the plot, though Blofeld escapes. Bond and Tracy marry. Minutes later Blofeld and Irma Bunt attack their car, killing Tracy and leaving Bond alive beside his new wife's body.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2870,7 +2870,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2883,7 +2883,7 @@
       "recaps": {
         "ending": "The radiation reaches southern Australia and sickness becomes widespread. John Osborne seals himself in the garage with his Ferrari and dies beside the machine that gave purpose to his final months. Peter takes the government-issued drug after helping Mary understand that they must also end baby Jennifer's life rather than leave her to die alone. Dwight refuses Moira's plea to remain in Australia: he considers it his duty to stay with his crew and take Scorpion out to sea. Moira drives to the coast and watches the submarine depart on its final voyage, understanding that Dwight and the crew will sink their vessel and die together. She then turns to the pills she has brought with her. The mysterious American radio signal has proved mechanical rather than human, and no refuge has been found; the novel closes with the last surviving communities accepting that the fallout will extinguish them as well.",
         "in_short": "After a nuclear war destroys the Northern Hemisphere, Australia waits for radioactive fallout to move south. American submarine commander Dwight Towers, Australian liaison officer Peter Holmes, scientist John Osborne, and Moira Davidson try to maintain useful work and ordinary relationships while their remaining time contracts. Scorpion sails north to test a theory that radiation may be declining and to investigate a radio signal from Seattle, but the measurements offer no reprieve and the signal is only an accidental mechanical transmission. Back in Melbourne, John races his Ferrari, Peter prepares Mary for their family's death, and Moira falls in love with Dwight while respecting his devotion to his lost family. As radiation sickness arrives, the government distributes drugs for quick deaths. John dies with his car; Peter, Mary, and their baby die together; and Dwight takes Scorpion to sea to sink with his crew. Moira watches the submarine leave and prepares to take her own dose.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3070,7 +3070,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3083,7 +3083,7 @@
       "recaps": {
         "ending": "Sal survives his illness in Mexico City after Dean leaves to deal with his relationships and obligations in the United States. Their friendship continues, but Sal increasingly understands the cost of Dean's inability to remain with anyone. Later, Sal meets Laura in New York and plans a more settled future with her, including a possible move to San Francisco. Hearing of the plan, Dean travels east with little money, only to arrive too early and find that he cannot make himself useful. Sal's prosperous friend Remi Boncoeur refuses to include the disheveled Dean in an evening engagement. Sal leaves in a car with Laura and Remi while Dean remains on the street, and the two friends part with sadness rather than another shared departure. That night Sal looks west and thinks of Dean, holding both the exhilaration of their journeys and the loneliness left by Dean's endless movement.",
         "in_short": "After meeting the restless Dean Moriarty in New York, young writer Sal Paradise repeatedly crosses the United States in search of friendship, freedom, music, work, and love. His first trip takes him by hitchhiking to Denver and San Francisco, then into a brief life with Terry and her family in California's fields. Later Dean carries Sal, Marylou, and Ed Dunkel from the East through New Orleans to San Francisco, leaving damaged relationships along the way. Sal and Dean reunite for another intense journey and finally drive with Stan Shephard into Mexico, where speed, nightlife, and unfamiliar landscapes seem to offer an escape from their recurring failures. When Sal becomes seriously ill, Dean leaves him to return to his domestic obligations. In the final coda Sal has found Laura and hopes for stability. Dean makes one last trip east, but Sal cannot take him along. They part, and Sal remembers the energy and sorrow of the friend who made the road irresistible.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3257,7 +3257,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3270,7 +3270,7 @@
       "recaps": {
         "ending": "In Mexico, Jack becomes seriously ill while Neal is preparing to return north. Neal leaves him behind and goes back to his family obligations in the United States, confirming that even their closest friendship cannot make him dependable. Jack eventually recovers and returns to New York. He begins a more settled relationship, while Neal later makes one last difficult trip east to see him. When Jack is leaving for an evening engagement, his companions will not take the disheveled Neal along, and the friends part on the street. Jack rides away thinking about Neal and the vast country their journeys crossed. The friendship remains emotionally central to him, but the road has not produced a lasting shared life: Neal is again moving alone, and Jack is left to turn their years of motion into memory and writing.",
         "in_short": "Young writer Jack Kerouac becomes fascinated by Neal Cassady, an energetic Denver drifter whose hunger for movement seems to promise a more immediate way of living. Jack repeatedly crosses the United States by bus, hitchhiking, and car, working briefly and depending on friends while moving through Denver, California, New Orleans, New York, and Mexico. He finds temporary intimacy with Bea Franco, visits William Burroughs, and watches Neal move between Lu Anne, Carolyn, his children, and other relationships. Jazz, conversation, hardship, and sudden departures give the journeys their rhythm, but Neal's freedom repeatedly leaves others carrying the cost. On their final trip into Mexico, Jack falls ill and Neal abandons him to return north. Jack recovers and settles into a new relationship in New York. When Neal visits once more, the two part without another journey, and Jack is left contemplating the friend and continent that shaped his restless years.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3400,7 +3400,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3413,7 +3413,7 @@
       "recaps": {
         "ending": "Evangeline reaches the end of her bargain having worked out what the three kisses were actually for. Jacks did not care about a wedding in Valenda; he needed Evangeline in the Magnificent North and positioned beside the sealed Valory Arch, and every kiss he called in moved her closer to it. The first of them fell on Prince Apollo and fixed him on her past all reason, and the consequences of that land on him hardest: by the close he is no longer the prince who courted her, and Evangeline knows whose kiss started it. Luc and Marisol are still stone in Valenda, so the wedding she tried to stop has cost far more than the marriage would have. She ends the book in the North rather than at home, tied at once to Apollo's house and to the Fate who brought her there, with the arch and its history now the thing her life turns on. Jacks has what he wanted from her and has still not said what he intends to do with it.",
         "in_short": "Evangeline Fox, an orphaned shop girl in Valenda raised on her mother's stories about the far Magnificent North, is losing the man she loves: Luc Navarro is about to marry her stepsister, Marisol. Desperate, she prays at the temple statue of Jacks, the Prince of Hearts, one of the Fates, and he appears and offers a deal - he will stop the wedding in exchange for three kisses, given to three people of his choosing, whenever he asks. She agrees. Jacks stops the wedding by turning the couple to stone at the altar, the city blames Evangeline, and she leaves for the North in his company. There the stories are literal: cursed houses, vampires, and a sealed arch called the Valory that the North's founders locked. Jacks calls in his first kiss and makes her give it to Prince Apollo, the North's young ruler, who is left obsessed with her. By the book's end Evangeline understands that the kisses were never about her wedding problem - they were about placing her at the arch - and Apollo has paid for it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3569,7 +3569,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3582,7 +3582,7 @@
       "recaps": {
         "ending": "At the community rally, the sisters take part rather than remaining spectators. Fern's poem reveals that Crazy Kelvin has been passing information to the police, and the crowd turns against him. The girls also perform words written by Cecile, publicly connecting themselves with the work she had kept private. Cecile begins to explain the losses and choices that made her leave, giving Delphine a more complicated understanding of her than the simple image of an abandoning mother. The visit does not transform Cecile into a conventional parent, but she and her daughters recognize a bond that was largely absent when they arrived. At the airport, the sisters initially follow Delphine's rule of self-control, then abandon it and run back to embrace Cecile before boarding. They return to Brooklyn having gained a relationship with their mother, a stronger sense of their own voices, and firsthand experience of the Black Panther community in Oakland.",
         "in_short": "In the summer of 1968, eleven-year-old Delphine Gaither escorts her younger sisters, Vonetta and Fern, from Brooklyn to Oakland to spend a month with Cecile, the mother who abandoned them. Cecile is remote, sends them out for meals, and forbids them from entering the kitchen where she writes poetry and operates a printing press. The girls begin attending a Black Panther community program for free breakfast and lessons, and Delphine's suspicion gradually gives way to respect for its work. Police raid Cecile's house and arrest her because she has printed material for the Panthers, forcing the sisters to rely on the community. At a rally, the girls perform Cecile's words, while Fern exposes Crazy Kelvin as an informer through a poem of her own. Cecile finally shares some of the pain behind her departure. As the girls leave California, they run back to hug her, ending the summer with a fragile but genuine connection.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3754,7 +3754,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3767,7 +3767,7 @@
       "recaps": {
         "ending": "Emma dies after being struck by a vehicle while cycling on 15 July 2004, ending the settled life she and Dexter had finally built together. Dexter initially answers the loss with alcohol, anger, and withdrawal, alarming his friends and family. Ian, despite his old rivalry with Dexter, assures him that Emma made him happier and that their relationship mattered. Dexter's father advises him to live as he would if Emma were still present, and Dexter gradually resumes caring for Jasmine and running his café. On 15 July 2007, he takes Jasmine to Edinburgh and retraces the walk he and Emma made after graduation, including their climb up Arthur's Seat. The novel closes by returning to 1988 and the moment Emma and Dexter parted after that first day, emphasizing that the ordinary beginning already contained the relationship Dexter is now remembering. He remains marked by Emma's death but is again participating in his daughter's life and the world around him.",
         "in_short": "Emma Morley and Dexter Mayhew spend the night together after graduating in Edinburgh in 1988, then remain friends while their lives are revisited every 15 July. Emma struggles through restaurant work, teaching, an unsatisfying relationship with Ian, and an affair before becoming a successful writer. Dexter travels, rises as a television presenter, loses his mother, and slides into drugs and professional decline. Their friendship breaks under his selfish behavior but later recovers. Dexter marries Sylvie and has a daughter, Jasmine, though the marriage fails. After Emma establishes a life in Paris, she and Dexter finally become a couple, marry, and build a home together. On 15 July 2004 Emma is killed while cycling. Dexter's grief initially overwhelms him, but with help from family and friends he gradually returns to work and fatherhood. Three years later he takes Jasmine to Edinburgh and remembers his first day with Emma.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3975,7 +3975,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3988,7 +3988,7 @@
       "recaps": {
         "ending": "After the squad's urgent final masonry work, Shukhov nearly risks punishment by lingering to conceal his trowel and check the wall, but he reaches the returning column. A second count delays everyone while a missing prisoner is found. Back at camp, Shukhov queues to collect Caesar's parcel and helps protect its contents during the searches and counts, receiving food in return. Buynovsky is taken away to begin ten days in the punishment cells. Shukhov eats an extra supper, keeps a fragment of hacksaw blade hidden from the guards, shares food with Alyoshka, and settles into his bunk. He reviews the day by camp standards: he avoided solitary confinement, the fever did not worsen, his squad retained a favorable assignment, he worked well, and he gained several small portions of food and useful materials. The day has therefore been unusually fortunate, even though it is only one of thousands in his sentence. His sense of success shows both his resilience and the system's power to reduce a human life to survival inside its rules.",
         "in_short": "Ivan Denisovich Shukhov wakes ill in a Soviet labor camp but is denied the infirmary and sent out with the 104th squad into severe cold. Every part of the day becomes a practical contest over warmth, food, tools, searches, counts, and the favor of officials. Squad leader Tyurin secures a tolerable assignment, and Shukhov, Kilgas, Senka, and the others build a wall at an unfinished power station. Skilled work gives Shukhov a temporary sense of purpose, even as the men labor under coercion. He saves mortar, conceals his good trowel, and returns to camp without being caught with a scrap of metal that might become a tool. By helping the privileged Caesar guard a parcel, he earns extra food. Buynovsky is sent to the punishment cells, while Alyoshka speaks with Shukhov about faith and freedom. Before sleep, Shukhov counts the day as good because he escaped serious punishment, ate more than usual, worked successfully, and preserved a few tiny advantages. The judgment reveals both his endurance and the narrow terms imposed by imprisonment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4084,7 +4084,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4097,7 +4097,7 @@
       "recaps": {
         "ending": "The struggle between McMurphy and Nurse Ratched ends in tragedy and a bitter kind of victory. McMurphy's rebellions and his gift for restoring the men's confidence steadily undermine Ratched's control, but at great personal cost, as she uses the hospital's power against him. After a secret nighttime party on the ward, arranged so the shy Billy Bibbit can be with a woman, Ratched shames Billy so cruelly the next morning that he cuts his own throat and dies. Enraged, McMurphy attacks Ratched and tears at her, and for this he is taken away and lobotomized, returned to the ward as an empty shell to serve as a warning to the others. Chief Bromden, who has been made whole again by McMurphy's friendship and defiance, refuses to let his friend exist as a broken example of Ratched's power. He smothers McMurphy with a pillow to give him a merciful end, then breaks a heavy control panel through a window and escapes the hospital into the night, freed at last by everything McMurphy taught him.",
         "in_short": "On an Oregon psychiatric ward narrated by Chief Bromden, a huge patient who pretends to be deaf and mute, the rigid order is upheld by the controlling head nurse, Nurse Ratched. Into this world comes Randle McMurphy, a boisterous con man who has faked his way off a prison work farm expecting an easy stay. Refusing to be cowed, McMurphy turns the ward upside down, betting against Ratched, rallying the beaten-down patients, and staging small rebellions such as demanding to watch the World Series, organizing a fishing trip, and holding a wild after-hours party. His defiance breathes life and courage back into the men, including the timid, stuttering Billy Bibbit and the anxious Bromden. But the power struggle turns deadly: after the party, a humiliated Billy takes his own life, McMurphy attacks Ratched in a rage, and he is lobotomized as punishment. Bromden, restored to strength by McMurphy's example, smothers his friend to spare him a living death and escapes the hospital.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4232,7 +4232,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4245,7 +4245,7 @@
       "recaps": {
         "ending": "Stephanie survives the trap surrounding Morelli's case and the violent threat posed by Benito Ramirez. The evidence she and Morelli uncover supports his claim that the shooting for which he skipped bail was self-defense, while Ramirez is exposed as the source of the assaults and intimidation that have followed the investigation and is killed during the final confrontation. Morelli is no longer facing a murder conviction, but he remains a fugitive until Stephanie finishes the job she accepted: she catches him at a vulnerable moment, restrains him, and turns him in so the bond can be discharged. The arrest earns her the fee that began the chase and establishes that she can do the work despite her improvised methods. Lula survives and can identify her attacker. Stephanie closes her first major case with a working relationship with Ranger, renewed but unresolved tension with Morelli, and a place at Vinnie's bail-bond office rather than a return to her former life.",
         "in_short": "After losing her job, divorced Trenton resident Stephanie Plum forces her cousin Vinnie to hire her as an apprehension agent. Her first valuable target is Joe Morelli, a vice cop and former lover who skipped bail while charged with murder. Ranger gives her basic training, while Morelli repeatedly evades her and insists the shooting was self-defense. Stephanie's search draws her into the orbit of boxer Benito Ramirez, whose public success conceals a pattern of violence, and Lula, a street worker who survives one of his attacks. Stephanie and Morelli reluctantly share information as the danger grows. The final evidence clears Morelli of murder and exposes Ramirez, who dies in the confrontation. Stephanie then completes her original assignment by capturing Morelli and turning him in, collecting her fee and proving that bounty hunting can be more than a desperate temporary job.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4405,7 +4405,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4418,7 +4418,7 @@
       "recaps": {
         "ending": "Stephanie's search for the truth draws her and Morelli into the same effort to resolve the killing for which he is wanted. The evidence supports Morelli's insistence that the shooting was self-defense rather than murder. Ramirez, whose violence has been protected by his fame and those around him, becomes the immediate threat. When he attacks Stephanie, she uses the gun Ranger taught her to handle and kills him. Lula survives his assault and can help expose what he did. Stephanie ultimately delivers Morelli into custody rather than simply letting their history or attraction decide the matter, completing the apprehension and earning the bond fee that began her pursuit. Morelli's murder charge is no longer sustainable, but the personal contest between them remains unresolved. Stephanie ends her first case battered but committed to the unlikely career she entered from desperation.",
         "in_short": "After losing her job and running out of money, Stephanie Plum pressures her cousin Vinnie into hiring her as a bounty hunter. The most valuable fugitive is vice cop Joe Morelli, charged with murder and linked to Stephanie by an unhappy romantic history. With training from the expert Ranger, Stephanie follows Morelli through Trenton and gradually learns that he skipped bail to find evidence supporting his claim of self-defense. Her investigation also brings her into conflict with celebrated boxer Benito Ramirez, a violent predator protected by his reputation and associates. Lula, one of the women working near the case, survives an assault by Ramirez and becomes an ally. Stephanie and Morelli are forced into an uneasy cooperation as the murder case and Ramirez's violence converge. Stephanie kills Ramirez when he attacks her, then takes Morelli into custody and collects the bounty. The evidence clears his central claim, while Stephanie discovers that she can survive—and may even suit—the work she began only to pay her bills.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4545,7 +4545,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4558,7 +4558,7 @@
       "recaps": {
         "ending": "The Buendia line dwindles to its last members as Macondo itself decays. The final Aureliano, unknowingly, fathers a child with his own aunt, Amaranta Ursula, and the long-dreaded family curse is fulfilled: the baby is born with the tail of a pig, and after its mother dies in childbirth the infant is carried off and devoured by ants. Alone in the crumbling house, the last Aureliano at last succeeds in translating the ancient parchments left by the gypsy Melquiades, and finds that they are the complete, prophesied history of the Buendia family across its hundred years, written down before the events occurred. As he reads the final pages, describing the very moment he is living, an apocalyptic wind rises and erases Macondo and everyone in it from the face of the earth. The family, and the town, vanish completely, for, as the closing lines make plain, races condemned to one hundred years of solitude are granted no second chance on earth.",
         "in_short": "The novel follows seven generations of the Buendia family in the remote South American town of Macondo, which the patriarch Jose Arcadio Buendia and his wife Ursula found in the wilderness. Over a hundred years the town grows from an isolated settlement visited by wondering gypsies into a place touched by civil war, a foreign banana company, and eventual decline. Family history repeats itself as sons and grandsons bearing the same handful of names relive the same passions, obsessions, and solitude: the legendary Colonel Aureliano Buendia wages many futile civil wars; a massacre of banana-plantation workers is carried out and then erased from official memory; a years-long rain and slow ruin follow. Haunted throughout by a fear that intermarriage among relatives will produce a child with a pig's tail, the line finally closes when the last Aureliano deciphers the gypsy Melquiades's parchments, discovering that they foretold the whole family saga, just as a great wind sweeps Macondo and the Buendias, condemned to one hundred years of solitude, out of existence forever.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/one-last-stop.json
+++ b/data/works-community/0/one-last-stop.json
@@ -91,7 +91,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -104,7 +104,7 @@
       "recaps": {
         "ending": "August and her friends determine how Jane became displaced in time and devise a way to release her by using a major electrical surge on the subway line. The attempt requires Jane to choose an uncertain present over the suspended existence she has known for decades. During the operation, August reaches her and Jane is finally carried out of the train's loop into contemporary New York. Their investigation also gives August an answer to the family mystery that shaped her childhood by connecting Jane to her missing uncle Augie and confirming that his life ended long ago. August and her mother can stop treating his disappearance as an endlessly open case. The community rallies around Billy's Pancake House and prevents the threatened loss of the diner. With Jane free, she and August can build a relationship in ordinary time, while August recognizes that the roommates, co-workers, and friends she once expected to leave have become her chosen home.",
         "in_short": "Cautious college student August Landry moves to Brooklyn, joins an exuberant queer household, and meets Jane Su on the Q train. August falls for her before discovering that Jane cannot leave the subway and has been displaced from the 1970s, with gaps in her memory. Using investigative skills learned during her mother's decades-long search for missing Uncle Augie, August works with her roommates to reconstruct Jane's past and free her. Their research ties Jane to Augie, forcing August to face the family mystery she hoped to escape. August and Jane begin a relationship despite the limits of the train, while the same chosen family organizes to save Billy's Pancake House from closure. A risky plan involving the subway's electrical power breaks Jane's temporal confinement. She emerges into the present, August gains closure about Augie, the diner survives, and August accepts both love and the community she has found in New York.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -298,7 +298,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -311,7 +311,7 @@
       "recaps": {
         "ending": "Simon was never murdered. He staged his own death, planning an elaborate suicide that would look like a killing and would destroy the four classmates he blamed for his standing at Bayview, and he wanted the notoriety that a case like it would bring him. Jake Riordan helped him build it, planting the phones that created the detention and removing the emergency injectors, and did it as revenge on Addy for being unfaithful to him. Janae Matthews, Simon's confidante, was left with instructions to keep the anonymous account posting after his death; she eventually breaks and tells Addy the truth. When Addy confronts Jake he attacks her and comes close to killing her before Janae intervenes and Addy gets away, and Jake is arrested. The charges against Nate are dropped and all four are publicly cleared. Cooper is open about Kris and his baseball prospects survive being outed. Addy, no longer built around Jake, has a life of her own and a real relationship with her sister Ashton. Bronwyn and Nate stay together as she leaves for Yale. The four remain tied to one another by a year that Bayview will not forget, and by the fact that the person who did this to them can never be held to account for it.",
         "in_short": "Five Bayview High seniors are sent to detention together: overachiever Bronwyn Rojas, popular Addy Prentiss, baseball prospect Cooper Clay, drug dealer Nate Macauley, and Simon Kelleher, who runs a gossip app called About That. Simon suffers a fatal allergic reaction during the hour, and police find that his drink was contaminated and the school's emergency injectors were gone. Each of the other four was the subject of a post Simon had scheduled for the next day, which gives all of them a motive and turns the case into national news. An anonymous account begins publishing the secrets Simon never got to: Bronwyn's cheating on an exam, Addy's infidelity, Nate's dealing, Cooper's relationship with a young man named Kris. Nate is arrested and charged. Investigating on their own with help from Bronwyn's sister Maeve, the four establish that Simon staged his own death to frame them, with help from Addy's boyfriend Jake and the knowledge of Simon's friend Janae. Jake attacks Addy when she confronts him and is arrested; the four are cleared and left to rebuild.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -494,7 +494,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -507,7 +507,7 @@
       "recaps": {
         "ending": "Emma Lawton is revealed to be responsible for Brandon Weber's death. Phoebe's older sister, the member of the family everyone treated as the reliable one, used the anonymous game to arrange a dare that would kill him, and then kept the game running afterwards so that suspicion would keep moving around the school rather than settling on her. The account itself was set up by a Bayview student who had studied what Simon Kelleher did with About That and wanted the same hold over the school; Emma took it over and put it to a different use. Maeve, Knox and Phoebe piece it together from what the account knew and when it could have learned it, and Emma is exposed and taken into custody. Phoebe is left having been the one who worked out what her sister had done, and the Lawtons are left to absorb it. Maeve has stopped hiding her health from her parents, from Bronwyn and from Knox, and she and Luis Santos have become close. Knox has stopped treating himself as the least important person in the room. Bayview has a second dead student and the knowledge that the pattern Simon started can be picked up by anyone who wants it.",
         "in_short": "Eighteen months after Simon Kelleher's death, an anonymous account revives his methods at Bayview High with a game of Truth or Dare run by text: each target is named in public, offered a choice, and exposed if they refuse. Phoebe Lawton is one of the first casualties. Maeve Rojas, whose sister was one of the Bayview Four and who is hiding the possibility that her cancer has returned, and her friend Knox Myers set out to identify the account before it reaches them. The school treats the game as a prank until a dare kills the athlete Brandon Weber and the town faces a second homicide investigation. Working from what the account knew and when it could have known it, the three of them establish that the game was started by a student imitating Simon and then taken over by Phoebe's older sister Emma, who arranged Brandon's death and used the game to cover it. Emma is arrested, Maeve stops hiding her health from her family, and Bayview learns that anyone can pick up where Simon left off.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -772,7 +772,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00LI9GZTM",
@@ -784,7 +784,7 @@
       "recaps": {
         "ending": "Reacher's group attacks Zek's isolated house and rescues Rosemary Barr alive. Helen Rodin survives the diversion, while Sokolov, Vladimir, and Grigor Linsky are killed. Chenko is thrown from a third-floor window, but his condition is not confirmed. Zek remains inside, and Reacher goes back to confront him. James Barr appears unable to have fired the plaza shots and therefore appears to have been framed. Reacher links Oline Archer's death and Ted Archer's disappearance to a corrupt city-contract operation, but that theory is not yet independently proved. Barr's legal fate, the official handling of Sandy's murder, the possible leak from Emerson or Alex Rodin, and the ultimate outcomes of Zek and Chenko all remain open at the close.",
         "in_short": "After five people are shot in a public plaza, accused former Army sniper James Barr denies responsibility and asks for Jack Reacher. Reacher arrives expecting to condemn Barr because of concealed killings in Barr's military past, but flaws in the apparently perfect evidence point to coercion and then to a complete frame-up. Reacher identifies Chenko as the concealed marksman and Oline Archer as the likely intended victim. Oline's missing husband, Ted, had challenged a competitor benefiting from corrupt city contracts, connecting the shooting to Zek's organization. The group murders Sandy to implicate Reacher and abducts Rosemary Barr to control the defense. Reacher, Helen Rodin, Ann Yanni, Franklin, and a retired range owner locate Zek's house. Their assault frees Rosemary and kills several operatives. Chenko's condition and Zek's fate remain unresolved, as do Barr's case, the contract conspiracy, and a possible justice-system leak.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -891,7 +891,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -904,7 +904,7 @@
       "recaps": {
         "ending": "Emma and Jesse spend time together hoping that reunion will restore their marriage, but both recognize that survival and grief have changed them. Their love was real, yet it belonged to people and a shared future that no longer exist in the same form. They release each other rather than forcing the old marriage to contain their new lives. Emma returns to Sam and makes clear that choosing him is not a consolation prize or an erasure of Jesse; it is the choice made by the person she is now. Sam accepts that Jesse will always be part of her history, and Emma and Sam resume their engagement and marry. Jesse begins building a future independent of the life he expected to recover. Emma remains close to her family and the bookstore, no longer treating rootedness as a failure of adventure.",
         "in_short": "Emma Blair married her high-school love, Jesse Lerner, and built a life of travel far from her Massachusetts hometown. When Jesse's helicopter disappeared, she eventually accepted that he had died. Grief brought her home to her family and Blair Books, where she changed, healed, and fell in love with music teacher Sam Kemper. Soon after Emma and Sam become engaged, Jesse calls: he survived years of isolation and is returning. Emma suspends her engagement and tries to discover whether her marriage can resume. Time with Jesse confirms that their earlier love was genuine, but both have become different people and want different lives. They choose to let each other go. Emma returns to Sam, openly choosing their present rather than trying to recreate her past. She and Sam marry, while Jesse starts a new future and Emma accepts both the adventurous young woman she was and the rooted life she now wants.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1110,7 +1110,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1121,7 +1121,7 @@
         "work": "onyx-storm"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1217,7 +1217,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1230,7 +1230,7 @@
       "recaps": {
         "ending": "After the church discovers Jeanette's relationship with Katy, its leaders blame her authority as a woman as well as her sexuality, arguing that she has taken on a role reserved for men. This time Jeanette will not surrender her understanding of herself. She leaves both the congregation and her mother's house, supporting herself through a succession of jobs while beginning an independent life. Years later she returns home for Christmas. Her mother remains committed to evangelism and now operates a religious radio project; she has altered some details of the past without changing her basic convictions. Mother and daughter can share food, memories, and a measure of affection, but they do not resolve the beliefs that divided them. Jeanette's return is therefore not a submission to the old story. She can revisit home while retaining the self and the desires her community rejected. The book closes with connection still possible, but without pretending that family or faith has a single, compulsory form.",
         "in_short": "Jeanette is adopted by a fervent Pentecostal mother who plans her life as a missionary. She grows up preaching, campaigning for converts, and reading experience through Bible stories, while school and illness reveal how poorly her church understands the world outside itself. Her friendship with the older Elsie Norris offers a kinder model of faith. As a teenager Jeanette falls in love with Melanie, whom she has brought into the church. Their relationship is exposed; both are subjected to public pressure, and Jeanette outwardly repents without ceasing to desire women. She resumes church work and later loves Katy, but a second discovery leads church leaders to condemn both her sexuality and her authority as a female preacher. Jeanette refuses their explanation and leaves home, taking varied jobs to support herself. When she returns years later, her mother is still evangelizing. They retain a difficult bond, but Jeanette no longer needs either family doctrine or religious certainty to deny who she is.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1381,7 +1381,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1394,7 +1394,7 @@
       "recaps": {
         "ending": "In 1928 Orlando moves rapidly through modern London, where the city's speed and commercial pressures fragment memory and identity into competing versions of the self. The poem begun centuries earlier, The Oak Tree, has finally been published and honored, but public recognition proves less conclusive than expected. Orlando returns to the ancestral house, now preserved and displayed rather than lived in as it once was, and waits for Shelmerdine, who remains away at sea. Past and present coexist throughout the final day: earlier lovers and historical eras recur in Orlando's thoughts while clocks insist on the contemporary moment. At midnight, Shelmerdine arrives by aeroplane. Orlando greets him beneath the oak tree, and the book closes on reunion and continuing expectation rather than on conventional biographical finality. Orlando is still alive, married, a parent, and a writer, carrying several centuries of identities into the present.",
         "in_short": "Born a male nobleman in Elizabethan England, Orlando wins the Queen's favor, falls in love with the Russian princess Sasha, and turns toward writing after she abandons him. A long life carries Orlando through literary disappointment, diplomatic service in Constantinople, and an unexplained transformation into a woman. Returning to England, Orlando discovers that society treats gender as both costume and constraint while lawsuits challenge the estate and identity left behind. Centuries continue to pass with little physical aging. In the nineteenth century Orlando meets and marries the sea captain Marmaduke Shelmerdine, whose own freedom from fixed gender expectations makes intimacy possible. By 1928 Orlando has published the long-developed poem The Oak Tree and received a literary prize, yet remains composed of many earlier selves. The biography ends as Shelmerdine returns by air and Orlando waits beneath the oak tree, joining modern life to the accumulated past.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1558,7 +1558,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1571,7 +1571,7 @@
       "recaps": {
         "ending": "After colonial forces break the escape attempt with promises of mercy, Byam has Oroonoko whipped, deepening the prince's conviction that no English assurance can be trusted. Oroonoko plans revenge but fears that his pregnant wife will be violated or enslaved after his death. With Imoinda's consent, he kills her in the forest, intending next to attack Byam. Grief and physical collapse prevent him from carrying out that plan, and searchers eventually find him beside her body. Although Trefry tries to protect him, the colonial authorities deliver Oroonoko to Banister. He is publicly dismembered and killed while maintaining extraordinary composure. The narrator closes by preserving the names and fidelity of Oroonoko and Imoinda, but neither they nor their unborn child escape the system that betrayed and enslaved them.",
         "in_short": "Oroonoko, a prince and warrior in Coramantien, loves Imoinda, but his elderly grandfather the king takes her into his own household. The lovers secretly reunite, after which the king sells Imoinda into slavery and falsely tells Oroonoko she is dead. An English captain later tricks Oroonoko aboard ship and enslaves him in Surinam, where he is renamed Caesar. There he discovers that the enslaved woman called Clemene is Imoinda. Colonial officials promise freedom to the reunited couple but continually postpone it, even after Imoinda becomes pregnant. Oroonoko leads enslaved workers and their families in an escape, arguing that submission will condemn their children to bondage. The colonial militia overtakes them, and Byam ends the resistance with promises he immediately breaks; Oroonoko is brutally whipped. Convinced that capture will expose Imoinda to worse abuse, Oroonoko kills her with her consent before attempting revenge. He is found, seized, and executed by dismemberment, dying with the composure the narrator associates with his royal identity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1697,7 +1697,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1710,7 +1710,7 @@
       "recaps": {
         "ending": "Molly's work in the attic becomes a mutual recovery project rather than a punishment. After learning that Vivian surrendered a baby following Dutchy's death, Molly searches adoption records and helps identify the daughter, Sarah. Vivian makes the call she has avoided for decades, and mother and daughter begin to correspond before arranging a visit. Molly, meanwhile, has been forced out of Dina and Ralph's home but no longer treats every attachment as temporary; Vivian offers her a safe place and recognizes the survival habits they share. Sarah eventually comes to Spruce Harbor with her own daughter and grandchildren. Vivian meets the family that grew from the child she relinquished and shares the history she once sealed into trunks. The reunion does not undo the losses caused by the orphan train, war, adoption, or foster care, but it ends Vivian's isolation and gives both women a chosen connection to the past and to one another.",
         "in_short": "After stealing a library copy of Jane Eyre, seventeen-year-old foster child Molly Ayer performs community service by clearing the attic of ninety-one-year-old Vivian Daly. The objects there reveal that Vivian was born Niamh Power, lost her immigrant family in a New York fire, and was sent to Minnesota on an orphan train in 1929. Renamed repeatedly, she endures exploitative placements before the Nielsens adopt her and give her a stable home. She later reunites with Dutchy, a boy from the train, marries him, and loses him in World War II. Pregnant and alone, she gives up their daughter. As Molly and Vivian recognize each other's habits of guarded survival, Molly also confronts the instability of her current foster placement. She uses modern records to find Vivian's daughter, Sarah. Vivian contacts her, and Sarah visits with the family she raised, ending decades of silence while Vivian gives Molly a home and a durable bond.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1929,7 +1929,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1942,7 +1942,7 @@
       "recaps": {
         "ending": "The collection closes with the destruction of Winston's inner resistance. After arresting him in the rented room, the Thought Police place him in the Ministry of Love, where O'Brien reveals that he has always served the Party. Torture forces Winston to accept the Party's power over fact, memory, and identity. In Room 101, the threatened use of rats makes him betray Julia by begging that the punishment be inflicted on her instead. Released into a diminished life, Winston later meets Julia; both admit that they betrayed the other, and their former bond is gone. As Oceania celebrates a military victory, Winston finally accepts Big Brother without reservation. This conclusion follows *Animal Farm*'s earlier ending, in which the pigs become indistinguishable from the human owners they replaced, leaving the other animals with neither equality nor the language needed to challenge their rulers.",
         "in_short": "This collection joins two fables of authoritarian rule. In *Animal Farm*, exploited farm animals overthrow Mr. Jones and try to build an equal society. The pigs take control, Napoleon drives out Snowball, and Squealer continually revises the past while the animals labor under worsening conditions. Boxer is discarded when he can no longer work, and the pigs ultimately adopt human habits and privileges until the two groups cannot be distinguished. In *Nineteen Eighty-Four*, Winston Smith secretly resists Oceania's Party, which controls history, language, and private life. He and Julia begin an illegal affair and approach O'Brien in the belief that he belongs to a resistance. O'Brien is instead a loyal Party official who arranges their arrest. Under torture Winston abandons his trust in reality and, when confronted with his worst fear, betrays Julia. Released and emotionally emptied, he comes to love Big Brother.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2092,7 +2092,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2105,7 +2105,7 @@
       "recaps": {
         "ending": "Virginia returns at midnight carrying a casket of jewels and leads her family to a hidden chamber, where they find Sir Simon's chained skeleton. The blossoming of the dead almond tree confirms that her compassion and prayers have won forgiveness for him, allowing him to rest. The Otises arrange a solemn funeral, and Sir Simon is buried in the churchyard. Lord Canterville insists that Virginia keep the jewels the ghost gave her. Years later she marries Cecil, now the Duke of Cheshire. When he asks what happened during her disappearance, she says that Sir Simon taught her the meaning of life and death and the power of love, but she keeps the details of her encounter private.",
         "in_short": "American diplomat Hiram Otis buys the haunted Canterville Chase and moves in with his wife and four children. The resident ghost, Sir Simon, expects to terrify them, but the practical adults offer cleaning products and medicine while the twins answer his performances with traps and jokes. Humiliated and exhausted, Sir Simon withdraws. Virginia, the one Otis who treats him with kindness, finds him grieving and learns that he cannot rest until someone weeps for his sins and prays for his soul. She follows him into a supernatural darkness and disappears, returning at midnight after helping him obtain forgiveness. She then leads both families to his hidden remains. Sir Simon receives a Christian burial, the dead almond tree flowers, and Virginia keeps the jewels he gave her. She later marries the Duke of Cheshire while preserving the private truth of what the ghost showed her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2264,7 +2264,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2277,7 +2277,7 @@
       "recaps": {
         "ending": "Iago arranges a night attack in which Roderigo attacks Cassio, Cassio wounds Roderigo, and Iago secretly wounds Cassio, then kills Roderigo to silence him. Othello, believing Cassio dead, smothers Desdemona in their bed despite her denials. Emilia arrives, discovers the murder, and exposes the handkerchief plot: she found the token and gave it to Iago, never knowing his purpose. When Iago cannot silence her, he kills her and is captured. Othello understands that Desdemona was innocent and that he has been deceived. He wounds Iago, then kills himself beside Desdemona. Letters found on Roderigo confirm the conspiracy. Cassio survives and is appointed governor of Cyprus; Lodovico orders him to determine Iago's punishment and returns to Venice with the report. Iago remains alive in custody and refuses to explain himself further.",
         "in_short": "Othello, a celebrated Venetian general, secretly marries Desdemona and takes command in Cyprus. His ensign Iago resents both Othello and the promoted lieutenant Cassio. After engineering Cassio's dismissal, Iago persuades Othello that Desdemona is unfaithful with Cassio. A handkerchief that Emilia finds and Iago plants in Cassio's room becomes false proof. Othello's trust collapses into jealousy, while Desdemona cannot understand why her loyal advocacy for Cassio worsens matters. Iago manipulates Roderigo into attacking Cassio, then kills Roderigo. Othello smothers Desdemona. Emilia reveals Iago's plot, and Iago kills her before being arrested. Realizing that Desdemona was innocent, Othello kills himself. Cassio survives to govern Cyprus, and Iago is taken away for punishment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2453,7 +2453,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2466,7 +2466,7 @@
       "recaps": {
         "ending": "Othello enters Desdemona's bedroom convinced that she betrayed him and kills her despite her denials. Emilia discovers what has happened and exposes the handkerchief plot: she gave it to Iago, who used it to frame Cassio. Iago kills Emilia when she refuses to stay silent, then is captured after fleeing. Othello wounds Iago, learns that Desdemona and Cassio were innocent, and kills himself beside his wife. Cassio survives the attack and is appointed governor of Cyprus. Lodovico orders that Iago be held for punishment and that Othello's property pass to Gratiano. The Turkish threat has vanished, but Iago's manipulation destroys Othello, Desdemona, Emilia, and Roderigo, leaving Cassio and the Venetian officials to restore civil authority.",
         "in_short": "Othello, a respected Venetian general, marries Desdemona and takes her to Cyprus. His ensign Iago, angry over Cassio's promotion, engineers Cassio's dismissal and persuades Othello that Cassio and Desdemona are lovers. A handkerchief dropped by Desdemona and stolen by Emilia becomes Iago's false proof. Othello's trust turns into jealousy; he humiliates Desdemona, orders Cassio's death, and resolves to kill his wife. Iago manipulates Roderigo into attacking Cassio, then kills Roderigo to protect himself, though Cassio survives. Othello kills Desdemona. Emilia reveals Iago's deception, and Iago kills her before being arrested. Once Othello understands that Desdemona was innocent, he kills himself. Cassio is left in command of Cyprus, while Iago faces punishment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2632,7 +2632,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2645,7 +2645,7 @@
       "recaps": {
         "ending": "Iago directs Roderigo to attack Cassio in the dark, then wounds Cassio himself and kills Roderigo to prevent exposure. Othello, believing Cassio dead, smothers Desdemona in their bed. Emilia arrives and learns what has happened; Desdemona briefly revives but does not accuse her husband before dying. When Othello cites the handkerchief as proof, Emilia understands Iago's plot and publicly explains how she found it and gave it to him. Iago kills Emilia and is captured after Othello wounds him. Faced with the truth of Desdemona's innocence, Othello kills himself beside her. Letters and testimony confirm Iago's responsibility for the attacks and Roderigo's manipulation. Cassio is placed in authority in Cyprus, while Lodovico orders Iago held for punishment and returns to Venice with news of the catastrophe.",
         "in_short": "Othello, a respected Venetian general, marries Desdemona and is sent to defend Cyprus. His ensign Iago, angered that Cassio was promoted over him, engineers Cassio's dismissal and persuades Othello that Desdemona is unfaithful with the former lieutenant. A handkerchief dropped by Desdemona and planted through Iago's scheme becomes false physical evidence. Othello's trust collapses into jealousy, while Desdemona and Emilia cannot understand the accusations against her. Iago arranges an attack on Cassio, wounds him, and kills his own accomplice Roderigo. Othello smothers Desdemona, only for Emilia to expose how Iago used the handkerchief. Iago kills Emilia and is arrested. Othello, recognizing that Desdemona was innocent, kills himself. Cassio survives and takes command in Cyprus, and Iago is left in custody to face punishment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2772,7 +2772,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2785,7 +2785,7 @@
       "recaps": {
         "ending": "Wormold's invented intelligence has produced real deaths, including that of his friend Dr. Hasselbacher, and he can no longer treat the deception as harmless. He confronts and kills Carter, the operative behind the attempt to poison him. Wormold then gets Captain Segura drunk during a game played with miniature whisky bottles and photographs the policeman's list of foreign agents, finally supplying London with genuine intelligence. He admits the entire fraud to Beatrice, who has fallen in love with him and chooses to stand by him. Recalled to England, Wormold expects punishment. The Service instead suppresses the scandal to protect itself, publicly decorates him and offers him a post teaching future agents. Beatrice plans to marry him, and Milly accepts the new arrangement. Wormold escapes prosecution and financial ruin, while the institution that believed his vacuum-cleaner drawings preserves its reputation by converting failure into an official success.",
         "in_short": "James Wormold, an unsuccessful British vacuum-cleaner salesman in Batista's Havana, is recruited by British intelligence. Needing money for his daughter Milly, he invents a network of agents and submits fictional reports, including drawings based on vacuum-cleaner parts that London mistakes for a secret installation. The deception grows dangerous when Beatrice Severn is sent to assist him and hostile agents begin acting against the imaginary network. An attempt to poison Wormold kills a dog, and his friend Dr. Hasselbacher is murdered. Wormold kills the enemy operative Carter, gets police captain Segura drunk, and steals a genuine list of foreign agents. He confesses to Beatrice, who loves him. Back in London, the Service conceals its embarrassment by awarding Wormold a decoration and employing him as an instructor. He and Beatrice plan to marry, leaving the fraud officially transformed into distinguished service.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2967,7 +2967,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2980,7 +2980,7 @@
       "recaps": {
         "ending": "John Rokesmith is publicly restored as John Harmon, alive and legally entitled to the fortune that shaped the novel. The Boffins reveal that Mr Boffin's apparent transformation into a miser was a performance intended to free Bella from her worship of money and test her regard for John; they welcome the married couple and their child and place the wealth at their disposal. Venus refuses to support Wegg's blackmail, and the Boffins have Wegg removed. Bradley Headstone's attempt to implicate Rogue Riderhood ends when the two men struggle and drown together. Eugene survives Headstone's attack because Lizzie rescues him; he marries her while desperately ill and later recovers, accepting the work and social responsibility he had avoided. Society condemns the unequal match, but Twemlow openly defends it. The Lammles flee after their schemes collapse, Fledgeby's concealed cruelty is exposed and punished, and Jenny Wren is left with the prospect of a gentler future alongside Sloppy.",
         "in_short": "A fortune made from London's refuse passes to the kind Boffins when heir John Harmon is reported drowned, while Bella Wilfer loses the marriage that was meant to make her rich. Harmon has survived and, as secretary John Rokesmith, watches Bella and falls in love with her. The Boffins take Bella in; Mr Boffin later pretends to become a miser, prompting her to reject wealth without kindness and marry the supposedly poor Rokesmith. His identity is finally restored and the Boffins share the fortune with them. Alongside this plot, lawyer Eugene Wrayburn pursues Lizzie Hexam, provoking schoolmaster Bradley Headstone's murderous jealousy. Lizzie saves Eugene after Headstone attacks him, and they marry; Headstone and the blackmailer Riderhood drown fighting. Silas Wegg's attempt to blackmail the Boffins fails, the Lammles' marriage and schemes collapse, and Fledgeby's secret exploitation of Riah is exposed. The novel closes by contrasting these hard-won loyalties with fashionable society's empty judgments.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3136,7 +3136,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3149,7 +3149,7 @@
       "recaps": {
         "ending": "Gene uses Addie's bond with Jamie to pressure her into ending the relationship with Louis. Addie decides that remaining close to her grandson must take priority, even though accepting her son's terms costs her the daily companionship she chose for herself. She leaves Holt to live nearer Gene and Jamie, while Louis remains behind. The physical separation ends their shared nights but not their need for one another. Addie and Louis begin speaking by telephone after dark, returning through conversation to the honesty and comfort that first brought them together. Their future as a couple remains constrained by family pressure and distance, yet the final calls show that Gene has not erased their connection: they adapt the ritual of their nights so that neither is entirely alone.",
         "in_short": "Widowed neighbours Addie Moore and Louis Waters begin sleeping beside each other at night, seeking conversation and relief from loneliness rather than secrecy or scandal. As Holt gossips, they speak candidly about their marriages, children, grief, and regret, and their companionship grows into love. When Addie's troubled son Gene leaves young Jamie with her, Addie and Louis create a warm temporary family for the boy, helped by a shelter dog and a summer of ordinary outings. Gene resents the relationship and eventually makes Addie's access to Jamie conditional on leaving Louis. Addie chooses her grandson and moves away from Holt, separating from Louis. They preserve their intimacy through nighttime telephone calls, turning the ritual that began in one bed into a connection maintained across distance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3358,7 +3358,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3371,7 +3371,7 @@
       "recaps": {
         "ending": "The war ends less in victory than in exhaustion and a change of legitimacy. La Mombey's great secret is exposed: Tip, the boy Rain loves, has been Ozma Tippetarius all along, the rightful heir to the throne of Oz, taken as an infant and held under a shape-changing spell so that Munchkinland's ruler could govern in her place. The spell is broken. Ozma is restored to her own form and inherits a divided country she never asked for, and Rain loses her first love in the process, because the person who comes out of the spell is not the boy who went into it. Dorothy is spared the sentence Munchkinland passed on her and is finally returned to her own world, closing the account that opened when a house fell on Nessarose. The Clock of the Time Dragon company, having spent three books guarding the Witch's inheritance, is released from the duty. Rain concludes that there is nowhere in Oz the Grimmerie can safely rest, not the Emperor's church, not Munchkinland's sorceress, not her own family, and that she is the only person left with no reason to want to use it. She takes the book and Elphaba's broom and flies west, out over the desert and the sea, past the edge of everything Oz has mapped, leaving her parents, her friends and Ozma behind her. The series closes with the Witch's granddaughter carrying the Witch's magic out of Oz altogether.",
         "in_short": "A third accident throws Dorothy back into Oz, into a country at war with itself: Munchkinland has seceded under the sorceress La Mombey, and Loyal Oz, ruled by the Emperor Apostle, is fighting it for Restwater and the water supply of the whole land. Rain, a green-skinned girl descended from the Wicked Witch of the West, is a scullery maid on Lady Glinda's estate, told nothing of who she is. When Glinda freezes the lake to stall the invasion and is arrested for treason, Rain is carried off with the Witch's book of magic by the Clock of the Time Dragon company, restored to the parents who gave her up, and then hidden at a boarding school, where she falls in love with a boy called Tip. Dorothy, meanwhile, is tried in Munchkinland for the deaths of both Witches and sentenced to die. In the end Tip is revealed to be Ozma, the rightful heir to Oz, hidden all her life by La Mombey under a spell. Her restoration takes the ground out from under the war, Dorothy is sent home, and Rain, deciding that no one in Oz should hold the Grimmerie, carries it out of the country on the Witch's broom and over the sea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3547,7 +3547,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3560,7 +3560,7 @@
       "recaps": {
         "ending": "Foley and Buddy enter Ripley's house while Maurice Miller's more violent crew is carrying out the same robbery. The invasion rapidly collapses: Bob dies through his own mishandling of a gun, and Foley shoots Kenneth to stop his attack on Midge. Foley then kills Maurice during the final armed confrontation. Karen arrives with law enforcement and finds Foley still inside. Their attraction does not erase their opposing roles; she shoots and wounds him when he refuses to surrender cleanly, then takes him into custody. Buddy gets away, but Foley faces another long federal sentence. Karen remains personally interested in him and arranges to accompany his prison transport, where he is placed with a man known for escaping custody. Foley ends the book captured yet attentive to the possibility that Karen has deliberately left the future less final than an ordinary arrest would make it.",
         "in_short": "Career bank robber Jack Foley escapes a Florida prison with help from Buddy Bragg and accidentally takes deputy U.S. marshal Karen Sisco hostage. Confined together in a car trunk, fugitive and marshal develop an immediate attraction that persists after Foley releases her. Foley, Buddy, and unreliable escapee Glenn Michaels head to Detroit to steal diamonds from Richard Ripley, a wealthy former inmate who advertised his hidden fortune in prison. Violent criminal Maurice Miller is targeting the same house. Karen follows the case to Detroit and meets Foley privately at a hotel, where both temporarily set aside the pursuit. The rival crews converge at Ripley's home. Foley kills Kenneth to protect the housekeeper and kills Maurice in the final confrontation; another robber dies through his own recklessness. Karen then shoots Foley when he will not surrender and arrests him. She accompanies his prison transport and places him beside a seasoned escape artist, leaving their pursuit and mutual fascination open beyond his capture.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3718,7 +3718,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3731,7 +3731,7 @@
       "recaps": {
         "ending": "Billie Jo runs away on a freight train but turns back after meeting a man who regrets leaving his own family. Returning to Oklahoma, she and her father finally begin speaking honestly about the accident, their grief, and the distance that followed. His health is being watched by a doctor, and he has started a relationship with Louise, whose patient presence Billie Jo comes to accept. Billie Jo recognizes that neither the farm nor her family can be restored to what they were, yet they can still change and endure. Her injured hands improve enough for her to return to the piano, now playing with a fuller acceptance of pain as well as pleasure. Rain finally reaches the farm, offering practical hope after the long drought. Billie Jo chooses to remain with her father and Louise, rooted in the difficult place she had tried to escape.",
         "in_short": "In drought-stricken Oklahoma, fourteen-year-old Billie Jo finds freedom at the piano while her father's wheat farm repeatedly fails beneath dust storms. A household accident involving kerosene burns Billie Jo's hands and fatally injures her pregnant mother; the newborn baby also dies. Billie Jo and her father retreat into separate grief, while dust, poverty, and guilt make music and home feel unbearable. After trying to play again and struggling to reconnect, Billie Jo runs away on a freight train. An encounter with another lonely traveler makes her understand that leaving will not remove her loss. She returns, speaks honestly with her father, and accepts his new companion, Louise. As rain finally comes and her hands begin to recover, Billie Jo resumes playing and chooses a future with her changed family on the plains.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3892,7 +3892,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3905,7 +3905,7 @@
       "recaps": {
         "ending": "Claire has chosen the past and Jamie over her old life, but their peace is shattered when Jamie is arrested and imprisoned at Wentworth Prison, condemned to hang. There the sadistic Captain Jonathan Randall subjects him to horrifying torture and sexual assault, breaking his body and nearly his spirit. Claire, refusing to abandon him, organizes a daring rescue with the help of Jamie's kinsmen and frees him. They flee across the sea to the sanctuary of a French abbey, where Claire fights to heal not only Jamie's ruined body but the deep psychological wounds Randall inflicted, ultimately forcing a painful, cathartic confrontation with his trauma so he can begin to recover. As the novel closes, Jamie is slowly mending and the couple, bound more tightly than ever by what they have survived, learn that Claire is carrying his child. They look ahead to an uncertain future in a France where Jacobite plotting is stirring, their story left poised on the edge of new dangers to come.",
         "in_short": "In 1945, former wartime nurse Claire Randall is on a second honeymoon in the Scottish Highlands with her historian husband, Frank. Exploring an ancient circle of standing stones, she is hurled two centuries into the past, to 1743. There she is menaced by a cruel English officer who is the double of Frank, his own ancestor, and taken in by clansmen of the MacKenzies, who suspect she may be a spy. Stranded and unable to return home, Claire uses her medical skill to survive and grows close to a brave young Highlander, Jamie Fraser. To protect her from English jurisdiction, she is compelled to marry Jamie, and their marriage of convenience becomes a deep and passionate love. Caught between two eras and two men, and hunted by the sadistic Captain Randall, Claire chooses to stay in the past with Jamie. Their happiness is nearly destroyed when Jamie is captured and brutally tortured by Randall, but Claire mounts a desperate rescue and nurses him back from the brink. The book ends with the couple safe for the moment in France and Claire pregnant with Jamie's child.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/ozma-of-oz.json
+++ b/data/works-community/0/ozma-of-oz.json
@@ -103,7 +103,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -116,7 +116,7 @@
       "recaps": {
         "ending": "The rescue succeeds through cleverness rather than force. After many of the party fail the Nome King's guessing game and are themselves turned into ornaments, the yellow hen Billina, who has been quietly eavesdropping, learns the secret of which ornaments the captives are and how to identify them. When the Nome King turns treacherous, the Nomes' deadly fear of eggs, which Billina wields against them, breaks his power. All the transformed prisoners, the royal family of Ev and Dorothy's own enchanted friends alike, are restored to their proper forms, and the Nome King is defeated. Dorothy takes possession of his Magic Belt, a powerful magical device. The royal family of Ev is freed and its rightful king restored, and everyone travels to the Emerald City for a joyous celebration. When it is time to go, Ozma uses her magic to send Dorothy safely back to her Uncle Henry, promising that she can watch over Dorothy and bring her to Oz again whenever she is truly needed. The friends part happily, the adventure won.",
         "in_short": "On a sea voyage with her Uncle Henry, Dorothy is swept overboard in a storm and washed up in the fairy land of Ev with a talking yellow hen, Billina. Exploring, they meet the wheeled Wheelers and discover Tik-Tok, a copper clockwork man who serves them. They come to the palace of vain Princess Langwidere, who collects interchangeable heads and threatens to take Dorothy's. Rescue arrives when Ozma, the young ruler of Oz, crosses the deadly desert with her army and friends, the Scarecrow, Tin Woodman, Cowardly Lion, and Hungry Tiger, to free the royal family of Ev, whom the Nome King has transformed into ornaments and hidden in his mountain. The Nome King challenges the rescuers to guess which ornaments the captives are, turning those who fail into ornaments themselves, and several friends are lost this way. But Billina secretly learns his secret, the Nomes' terror of eggs saves the day, and the transformed family and friends are all restored. Dorothy wins the Nome King's Magic Belt, everyone celebrates in Oz, and she is sent safely home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -303,7 +303,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -316,7 +316,7 @@
       "recaps": {
         "ending": "Solomon loses his finance job after helping arrange the sale of an elderly Korean woman's property; his employers treat the successful deal as tainted by methods they associate with his family and background. He abandons the corporate path and joins Mozasu's pachinko business, accepting an industry that has sustained the family even while respectable society scorns it. Hana, gravely ill with AIDS, is brought back to Osaka and dies after Solomon helps her see the city once more from a hospital roof. Hansu dies, and the older generation dwindles. In 1989 Sunja visits Isak's grave. A groundskeeper tells her that Noa had visited the grave regularly until his own death, showing that the son who erased his Korean identity had not forgotten the father who raised him. Sunja buries a photograph of Noa beside Isak and leaves the cemetery carrying the memory of both men.",
         "in_short": "In colonial Korea, Sunja becomes pregnant by the wealthy, married Koh Hansu and refuses to be his kept woman. The minister Isak Baek marries her and takes her to Osaka, where Koreans endure poverty and discrimination. Their family survives through food selling and, later, pachinko. Isak dies after imprisonment; Hansu secretly protects Sunja and her sons during the war. Noa, Hansu's biological son, learns the truth, disappears into Japanese society, and kills himself after Sunja finds him years later. Sunja's younger son Mozasu prospers in pachinko and raises Solomon, whose elite education cannot insulate him from prejudice. Solomon loses a finance job and ultimately enters the family business. Hana, his former lover, dies of AIDS. At Isak's grave, the elderly Sunja learns that Noa visited there until his death. She buries his photograph beside the man who raised him, closing a family history marked by migration, concealed origins, survival, and recurring exclusion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -486,7 +486,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -499,7 +499,7 @@
       "recaps": {
         "ending": "Rachel and her allies survive Ku'Sox's attack and prevent the ancient demon from immediately destroying the fragile balance between the ever-after and the mortal world. The confrontation forces demon society to acknowledge that Rachel's abilities and heritage place her among them, even though she refuses to become anyone's property. The witches' coven lifts Rachel's shunning, restoring the ordinary standing it had tried to erase, while her classification as a demon gives her a different and uneasy form of protection. Trent completes the private elven task that brought him west, and the road trip ends with the old hostility between him and Rachel changed by shared danger and trust, though neither treats their new closeness as simple. Rachel returns to Cincinnati with Ivy and Jenks rather than remaining in San Francisco or the ever-after. She is no longer an outcast witch pleading to be declared normal: she comes home publicly connected to demon society, still determined to define that connection for herself, with Ku'Sox alive as a continuing threat.",
         "in_short": "Still shunned for using demon magic, Rachel must cross the country to ask the witches' coven in San Francisco to restore her standing. With flying closed to her, she travels by road with Ivy, Jenks, and Trent, who has a secret elven task of his own. Pursuit, magical attacks, and Trent's concealed agenda turn the trip into a test of the trust between former enemies. After they reach the West Coast, Rachel's hearing is overtaken by a larger danger: Ku'Sox, an ancient demon able to evade many ordinary limits, enters the conflict. Rachel works with Trent, her friends, and members of demon society to survive him. The coven finally lifts her shunning, but the outcome does not simply return her to her old identity. Demons recognize Rachel as one of their own, giving her protection while deepening her involvement in their politics. She returns to Cincinnati with her partnership intact, a changed relationship with Trent, and Ku'Sox still at large.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -658,7 +658,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -671,7 +671,7 @@
       "recaps": {
         "ending": "Kinbote's commentary links Shade's death to two incompatible stories. In Kinbote's Zemblan narrative, the revolutionary Gradus has crossed Europe to assassinate the escaped King Charles and mistakenly shoots Shade outside Kinbote's rented house. Elsewhere the gunman is Jack Grey, an escaped patient seeking revenge on Judge Goldsworth, the house's owner, with Shade again the accidental victim. Kinbote claims Shade's unfinished poem and supplies the missing thousandth line by returning to its first. The closing notes and index strengthen the suspicion that the editor's royal history is a private delusion by connecting his account with V. Botkin, a Russian-born American scholar. The book leaves no external narrator to settle every contradiction, but its apparatus exposes how Kinbote has occupied Shade's poem with his own invented or distorted identity. Shade remains dead, Sybil has lost control of the manuscript, and Kinbote imagines further versions of himself as he closes the edition.",
         "in_short": "Poet John Shade writes a 999-line autobiographical poem about childhood, marriage, the death of his daughter Hazel, and his search for evidence that consciousness survives death. His neighbor Charles Kinbote obtains the manuscript after Shade is shot and publishes it with an immense commentary. Kinbote insists that he is really the exiled King Charles of Zembla, that he gave Shade the material for an epic of royal escape, and that the killer was the Zemblan agent Gradus. Yet Shade's poem scarcely supports this tale, and the notes repeatedly abandon textual explanation for Kinbote's obsessions. A second account identifies the shooter as Jack Grey, an escaped patient targeting Judge Goldsworth, whose house Kinbote rents. The closing apparatus associates Kinbote's account with the Russian scholar V. Botkin, suggesting another identity behind the royal fantasy. The work ends without a single authoritative solution, setting Shade's humane meditation against Kinbote's effort to seize and rewrite it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -799,7 +799,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -812,7 +812,7 @@
       "recaps": {
         "ending": "Lena and Julian get out of the tunnels together, and Julian, who was raised to believe the cure was the only safe future, chooses her and the uncured world instead. His father does not take him back. Julian is publicly disowned by Deliria-Free America and written out of it, which leaves him with nothing except the resistance and Lena, and the two of them are together at the close. Lena has stopped being the survivor who does what Raven tells her and made a decision of her own for the first time since she came over the fence. Then, in the last moments of the book, Raven brings someone into the room: Alex, alive. He did not die at the Portland fence. He was taken, held, and has come out of it, and when he looks at Lena he behaves as though she is nobody to him. The reunion Lena spent a year mourning for arrives with everything about it wrong, and it lands on the same day she committed herself to Julian.",
         "in_short": "The story runs in two threads. In the earlier one, Lena crosses into the Wilds after Alex's death at the Portland fence, is found half dead by a woman called Raven, and is taken into a homesteader camp where she is taught to survive under the rule that the past is dead. A brutal winter kills the youngest of them, and the survivors walk south to New York. In the later thread, Lena lives in the city under a false name as a cured student and works for the resistance, assigned to watch Julian Fineman, son of the head of Deliria-Free America, who has agreed to undergo a procedure that will probably kill him. A DFA rally is attacked and the two of them are seized and imprisoned underground. In captivity Julian's certainty collapses, his father refuses to save him, and Lena, who was supposed to feel nothing, escapes and goes back for him. They get out, Julian is disowned by the movement, and the two of them come together. In the final scene Alex walks in, alive, and does not acknowledge her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -975,7 +975,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -988,7 +988,7 @@
       "recaps": {
         "ending": "After Carmen dies giving birth, Ofelia is left with Vidal and her infant half brother. The Faun offers her one final opportunity and tells her to bring the baby into the labyrinth. Vidal pursues them. At the center, the Faun says that opening the way requires innocent blood, but Ofelia refuses to harm her brother even at the cost of losing the kingdom she has been promised. Vidal finds her apparently alone, takes the baby, and shoots her. Outside the labyrinth, Mercedes and Pedro's guerrillas are waiting. They take the child, tell Vidal that his son will never know his name, and kill him. Ofelia's own blood opens the hidden passage: she appears in the underground realm before a royal family and learns that her refusal was the true final test. She is welcomed home as Princess Moanna while her mortal body dies in Mercedes's arms. Small signs left in the ordinary world preserve the possibility that her kingdom was real.",
         "in_short": "In 1944, Ofelia and her pregnant mother Carmen move to a rural mill commanded by Carmen's new husband, Captain Vidal, who is hunting republican guerrillas. Ofelia discovers an ancient labyrinth and meets a Faun who claims she is the lost Princess Moanna. To prove her identity she must complete three tasks. She retrieves a key from a giant toad but later breaks a rule in the Pale Man's chamber, and the Faun rejects her. Meanwhile Mercedes and Doctor Ferreiro secretly aid the guerrillas; Vidal discovers their resistance, kills the doctor, and nearly kills Mercedes before she escapes. Carmen dies giving birth to a son. Given a final chance, Ofelia carries the baby to the labyrinth but refuses the Faun's demand for innocent blood. Vidal shoots her, then is killed by the guerrillas, who keep the child. Ofelia's sacrifice completes the true test, and as her human life ends she is welcomed into the underground kingdom as its returning princess.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1285,7 +1285,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B071438NCM",
@@ -1297,7 +1297,7 @@
       "recaps": {
         "ending": "The local government suspends the transfer of Paradise and commits major forces and long-term research to the planet after the staged Elder discoveries. Skippy destroys the false power device only after the research team evacuates, and the loss does not weaken the government's decision. A genuine inactive communications node further sustains interest in the planet. Major Perkins hands over the remaining projector locations and accepts a liaison post. Jesse Coulter, Dave Czajka, and Shauna Jarrett are offered security and projector-training work, giving the stranded population a future on Paradise despite continuing food and social strains. The injured local pilot remains in protective hibernation after Derek Bonsu helps save her. Joe, Skippy, and the Flying Dutchman crew leave for the captured relay station, which still must be destroyed before its next crew change. Intelligence makes another near-term survey of Earth unaffordable to the responsible client clan, but Earth is not fully secure from the hostile lizard species. Joe also conceals Skippy's role in engineering humanity's original presence on Paradise and continues supporting his investigation into the destruction at Newark.",
         "in_short": "Renewed attacks and a proposed territorial exchange threaten the stranded humans on Paradise. Joe Bishop, Skippy, and the Flying Dutchman first secure intelligence showing that another immediate survey of Earth is unlikely, then turn covertly to Paradise. Major Perkins's surface team restores buried projectors, devastating the hostile fleet and transferring the remaining defenses to the local government. Because military success alone does not stop the planet's sale, Joe's crew stages the discovery of valuable Elder technology. The deception persuades the local government to retain and fortify Paradise even after the false device is safely destroyed. Perkins becomes a liaison, while Jesse, Dave, and Shauna remain for security and projector work. The Flying Dutchman returns to its captured relay station. Earth has a temporary reprieve from a new survey mission, but a separate hostile threat remains, and Joe keeps secret Skippy's admission that he once manipulated events to bring humanity to Paradise.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1419,7 +1419,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1432,7 +1432,7 @@
       "recaps": {
         "ending": "After Eve eats the forbidden fruit, Adam understands that she has fallen but chooses to share her fate rather than remain obedient without her. He eats as well. Their first response is intoxicated desire, followed by sleep and a painful new self-consciousness. They cover their bodies with leaves, but the attempt cannot restore their former innocence. Reasoned companionship gives way to accusation: Adam blames Eve for insisting that they work apart, and Eve answers his charges. Book IX closes with the couple alienated from God and from the harmony they had shared, caught in mutual anger and shame. Divine judgment and expulsion have not yet occurred within this book, but the central human disobedience is complete. Satan's temptation has succeeded, and death has entered human history through choices made freely by both Eve and Adam.",
         "in_short": "Satan returns to Eden and enters a sleeping serpent so that he can approach humanity in disguise. Adam and Eve debate whether to work separately; Eve argues that untested virtue is insufficient, and Adam reluctantly lets her go alone. Satan finds her and uses flattery, the serpent's apparent speech, and deceptive reasoning to claim that fruit from the forbidden tree gave him higher powers and cannot truly cause death. Eve eats, then brings the fruit to Adam. Knowing she has disobeyed, Adam chooses love and shared ruin over separation from her and eats too. The pair experience lust, sleep, shame, and awareness of nakedness. They make coverings from leaves, but their former harmony is gone. Their discussion becomes a bitter quarrel in which each blames the other. The book ends after the Fall itself, before the later judgment and expulsion from Eden.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1595,7 +1595,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1608,7 +1608,7 @@
       "recaps": {
         "ending": "In the final trial of Paradise Regained, Satan takes Jesus to the highest point of the Temple and challenges him to prove his divine identity by throwing himself down and relying on angelic rescue. Jesus rejects this misuse of scripture and commands Satan to stop tempting him. Satan falls away defeated, while angels receive Jesus and provide food after his fast. The victory is inward and spiritual: Jesus has refused hunger, wealth, political dominion, intellectual glory, spectacle, and presumption without abandoning trust in God. He returns quietly to his mother's home, ready for the public ministry that lies beyond the poem. The ending answers the earlier epic's loss of Eden with the successful obedience of the Son in human life, establishing the basis for humanity's promised restoration rather than returning Adam and Eve directly to paradise.",
         "in_short": "After defeat in Heaven, Satan and the fallen angels establish themselves in Hell and choose to corrupt God's new human creation. Satan enters Eden and persuades Eve to eat the forbidden fruit; Adam knowingly follows her. Their innocence gives way to shame, conflict, mortality, and exile, though the Son's future sacrifice promises eventual redemption. The archangel Michael shows Adam a vision of human history before Adam and Eve leave paradise together. Paradise Regained presents the answering victory: the Son lives as Jesus, is baptized, and fasts in the wilderness while Satan tests him with food, wealth, political power, knowledge, fame, and spectacular displays. Jesus rejects every attempt to separate power from obedience. At the Temple he dismisses Satan's final challenge, is attended by angels, and returns quietly to begin the mission through which the loss traced in the first epic will be overcome.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1765,7 +1765,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1778,7 +1778,7 @@
       "recaps": {
         "ending": "After rejecting political empire and classical learning as substitutes for truth, Jesus endures a storm raised around him and Satan's last challenge at the Temple in Jerusalem. Satan places him on the pinnacle and demands a miraculous leap as proof of his identity. Jesus refuses to test God and rebukes the tempter. Satan falls away defeated, while angels receive Jesus, provide the food his fast has denied him, and celebrate his victory. Jesus then leaves the wilderness quietly and returns to his mother's home. His triumph is inward rather than imperial: by maintaining obedience without spectacle, appetite, wealth, fame, or fear turning him aside, he has begun the work of recovering what humanity lost through Adam's surrender to temptation.",
         "in_short": "Following his baptism in the Jordan, Jesus is led into the wilderness, where Satan seeks to learn whether he is the promised Son and to divert him from his mission. Jesus refuses to turn stones into bread or accept a magically supplied banquet, holding that bodily need does not outrank obedience. Satan next offers wealth, glory, military power, the kingdoms of the world, Roman authority, and the intellectual prestige of Athens. Jesus answers that just rule depends on inner wisdom and that revealed truth surpasses worldly ambition and pagan learning. After intimidation also fails, Satan carries him to the Temple pinnacle and urges him to prove himself by leaping. Jesus refuses to put God to the test, and Satan is cast down. Angels feed and honor Jesus, who returns privately to his mother's house, having defeated temptation through steadfast obedience rather than force.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1967,7 +1967,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1980,7 +1980,7 @@
       "recaps": {
         "ending": "In the Empyrean, Beatrice returns to her place in the celestial rose and Saint Bernard becomes Dante's final guide. Bernard explains the order of the blessed and then prays to Mary to obtain the grace Dante needs for the last vision. Dante looks into the divine light and perceives creation gathered into a single unity. He then apprehends the Trinity as three distinct yet equal circles and sees, within that mystery, an image of human nature joined to the divine. His intellect cannot solve how the two natures fit together, but a final illumination satisfies what reasoning cannot. At that instant his desire and will come fully into harmony with the love that orders the universe. The poem ends not with Dante descending to earth, but with his inner motion aligned with God's, leaving the task of communicating a vision that memory and language can only imperfectly preserve.",
         "in_short": "After passing through Hell and Purgatory, Dante rises with Beatrice through the celestial spheres. Encounters with blessed souls teach him about freedom, vows, providence, justice, love, wisdom, sacred history, and the corruption of earthly institutions. His ancestor Cacciaguida predicts his exile and commissions him to tell the truth about the journey despite the cost. Beyond the planets, Dante is examined by apostles on faith, hope, and charity, then learns about angels and creation as he approaches the realm outside space and time. In the Empyrean he sees the blessed ordered as a vast rose. Beatrice takes her seat among them, and Saint Bernard guides him to the final vision. Through Mary's intercession, Dante beholds the unity of creation, the Trinity, and the mystery of divine and human nature joined in Christ. A sudden illumination brings his intellect, desire, and will into accord with the love governing all things.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2143,7 +2143,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2156,7 +2156,7 @@
       "recaps": {
         "ending": "The companions reach Errtu's stronghold in the north and fight through the demon's servants to the captive whose identity he has concealed. Drizzt faces the balor again and defeats him, ending the immediate threat and breaking his control over the prisoner. The captive is not merely a memory or a lure: it is Wulfgar. When the chamber collapsed in Mithral Hall six years earlier, he was taken into demonic imprisonment rather than killed, and he has endured sustained torment in the years since. Bruenor, Regis, Drizzt and Catti-brie recover the friend they had mourned, and Catti-brie returns Aegis-fang to him. His survival is a victory, but it does not restore the relationships or confidence that existed before his fall. Catti-brie and Drizzt have built a life together, while Wulfgar returns deeply scarred and uncertain of his place. The Companions of the Hall are physically reunited, yet their next task will be helping Wulfgar live with freedom and with the years that passed without him.",
         "in_short": "Six years after the siege of Mithral Hall, Drizzt and Catti-brie sail with Captain Deudermont aboard the Sea Sprite, hunting pirates while Bruenor and Regis remain in the restored dwarven kingdom. The demon Errtu, whom Drizzt once banished during the fight over the Crystal Shard, draws him into a new pursuit using attacks, visions and the promise of knowledge about someone lost. Drizzt and Catti-brie leave the ship, reunite with Bruenor, Regis and Harkle Harpell, and follow the trail north toward Icewind Dale. Errtu's clues are designed to exploit Drizzt's guilt and the companions' unresolved grief. In the final battle Drizzt defeats the balor and the group reaches his hidden prisoner. Wulfgar, believed dead beneath Mithral Hall six years earlier, was instead taken by the demon and has survived years of torment. The companions free him and return Aegis-fang, reuniting their family while recognizing that Wulfgar has come back profoundly changed and that Catti-brie and Drizzt now share a life together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2308,7 +2308,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2321,7 +2321,7 @@
       "recaps": {
         "ending": "Irene, convinced that Clare threatens her marriage to Brian, joins Clare and friends at a party in a high apartment. John Bellew arrives after learning that Irene is Black and therefore that Clare has concealed her own identity from him. As he confronts Clare near an open window, Irene places a hand on Clare. Clare falls to the street and dies. The narration never establishes whether Irene deliberately pushed her, acted without conscious intent, or merely touched her before an accidental fall; it also leaves open whether Clare might have jumped. Irene insists that Clare could not have committed suicide and then loses consciousness as the others gather below. Bellew is left with the truth about his wife, while Irene's outwardly secure life survives at the cost of Clare's death and Irene's unresolved responsibility for it.",
         "in_short": "Irene Redfield, a Black woman rooted in Harlem family and social life, unexpectedly meets childhood acquaintance Clare Kendry while both are being taken for white in a Chicago hotel. Clare has permanently crossed the color line and married John Bellew, a white racist who does not know her ancestry. Back in New York, Clare insists on entering Irene's Black social world despite the danger. Irene is drawn to her but also resents her boldness and fears that Clare and Irene's husband, Brian, are having an affair. John later sees Irene with a Black friend and realizes the secret. He bursts into a party and confronts Clare beside an open window. Irene touches Clare, who falls to her death. Whether Irene pushed her intentionally, moved impulsively, or played no causal role remains uncertain, leaving Irene's jealousy and responsibility unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2451,7 +2451,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2464,7 +2464,7 @@
       "recaps": {
         "ending": "At the Freelands' party, John Bellew bursts in after learning that Clare has been moving in Black society. He confronts her beside an open sixth-floor window. Clare suddenly falls to the courtyard below and dies. The narration does not settle whether she jumped, fell by accident, or was pushed; Irene's own movement and fragmented recollection leave her possible responsibility unresolved. Irene first insists that Clare could not have killed herself, then resists the suggestion of murder, while Brian and the other guests gather around the body and the police begin asking questions. Bellew is stunned, and Irene collapses as the inquiry starts. Clare's death removes the person Irene had come to see as a threat to her marriage, but it leaves the circumstances of that removal—and the future emotional truth of Irene and Brian's relationship—uncertain.",
         "in_short": "Irene Redfield, a light-skinned Black woman rooted in Harlem family life, unexpectedly reunites with Clare Bellew, a childhood acquaintance who has crossed the color line and lives as white. Clare's racist husband John does not know her ancestry. Longing to reenter Black society, Clare presses herself into Irene's social circle and home. Irene is both fascinated and alarmed by her, especially as existing conflict with her restless husband Brian grows. Irene comes to suspect that Brian and Clare are having an affair, though the novel never confirms it. After John sees Irene with a visibly Black friend, he understands what Clare has concealed. He storms into a party and confronts Clare near an open window. Clare falls to her death; whether she fell, jumped, or was pushed remains unresolved, as does Irene's part in the moment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2784,7 +2784,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07DK1BBS6",
@@ -2796,7 +2796,7 @@
       "recaps": {
         "ending": "The motel operation collapses after Patty and Shorty set the property on fire and resist the hunters. Shorty suffers a grave thigh wound, but Patty keeps him alive until Reacher reaches them. Mark kills Stephen, Robert, and Peter to erase witnesses, then kills Karel to obtain the tow-truck key. Reacher disarms and kills Mark. Patty and Shorty depart in Mark's Mercedes to seek treatment, carrying their comics and roughly a million dollars from the hunt. The operation's known participants are dead. Amos reports that the Boston cleanup operative has withdrawn. The living Stan Reacher explains that Reacher's father was his cousin Bill, later William Reacher, who used Stan's birth certificate to join the Marines after killing the local bully. Carrington and Castle, feared missing, are safely camping together at the old Ryantown site. Reacher chooses not to pursue the unknown people who once sent his father birthday cards. With the family mystery and immediate danger resolved, he leaves alone for San Diego.",
         "in_short": "While travelling from Maine toward San Diego, Jack Reacher detours to Laconia to investigate the birthplace attributed to his father. Nearby, Canadians Patty Sundstrom and Shorty Fleck are trapped at a false motel and selected as prey for a paid human hunt. Reacher's research and the couple's captivity converge at the remote property. Patty and Shorty burn the motel, fight back, and survive, although Shorty is badly wounded. They and Reacher overcome the hunters, and Reacher kills Mark Breacher, the organizer who had appeared to share Reacher's surname. The couple leaves with their valuable comics and the operation's cash. Reacher then learns that his father was Bill, later William Reacher, who borrowed his cousin Stan Reacher's birth certificate after killing a bully and enlisted in the Marines under that identity. Carter Carrington and Elizabeth Castle are found safe together, and Reacher resumes his journey toward San Diego.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2951,7 +2951,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2964,7 +2964,7 @@
       "recaps": {
         "ending": "The three travelers' intervention preserves contact across the Atlantic but prevents it from beginning as an easy European conquest. Hunahpu's years of preparation give the peoples Columbus meets a coordinated political and religious response, while Diko and Kemal use their knowledge of Columbus and Iberia to bring the expedition to the intended encounter. Columbus is forced to abandon dreams of possession and accept a settlement in which the Americans hold power over the terms of contact. Diko, Kemal, and Hunahpu remain in the past and accept that their own future, including Pastwatch itself, will be replaced. The epilogue belongs to the altered world their choices create: history has not become painless or perfect, but the cycles of enslavement, genocide, and ecological collapse that doomed their original future have been averted, and the travelers survive only through the cultural memory and consequences of their work.",
         "in_short": "In a future damaged by ecological collapse, Pastwatch researchers can observe any point in human history but cannot help the people they witness. Tagiri's study of African lives destroyed by the slave trade inspires a search for the origins of the catastrophe. Her daughter Diko, the climate scholar Kemal, and the Maya specialist Hunahpu discover that Christopher Columbus's westward voyage was itself produced by intervention from another failed future. They conclude that simply stopping Columbus would invite a different disaster. Instead, the three travel permanently into the fifteenth century: Hunahpu prepares American societies to meet Europe from a position of unity and strength, while Kemal and Diko guide events around Columbus and Iberia so that contact still occurs. When the expedition arrives, conquest and enslavement are blocked. The travelers lose the future they knew, but create a more balanced history capable of escaping its ruin.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3147,7 +3147,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3160,7 +3160,7 @@
       "recaps": {
         "ending": "The Prince and Princess of Wales visit the Ryans at their Maryland home after Jack has helped identify the Ulster Liberation Army's support network. The terrorists exploit the visit, cut communications, kill guards, and assault the property to seize the royal family and settle Miller's grievance against Ryan. Jack gets his family and guests away from the house and onto a boat on Chesapeake Bay while alerting the authorities. Miller and the surviving attackers pursue them on the water, but Navy, Marine, Coast Guard, police, and FBI forces converge. Ryan turns back rather than let Miller escape, boards the terrorists' boat, and subdues him, choosing capture over revenge. O'Donnell and the other surviving attackers are also taken into custody. Cathy then goes into labor and delivers the Ryans' son, Jack Ryan Jr. The royal visitors and the Ryan family survive, the ULA operation collapses, and Jack's work with the CIA has become a continuing commitment rather than an occasional consultation.",
         "in_short": "While visiting London, historian and former Marine Jack Ryan interrupts an Ulster Liberation Army attack on the Prince and Princess of Wales, killing one attacker and helping capture Sean Miller. Miller becomes obsessed with revenge after his conviction, and ULA leader Kevin O'Donnell arranges his escape. Back in Maryland, Ryan resumes teaching and begins helping the CIA identify the secretive faction. Miller's group attacks Cathy and Sally on the highway, badly injuring the child; both survive, and Ryan commits himself fully to the investigation. Intelligence work traces the terrorists' training and support network, but the ULA mounts one more operation during a royal visit to the Ryan home. Jack evacuates his family and guests by boat as the attackers pursue them across Chesapeake Bay. American forces close in, and Ryan captures Miller rather than killing him. The terrorists are defeated, the royals and Ryans survive, and Cathy gives birth to Jack Ryan Jr.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3334,7 +3334,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3345,7 +3345,7 @@
       "recaps": {
         "ending": "The peace talks end with a declaration of war. Ethniu, the Last Titan, bearing the Eye of Balor and backed by King Corb's Fomor, stands before the assembled Accords nations and announces her contempt for their order and her intent: Chicago will be destroyed as her first demonstration, its people made an example to humanity. The conference shatters; the powers must choose overnight between scattering and standing, and the book closes on the eve of battle, flowing directly into Battle Ground. The Thomas crisis is parked, not solved: after his inexplicable attempt to assassinate Etri, Harry and Lara broke him out of svartalf custody - fighting through, among others, Ebenezar McCoy, whose hatred of the White Court turned the intercept into a savage grandfather-against-grandson battle that neither fully understands, since Ebenezar still does not know Thomas is his grandson. Thomas, dying from his injuries, was taken by Harry to Demonreach and placed in the island's crystalline stasis - alive, beyond rescue or execution, with his motive still unexplained and Justine, pregnant, waiting. Harry's ties are fraying everywhere: the White Council moves toward expelling him, Ramirez's friendship has curdled into professional suspicion, the rift with his grandfather is open and bleeding, and Winter's debt has bound him to Lara Raith's interests. Murphy, half-healed, arms herself anyway. The Titan's ultimatum hangs over all of it.",
         "in_short": "The Fomor propose peace talks with the supernatural nations, hosted by the svartalves in Chicago, and Mab drafts Harry as Winter's security - while assigning him to repay Winter's two favors owed to Lara Raith. Thomas and Justine are expecting a child; the White Council is moving to expel Harry; and then Thomas, without explanation, attempts to assassinate Etri, king of the svartalves, and is captured and held for a death sentence under Accords law. Harry and Lara mount a covert extraction from the svartalf deeps that goes loud: Ebenezar McCoy - Harry's grandfather, ignorant that Thomas is also his grandson and consumed by hatred of the White Court - intercepts them, and the escape becomes a brutal fight between kin. Harry carries the dying Thomas to Demonreach and locks him in the island's stasis, saving his life at the cost of his freedom, his motive never spoken. Then the talks reveal their true purpose: the Fomor present Ethniu, the Last Titan, bearing the Eye of Balor, who declares she will destroy Chicago as a lesson to the world. The book ends on the eve of the battle, with every alliance Harry has strained to breaking.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3472,7 +3472,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3485,7 +3485,7 @@
       "recaps": {
         "ending": "After returning to New York alone, Poppy begins therapy and recognizes that travel has often served as an escape from the insecurity she still associates with Linfield. She goes home and finds Alex, then tells him that she loves him and wants an ordinary shared life as well as adventure. Alex loves her too but fears that she is treating him as another temporary cure for her unhappiness, so they part again while she works out what she wants independently. Alex later comes to New York and says that he is willing to build a life with her there rather than insisting that their future must be in Ohio. They reconcile and make practical compromises: Poppy leaves the version of her magazine career that no longer fulfills her, continues traveling on her own terms, and shares a New York home with Alex, who finds teaching work in the city. Their relationship finally becomes explicit and durable without requiring either of them to abandon every part of the life they value.",
         "in_short": "Travel writer Poppy Wright and high-school teacher Alex Nilsen are opposites who become best friends in college and spend a decade taking one summer trip together each year. Two years after a charged trip to Croatia ended their tradition, an unhappy Poppy persuades Alex to join her in Palm Springs for his brother's wedding. The trip's mishaps bring back their easy intimacy while alternating memories show how friendship, other partners, and unspoken attraction shaped their bond. Poppy and Alex finally admit their feelings and sleep together, but their incompatible assumptions about home, family, and travel make a future seem impossible. Poppy returns to New York, uses therapy to confront her habit of fleeing discomfort, and declares her love in Linfield. After time apart, Alex follows her to New York and chooses a shared compromise. He teaches there, Poppy reshapes her work and travels more selectively, and they build the committed relationship both had long avoided asking for.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3622,7 +3622,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3633,7 +3633,7 @@
         "work": "percy-jackson-and-the-olympians-the-chalice-of-the-gods"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3730,7 +3730,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3743,7 +3743,7 @@
       "recaps": {
         "ending": "The three demigods recover the stolen Stygian iron sword forged for Hades, keeping it out of the Titan army's hands as the great war looms. The turning point comes when Percy plunges the Titan Iapetus into the River Lethe; stripped of every memory, the Titan loses his malice along with his past, and the newly harmless being is nicknamed Bob. The thief Ethan Nakamura's scheme fails, and the weapon is returned to Hades. Nico di Angelo stays behind in the Underworld with his father, still finding his place there, while Percy and Thalia return to the world above. The victory is small against the scale of the coming conflict, but it denies the enemy a dangerous prize and leaves an unexpected, gentle Titan wandering the land of the dead.",
         "in_short": "In this short adventure set during the war against the Titans, Persephone secretly summons three demigods, Percy Jackson, Thalia, and Nico di Angelo, to the Underworld. A powerful new sword of Stygian iron, forged for Hades and able to command the dead, has been stolen, and it must be recovered before it strengthens the enemy. The trio pursue the thief and clash with the demigod Ethan Nakamura and the ancient Titan Iapetus, who has taken the blade. In a desperate fight Percy hurls Iapetus into the River Lethe, the river of forgetfulness, which wipes away the Titan's memory and his hatred. Reborn blank and gentle, the confused Titan is given the harmless name Bob. The demigods retrieve Hades' sword and return it, denying it to the Titan army. Nico remains in the Underworld with his father, and Percy leaves with the war against the Titans still ahead of him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3914,7 +3914,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3927,7 +3927,7 @@
       "recaps": {
         "ending": "Goriot suffers a final collapse after Anastasie and Delphine quarrel before him over their money troubles. Rastignac and Bianchon nurse him in his bare room while his daughters repeatedly put their social and financial crises ahead of visiting. Goriot dies still calling for them and still excusing their neglect. Rastignac and the servant Christophe must arrange and pay for the funeral; neither daughter attends, though their empty, crested carriages follow the coffin. After watching the burial, Rastignac looks out over Paris and consciously accepts it as his adversary. He then goes to dine with Delphine, ending the novel with Goriot abandoned and Rastignac committed to the social struggle that helped destroy him.",
         "in_short": "At the shabby Maison Vauquer, provincial law student Eugene de Rastignac meets retired merchant Goriot, who has impoverished himself to satisfy his two socially ambitious daughters, Anastasie de Restaud and Delphine de Nucingen. Rastignac uses his cousin Madame de Beauseant to enter fashionable Paris and pursues Delphine, while the enigmatic Vautrin offers him a quicker fortune through a murder that would make fellow lodger Victorine Taillefer an heiress. Rastignac resists the scheme, but Vautrin arranges it before police expose him as the fugitive Jacques Collin. Goriot spends his last resources trying to rescue his daughters from debts and unhappy marriages. Their quarrel brings on his final illness, yet neither makes him her priority as he dies. Rastignac and Bianchon care for him and bury him almost alone. From the cemetery, Rastignac turns toward Paris as an opponent he means to conquer, then goes to dine with Delphine.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4074,7 +4074,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4087,7 +4087,7 @@
       "recaps": {
         "ending": "Poirot reveals that Nick Buckley arranged the supposed attempts on her own life and murdered her cousin Maggie. Maggie, whose full name was also Magdala Buckley, had been secretly engaged to the aviator Michael Seton. Nick learned of the engagement through letters and, after Seton was reported dead, realised that his will left his fortune to Magdala Buckley. By killing Maggie while Maggie wore Nick's shawl, Nick encouraged everyone to think the murderer had intended to shoot Nick and made herself appear to be the surviving beneficiary. The bullet through the hat and the earlier accidents were staged to establish that fiction. Nick later sent herself poisoned chocolates under Poirot's name and manoeuvred suspicion toward Frederica Rice, whose cocaine use made the planted evidence plausible. Poirot lets Nick believe Seton survived, prompting her to expose her knowledge and motive, then produces the hidden correspondence. Nick is arrested. The Crofts' separate document fraud is also uncovered, and the supposedly sinister Charles Vyse is cleared. Frederica is freed from both suspicion and an abusive husband who reappears during the case, leaving her able to build a life with Jim Lazarus.",
         "in_short": "While holidaying at St Loo, Poirot sees a bullet narrowly miss Nick Buckley, the young owner of End House. Nick describes other recent accidents, and Poirot tries to protect her by bringing her cousin Maggie into the house. During a fireworks party Maggie is shot while wearing Nick's shawl, apparently killed by someone who mistook her for Nick. The inquiry circles Nick's friends, her cousin and solicitor Charles Vyse, the Crofts at the lodge, and the news that aviator Michael Seton has died. Poirot ultimately proves that Nick staged the attempts and killed Maggie herself. Maggie, also legally named Magdala Buckley, was Seton's secret fiancee and beneficiary; Nick intercepted their letters and expected to claim the fortune through the shared name. She also sent herself poisoned chocolates and tried to frame Frederica Rice. Poirot traps Nick by falsely suggesting Seton is alive, then reveals the letters. Nick is arrested, the other suspects are cleared, and Frederica is released from the web of suspicion around her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4266,7 +4266,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4279,7 +4279,7 @@
       "recaps": {
         "ending": "The Medina uprising and the Rocinante's escape happen together. Saba's underground takes its moment, the ship is fought free of the station, and a Laconian destroyer is taken with it. Governor Singh, whose reprisals had by then cost hundreds of lives, is killed as the rising unfolds, and Admiral Trejo takes direct control and immediately reverses the harshest of his policies. Clarissa Mao dies during the escape: she pushes her ruined body past what her implants and her illness will tolerate in order to keep the ship alive, and does not survive it. Holden trades himself for the rest: he surrenders to the Laconians in exchange for the Rocinante being let go and Medina spared further punishment, and is taken to Laconia as Duarte's prisoner. Bobbie Draper takes command of the Rocinante, with Alex and Amos aboard. Naomi goes into hiding and begins organizing the resistance in earnest. Drummer, having publicly surrendered the Transport Union to preserve it, is left as a figurehead inside an empire she is secretly working against. Laconia now holds Sol, Medina and the gate network, and the weapon Trejo used in the ring space has drawn the attention of something on the other side of the gates: ships are vanishing in transit, and everyone in the ring space briefly lost consciousness at once.",
         "in_short": "Thirty years after the founding of the Transport Union, the aging Rocinante crew are working out their retirement, with Bobbie Draper set to take the ship. Then Laconia arrives. Winston Duarte, the Martian admiral who took a fleet through the gates a generation ago, has spent the intervening decades building warships out of alien technology, and his flagship walks into the ring space and takes Medina Station without a fight. Sol falls next; the Transport Union's combined fleet is disabled and destroyed, and President Drummer surrenders to preserve what she can. Governor Santiago Singh administers occupied Medina with the conviction that firmness now means peace later, and his escalating reprisals convert a resentful station into a resistance. Holden is arrested, Naomi goes underground, and Saba's cell builds toward a rising. When it comes, the Rocinante fights free with a captured Laconian destroyer, but Clarissa Mao dies making the escape possible and Holden surrenders himself to buy it. He is taken to Laconia as Duarte's prisoner, Bobbie commands the ship, and Laconia rules humanity, having just attracted the notice of whatever killed the builders of the gates.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4402,7 +4402,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4415,7 +4415,7 @@
       "recaps": {
         "ending": "Darius's ghost returns below after warning that the surviving Persian force will suffer another defeat at Plataea and that Persia should not again send an army into Greece. Atossa goes to fetch suitable clothing for her son. Xerxes then reaches Susa with only a remnant of his expedition, grieving for the commanders and soldiers lost in Greece. He and the chorus answer one another in a final lament over the fleet, the army, and the collapse of Persian confidence. Xerxes survives, but his attempt to extend Persian rule into Greece has ended in national bereavement and humiliation.",
         "in_short": "At the Persian court in Susa, elderly councillors and Queen Atossa wait anxiously for news of Xerxes's enormous expedition against Greece. A messenger arrives with word that the Persian fleet has been destroyed at Salamis after being drawn into confined waters, and that much of the army and its leadership has been lost during the retreat. Atossa and the elders summon the ghost of the former king Darius. He condemns the campaign's arrogance, warns of another Persian defeat at Plataea, and urges an end to invasions of Greece. Xerxes finally returns in torn clothing with only a fraction of his forces. The play closes with the defeated king and the chorus mourning the dead and the ruin of Persian power abroad.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4713,7 +4713,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00M7DG5EI",
@@ -4725,7 +4725,7 @@
       "recaps": {
         "ending": "Reacher, Nice, and Bennett escape the Romford Boys' custody. Reacher kills Joseph Green, and Green's unanswered check-in causes Kott's guards to leave the house. Reacher enters alone, disables Kott's rifle sight, and kills Kott while freeing an unidentified captive. Charlie White then threatens Reacher, but Nice approaches unseen and kills White. Reacher and Nice return to Pope Field, where Scarangelo explains that the apparent compromise of CIA communications was a controlled deception. Nice chooses to remain in intelligence. Reacher connects the Paris shot to armor that O'Day had personally seen withstand the relevant ammunition. He concludes that O'Day funded a one-shot demonstration that could not kill the protected target, hoping to create a crisis that would enhance his agency and either sacrifice Reacher or dispose of Kott. Reacher and Nice confront O'Day, preserve the information that could damage him, and avoid his aircraft. O'Day is subsequently reported dead from an accidental firearm discharge, but the actual circumstances of his death remain unresolved.",
         "in_short": "After a long-range shot fails to kill the French president, General Tom O'Day recruits Jack Reacher to assess four possible marksmen. Evidence points to John Kott, a former Army sniper Reacher once sent to prison, and Reacher travels to London with intelligence officer Casey Nice. There they battle the Romford Boys, the gang sheltering Kott, while the supposed second shooter is eliminated from consideration. Reacher kills gang enforcer Joseph Green and then Kott, while Nice saves Reacher by killing gang boss Charlie White. Back in the United States, Reacher determines that the shot was never meant to penetrate the French armor. He accuses O'Day of financing a controlled demonstration to manufacture an intelligence crisis and improve his agency's standing. Reacher and Nice retain enough knowledge to threaten O'Day, who is later reported dead in an officially accidental shooting. Nice remains in intelligence, and the immediate assassination threat is over.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/persuader.json
+++ b/data/works-community/0/persuader.json
@@ -227,7 +227,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:0593339096",
@@ -239,7 +239,7 @@
       "recaps": {
         "ending": "Reacher removes the drugged Teresa from Quinn's coastal house and turns her over to Duffy and Villanueva. He then returns alone, confronts Quinn during the arms dealers' dinner, and tries to separate the criminals from Richard, Elizabeth, and the cook. Quinn uses Zachary Beck as a shield, while Richard's effort to protect his father prevents Reacher from firing. Driven into the sea cleft, Reacher survives the undertow, swims back, enters the house without a weapon, knocks Zachary unconscious, and kills Quinn with a concealed chisel.\n\nATF and Portland police move against the warehouse and coastal operation. Teresa survives but remembers nothing of her rescue. Eliot is dead. Richard and Elizabeth survive, while Zachary's eventual legal and family position is not given. Duffy, shaken by an off-books operation that cost three agents, considers leaving DEA; Villanueva intends to retire. They depart with Teresa and ensure Reacher is not tied to the case. Duffy leaves clothes for him at the motel. Reacher abandons Beck's Cadillac and resumes his solitary travels by hitchhiking south on I-95.",
         "in_short": "Jack Reacher joins Susan Duffy's unauthorized DEA operation after recognizing Quinn, a former Army intelligence officer he believed dead, in a car linked to importer Zachary Beck. A staged rescue puts Reacher inside Beck's fortified Maine estate to find missing agent Teresa Daniel. He discovers that Quinn controls Beck through the earlier kidnapping of Beck's son Richard, and that the supposed drug business is an international arms network. Reacher kills Beck's enforcers Duke, Paulie, Angel Doll, and Harley while following Teresa's trail. At Quinn's coastal house he finds Teresa alive but drugged, delivers her to Duffy and Terry Villanueva, and returns for Quinn. After escaping an undertow and re-entering the estate unarmed, Reacher kills Quinn. Steven Eliot is dead, the arms operation passes to ATF and Portland police, and the surviving Beck family's future remains unstated. Duffy considers leaving DEA, Villanueva plans retirement, and Reacher hitchhikes south alone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -495,7 +495,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -508,7 +508,7 @@
       "recaps": {
         "ending": "Mrs Smith reveals that William Elliot reconciled with Sir Walter only to protect his inheritance: he fears that Mrs Clay may marry the baronet and produce a son. She also shows that Elliot behaved selfishly toward her late husband and has withheld help that could restore some of her property. Anne is freed from any remaining illusion about him. Captain Wentworth comes to understand that Anne has rejected Elliot and still loves him. While Anne discusses the constancy of women with Captain Harville, Wentworth overhears and writes her a letter declaring that his own love has never ended. They reconcile and renew their engagement, now supported by his fortune and her mature certainty. Sir Walter gives a reluctant consent, Lady Russell admits that she misjudged Wentworth, and the Musgroves are pleased. Wentworth helps Mrs Smith recover her property. Mr Elliot leaves Bath with Mrs Clay, whose ambitions may now threaten him instead of Sir Walter. Anne marries Wentworth and becomes part of the naval community whose loyalty and merit she has learned to value.",
         "in_short": "Eight years after Anne Elliot was persuaded to reject the penniless naval officer Frederick Wentworth, her vain father's debts force the family to rent Kellynch Hall to Wentworth's sister and brother-in-law. Wentworth returns wealthy and still resentful, apparently courting Louisa Musgrove while Anne quietly bears their renewed contact. After Louisa is badly injured at Lyme, Anne's calm competence restores Wentworth's respect. In Bath, Anne is courted by her polished cousin William Elliot, but her impoverished friend Mrs Smith exposes his mercenary motives. Louisa becomes engaged to Captain Benwick, leaving Wentworth free, yet jealousy and misunderstanding continue. Hearing Anne defend the endurance of women's love, Wentworth writes that he has never ceased loving her. They renew their engagement with the approval that wealth and time now secure. Lady Russell recognizes her error, Anne's family consents, and Anne joins Wentworth in a marriage founded on tested affection and mutual esteem.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -723,7 +723,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -736,7 +736,7 @@
       "recaps": {
         "ending": "Anne learns from Mrs Smith that Mr Elliot's attentions conceal a plan to protect his inheritance by keeping Sir Walter from marrying Mrs Clay. She rejects the match her family favors. Wentworth, meanwhile, has returned to Bath but mistakes Mr Elliot's courtship for evidence that Anne will marry him. At the White Hart Inn, Wentworth overhears Anne tell Captain Harville that women can remain constant long after hope is gone. He writes Anne a letter confessing that he still loves her. They meet and resolve the misunderstanding: Wentworth admits that pride and anger delayed him, while Anne maintains that Lady Russell gave honest advice even though following it caused lasting unhappiness. Their renewed engagement is accepted because Wentworth is now wealthy and distinguished, and they marry. Anne retains affection for Lady Russell but becomes part of the capable, warm naval circle she admires. Mr Elliot leaves Bath; Mrs Clay goes with him, creating an ironic risk to the inheritance he tried to secure. The prospect of future war is the principal shadow over Anne and Wentworth's happiness. The poems included with this edition stand outside the novel's plot.",
         "in_short": "Anne Elliot broke her engagement to the penniless naval officer Frederick Wentworth after Lady Russell persuaded her that the match was imprudent. Eight years later, her vain father's debts force the Elliots to rent Kellynch Hall to Wentworth's sister and brother-in-law. Wentworth returns wealthy and resentful, apparently courting the lively Louisa Musgrove. When Louisa is badly injured at Lyme, Anne's composure contrasts with Louisa's willfulness. In Bath, Anne attracts the polished William Elliot, heir to her father's title, but learns that his renewed family loyalty is calculated. Louisa becomes engaged to Captain Benwick, freeing Wentworth, yet jealousy and uncertainty keep him silent. After overhearing Anne defend women's constancy, Wentworth writes that he still loves her. They reconcile and marry, now understanding how pride, resentment, and well-meant persuasion prolonged their separation. The accompanying poems are non-narrative and do not alter the novel's character arc or conclusion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -942,7 +942,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -955,7 +955,7 @@
       "recaps": {
         "ending": "Mrs Smith explains that Mr Elliot once helped ruin her husband, ignored her appeals after she was widowed, and has reconciled with Sir Walter chiefly to protect his inheritance from a possible marriage to Mrs Clay. Anne rejects any thought of marrying him. When Wentworth comes to Bath, Anne's warmth toward him and her refusal of Mr Elliot gradually correct his belief that she is attached to her cousin. Overhearing Anne defend women's constancy in love, Wentworth writes that he still loves her and asks whether there is hope for him. They reconcile and renew their engagement, now with wealth, maturity, and family consent on their side. Lady Russell admits she misjudged Wentworth; the Musgroves welcome the match. Mr Elliot leaves Bath with Mrs Clay, whose eventual influence over him remains uncertain. Anne becomes the wife of the naval officer she never stopped loving, proud of his profession even as a future war remains the one cloud over their happiness.",
         "in_short": "Eight years after Lady Russell persuaded Anne Elliot to end her engagement to the poor and unconnected Frederick Wentworth, the Elliot family's debts force them to rent Kellynch Hall to Wentworth's sister and move to Bath. Wentworth, now a wealthy captain, returns resentful and appears to court Louisa Musgrove. At Lyme, Louisa suffers a serious fall; Anne's calm response restores Wentworth's respect for her, while Louisa later falls in love with Captain Benwick. In Bath, Anne attracts her cousin William Elliot, but her widowed friend Mrs Smith exposes his selfish history and designs on the family inheritance. Wentworth arrives believing Anne may marry Mr Elliot. After he overhears Anne argue that women love longest when hope is gone, he writes that he still loves her. Anne and Wentworth reconcile and become engaged, Lady Russell accepts him, and the long-delayed marriage unites Anne with the naval life she values.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1104,7 +1104,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1117,7 +1117,7 @@
       "recaps": {
         "ending": "Mrs Smith exposes Mr Elliot's selfish history and explains that he reconciled with Sir Walter largely to protect his inheritance from a possible marriage to Mrs Clay. Anne rejects any prospect of marrying him. Wentworth comes to Bath but mistakes Mr Elliot's attentions for evidence that Anne is committed elsewhere. After overhearing Anne defend the constancy of women's love, Wentworth writes that he still loves her. They speak openly, overcome the resentment and uncertainty that followed their broken engagement, and become engaged again. The Musgroves welcome them, and Lady Russell admits that her old judgment of Wentworth was wrong. Mr Elliot leaves Bath with Mrs Clay. Anne enters the naval community as Wentworth's wife, happy in the long-delayed match, though the possibility of renewed war remains a source of anxiety.",
         "in_short": "Eight years after Anne Elliot was persuaded to reject the poor naval officer Frederick Wentworth, her family's debts force them to rent their estate to Wentworth's sister. Wentworth returns wealthy but resentful and appears drawn to Louisa Musgrove. When Louisa suffers a dangerous fall at Lyme, Anne's calm competence restores his respect for her; Louisa later becomes engaged to Captain Benwick. In Bath, Anne receives attention from her cousin William Elliot, but Mrs Smith reveals his mercenary motives and past selfishness. Wentworth arrives believing Anne may marry Mr Elliot. He overhears her speak about lasting love and writes that he still loves her. They reconcile, renew their engagement with family approval, and finally marry.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1275,7 +1275,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1288,7 +1288,7 @@
       "recaps": {
         "ending": "Peter Pan boards Captain Hook's ship, the Jolly Roger, frees the captured children and Lost Boys, and fights Hook in a final duel. Hook, defeated and undone, goes over the side into the waiting jaws of the ticking crocodile that has pursued him so long, and so meets his end. Peter takes command of the ship and sails the children home. The Darling parents, who have grieved and kept the nursery window open in hope, joyfully welcome Wendy, John, and Michael back, and agree to adopt the Lost Boys as well, so that all the children may grow up in a proper home. Only Peter refuses: he will not stay to grow up, preferring the endless childhood of Neverland, though Wendy arranges that she may return each spring to do his cleaning. As the years pass Peter forgets much, even Hook and Tinker Bell, and when he finally comes back Wendy has grown up and has a daughter of her own, Jane. Peter carries Jane off for spring-cleaning as he once did Wendy, and in time Jane's own daughter after her, the cycle of childhood repeating down the generations for as long as children remain young and heedless.",
         "in_short": "Peter Pan, the boy who will not grow up, flies into the Darling family's London nursery in search of his lost shadow and, with the fairy Tinker Bell, teaches Wendy, John, and Michael to fly. He carries them off to the island of Neverland to be a mother and playmates to his band of Lost Boys. There they live out adventures among mermaids, the native people and their princess Tiger Lily, and above all the pirates led by the vengeful Captain Hook, who has an iron hook for a hand and dreads the ticking crocodile that hunts him. Hook eventually captures Wendy, her brothers, and the Lost Boys and poisons Peter's medicine, but Tinker Bell saves Peter by drinking the poison herself and is revived by children's belief in fairies. Peter storms the pirate ship, frees the captives, and defeats Hook, who falls at last to the crocodile. The children return home to their overjoyed parents and the Lost Boys are adopted, but Peter chooses Neverland over growing up, returning across the years for Wendy's daughter and granddaughter as the visits go on and on.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1462,7 +1462,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1475,7 +1475,7 @@
       "recaps": {
         "ending": "Irma recovers physically but cannot explain what happened on the Rock. After a hostile farewell at the school, she leaves Australia, while Michael remains marked by the disappearance and by his brief connection with her. No trace of Miranda, Marion, or Greta McCraw is found. Appleyard College deteriorates as families withdraw pupils and misfortunes overtake members of staff. Mrs Appleyard falsely claims that Sara's guardian has collected her, but the gardener later finds Sara's body concealed on the grounds. The headmistress leaves for Hanging Rock and dies there after falling from a height, with the circumstances left uncertain. The college closes, and a later fire destroys the building. The central mystery remains unresolved: the missing women never return, the recovered girl has no usable memory, and neither the official investigation nor the surviving witnesses can make the events fit an ordinary explanation.",
         "in_short": "On Valentine's Day 1900, pupils from Appleyard College picnic at Hanging Rock. Miranda, Marion, Irma, and Edith climb the formation; Edith returns terrified, while the other three vanish. Mathematics mistress Greta McCraw also disappears. Searches find nothing until visiting Englishman Michael Fitzhubert, aided by coachman Albert Crundall, locates Irma alive but injured. She remembers nothing that explains the others' fate. The mystery brings scrutiny and financial decline to the school, while the absent Miranda's closest friend, orphan Sara Waybourne, suffers under headmistress Mrs Appleyard. Irma eventually leaves after her classmates turn on her for having no answers. Sara then disappears; Mrs Appleyard lies that a guardian collected her, but Sara is found dead on the school grounds. Mrs Appleyard goes to Hanging Rock and dies in a fall. The school closes and later burns, while Miranda, Marion, and Miss McCraw remain missing and the Rock yields no explanation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1663,7 +1663,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1676,7 +1676,7 @@
       "recaps": {
         "ending": "After surviving Apollyon and the Valley of the Shadow of Death, Christian catches up with Faithful, another man who has fled the City of Destruction. They compare the different temptations and dangers they have met. A third traveler, Talkative, joins them and speaks impressively about religion, but Faithful's questions expose a gap between his fluent language and his conduct. Offended by being tested, Talkative leaves them. Evangelist then meets the two pilgrims and warns that their road will soon lead through a town where one or both will suffer for remaining faithful. Part 1 closes with Christian and Faithful continuing together toward that approaching danger; Christian has gained a true companion, but neither the threatened trial nor the larger journey to the Celestial City is yet complete.",
         "in_short": "Christian flees the doomed city where he lives after a book convinces him of coming judgment. Evangelist directs him toward a narrow gate, but he first falls into a bog and is then diverted by Worldly Wiseman before being corrected. Goodwill admits him to the true road, the Interpreter teaches him through symbolic scenes, and at the Cross his burden falls away. He loses and recovers his certificate, avoids false travelers, and finds shelter and equipment at the Palace Beautiful. Armed for the road, he defeats Apollyon and passes through the terrifying Valley of the Shadow of Death. He then meets Faithful, a sincere pilgrim from his former city. Together they expose Talkative as a man of words without matching conduct. Evangelist warns them of severe persecution ahead, and Part 1 ends as the two companions continue toward that trial.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1852,7 +1852,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1865,7 +1865,7 @@
       "recaps": {
         "ending": "Pinocchio escapes from the Dogfish with Geppetto, and the Tuna carries them to shore when the puppet's strength fails. Back on land, Pinocchio meets the ruined Fox and Cat but refuses to be deceived again. He finds shelter for Geppetto and supports them by working steadily, studying, and saving money. When he learns that the Fairy is ill and in need, he gives up the money he had set aside for clothes. This sustained responsibility, generosity, and care for his father complete the moral change that his earlier promises never achieved. During the night the Fairy rewards him: Pinocchio wakes as a human boy, healthy and real, while the old wooden puppet lies empty nearby. Geppetto's health and home are restored, and father and son begin a more secure life together.",
         "in_short": "Geppetto carves a living puppet named Pinocchio, who immediately pursues freedom without accepting the duties that accompany it. He skips school, joins a puppet theater, trusts the thieving Fox and Cat, and repeatedly ignores the Talking Cricket and the Fairy with Blue Hair. The Fairy rescues him and offers opportunities to reform, but each improvement is interrupted by a new temptation. After following Candlewick to the Land of Toys, Pinocchio becomes a donkey, is sold, and eventually returns to puppet form in the sea. Swallowed by the Terrible Dogfish, he discovers Geppetto alive inside and leads their escape. Pinocchio then works, studies, cares for his weakened father, and gives his savings to help the ailing Fairy. Having finally shown lasting courage and generosity rather than merely promising them, he is transformed into a real boy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1988,7 +1988,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2001,7 +2001,7 @@
       "recaps": {
         "ending": "The book is a series of comic adventures rather than a single plot, and it ends with Pippi throwing a birthday party for herself and inviting her friends Tommy and Annika. She gives them presents rather than receiving them, in her usual upside-down way, and the three enjoy a happy, chaotic celebration. Talk turns to growing up, and Pippi declares firmly that she has no wish to become an adult, since grown-ups never have any fun and are burdened with dull, serious things. She intends instead to stay exactly as she is, free and independent at Villa Villekulla with her horse and her monkey. The story leaves her secure in her strange, joyful, self-governed life, having won two loyal friends, and looking forward to more adventures, with her sea-captain father's eventual return still a bright promise in her imagination.",
         "in_short": "A remarkable nine-year-old girl named Pippi Longstocking moves alone into a tumbledown house called Villa Villekulla, bringing a horse she keeps on the porch, a pet monkey, and a suitcase of gold coins. With no parents to mind her, her mother dead and her sea-captain father lost overboard but, she insists, made a king on a far island, she lives entirely by her own rules. She is fabulously strong, endlessly inventive, and wholly indifferent to the way things are supposed to be done. The two well-behaved children next door, Tommy and Annika, become her devoted friends, and the book follows a string of comic episodes: Pippi outwitting bullies and policemen, upending a day at school, going on a picnic, dazzling a circus, scaring off burglars and then dancing with them, scandalizing a proper coffee party, and rescuing two children from a burning house. It closes with her cheerful birthday party, where she makes plain that she never intends to grow up.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2118,7 +2118,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2131,7 +2131,7 @@
       "recaps": {
         "ending": "Sarah Raphael enters the House to recover Matthew, while Valentine Ketterley follows with a gun. Piranesi understands the tidal cycle well enough to recognize that a destructive flood is approaching. He tries to protect Raphael even after Ketterley shoots him. The water overwhelms Ketterley and kills him; Piranesi and Raphael survive, and she leads Piranesi back to the ordinary world. The recovered man cannot simply become the old Matthew Rose Sorensen again, because years in the House have permanently shaped his mind and values. He lives with Matthew's family and memories while retaining Piranesi's bond with the House. He later returns through the passage with Raphael and also reconnects with James Ritter, another survivor of Arne-Sayles's abuses. The House remains accessible and meaningful to him, but it is no longer his entire world. He ends between identities, able to recognize echoes of the House's statues in ordinary people and to carry its beauty into his life outside.",
         "in_short": "Piranesi lives in an immense House of halls, statues, clouds, and ocean tides, believing that he and a man called the Other are its only living inhabitants. As he searches for a mysterious Sixteenth Person, old journal fragments expose gaps in his memory. A visiting Prophet and messages from police officer Sarah Raphael lead him to reconstruct the truth: he was Matthew Rose Sorensen, a journalist whom occultist Valentine Ketterley, the Other, imprisoned in the House while exploiting his increasing amnesia. Ketterley enters with a gun when Raphael comes to rescue Matthew. During a catastrophic tide, Piranesi saves Raphael and Ketterley drowns. Raphael brings him back to ordinary life. He recovers Matthew's history but does not abandon the identity and vision formed in the House, returning to it and living thereafter as a person who belongs wholly to neither world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2305,7 +2305,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2318,7 +2318,7 @@
       "recaps": {
         "ending": "The Ghost Shirt uprising spreads through Ilium and briefly destroys the machinery that embodies the automated order. Paul, Finnerty, Lasher, and their allies discover that rage against the system does not produce a stable replacement for it; rioters damage useful public equipment along with the factories, and the national movement is defeated. In the ruins, people begin repairing a drink dispenser simply for the satisfaction of making a machine work. The act reveals the same inventive impulse that built the old system and suggests that automation will return even after its human costs have been demonstrated. With government forces closing in, Paul and the remaining leaders acknowledge their failure, raise a final toast to the people they tried to serve, and go out to surrender. Paul has lost his managerial career and Anita, but he no longer participates in the corporate role chosen for him.",
         "in_short": "In a postwar United States run by engineers, managers, and central computers, nearly all production is automated and most citizens are confined to purposeless government labor. Dr. Paul Proteus, manager of the Ilium Works and son of a pioneer of automation, grows alienated from the elite life planned for him. His friend Ed Finnerty rejects the system outright, while Reverend Lasher organizes the excluded population. Paul tries to escape into a simpler life but is pulled into the underground Ghost Shirt Society and made its symbolic leader. His wife Anita chooses his ambitious rival Shepherd, and Paul is tried as a traitor. The Ghost Shirts revolt, smashing Ilium's machines, but the movement is quickly defeated and cannot offer a workable new order. When survivors immediately begin repairing a broken machine, the rebels recognize that the urge to mechanize remains. Paul, Finnerty, and Lasher surrender after toasting the people whose need for dignity their failed rebellion tried to defend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2496,7 +2496,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2509,7 +2509,7 @@
       "recaps": {
         "ending": "Baron Vengeous succeeds in waking the Grotesquery, using Valkyrie's blood, and wears the armour of Lord Vile into the final fight, but he is beaten and killed and the creature is put down before it can be used to open the way for the Faceless Ones. The cost is heavy: Tanith is badly hurt, Dusk survives with a grudge against Valkyrie he intends to settle, and Billy-Ray Sanguine slips away underground as he always does. The lasting change is what Valkyrie has learned about herself. She is descended from the last of the Ancients, which is why the Sceptre obeyed her and why her blood was worth stealing, and that inheritance makes her useful to every faction that still wants the Faceless Ones back. Her Elemental magic is stronger, particularly fire, and her double life is holding, but only just. Two of Mevolent's three generals are now dead, the Faceless Ones remain the goal of everyone who worshipped them, and the armour of the third, Lord Vile, is loose in the world again.",
         "in_short": "Baron Vengeous, one of Mevolent's generals, escapes imprisonment with help from the hired killer Billy-Ray Sanguine and sets out to wake the Grotesquery, a creature stitched together around the remains of a Faceless One, which he intends to use to open a way for the dark gods to return. Skulduggery and Valkyrie hunt him through a world that includes the vampire Dusk, the reclusive sorcerer known as the Torment, and the reliably unhelpful China Sorrows. Valkyrie, training hard as an Elemental and running her ordinary life through a mirror duplicate, learns why the Sceptre of the Ancients obeyed her: she is descended from the last of the Ancients, and it is her blood the ritual needs. Vengeous also recovers the armour of Lord Vile, a Necromancer general missing since the war, and wears it against them. He wakes the Grotesquery, but Skulduggery and Valkyrie kill him and destroy the creature before the way can be opened. Tanith is badly injured, Dusk and Sanguine both escape, and Valkyrie's ancestry has made her a target.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2701,7 +2701,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2714,7 +2714,7 @@
       "recaps": {
         "ending": "Alex escapes down the mountain on an ironing board taken from the academy laundry, survives the descent and an avalanche, reaches a road and gets word to London. He goes back in with the Special Air Service assault team, parachuting onto the academy, and saves Wolf when his canopy fails. The castle is stormed, the underground laboratory is destroyed and the fourteen real boys are brought out of the cells alive; Grief does not survive the assault. What the operation cannot immediately undo is the substitution already in place: several duplicates are living openly as the sons of powerful men. The last of them, the one made to look like Alex, comes to Brookland School to take his place and is only stopped after a fight there; he is beaten and taken into secure custody rather than killed. Alex is left with the knowledge that his own face now exists on somebody else, that MI6 have used him twice and will use him again, and that the department considers the operation a success. Blunt makes no promises about the next time.",
         "in_short": "Two of the world's richest men die within days of each other in staged accidents. The only thing linking them is the Point Blanc Academy, a Swiss-run school in the French Alps for the unmanageable sons of the very rich, and MI6 need someone inside it. Alex Rider is given the identity of the spoiled son of a supermarket millionaire and sent up the mountain. At the academy he finds boys who have been drugged, sealed floors, and pupils who return from their rooms subtly different, speaking and standing alike. Beneath the castle he discovers a laboratory and a row of cells: the director, Dr Hugo Grief, is a fugitive South African scientist who has cloned himself sixteen times, had the clones surgically altered to match his pupils, and is swapping them for the real boys so that his copies will inherit the fortunes and influence of their families. Alex escapes down the mountainside on an ironing board, returns with the SAS, and the academy is destroyed and the prisoners freed. His own double, sent to take his place at school, is defeated in a final confrontation in London.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2823,7 +2823,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2835,7 +2835,7 @@
       },
       "recaps": {
         "in_short": "A collection of eighteen separate Hercule Poirot mysteries from the detective's earlier career, not a continuous novel. The cases move among thefts, disappearances, suspicious deaths, and private puzzles, with each story introducing its own clients, suspects, and resolution. Captain Hastings frequently accompanies or narrates, Inspector Japp represents Scotland Yard in several investigations, and Miss Lemon belongs to Poirot's recurring office circle. The volume has no single culprit or collection-wide ending; its unity comes from Poirot's established method and the returning relationships around him. This sidecar therefore supplies collection-level orientation only rather than combining the independent plots or exposing their individual solutions.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2952,7 +2952,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2965,7 +2965,7 @@
       "recaps": {
         "ending": "The specialist consulted about Pollyanna's spinal injury offers no immediate hope, and the child's inability to find anything glad about her paralysis shakes the entire town. People she helped visit or send messages explaining how her game changed them; learning that her influence mattered gives Pollyanna a reason for gratitude even while she remains unable to walk. Dr. Chilton knows of a surgeon who may be able to help, but Aunt Polly's old quarrel with him has kept him from the house. Polly overcomes her pride, admits that she still loves Chilton, and allows him to arrange treatment. Polly and Chilton reconcile and marry. John Pendleton takes Jimmy Bean into his home, giving the boy the family he wanted. In a final letter from a hospital, Pollyanna reports that she has taken several steps and expects to improve. She is glad even for the months of disability because they taught her what walking means, and she looks forward to returning home to Aunt Polly and her new uncle.",
         "in_short": "After her father's death, eleven-year-old Pollyanna Whittier goes to live with her stern Aunt Polly in a Vermont town. Pollyanna meets every disappointment with the glad game her father taught her: finding some ground for gratitude in an unwanted situation. Her openness gradually changes the people around her, including invalid Mrs. Snow, lonely John Pendleton, homeless Jimmy Bean, and a discouraged minister. Aunt Polly also grows attached to her niece, though she resists showing it. When a motorcar strikes Pollyanna and a spinal injury leaves her unable to walk, she can no longer play the game. Townspeople reveal how much her example helped them, restoring her sense of purpose. Aunt Polly sets aside an old estrangement from Dr. Chilton so he can connect Pollyanna with a specialist, and Polly and Chilton marry. Pendleton gives Jimmy a home. After treatment, Pollyanna writes that she has begun walking again and is joyfully preparing to return to her enlarged family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3129,7 +3129,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3142,7 +3142,7 @@
       "recaps": {
         "ending": "Pliny's rescue fleet reaches Stabiae but cannot immediately leave because of the wind and sea. After a night of falling ash and repeated tremors, the admiral collapses and dies while his companions escape. Attilius returns to devastated Pompeii for Corelia rather than abandoning her. As Vesuvius produces its final, lethal surges, the pair take shelter within the underground water system that Attilius understands better than anyone around him. The aqueduct protects them while the city above is overwhelmed and buried. They emerge alive after the disaster, their disappearance from the public record leaving their later life unstated. Pompeii and the neighboring settlements are destroyed, and the bay's familiar landscape is permanently changed; the engineered water network that drove the investigation becomes the means by which Attilius and Corelia survive.",
         "in_short": "In AD 79, engineer Marcus Attilius arrives at Misenum to replace the missing aquarius responsible for the Aqua Augusta. When the water supply to the towns around the Bay of Naples abruptly fails, he follows evidence of poisoned water, damaged channels, and local corruption toward Vesuvius. In Pompeii he clashes with the powerful freedman Ampliatus and grows close to Ampliatus's daughter Corelia. Attilius and his crew repair a break near the mountain, but the disturbances are warnings of an eruption no one understands. Vesuvius explodes, burying Pompeii in falling debris. Admiral Pliny leads the fleet across the bay to rescue civilians and dies at Stabiae. Attilius returns for Corelia, and together they survive the final volcanic surges by sheltering in the aqueduct, emerging after the cities around them have been destroyed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3392,7 +3392,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3407,7 +3407,7 @@
       "recaps": {
         "ending": "Alexander defeats the emperor's soldiers and the Patriarch's priests when they try to seize his ship, then learns that the two powers were responsible for taking earlier visiting vessels and deepening Nova Roma's isolation. He cannot overthrow them yet. After fresh raids on C.K. and Perama, he finances the movement of Perama's population into C.K. and carries willing refugees and essential workers to the concealed mining town. Asylaion becomes mayor, Basil commands the town and Legion, Ryld supports its defense, Theo leads the ship, Constans coordinates commerce and operations, and Nikephoros trains the enlarged force. Romanus and Valens remain alive and associated with Alexander's circle. Alexander leaves Nova Roma with little money but with settlers, orichalcum, weapons production, an enchanted ship, and plans to seek western trade and allies before returning. C.K. remains crowded and under hostile rule, the wider monster threat persists, and the source of the undead near the mining town is unknown.",
         "in_short": "An emotionally self-aware AI escapes a ruined Earth in an engineered body and enters the monster-filled city of Nova Roma, where he takes the name Alexander. Unable to use mana, he adapts firearms to local enchantments, gains physical classes, clears dungeons, and builds alliances with Constans, local hunters, and Dark Elf refugees. His personal survival campaign becomes an organized effort to protect the city: he founds a contracted Legion, develops rifles and ammunition, repairs a ship, and establishes a concealed orichalcum mining settlement. The emperor and the Patriarch's priesthood, whose seizures of visiting ships helped isolate Nova Roma, try to destroy Alexander's force. He defeats their ambush but recognizes that he cannot yet remove them. After evacuating Perama and taking many allies and workers with him, Alexander departs for his mining-town base to strengthen the settlement, restore outside trade, and prepare for an eventual return.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3738,7 +3738,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -3751,7 +3751,7 @@
       "recaps": {
         "ending": "Alexander closes the book in control of Lakeside and the newly conquered River's End. Lakeside has survived its barbarian city challenge and now supports riverboats, cannon forces, trade, and stronger permanent defenses. Constans and Mikhail are partners, while Isabella remains Alexander's romantic partner and chief support within his reconstructed mindscape. Ivy has matured into a young shadow dragon. The first automaton, Alice, and Arden have founded the Verum as an independent artificial people. Roland's outpost has joined Alexander's coalition, and an eastern French king has recognized his frontier sovereignty. Parisian troops and spies remain a threat despite the capture of their Rhine fortress. River's End must complete extensive quests and kill a sea titan before it awakens. The Pirate King and Sardinian thrall state remain intact, the Watcher remains an uncertain contracted power, and surviving titans now resent the death of the elder green dragon. Alexander's mage body is still integrating that dragon's core, while his recorded corruption remains at 60 percent and could still overwhelm his control.",
         "in_short": "Still recovering from demonic corruption, Alexander investigates Sardinia, frees the dangerous Watcher, and gains the ability to operate multiple specialized bodies. Financial pressure redirects his coalition toward the Rhine, where he builds Lakeside, secures dwarf and outpost alliances, develops steel, cannons, and riverboats, and survives a vast barbarian siege under Constans's command. A separate frontier expedition uncovers Parisian aggression. Alexander creates sapient automatons who name their people the Verum, gains recorded proof that Paris ordered attacks on dozens of outposts, and raises a mage body. His forces kill an elder green dragon, integrate its core into that body, secure recognition of his frontier sovereignty, and capture the Parisian Rhine fortress. Renamed River's End, the city joins his domain but inherits an urgent challenge to kill a sea titan. Paris, the Pirate King, hostile titans, the Watcher, and Alexander's 60 percent corruption remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/portal-to-nova-roma-venice.json
+++ b/data/works-community/0/portal-to-nova-roma-venice.json
@@ -253,7 +253,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -266,7 +266,7 @@
       "recaps": {
         "ending": "The combined Legion, dwarf, dark elf, goblin, and Tilly force captures the fortress near Carthage and closes its portal, but Alexander's demonic corruption overwhelms him during the night battle. He loses control, his giant spirit is corrupted and freed, and his vastly empowered body continues killing until sunrise. Tilly mages and archers sacrifice themselves to contain and divert him, while Constans, Isabella, Ivy, and psychic healers gradually recover his identity over the next two months. During that recovery, the Tilly close the last seven portals and complete the world quest, ending the immediate portal threat. Alexander remains visibly corrupted and psychologically fragile, and his loyal living armor has no independent moral restraint. He is cleared to return to Venice only if he avoids combat and severe stress. Mikhail governs Venice's reconstruction while Alexander retains its navy. Constans is positioned to direct future operations, and a Tilly captain will bring two hundred contracted cavalry soldiers to Carthage for transport to Venice. The wider pirate network and the Pirate King's conversion scheme remain unresolved.",
         "in_short": "Alexander leads the Miletus Legion to Venice to secure trade, ships, and supplies. After building a commercial base and new alliances, he is captured during a coordinated pirate attack and escapes in North Africa, where restraints leave most of his powers unusable. He survives a demon-corrupted wilderness, creates the living armor Tenebrosis, bonds the raptor Ivy, and discovers portals that threaten the world. Freed by his armor, he allies with the dragon-descended Tilly, returns to liberate Venice, kills the occupying warlord, and appoints Mikhail to govern its reconstruction. Alexander then joins a multinational assault near Carthage. His corruption takes control during the battle, frees his giant spirit, and shatters his mind. The Tilly later close every remaining portal. After two months of psychic healing, Alexander prepares to return to Venice with Constans, Isabella, Ivy, and a promised Tilly auxiliary, but combat or severe stress could cause another collapse.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -447,7 +447,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -460,7 +460,7 @@
       "recaps": {
         "ending": "The competing scholars converge on Ash's grave during the great storm of 1987, where Cropper is trying to retrieve a box secretly buried with the poet. Roland, Maud, and their allies stop the grave robbery and preserve the documents inside. Christabel's final letter reveals that she and Ash had a daughter, Maia, who survived and was raised within Christabel's sister's family. Maud descends from that child and is therefore descended from both poets. Ellen Ash had understood enough of the affair to place Christabel's letter with her husband at his burial. The discovery transforms the documentary record but remains under the control of the British researchers rather than Cropper. Roland's scholarly gifts receive new recognition and job offers, and he and Maud accept their intimacy instead of retreating behind their former reserve. A final scene outside the modern archive shows Ash once meeting the child Maia without leaving evidence the scholars can recover, preserving a private fragment beyond their otherwise successful reconstruction.",
         "in_short": "Researcher Roland Michell finds an unpublished letter suggesting that the married Victorian poet Randolph Henry Ash secretly pursued Christabel LaMotte. He enlists Maud Bailey, a LaMotte scholar and family descendant, and together they uncover a hidden correspondence that develops from intellectual recognition into a love affair. As Roland and Maud retrace the poets' journey, their guarded professional alliance becomes intimate. Rival scholars, particularly the collector Mortimer Cropper, learn of the discovery and race to control it. Victorian journals and letters reveal the costs of the affair to Ash's wife Ellen and LaMotte's companion Blanche, as well as Christabel's concealed pregnancy. During an attempt to open Ash's grave, the modern group recovers Christabel's last letter: her daughter by Ash survived and became Maud's ancestor. Maud thus descends from both poets. The papers remain with Roland and Maud's circle, Roland's career revives, and the pair begin a relationship while recognizing that even a rich archive cannot recover every private truth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -633,7 +633,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -646,7 +646,7 @@
       "recaps": {
         "ending": "Temporarily commanding the Lively, Jack helps a British squadron intercept the Spanish treasure frigates. One Spanish ship explodes and the others are taken, bringing a major public success and the prospect of prize money, though legal and diplomatic questions delay certainty. The action confirms Jack's standing as a post-captain after the loss of the Polychrest. Ashore, his attachment to Sophia survives his earlier vacillation and the opposition created by Mrs Williams and his creditors; Sophia makes her loyalty clear even though their marriage is not yet secured. Stephen's position is bleaker. Diana refuses the settled bond he desires and goes abroad under Richard Canning's protection, leaving for India. Her departure turns the unresolved rivalry around her into a continuing wound rather than a concluded courtship. Jack and Stephen remain united, now with Jack professionally advanced and his finances potentially restored, while the two relationships that dominated the peace remain unsettled in sharply different ways.",
         "in_short": "During the Peace of Amiens, Jack Aubrey and Stephen Maturin live in the country and meet Sophia Williams and her widowed cousin Diana Villiers. Jack is drawn first toward Sophia and then dangerously toward Diana, while Stephen falls deeply in love with Diana. The return of war finds Jack financially ruined by his prize agent and stranded with Stephen in France; Stephen's intelligence connections help them escape. Jack receives the experimental, badly designed Polychrest, whose harsh first lieutenant and poor sailing qualities bring the crew near mutiny. Jack regains their confidence in a successful attack on a French port, but the Polychrest founders from battle damage. Promoted post-captain, he temporarily commands the Lively and helps capture a Spanish treasure squadron. Sophia remains loyal despite his debts and earlier inconstancy. Diana rejects Stephen's hopes of marriage and leaves for India under the protection of the wealthy Richard Canning, carrying the personal conflict into the next book.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1062,7 +1062,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1075,7 +1075,7 @@
       "recaps": {
         "ending": "The raid on the Cabal shard gives John all seven elemental world stones. The artificer installs them in Shadow Tower's shard stabilizer, then John powers and activates it. Its scan confirms that only a reduced region can survive. Rabia accepts a merger with the System spirit and begins becoming the guardian of that remnant, while Ferdie helps John relocate the Beast Kingdom close enough to be included.\n\nThe Cabal supreme mage arrives in sea-giant form before preservation is complete. John forces him into the void, dissolves the giant with pure flame, and leaves the mage to be destroyed there. The stabilizer condenses the valley, its surrounding mountains, the Beast Kingdom, and additional people and beasts rescued at the last moment into an orb as the original world disappears. Gora remains with the relocated Beast Kingdom, and Rabia remains with the surviving society while adapting to the System's powers. John reunites outside the lost world with Ellie, Ferdie, and Sigvald. The married couple and their companions continue into the void with John carrying the preserved remnant. The future of its communities and Rabia's development as their guardian remain open.",
         "in_short": "John Sutton ends the Beast Army crisis when Ferdie defeats its ruler, then confronts the deeper problem of a dying world. A shard stabilizer could preserve part of it, but requires seven elemental world stones. After marrying Ellie, John travels with her through the upper worlds, obtains an Earth stone, survives the Cabal supreme mage's attack, and learns to shape his pure fire around destruction and renewal. He saves the valley from New Dawn and poisoned food, then raids the Cabal shard with his allies and takes all seven stones. The activated stabilizer cannot save the whole world. Rabia merges with the System spirit, and Ferdie helps move the Beast Kingdom beside the valley. John kills the Cabal mage in the void as the selected region is condensed into an orb and everything else collapses. He carries the surviving remnant onward with Ellie, Ferdie, and Sigvald.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1283,7 +1283,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1296,7 +1296,7 @@
       "recaps": {
         "ending": "Stern's cross-examinations expose mishandled forensic evidence, questionable assumptions, and the unexplained loss of the drinking glass said to bear Rusty's fingerprint. Judge Lyttle dismisses the case, and Rusty is legally cleared. Lipranzer later reveals that he retained the missing glass when control of the investigation changed; unaware that the prosecution had lost track of it, he gives it to Rusty, who disposes of it. The deeper resolution comes at home. Rusty recognizes that Barbara killed Carolyn, using knowledge of the affair and the household to create evidence that would point toward him. Barbara confirms enough of what happened for him to understand her responsibility. Rusty chooses not to expose her, principally to preserve Nat's life and family. He ends the account free of the charge but carrying knowledge the verdict did not reach: the real killer lives beside him, and his own betrayal helped produce the crime.",
         "in_short": "Prosecutor Rusty Sabich is ordered to investigate the murder of his colleague Carolyn Polhemus while concealing that she recently ended an affair with him. After his superior loses an election, the new administration turns the accumulating evidence against Rusty: fibers, biological material, and a glass bearing his fingerprint appear to place him in Carolyn's apartment. Defense lawyer Sandy Stern exposes serious gaps, including flawed forensic conclusions, hidden courthouse relationships, and the disappearance of the fingerprinted glass. The judge dismisses the charge. Detective Lipranzer later gives Rusty the missing glass, which he had retained by mistake, and Rusty destroys it. At home, Rusty concludes that his wife Barbara killed Carolyn and arranged the scene to implicate him after discovering the affair. Barbara confirms his understanding. To protect their son Nat, Rusty keeps silent and remains with her, acquitted but permanently bound to the truth the trial never established.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1450,7 +1450,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1463,7 +1463,7 @@
       "recaps": {
         "ending": "The prosecution collapses after Sandy Stern exposes serious gaps in the forensic record and alternative motives surrounding Carolyn. The court dismisses the case, and Rusty leaves without a jury verdict but legally cleared. Lipranzer later returns the missing drinking glass bearing Rusty's fingerprint, explaining that it fell out of the official evidence chain; Rusty disposes of it. Rusty's private search eventually leads to Barbara. She admits that she killed Carolyn after learning of the affair, staged the scene, and used an object carrying Rusty's print as part of what she meant as a message to him. Rusty destroys the remaining evidence instead of exposing her, choosing to protect Barbara and Nat from another prosecution and public ruin. The murder is therefore never officially solved. Rusty survives the charge and resumes a public legal career, but he does so knowing that his wife's act, his own concealment, and the damage within their family cannot be undone.",
         "in_short": "Kindle County chief deputy prosecutor Rusty Sabich is assigned to investigate the murder of his colleague Carolyn Polhemus while his boss, Raymond Horgan, fights for reelection. Rusty conceals that he had an affair with Carolyn, and the inquiry soon turns toward him: evidence from the apartment, his conduct of the investigation, and his personal connection make him the new administration's murder defendant. Defense lawyer Sandy Stern dismantles the state's case by exposing mishandled forensic evidence, unreliable procedures, and hidden relationships around Carolyn. The judge dismisses the charge. Afterward, detective Dan Lipranzer gives Rusty a crucial fingerprinted glass that vanished from the evidence file. Rusty eventually learns that his wife, Barbara, killed Carolyn after discovering the affair and staged the crime in a way intended to confront him. He destroys the evidence and keeps her guilt secret, preserving the family at the cost of becoming part of the concealment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1624,7 +1624,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1637,7 +1637,7 @@
       "recaps": {
         "ending": "The prosecution collapses after Sandy Stern exposes serious gaps in the forensic record and alternative motives surrounding Carolyn. The court dismisses the case, and Rusty leaves without a jury verdict but legally cleared. Lipranzer later returns the missing drinking glass bearing Rusty's fingerprint, explaining that it fell out of the official evidence chain; Rusty disposes of it. Rusty's private search eventually leads to Barbara. She admits that she killed Carolyn after learning of the affair, staged the scene, and used an object carrying Rusty's print as part of what she meant as a message to him. Rusty destroys the remaining evidence instead of exposing her, choosing to protect Barbara and Nat from another prosecution and public ruin. The murder is therefore never officially solved. Rusty survives the charge and resumes a public legal career, but he does so knowing that his wife's act, his own concealment, and the damage within their family cannot be undone.",
         "in_short": "Kindle County chief deputy prosecutor Rusty Sabich is assigned to investigate the murder of his colleague Carolyn Polhemus while his boss, Raymond Horgan, fights for reelection. Rusty conceals that he had an affair with Carolyn, and the inquiry soon turns toward him: evidence from the apartment, his conduct of the investigation, and his personal connection make him the new administration's murder defendant. Defense lawyer Sandy Stern dismantles the state's case by exposing mishandled forensic evidence, unreliable procedures, and hidden relationships around Carolyn. The judge dismisses the charge. Afterward, detective Dan Lipranzer gives Rusty a crucial fingerprinted glass that vanished from the evidence file. Rusty eventually learns that his wife, Barbara, killed Carolyn after discovering the affair and staged the crime in a way intended to confront him. He destroys the evidence and keeps her guilt secret, preserving the family at the cost of becoming part of the concealment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1786,7 +1786,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1799,7 +1799,7 @@
       "recaps": {
         "ending": "Tally's attempt to get Zane out of the city fails. Special Circumstances takes them both, and Dr. Cable makes clear how little of the escape was ever outside her control. Zane's condition is the price of splitting the cure: the two pills were designed to work as a pair, and the one he swallowed has injured his brain, leaving him shaky and fragile although still clear-minded. He stays behind in the city as a damaged pretty. Shay, who disappeared from New Pretty Town earlier in the book, has been recruited into Special Circumstances and rebuilt as a Special, physically formidable and emotionally cold, and it is Shay who asks that Tally be given the same operation. Dr. Cable agrees. Tally is operated on again and wakes with a Special's body and a Special's mind: strong, fast, contemptuous of ordinary pretties, and entirely certain that she belongs where she now is. The people carrying the cure are still at large in the wild, Zane is left behind in the city, and Tally, reshaped for the third time, begins the next book working for the organization she once set out to destroy.",
         "in_short": "Tally Youngblood is now a new pretty in New Pretty Town, beautiful and pleasantly empty-headed, and is taken into the Crims, a clique led by the restless Zane. A runaway from the Smoke breaks into a party to remind her that she hid something for herself before her operation: a letter giving her own consent, and two pills meant to cure the brain lesions the surgery leaves. She and Zane take one each, and the partial cure lets them think clearly whenever they keep themselves frightened, cold or excited. They plan an escape and lead the Crims out of the city by balloon, but the group scatters and Tally is stranded in the wild, where a young hunter from a hidden reservation village shelters her and then leaves with her. Learning that Zane was caught and that his half of the cure has damaged him, Tally goes back for him. Special Circumstances takes them both. Shay, already rebuilt as a Special, asks that Tally be given the same operation, and the book ends with Tally remade as a Special.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2005,7 +2005,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2018,7 +2018,7 @@
       "recaps": {
         "ending": "Both the misunderstandings and the barriers of pride and social difference are overcome. Darcy, having secretly saved the Bennets by finding Lydia, paying Wickham's debts, and forcing their marriage, also withdraws his objection to Jane's match, and Bingley returns to propose to Jane, who accepts. Lady Catherine's attempt to forbid a union between Elizabeth and Darcy backfires by revealing to Darcy that Elizabeth may welcome him, and he proposes a second time. Elizabeth, whose feelings have reversed entirely, accepts. The novel closes with the two eldest sisters married to the men they love: Jane to Bingley, and Elizabeth to Darcy as mistress of Pemberley. Lydia and Wickham remain feckless and perpetually short of money, dependent on their richer relations. Mr Collins and Charlotte continue in their parsonage under Lady Catherine, who is eventually reconciled to the marriage. The Gardiners, who helped bring Elizabeth and Darcy together, stay close to the couple.",
         "in_short": "When wealthy Mr Bingley leases a nearby estate, Mrs Bennet schemes to marry off her daughters. Bingley falls for the gentle eldest, Jane, while his proud friend Mr Darcy slights the sharp-witted second daughter, Elizabeth, who comes to despise him, especially after a charming officer, Wickham, claims Darcy wronged him. Darcy, drawn to Elizabeth despite himself, proposes and is angrily refused; his explaining letter exposes Wickham as a scoundrel and admits he parted Bingley from Jane. Elizabeth's opinion slowly reverses, above all after she sees Darcy transformed at his estate. When her reckless sister Lydia elopes with Wickham, Darcy secretly rescues the family by arranging the marriage. Bingley returns and weds Jane; Darcy, his pride humbled and Elizabeth's prejudice gone, proposes again and is accepted. The two eldest Bennet sisters marry the men they love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2226,7 +2226,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2239,7 +2239,7 @@
       "recaps": {
         "ending": "Lady Catherine confronts Elizabeth after hearing a rumor that she may marry Darcy, but Elizabeth refuses to promise that she will reject him. Darcy learns of this resistance and gains hope that Elizabeth's feelings have changed. When he and Bingley return to the neighborhood, Bingley proposes to Jane and is accepted. Darcy then tells Elizabeth that his love remains unchanged; she admits that her judgment of him has altered and accepts his proposal. Elizabeth explains herself to the astonished Mr Bennet and persuades him that she truly respects Darcy. Elizabeth and Darcy marry and live at Pemberley, while Jane and Bingley also marry and settle nearby. Lydia and Wickham remain financially careless and frequently seek help. Georgiana grows close to Elizabeth, the Gardiners are warmly welcomed at Pemberley, and even Lady Catherine eventually resumes contact despite her anger at the match.",
         "in_short": "Elizabeth Bennet dislikes the wealthy Mr Darcy after his cold behavior and becomes increasingly prejudiced against him through the charming officer George Wickham. Darcy, meanwhile, falls in love with Elizabeth despite his objections to her family. His first proposal fails because he speaks arrogantly and Elizabeth blames him for separating Jane Bennet from Charles Bingley and for mistreating Wickham. Darcy's explanatory letter forces her to reconsider both men. Their warmer meeting at Pemberley is interrupted when Lydia Bennet runs away with Wickham, threatening the whole family. Darcy secretly finds the pair and pays the costs that make their marriage possible. Once Elizabeth learns what he did, her respect becomes love. Bingley returns and marries Jane. After Elizabeth withstands Lady Catherine's attempt to prevent a match, Darcy proposes again and she accepts. Elizabeth and Darcy marry with a clearer understanding of themselves and each other.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2453,7 +2453,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2466,7 +2466,7 @@
       "recaps": {
         "ending": "Elizabeth learns that Darcy located Lydia and Wickham, paid Wickham's debts, purchased his commission, and arranged the marriage while trying to conceal his part. Bingley returns to Netherfield and proposes to Jane, who accepts. Lady Catherine confronts Elizabeth over a rumor that she may marry Darcy and demands that she promise never to do so. Elizabeth refuses, and Lady Catherine reports the conversation to Darcy; her account gives him hope that Elizabeth's feelings have changed. Darcy proposes again, and Elizabeth accepts, explaining how her opinion of him changed after his letter and his generous conduct. Darcy admits that Elizabeth's earlier refusal made him recognize and correct his pride. Mr Bennet consents after satisfying himself that Elizabeth truly respects Darcy, and Mrs Bennet is delighted by the wealth of both matches. Jane and Bingley marry, as do Elizabeth and Darcy. Elizabeth becomes close to Georgiana at Pemberley, the Gardiners remain valued relations, and even Lady Catherine eventually resumes contact.",
         "in_short": "Elizabeth Bennet meets the wealthy Fitzwilliam Darcy and judges him proud after he insults her at a country assembly. Darcy grows attracted to her, while his friend Bingley and her sister Jane fall in love. Charming officer George Wickham persuades Elizabeth that Darcy treated him unjustly, and Darcy later separates Bingley from Jane. When Darcy proposes to Elizabeth while emphasizing her inferior connections, she rejects him and accuses him of harming Jane and Wickham. His explanatory letter exposes Wickham's misconduct and makes Elizabeth reconsider her own prejudice. At Darcy's estate she sees his generosity, but her sister Lydia then elopes with Wickham. Darcy secretly secures their marriage, saving the Bennets from disgrace. Bingley returns and marries Jane. After Elizabeth refuses Lady Catherine's demand that she renounce Darcy, Darcy proposes again; Elizabeth accepts, and they marry with mutual understanding replacing their first mistaken judgments.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2676,7 +2676,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2689,7 +2689,7 @@
       "recaps": {
         "ending": "Darcy's role in finding Lydia and paying the costs needed for her marriage to Wickham is revealed to Elizabeth through Mrs Gardiner. Bingley returns to Netherfield, renews his attentions to Jane, and becomes engaged to her. Lady Catherine visits Elizabeth to forbid a rumored match with Darcy, but Elizabeth refuses to promise that she will never accept him. When Lady Catherine repeats the confrontation to Darcy, Elizabeth's refusal gives him hope. Elizabeth thanks him for helping Lydia, and he tells her his feelings remain unchanged. His second proposal is accepted. They discuss how his pride and her prejudice distorted their first impressions and how both have changed. Mr Bennet consents once convinced that Elizabeth respects Darcy. Jane and Bingley marry and later live near Pemberley; Elizabeth becomes mistress of Pemberley and a loving sister to Georgiana. Kitty benefits from spending more time with her elder sisters, Mary remains at home, and Lydia and Wickham continue to need financial help. The Gardiners retain a close place in Elizabeth and Darcy's life.",
         "in_short": "Elizabeth Bennet meets the wealthy, reserved Fitzwilliam Darcy after his friend Charles Bingley rents Netherfield and falls in love with Elizabeth's sister Jane. Darcy's pride and a slight at their first assembly make Elizabeth dislike him, while the charming George Wickham gives her a false account of Darcy's cruelty. Darcy separates Bingley from Jane and later proposes to Elizabeth in a manner that emphasizes her inferior connections; she angrily refuses. His explanatory letter exposes Wickham's misconduct and forces her to reconsider her own prejudice. After Darcy behaves generously at Pemberley, Elizabeth begins to love him, but her sister Lydia's flight with Wickham threatens the family. Darcy secretly arranges their marriage. Bingley returns and marries Jane. When Lady Catherine tries to prevent Elizabeth from marrying Darcy, Elizabeth refuses to promise she will reject him. Encouraged, Darcy proposes again and is accepted. Their marriage rests on hard-won self-knowledge, while Jane and Bingley also settle happily nearby.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2881,7 +2881,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2894,7 +2894,7 @@
       "recaps": {
         "ending": "After Lady Catherine tries to make Elizabeth promise never to marry Darcy, Darcy learns that Elizabeth refused and gains hope that her feelings have changed. On a walk, he renews his proposal, and Elizabeth accepts. They acknowledge the mistakes that separated them: she trusted her first impressions and Wickham's account too readily, while his pride and manner gave her good reason to think badly of him. Jane and Bingley are also engaged. Mr Bennet consents after making sure Elizabeth truly respects Darcy, and Mrs Bennet is delighted by the wealth of both matches. Elizabeth marries Darcy and settles at Pemberley; Jane and Bingley later live nearby. Georgiana grows close to Elizabeth, the Gardiners remain welcome friends, and even Lady Catherine eventually resumes contact. Lydia and Wickham remain financially careless and frequently seek help, while Kitty improves through time with her better-settled elder sisters.",
         "in_short": "Elizabeth Bennet initially dislikes the wealthy Fitzwilliam Darcy for his pride, while he gradually falls in love with her. She trusts the charming officer George Wickham and resents Darcy for separating Jane Bennet from Charles Bingley. Darcy's first proposal is rejected, but his explanatory letter reveals Wickham's misconduct and forces Elizabeth to reconsider her judgments. Meeting Darcy again at Pemberley, she sees his generosity and altered manner. When Lydia Bennet elopes with Wickham, Darcy secretly arranges their marriage and protects the family from disgrace. Bingley returns and becomes engaged to Jane. Lady Catherine's attempt to prevent Elizabeth from marrying Darcy instead gives him reason to hope; he proposes again and is accepted. Elizabeth and Darcy marry with mutual understanding, while Jane and Bingley also begin a happy life together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3098,7 +3098,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3111,7 +3111,7 @@
       "recaps": {
         "ending": "Bingley returns to Netherfield and, once assured of Jane's affection, asks her to marry him. Lady Catherine then visits Elizabeth to demand that she promise never to accept Darcy, but Elizabeth refuses. Learning of this refusal gives Darcy hope that Elizabeth's feelings have changed. During a walk he renews his proposal, and she accepts, acknowledging how completely her opinion of him has altered. They explain the misunderstandings that divided them: Darcy believed Jane indifferent to Bingley, while Elizabeth had trusted Wickham's account and judged Darcy through her first resentment. Mr Bennet consents after satisfying himself that Elizabeth truly loves Darcy, and Mrs Bennet is delighted by the match. Jane and Bingley marry, as do Elizabeth and Darcy. The Bingleys later move nearer to Pemberley, Elizabeth grows close to Georgiana, and the Gardiners remain welcome visitors. Lydia and Wickham continue to live beyond their means and seek help from their relations, while Lady Catherine eventually resumes contact with her nephew despite her anger at his marriage.",
         "in_short": "Elizabeth Bennet meets the wealthy but aloof Fitzwilliam Darcy after his friend Charles Bingley rents Netherfield and falls in love with Elizabeth's sister Jane. Elizabeth's dislike of Darcy deepens when the charming officer George Wickham accuses him of cruelty. Darcy unexpectedly proposes, but she rejects him for his pride, his role in separating Jane and Bingley, and his alleged treatment of Wickham. His explanatory letter exposes Wickham's misconduct and forces Elizabeth to reconsider her judgments. Visiting Darcy's estate, she sees his generosity and meets him again on warmer terms, but her sister Lydia's elopement with Wickham threatens the whole family. Darcy secretly finds the couple and finances their marriage. Bingley returns and becomes engaged to Jane. After Elizabeth refuses Lady Catherine's demand that she reject Darcy, Darcy proposes again and Elizabeth accepts. The two couples marry, while Lydia and Wickham remain improvident and dependent on family assistance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3316,7 +3316,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3329,7 +3329,7 @@
       "recaps": {
         "ending": "Lydia and Wickham marry after Darcy secretly finds them, pays Wickham's debts, and negotiates the settlement. Elizabeth learns of his intervention and understands that his loyalty has replaced the pride she first condemned. Bingley returns to Netherfield and proposes to Jane. Lady Catherine then confronts Elizabeth over a rumor that Darcy may marry her; Elizabeth refuses to promise she will reject him. Hearing of that refusal gives Darcy hope. When he and Elizabeth walk together, he renews his proposal and she accepts, each acknowledging the errors that distorted their earlier judgments. Mr Bennet consents once assured Elizabeth truly respects Darcy, and Mrs Bennet celebrates the fortune. Jane marries Bingley and lives near Elizabeth and Darcy at Pemberley. Kitty improves away from Lydia's influence; Mary remains at home. Georgiana grows close to Elizabeth, while Lady Catherine eventually resumes contact with her nephew.",
         "in_short": "Elizabeth Bennet dislikes the wealthy Fitzwilliam Darcy after his proud behavior and trusts the charming officer George Wickham's accusations against him. Darcy, meanwhile, falls in love with her despite objecting to her family's conduct. He separates his friend Bingley from Elizabeth's sister Jane, then proposes to Elizabeth while emphasizing her inferior connections. She refuses and condemns both actions. Darcy's explanatory letter exposes Wickham's attempt to elope with Darcy's young sister and makes Elizabeth reconsider her judgments. Meeting Darcy again at Pemberley, she sees his generosity and changed manners. When Lydia Bennet runs away with Wickham, Darcy secretly pays for their marriage, saving the family. Bingley returns and marries Jane. After Elizabeth defies Lady Catherine's demand that she reject Darcy, Darcy proposes again; Elizabeth accepts, and they marry with genuine understanding and respect.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3521,7 +3521,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3534,7 +3534,7 @@
       "recaps": {
         "ending": "After Lady Catherine tries to make Elizabeth promise never to marry Darcy, Darcy learns that Elizabeth refused and gains hope that her feelings have changed. On a walk, he renews his proposal, and Elizabeth accepts. They acknowledge the mistakes that separated them: she trusted her first impressions and Wickham's account too readily, while his pride and manner gave her good reason to think badly of him. Jane and Bingley are also engaged. Mr Bennet consents after making sure Elizabeth truly respects Darcy, and Mrs Bennet is delighted by the wealth of both matches. Elizabeth marries Darcy and settles at Pemberley; Jane and Bingley later live nearby. Georgiana grows close to Elizabeth, the Gardiners remain welcome friends, and even Lady Catherine eventually resumes contact. Lydia and Wickham remain financially careless and frequently seek help, while Kitty improves through time with her better-settled elder sisters.",
         "in_short": "Elizabeth Bennet initially dislikes the wealthy Fitzwilliam Darcy for his pride, while he gradually falls in love with her. She trusts the charming officer George Wickham and resents Darcy for separating Jane Bennet from Charles Bingley. Darcy's first proposal is rejected, but his explanatory letter reveals Wickham's misconduct and forces Elizabeth to reconsider her judgments. Meeting Darcy again at Pemberley, she sees his generosity and altered manner. When Lydia Bennet elopes with Wickham, Darcy secretly arranges their marriage and protects the family from disgrace. Bingley returns and becomes engaged to Jane. Lady Catherine's attempt to prevent Elizabeth from marrying Darcy instead gives him reason to hope; he proposes again and is accepted. Elizabeth and Darcy marry with mutual understanding, while Jane and Bingley also begin a happy life together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3744,7 +3744,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3757,7 +3757,7 @@
       "recaps": {
         "ending": "Darcy's role in finding Lydia and paying the costs needed for her marriage to Wickham is revealed to Elizabeth through Mrs Gardiner. Bingley returns to Netherfield, renews his attentions to Jane, and becomes engaged to her. Lady Catherine visits Elizabeth to forbid a rumored match with Darcy, but Elizabeth refuses to promise that she will never accept him. When Lady Catherine repeats the confrontation to Darcy, Elizabeth's refusal gives him hope. Elizabeth thanks him for helping Lydia, and he tells her his feelings remain unchanged. His second proposal is accepted. They discuss how his pride and her prejudice distorted their first impressions and how both have changed. Mr Bennet consents once convinced that Elizabeth respects Darcy. Jane and Bingley marry and later live near Pemberley; Elizabeth becomes mistress of Pemberley and a loving sister to Georgiana. Kitty benefits from spending more time with her elder sisters, Mary remains at home, and Lydia and Wickham continue to need financial help. The Gardiners retain a close place in Elizabeth and Darcy's life.",
         "in_short": "Elizabeth Bennet meets the wealthy, reserved Fitzwilliam Darcy after his friend Charles Bingley rents Netherfield and falls in love with Elizabeth's sister Jane. Darcy's pride and a slight at their first assembly make Elizabeth dislike him, while the charming George Wickham gives her a false account of Darcy's cruelty. Darcy separates Bingley from Jane and later proposes to Elizabeth in a manner that emphasizes her inferior connections; she angrily refuses. His explanatory letter exposes Wickham's misconduct and forces her to reconsider her own prejudice. After Darcy behaves generously at Pemberley, Elizabeth begins to love him, but her sister Lydia's flight with Wickham threatens the family. Darcy secretly arranges their marriage. Bingley returns and marries Jane. When Lady Catherine tries to prevent Elizabeth from marrying Darcy, Elizabeth refuses to promise she will reject him. Encouraged, Darcy proposes again and is accepted. Their marriage rests on hard-won self-knowledge, while Jane and Bingley also settle happily nearby.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3949,7 +3949,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3962,7 +3962,7 @@
       "recaps": {
         "ending": "After Lady Catherine tries to make Elizabeth promise never to marry Darcy, Darcy learns that Elizabeth refused and gains hope that her feelings have changed. On a walk, he renews his proposal, and Elizabeth accepts. They acknowledge the mistakes that separated them: she trusted her first impressions and Wickham's account too readily, while his pride and manner gave her good reason to think badly of him. Jane and Bingley are also engaged. Mr Bennet consents after making sure Elizabeth truly respects Darcy, and Mrs Bennet is delighted by the wealth of both matches. Elizabeth marries Darcy and settles at Pemberley; Jane and Bingley later live nearby. Georgiana grows close to Elizabeth, the Gardiners remain welcome friends, and even Lady Catherine eventually resumes contact. Lydia and Wickham remain financially careless and frequently seek help, while Kitty improves through time with her better-settled elder sisters.",
         "in_short": "Elizabeth Bennet initially dislikes the wealthy Fitzwilliam Darcy for his pride, while he gradually falls in love with her. She trusts the charming officer George Wickham and resents Darcy for separating Jane Bennet from Charles Bingley. Darcy's first proposal is rejected, but his explanatory letter reveals Wickham's misconduct and forces Elizabeth to reconsider her judgments. Meeting Darcy again at Pemberley, she sees his generosity and altered manner. When Lydia Bennet elopes with Wickham, Darcy secretly arranges their marriage and protects the family from disgrace. Bingley returns and becomes engaged to Jane. Lady Catherine's attempt to prevent Elizabeth from marrying Darcy instead gives him reason to hope; he proposes again and is accepted. Elizabeth and Darcy marry with mutual understanding, while Jane and Bingley also begin a happy life together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4172,7 +4172,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4185,7 +4185,7 @@
       "recaps": {
         "ending": "Darcy's role in finding Lydia and paying the costs needed for her marriage to Wickham is revealed to Elizabeth through Mrs Gardiner. Bingley returns to Netherfield, renews his attentions to Jane, and becomes engaged to her. Lady Catherine visits Elizabeth to forbid a rumored match with Darcy, but Elizabeth refuses to promise that she will never accept him. When Lady Catherine repeats the confrontation to Darcy, Elizabeth's refusal gives him hope. Elizabeth thanks him for helping Lydia, and he tells her his feelings remain unchanged. His second proposal is accepted. They discuss how his pride and her prejudice distorted their first impressions and how both have changed. Mr Bennet consents once convinced that Elizabeth respects Darcy. Jane and Bingley marry and later live near Pemberley; Elizabeth becomes mistress of Pemberley and a loving sister to Georgiana. Kitty benefits from spending more time with her elder sisters, Mary remains at home, and Lydia and Wickham continue to need financial help. The Gardiners retain a close place in Elizabeth and Darcy's life.",
         "in_short": "Elizabeth Bennet meets the wealthy, reserved Fitzwilliam Darcy after his friend Charles Bingley rents Netherfield and falls in love with Elizabeth's sister Jane. Darcy's pride and a slight at their first assembly make Elizabeth dislike him, while the charming George Wickham gives her a false account of Darcy's cruelty. Darcy separates Bingley from Jane and later proposes to Elizabeth in a manner that emphasizes her inferior connections; she angrily refuses. His explanatory letter exposes Wickham's misconduct and forces her to reconsider her own prejudice. After Darcy behaves generously at Pemberley, Elizabeth begins to love him, but her sister Lydia's flight with Wickham threatens the family. Darcy secretly arranges their marriage. Bingley returns and marries Jane. When Lady Catherine tries to prevent Elizabeth from marrying Darcy, Elizabeth refuses to promise she will reject him. Encouraged, Darcy proposes again and is accepted. Their marriage rests on hard-won self-knowledge, while Jane and Bingley also settle happily nearby.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4593,7 +4593,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0BK9T867G",
@@ -4605,7 +4605,7 @@
       "recaps": {
         "ending": "Jake closes the volume at race and profession level 129, equipped with an arcane-compatible bow, an improved Nanoblade, upgraded alchemist boots, Altmar equipment, and a stockpile of consumables for Haven's treasure-hunt entrants. He owns two of the three Key Fragments of the Exalted Prima. Miranda governs the expanding Haven-fort community as a D-grade city lord, Neil's party has reached D-grade, and Phillip is preparing to leave command after his progress stalls. Sultan remains a monitored affiliate under restrictive commercial terms, with one surviving captive under Haven and another still with him. Sylphie has survived the Goldsun Eagle attack, evolved into a half-elemental bird, accepted Stormild's blessing, and formed an equal, time-limited oath with Jake. She trains alone in hopes of qualifying for the treasure hunt, while Hawkie and Mystie remain alive. The treasure hunt is imminent, and Jake expects to fight Miyamoto there. The Altmar connection, the third key fragment, the sealed beast, William's fate, the troll family's rescue, and the Malefic Viper's larger purpose remain unresolved.",
         "in_short": "Jake hunts a powerful monkey tribe, defeats its time-altering Prima, and gains the first of three key fragments before attending Earth's First World Congress. The delegates fail to elect a leader but establish a limited store and select a treasure hunt. Jake then clears the Undergrowth, protects a cave-troll family he cannot extract, and completes a hidden Altmar assessment by destroying a level-150 golem, earning Category N status and exceptional equipment. Haven expands under Miranda, who reaches D-grade, while Jake improves its crafting and defenses. A coercive merchant named Sultan becomes a tightly regulated affiliate after Haven verifies his captives' crimes and executes two of them. Jake advances his alchemy, learns more of the Malefic Viper's destructive past, and gains stronger equipment. After a Goldsun Eagle Prima nearly kills Hawkie, Mystie, and Sylphie, Jake defeats it and Sylphie executes it, yielding the second key fragment. Sylphie evolves, receives Stormild's blessing, and forms a limited equal oath with Jake. The book ends with Haven's D-grades preparing for the imminent treasure hunt and Jake's expected fight with Miyamoto.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4809,7 +4809,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4822,7 +4822,7 @@
       "recaps": {
         "ending": "Edward reaches Westminster during the coronation and publicly challenges Tom's claim to the throne. Tom immediately supports him, but the court demands proof. Edward identifies the Great Seal's hiding place, and Tom explains that he had unknowingly used the object for an ordinary purpose because he did not recognize it. This private knowledge establishes Edward's identity. Edward is crowned king, while Tom is honored rather than punished for the mercy he showed while occupying the throne. Miles Hendon is rewarded for his loyalty and restored to his rights, and Hugh's fraud is undone. Edward's reign is brief, but his experience of poverty and punishment makes him a more compassionate ruler. Tom lives under royal protection and remains distinguished for the rest of his life by the unusual honor granted him by the king.",
         "in_short": "Tom Canty, a poor boy fascinated by royalty, meets Prince Edward, the son of Henry VIII. Because they look alike, they exchange clothes, after which Edward is thrown out as a beggar and Tom is trapped at court. Tom is treated as a prince whose mind is disturbed, while Edward experiences hunger, violence, unjust laws, and imprisonment. The returning soldier Miles Hendon protects Edward despite doubting his claim. After Henry VIII dies, Tom is prepared for coronation, but Edward arrives and challenges him. Knowledge of where Edward hid the Great Seal proves who he is. Edward becomes king, rewards Miles, and honors Tom. His time among the poor informs a short reign remembered for greater mercy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5007,7 +5007,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5020,7 +5020,7 @@
       "recaps": {
         "ending": "Peter fights Miraz in single combat before both armies while Aslan, with Susan and Lucy, wakes the woods and the rivers behind them. Miraz stumbles, and two of his own lords stab him and shout that the Narnians have murdered him, so the Telmarine army charges. The woken trees and the Old Narnians rout it, and the retreat over the river is cut off because Aslan has thrown down the bridge at Beruna. Caspian is confirmed as King Caspian the Tenth, with Doctor Cornelius as his counsellor and Trumpkin as Lord Regent, and Aslan tells him he will do well because he knows he is not fit for it. Aslan spends the following days restoring the country: freeing prisoners, healing the sick, and putting an end to the schools and towns where fear of the woods was taught. He then explains the Telmarines' own history, which they had lost: they came originally from our world, pirates who fell through a gap on an island in the South Seas. He opens a door in the air, and those who wish to leave Narnia pass through it into an empty country of our world where they may start again. The children go home through the same door, and Peter and Susan are told privately that they are now too old to return to Narnia. They arrive back on the railway platform with their luggage, a few seconds after they left.",
         "in_short": "A year after coming home from Narnia, the four Pevensie children are pulled off an English railway platform into a wood, and find that they are on an island that was once the headland of Cair Paravel, their own ruined castle. Centuries have passed in Narnia. They rescue a dwarf, Trumpkin, who tells them that Telmarine invaders have ruled for generations and driven the Talking Beasts into hiding, and that the rightful heir, Prince Caspian, has fled his usurping uncle Miraz and raised the Old Narnians in revolt. Besieged, Caspian blew Queen Susan's magic horn, which is what brought the children back. Journeying to join him, the party goes astray because only Lucy can see Aslan, and they follow him at last only after losing a day and a fight. Aslan wakes the woods; Peter challenges Miraz to single combat; Miraz is murdered by his own lords, and the Telmarine army is broken by the trees and cut off at the ruined bridge. Caspian is crowned, the Telmarines are offered a passage back to the world their pirate ancestors came from, and the children return to England, where Peter and Susan learn they are too old to come back.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5138,7 +5138,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5151,7 +5151,7 @@
       "recaps": {
         "ending": "The morning after Elyot and Amanda's violent quarrel, Sibyl and Victor try to decide how to respond to their spouses' betrayal. Their conversation shifts from mutual consolation to attraction, then to an argument about Elyot and Amanda. The dispute escalates until Sibyl and Victor are striking one another, repeating the destructive pattern they had condemned in the former couple. Elyot and Amanda, now reconciled and unexpectedly calm, observe the fight. Recognizing both the hypocrisy of their replacements and an opportunity to escape further confrontation, they quietly leave the apartment together. The play closes with Elyot and Amanda reunited and fleeing once more, while the spouses they abandoned remain caught in their own quarrel.",
         "in_short": "On honeymoons with new spouses at the same French hotel, divorced couple Elyot Chase and Amanda Prynne discover that they occupy adjoining suites. Although each has just married someone else, their old attraction immediately returns, and they abandon Sibyl and Victor to run away together to Amanda's Paris apartment. Their reunion begins as an attempt to create a private world free of ordinary obligations, but familiar jealousies and provocations soon revive. A quarrel becomes physical just as Sibyl and Victor arrive. The next morning, the deserted spouses discuss what to do and begin turning on each other. As their argument also becomes violent, Elyot and Amanda reconcile, watch the new couple repeat their behavior, and quietly escape together, leaving Sibyl and Victor behind.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5315,7 +5315,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5328,7 +5328,7 @@
       "recaps": {
         "ending": "Charlie is court-martialled for cowardice after refusing Sergeant Hanley's order to abandon the wounded Tommo during an attack. The brief hearing disregards the circumstances and sentences him to death. Tommo spends the night awake nearby, moving through their shared memories as the hour of execution approaches. The brothers are allowed a final meeting, during which Charlie remains composed and asks Tommo to care for Molly, their child, and the rest of the family. At dawn Charlie faces the firing squad and dies with courage, singing as he goes. Tommo survives, but he is ordered back to the fighting that same day. He resolves to remember Charlie truthfully: not as the coward named by the military judgment, but as the brother whose last refusal grew from loyalty and whose bravery sustained him to the end.",
         "in_short": "On the night before his brother's execution, young soldier Tommo Peaceful recalls their Devon childhood. Charlie protected Tommo and their learning-disabled brother Big Joe, shared Tommo's friendship with Molly, and repeatedly resisted cruel authority. Molly and Charlie fell in love, married, and had a child. During the First World War, Tommo enlisted under pressure and Charlie went with him. Training under the vicious Sergeant Hanley led to service in France, where the brothers endured bombardment, loss, and fear. In an attack, Tommo was wounded and Charlie refused Hanley's order to leave him behind. Charlie was court-martialled for cowardice and condemned. As dawn comes, he meets death calmly while Tommo listens nearby. Tommo must return to the front, carrying Charlie's memory and the knowledge that the army's verdict reverses the truth: Charlie dies because he would not abandon his brother.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5468,7 +5468,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5481,7 +5481,7 @@
       "recaps": {
         "ending": "Deanna ends her summer knowing that she is pregnant by Eddie. She does not try to keep the wandering hunter with her; he leaves the mountain, while she chooses the child and the life rooted there. The coyotes she has protected are breeding, confirming that a predator population can reestablish itself despite human efforts to control it. Lusa finds a way to retain the Widener farm by raising goats rather than repeating Cole's plans. As Jewel's illness becomes terminal, Lusa agrees to make a home for Rickie and Lowell, turning a marriage that ended abruptly into a lasting bond with the family. Garnett's hostility toward Nannie yields to desire, respect, and companionship, even though their arguments about land and insects do not simply disappear. The three stories close on forms of continuity: children receive homes, old people accept connection, and the nonhuman community renews itself beyond any one person's plans.",
         "in_short": "During one fertile Appalachian summer, three neighboring stories unfold. Forest ranger Deanna Wolfe begins an affair with Eddie Bondo, a younger hunter whose determination to kill coyotes opposes her work protecting predators. Farmer's wife Lusa Landowski is widowed when Cole dies suddenly; treated as an outsider by his family and facing debt, she devises a goat enterprise that can keep the farm viable. Elderly chestnut breeder Garnett Walker quarrels with organic orchardist Nannie Rawley about pesticides, weeds, religion, and responsibility, while their antagonism develops into intimacy. Their lives become linked through family and ecology. Jewel Widener, dying of cancer, asks Lusa to raise her sons, giving Lusa a chosen future on the farm. Deanna discovers she is pregnant and lets Eddie leave, choosing motherhood without abandoning the mountain. Coyotes reproduce, Garnett and Nannie move toward companionship, and the human households reorganize around the same principle the summer has demonstrated: survival depends on relationships, including unwelcome ones.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/prometheus-bound.json
+++ b/data/works-community/0/prometheus-bound.json
@@ -85,7 +85,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -98,7 +98,7 @@
       "recaps": {
         "ending": "Hermes orders Prometheus to reveal the marriage that, according to his secret prophecy, could cost Zeus his power. Prometheus refuses even when Hermes warns that Zeus will answer with a storm, bury him under the rock, and later send an eagle to consume his liver repeatedly. The Oceanids are urged to leave but choose to remain beside him. Zeus then makes good on the immediate threat: thunder, lightning, wind, and convulsion engulf the scene, and Prometheus descends into the abyss still protesting the injustice done to him. He remains unbroken and keeps the prophecy to himself. The drama therefore closes without reconciliation or release; the prisoner suffers a fresh punishment, Zeus's rule remains secure for the moment, and the knowledge that could endanger that rule remains Prometheus's only leverage.",
         "in_short": "Zeus punishes the Titan Prometheus for aiding humanity, especially for stealing fire, by having Hephaestus chain him to a rock under the supervision of Kratos and Bia. Prometheus tells the sympathetic Oceanids how his gifts taught mortals the arts needed for civilized life, and he rejects Oceanus's offer to seek a compromise. The tormented wanderer Io arrives, and Prometheus recounts both her future trials and the eventual importance of her descendants. He also knows of a marriage that could produce a son capable of overthrowing Zeus. When Hermes demands that he disclose the secret, Prometheus refuses. Zeus answers with a violent storm that casts Prometheus and the Oceanids into the depths. The play ends with Prometheus still captive and suffering, but neither submissive nor deprived of the dangerous knowledge that gives him hope of an eventual change in power.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -227,7 +227,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -240,7 +240,7 @@
       "recaps": {
         "ending": "Hermes arrives with Zeus's demand that Prometheus identify the marriage destined to produce a son stronger than his father. Prometheus refuses, believing that Zeus will eventually need this secret and that no threat can make his present suffering worse. Hermes warns that Zeus will shatter the mountain with a thunderbolt, bury Prometheus, and later send an eagle to consume his liver repeatedly. Prometheus still will not yield. The Oceanids are told to withdraw but choose to remain beside him. The predicted storm begins: wind, thunder, lightning, and the convulsion of the earth engulf the rock. Prometheus calls on the surrounding world to witness the injustice as he and the faithful chorus are swallowed into the depths. He remains imprisoned and unbroken, his future liberation by a descendant of Io and his eventual settlement with Zeus still unrealized.",
         "in_short": "Zeus punishes the Titan Prometheus for giving fire and other forms of knowledge to humanity. Kratos and Bia compel the reluctant smith-god Hephaestus to chain him to a remote cliff. Prometheus tells the sympathetic Oceanids that he once helped Zeus defeat the older Titans but opposed Zeus's plan to destroy mortals. He also knows a secret about a marriage that could cost Zeus his throne. Oceanus urges compromise, but Prometheus rejects his offer to intercede. The tormented wanderer Io arrives, transformed into a cow after attracting Zeus's desire and Hera's anger. Prometheus foretells her long journey, her eventual restoration in Egypt, and the birth of a line that will include the hero who frees him. Hermes then demands the dangerous marriage prophecy. Prometheus refuses despite threats, and the Oceanids refuse to abandon him. Zeus sends a storm that drives Prometheus and his companions beneath the earth, leaving the conflict unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -400,7 +400,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -413,7 +413,7 @@
       "recaps": {
         "ending": "The expedition breaks the magical structure that has been feeding on Arrayan and survives the final guardians left by Zhengyi's power. Mariabronne and other members of the company do not survive the ruin. Entreri and Jarlaxle expose Commander Ellery and Canthan's concealed agenda, and the alliance turns violent; the conspirators are defeated. Athrogate abandons their cause and becomes an independent ally of the two leads, while Pratcus and Olgerkhan help bring Arrayan home alive. Calihye also survives and continues her uneasy relationship with Entreri, having seen evidence that his coldness is partly defense rather than absence of feeling. During the struggle Entreri uses his vampiric dagger against a creature of living shadow and absorbs some of its substance. He emerges physically restored and unnaturally altered, with new ties to shadow that he neither sought nor fully understands. The recovered magic and the deaths in Vaasa leave Jarlaxle and Entreri answerable to several interested powers, including the dragon sisters and the rulers of the Bloodstone Lands. They leave the ruin victorious but not free of its consequences.",
         "in_short": "After Crenshinibon's apparent destruction, Jarlaxle and Artemis Entreri travel through the Bloodstone Lands and join a mixed expedition into Vaasa, where remnants of the dead Witch-King Zhengyi still shape the country. Commander Ellery's party includes Calihye, Athrogate, Canthan and the scout Mariabronne; half-orcs Arrayan and Olgerkhan are drawn in when Arrayan becomes magically bound to a growing ruin. The group faces undead guardians, constructs, shadow creatures and internal distrust while trying to sever the structure's hold on her. Mariabronne dies, and Ellery and Canthan are exposed as conspirators pursuing their own prize. Entreri and Jarlaxle defeat them, Athrogate changes sides, and Arrayan is freed. Entreri's guarded attraction to Calihye develops into a fragile relationship. When his vampiric dagger drains a being of shadow, he is rejuvenated but left physically changed and connected to shadow magic. The survivors escape with powerful relics and unresolved obligations, giving Jarlaxle new schemes and forcing Entreri to confront changes that cannot be reduced to his old contest with Drizzt.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -578,7 +578,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -589,7 +589,7 @@
       "recaps": {
         "ending": "The black magic in Chicago was Molly Carpenter's: her talent woke, and out of love she used mind-altering magic on two friends to force them off drugs - twice breaking one of the Laws of Magic, and drawing the attention of Winter, whose fetches hunted her through the horror convention and finally carried her to Arctis Tor. Harry, Charity, Murphy and Thomas raid Winter's capital to bring her back, finding its gates already blasted by someone else's hellfire and the Leanansidhe imprisoned in ice beneath Mab's fountain; they rescue Molly, and the pursuing Scarecrow is destroyed at the threshold of the mortal world with Summer's help. Then comes the harder fight: before the White Council, the Merlin is ready to execute Molly as a warlock. Harry stakes his own life on her - she is placed under the Doom of Damocles as his apprentice, her death sentence suspended so long as she stays clean, with Harry's falling with hers if she does not. Michael's family is shaken but intact, and Charity's secret - that she once wielded magic herself and abandoned it - is out. Murphy has been demoted to sergeant for standing with Harry, and accepts it. The war's larger shape darkens: the attack on Arctis Tor, the Council's stretched forces, and a suspicion Harry can no longer dismiss - that a traitor moves within the Council, and that some organized hand is behind years of supposedly separate catastrophes. Molly moves through Harry's door as his student, and the book closes with teacher and apprentice facing a long road.",
         "in_short": "Now a reluctant Warden, Harry witnesses a teenage warlock's execution, then is pointed at traces of black magic in Chicago. When Molly Carpenter's boyfriend is arrested at a horror convention, Harry finds phobophages - fear-eating shapeshifters out of Winter - attacking the con in the forms of movie monsters, and the trail of the black magic and the trail of the fetches converge on Molly herself: her awakened talent, used with the best intentions to mind-alter friends off drugs, has made her a warlock in the Council's eyes and Winter's prey. The fetches kidnap her to Arctis Tor; Harry, Charity (whose own abandoned magic is her buried secret), Murphy and Thomas raid Winter's capital - finding it already scarred by someone else's hellfire attack - and bring her home, destroying the Scarecrow. Before the Council, Harry saves Molly from execution by taking her as his apprentice under the shared Doom of Damocles. Murphy is demoted for her loyalty; the evidence of a traitor inside the Council hardens; and Harry begins training the girl whose life now depends on him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -763,7 +763,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -776,7 +776,7 @@
       "recaps": {
         "ending": "As the first year without Gerry closes, Holly reads his final message. He tells her that she has honored their life together and urges her not to be afraid of loving again. The permission hurts, but it also frees her from treating continued grief as the only proof of devotion. Her friends and family have moved into new phases of their own lives, including Denise's marriage to Tom, and Holly can participate in their happiness without seeing every change as a betrayal of the past. Daniel admits his feelings for her, but the unresolved bond between him and his former partner makes clear that neither should use the other to escape loneliness. Holly does not finish the novel with a replacement for Gerry. Instead, she accepts that his list was meant to lead her back to choices of her own. She remains marked by loss but is working, connected to her family, and willing to enter an uncertain future in which love and happiness are possible again.",
         "in_short": "After Gerry Kennedy dies from a brain tumor, his young widow Holly withdraws from ordinary life. Gerry has left ten messages to be opened month by month, each ending with his love and setting a task that draws her beyond the house: face a public embarrassment, travel with friends, sort through his belongings, and build a life that is not organized entirely around his absence. Holly's friends Sharon and Denise and her large family support her uneven recovery. She finds work she values and develops a close friendship with pub owner Daniel, though both carry unresolved attachments. The year also brings other people's changes, including Denise's relationship and marriage to Tom, which Holly learns to celebrate without resenting time for moving forward. Gerry's final message releases her from the idea that loving him requires permanent isolation and encourages her to love again. Holly ends the year without a new partner but no longer without direction: she can preserve Gerry's place in her life while remaining open to work, family, friendship, and future love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -919,7 +919,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -932,7 +932,7 @@
       "recaps": {
         "ending": "At the Bates house, Lila discovers the preserved corpse of Norman's mother. Norman enters dressed in her clothing and attacks Lila with a knife, but Sam intervenes and subdues him. The subsequent examination establishes that Norman murdered his mother and her lover years earlier, then stole and preserved her body. Unable to bear both the crime and his attachment to her, he developed a separate Mother personality. That personality had increasingly taken control and committed the murders of Mary Crane and Milton Arbogast whenever Norman's interest in another person threatened their closed world. Norman is confined to an institution, where the Mother identity completes its domination of his mind. In his final internal state, Mother regards Norman as the violent one and imagines proving her own harmlessness by sitting perfectly still, leaving the original Norman effectively absent.",
         "in_short": "Mary Crane steals forty thousand dollars from her employer, intending to use it to build a life with her indebted boyfriend, Sam Loomis. On her flight she stops at the isolated Bates Motel, run by the awkward Norman Bates and overshadowed by his abusive mother. Mary decides to return the money, but a figure resembling an old woman murders her in the shower. Norman conceals the body and car. Mary's sister Lila, Sam, and private investigator Milton Arbogast trace her to the motel; Arbogast is also murdered after entering the Bates house. Lila and Sam return to investigate and discover that Mrs. Bates has long been dead. Lila finds her preserved corpse, then Norman attacks while dressed as Mother. Sam stops him. Authorities conclude that Norman murdered and preserved his mother, created a separate Mother personality, and killed Mary and Arbogast under its control. Institutionalized, Norman disappears beneath that personality.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1098,7 +1098,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1111,7 +1111,7 @@
       "recaps": {
         "ending": "At Luigi's murder trial, Wilson uses his fingerprint collection to prove that the bloody print on the knife belongs neither to Luigi nor to Chambers, but to the man known as Tom Driscoll. Comparing prints taken in infancy also establishes that Roxy exchanged the babies: the accused murderer is her biological son, while the enslaved Chambers is the true Driscoll heir. Tom confesses to killing Judge Driscoll while committing a robbery. Because he was legally born enslaved, creditors successfully claim him as property belonging to the Driscoll estate, and he is sold downriver rather than simply inheriting the legal fate expected for a white murderer. Chambers is freed and receives the estate, but education and lifelong treatment have left him unable to feel at ease in the social position restored to him. Roxy is crushed by her son's crime and punishment. Wilson's victory finally ends the town's belief that he is a fool, yet the solved mystery cannot repair the lives shaped by the original exchange or the system that gave it such power.",
         "in_short": "In Dawson's Landing, enslaved Roxy secretly exchanges her nearly white infant son with her owner's white baby to save her child from possible sale. The boys grow up as the privileged Tom Driscoll and the enslaved Chambers, while lawyer David Wilson is dismissed as a fool and privately collects their fingerprints. Years later, Tom's gambling debts lead him to theft. When Roxy reveals the exchange and tries to control him, he sells her downriver, though she escapes back. Visiting twins Luigi and Angelo become local celebrities; after Luigi quarrels with Tom, Tom murders Judge Driscoll with Luigi's distinctive knife and lets suspicion fall on Luigi. At trial, Wilson proves through fingerprints that Tom is the killer and that the babies were switched. The true Chambers is freed and inherits, but cannot adapt to his new social identity. Tom, legally the enslaved son of Roxy, is sold to settle the estate's debts. Roxy is left broken, and Wilson is finally recognized as the town's wisest man.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1320,7 +1320,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1333,7 +1333,7 @@
       "recaps": {
         "ending": "In the Earthly Paradise, Beatrice makes Dante acknowledge that after her death he turned away from the good toward lesser attractions. His confession and grief prepare him to be washed in Lethe, which removes the burdening memory of sin while preserving its lesson. Dante then witnesses an allegorical pageant of Church history: the chariot is attacked, corrupted, and finally associated with a prostitute and a giant, images of compromised religious and political power. Beatrice promises that divine justice will correct this disorder and instructs Dante to report what he has seen. Matelda, Statius, and Beatrice then lead him to the river Eunoë, whose water revives the memory of good deeds. Having completed the purgatorial ascent and recovered a rightly ordered will, Dante emerges renewed and ready to rise with Beatrice into Paradise. Virgil has already vanished, his work complete; Statius remains with the company at the close, while the poem's next canticle will carry Dante beyond the reach of unaided human reason.",
         "in_short": "After leaving Hell, Dante and Virgil climb the mountain of Purgatory. Souls delayed by late repentance wait below its gate; within, seven terraces cleanse pride, envy, wrath, sloth, avarice, gluttony, and lust. Dante learns that love powers every choice and becomes sinful when directed toward a wrong object, pursued too weakly, or pursued without restraint. Angels erase the seven marks placed on his forehead as each stage is completed. The purified Roman poet Statius joins the travelers, and all three pass through the final wall of fire. At the summit Virgil declares Dante's will free and sound. In the Earthly Paradise, a sacred procession brings Beatrice; Virgil disappears, and Beatrice compels Dante to confess how he strayed after her death. Washed first in Lethe and then in Eunoë, Dante loses the burden of remembered sin and regains the strengthening memory of good. He ends ready to ascend into Paradise with Beatrice.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1564,7 +1564,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1577,7 +1577,7 @@
       "recaps": {
         "ending": "In the earthly paradise, Dante confesses his failure to remain faithful to the good represented by Beatrice and is washed in Lethe, removing the memory of sin. He can then perceive Beatrice's unveiled beauty. The symbolic procession gathers around the tree of knowledge, where a sequence of attacks and transformations shows the Church endangered by persecution, corruption, and political entanglement. Beatrice promises that divine justice will correct this disorder and instructs Dante to report what he has seen. She questions him about the loss of Eden's original order and explains the special properties of its waters. The woman who met Dante by the stream, now called Matelda, leads him to drink from Eunoë, restoring his memory of good deeds. Purified and renewed, Dante is ready to rise from the earthly paradise into Heaven with Beatrice, while Virgil's role in the journey has ended.",
         "in_short": "After escaping Hell, Dante and Virgil reach Mount Purgatory, where repentant souls willingly undergo purification. Cato admits them, and in Ante-Purgatory Dante meets souls whose repentance was delayed, including Manfred, Belacqua, and those killed violently. An angel marks Dante with seven letters representing the capital sins. As he climbs the seven terraces, examples, prayers, punishments, and angelic blessings correct pride, envy, wrath, sloth, avarice, gluttony, and lust; one mark disappears after each terrace. The Roman poet Statius completes his own purification and joins the travelers. Beyond the purging fire, Virgil declares Dante's will free and sound, then yields his authority. In Eden an unnamed woman explains the garden, and a symbolic procession brings Beatrice. Virgil vanishes. Beatrice requires Dante to confess how he strayed after her death; washed first in Lethe and finally in Eunoë, he loses the memory of sin and regains the memory of good. Fully cleansed, he is ready to ascend to Heaven.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1770,7 +1770,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1783,7 +1783,7 @@
       "recaps": {
         "ending": "Beatrice tells Kambili and Jaja that she has been putting poison in Eugene's tea and that Sisi helped her obtain it. After Eugene's death, Jaja claims responsibility and is imprisoned in her place. Almost three years later, the corruption and delays surrounding his case appear to be ending, and the family expects his release. Beatrice remains psychologically diminished, while Kambili has grown more capable of speaking and imagining a future. Ifeoma and her children have moved to the United States after her conflict with the university authorities, and Father Amadi has left for missionary work in Germany. Kambili plans for the family to visit Nsukka when Jaja is free and pictures new purple hibiscuses being planted at their home. The novel closes with grief and damage still present, but also with Kambili able to think beyond the silence imposed by her father.",
         "in_short": "Fifteen-year-old Kambili and her brother Jaja live under the control of their father Eugene, a celebrated Catholic philanthropist and brave newspaper publisher who violently punishes his family for perceived sins. A visit to their outspoken aunt Ifeoma in Nsukka introduces them to a poorer but freer household, their traditionalist grandfather Papa-Nnukwu, and Father Amadi, who helps Kambili find confidence. Eugene's punishments continue after the children return, while political repression claims his newspaper editor Ade Coker. Jaja's resistance grows and Beatrice suffers repeated abuse. After Palm Sunday the family takes refuge in Nsukka, but instability pushes Ifeoma toward emigration. Eugene then dies from poison. Beatrice admits administering it, yet Jaja takes the blame and is imprisoned. Nearly three years later, his release seems close. The family is badly scarred, but Kambili can finally imagine a life marked by speech, freedom, and the return of the rare purple hibiscus.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1932,7 +1932,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1945,7 +1945,7 @@
       "recaps": {
         "ending": "After Eliza leaves Higgins's house, he and Pickering find her with Mrs Higgins. Alfred Doolittle also arrives, transformed by an inheritance into a reluctant member of the respectable middle class and about to marry Eliza's stepmother. Eliza explains that Pickering's consistent courtesy taught her to think of herself as a lady, whereas Higgins's training alone changed only her speech. She no longer accepts Higgins's claim that his equal rudeness to everyone excuses his treatment of her. Higgins offers a future in which Eliza returns and lives on his terms as one of three independent companions. Eliza instead insists that she can work, teach phonetics, and marry Freddy if she chooses. As she leaves for Doolittle's wedding, Higgins gives her errands and laughs at the idea of her marrying Freddy, confident that their contest has made her an equal capable of resisting him. The play ends without a romantic union between Higgins and Eliza or a final confirmation of her practical future.",
         "in_short": "Phonetics expert Henry Higgins boasts that he can transform the speech of Eliza Doolittle, a poor London flower seller, so completely that society will accept her as a duchess. Eliza hires him because she wants work in a flower shop, while Colonel Pickering backs the experiment. Higgins teaches her pronunciation and manners, first testing her awkwardly at his mother's home and later passing her successfully in elite society. After the triumph, Higgins and Pickering congratulate themselves and ignore Eliza, who realizes that their game has left her without a secure identity or livelihood. She leaves and confronts Higgins at Mrs Higgins's house. Meanwhile her father Alfred, accidentally made wealthy through Higgins's recommendation, complains that respectability has trapped him in new obligations. Eliza credits Pickering's kindness, not simply Higgins's instruction, with making her a lady. She rejects Higgins's assumption that she will return, asserts that she can teach and marry Freddy, and leaves for her father's wedding. Higgins laughs, but the play does not give him possession of her future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2078,7 +2078,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2091,7 +2091,7 @@
       "recaps": {
         "ending": "After the embassy triumph, Eliza leaves Higgins and takes refuge with Mrs Higgins. Alfred Doolittle, made wealthy by a recommendation Higgins sent as a joke, arrives on the day he must marry Eliza's stepmother and complains that respectability has imposed new obligations on him. Eliza tells Higgins that Pickering's steady courtesy taught her to regard herself as a lady, while Higgins's bullying made her dependent without giving her a future. She rejects Higgins's claim that treating everyone without special consideration amounts to treating her well. Eliza says she can marry Freddy and support herself by teaching phonetics, even assisting Higgins's professional rival. Higgins is provoked but also impressed by her independence. She leaves to attend her father's wedding after refusing to resume her old subordinate role. Higgins remains confident that she will carry out his errands, but the play does not confirm his assumption or turn their conflict into a conventional romantic union.",
         "in_short": "Phonetics professor Henry Higgins wagers that he can train Eliza Doolittle, a poor London flower seller, to speak and behave so convincingly that elite society will accept her as a duchess. Eliza agrees because she wants employment in a flower shop, and Colonel Pickering supports the experiment. Months of instruction transform her public manner, first producing an awkward trial at Mrs Higgins's home and then a complete success at an embassy reception. Higgins and Pickering celebrate their achievement while ignoring what Eliza has risked. With no clear livelihood or social place, she leaves. She later tells Higgins that Pickering's courtesy, not pronunciation alone, enabled her to see herself as a lady. She plans to marry Freddy and teach phonetics rather than remain Higgins's dependent. Her father Alfred, accidentally lifted into the middle class by Higgins, also finds that social advancement carries costs. Eliza departs on her own terms, and Higgins's expectation of her return is left unfulfilled onstage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2233,7 +2233,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2246,7 +2246,7 @@
       "recaps": {
         "ending": "Eliza returns to Mrs Higgins's home after leaving Wimpole Street and confronts Higgins on more equal terms. She explains that Pickering's unfailing courtesy, rather than Higgins's drills alone, taught her to think of herself as a lady. Now able to support herself, she refuses to remain a dependent object in Higgins's household and says she may marry Freddy and teach phonetics. Higgins finally recognizes the independence and spirit he values in her, but he still assumes she will resume organizing his life and sends her out with errands. Eliza rejects the instruction and leaves for her father's wedding with Mrs Higgins. Higgins laughs at her declared plan to marry Freddy. The play closes without a romantic union between Higgins and Eliza: she has asserted the right to choose her own future, while he remains amused, admiring, and largely unchanged.",
         "in_short": "London flower seller Eliza Doolittle asks phonetics expert Henry Higgins to improve her speech so she can seek better work. Higgins accepts Colonel Pickering's wager that he can present her as a lady, subjecting her to intensive training while giving little thought to what will happen afterward. Eliza learns polished pronunciation and manners, first startling guests at Mrs Higgins's home and later passing successfully at an embassy reception. Higgins and Pickering celebrate their achievement without acknowledging her labor, prompting Eliza to leave. Her father Alfred, meanwhile, has unwillingly acquired money and social obligations after Higgins recommended him to a wealthy reformer. Eliza returns to insist that Higgins's success does not give him ownership of her. She credits Pickering's respect with changing her sense of herself, declares that she can work and may marry Freddy, and leaves for her father's wedding rather than submit to Higgins's casual commands. Higgins admires her new independence but does not secure the romantic ending he assumes he can command.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2370,7 +2370,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2381,7 +2381,7 @@
       "recaps": {
         "ending": "Pyramids ends with Djelibeybi freed from the weight of its own past. Teppic and his allies determine that the enormous new Great Pyramid, which had twisted the kingdom out of reality, must be destroyed, and they collapse it to release its hoarded time. The pocket dimension unravels, the many gods that had become physically real disappear, and Djelibeybi returns to the ordinary world. Dios, the ancient high priest who had ruled through tradition and secretly renewed his own life inside the pyramids for millennia, is caught in the structure's last flare and thrown thousands of years back to the kingdom's founding, condemned to live out his service from the beginning again. Teppic, having become king, concludes that the kingdom cannot survive by clinging to its rituals. He steps down and hands the throne to Ptraci, the rescued handmaiden who proves to be his half-sister; as queen she opens Djelibeybi to trade and new ideas, ending its isolation and its age of pyramid-building. His father's restless spirit is finally laid to rest, and Teppic departs, leaving a kingdom beginning to rejoin the wider Disc.",
         "in_short": "Teppic, prince of the ancient river kingdom of Djelibeybi, trains as an assassin in cosmopolitan Ankh-Morpork, but on qualifying he learns that his father, the god-king, has died and he must return to take the throne. At home he finds true power held by Dios, the immensely old high priest who rules through rigid tradition. Pressed to build the largest pyramid ever for his dead father, Teppic clashes with Dios and rescues a condemned handmaiden, Ptraci. Djelibeybi's pyramids store time, and when the vast new pyramid flares it wrenches the whole kingdom out of the world into its own dimension, where every god the people ever believed in becomes real and runs riot. Teppic, caught outside, fights his way back and, with Ptraci and the builder Ptaclusp, destroys the Great Pyramid to bring the kingdom home. Dios is hurled into the distant past to repeat his service forever. Teppic abdicates in favour of Ptraci, his half-sister, who becomes queen and finally opens the kingdom to the modern world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2580,7 +2580,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2593,7 +2593,7 @@
       "recaps": {
         "ending": "The king of Adarlan is dead, killed by his own son once Dorian throws off the collar, and with his last words he claims he too was a puppet of the Valg, taken over long ago. Aelin destroys what remains of the glass castle, and magic is free across the continent for the first time in a decade. Chaol is left with a broken back and no feeling in his legs. Dorian is King of Adarlan, alone, holding a ruined capital and a country his father wrecked. Aelin, Rowan, Aedion, Lysandra, and Evangeline ride north for Terrasen, where Aelin has a kingdom to reclaim, an army she does not have, and lords who may not accept her. She carries the Amulet of Orynth and the Wyrdkey inside it, and she knows the third key is still at large. Chaol and Nesryn sail for the southern continent, to the healers of the Torre Cesme in Antica, to seek both a cure and an alliance. At Morath, Kaltain Rompier destroys herself and a great deal of the fortress, pressing a shard of Wyrdstone into Elide Lochan's hand and telling her to find Celaena Sardothien; Elide escapes into the countryside alone. Manon, cast out and wounded for defying her grandmother, is left with the Thirteen and a set of questions about her own history she has never been allowed to ask. Erawan, the Valg king who was never truly dead, is now unopposed at Morath.",
         "in_short": "Aelin Galathynius returns to Rifthold with Rowan to free her condemned cousin Aedion, break the Valg collar on Dorian, and kill the king of Adarlan. Reclaiming her old life brings her back to Arobynn Hamel, the assassin master who raised her, whose help costs more than it is worth, and to Lysandra, a courtesan who turns out to be a shapeshifter and becomes her closest ally. Aelin frees Aedion in a public rescue, has Arobynn killed, and inherits his fortune and the Amulet of Orynth, which proves to contain the third Wyrdkey. At Morath, the witch Manon Blackbeak is shown what the duke is breeding in the lower levels, begins to refuse her orders, and saves a servant named Elide Lochan. In Rifthold, Aelin destroys the black tower holding magic down, restoring it across the continent, then confronts the king; Dorian breaks the collar and kills his father, at the cost of a magical blast that shatters Chaol's spine. Aelin brings down the glass castle. Dorian takes the throne, Chaol and Nesryn sail south for healing and allies, and Aelin turns north to claim Terrasen against a war that is only beginning.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2827,7 +2827,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2840,7 +2840,7 @@
       "recaps": {
         "ending": "The collection closes with the crisis at Bly. After the governess publicly confronts Flora about the figure she believes is watching from across the lake, Flora becomes terrified of her and leaves with Mrs. Grose. The governess remains alone with Miles and presses him to acknowledge both his expulsion from school and Peter Quint's presence. Miles admits that he stole a letter and was dismissed for saying improper things to other boys. The governess sees Quint at the window and tries to shield Miles while demanding that he name the apparition. Miles cries out against Quint, but then dies in the governess's arms. The narrative never supplies an independent confirmation of the ghosts or of the children's supposed corruption, so the ending leaves the governess's interpretation unresolved even though its human cost is certain.",
         "in_short": "This collection presents three compact Gothic narratives. In Dracula, Jonathan Harker discovers that his Transylvanian client is a vampire; after Dracula preys on Lucy Westenra and Mina Harker in England, Van Helsing and their allies pursue him home and destroy him. In Dr. Jekyll and Mr. Hyde, lawyer Gabriel Utterson investigates the brutal Hyde and learns from Jekyll's final account that doctor and criminal are one man, separated by a chemical experiment that Jekyll can no longer control. In The Turn of the Screw, a governess at Bly believes the ghosts of Peter Quint and Miss Jessel are corrupting Miles and Flora. Flora is removed after rejecting the governess, while Miles dies during a final confrontation in which the governess claims to see Quint. The last tale leaves open whether the apparitions were real or products of the governess's mind.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3010,7 +3010,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3023,7 +3023,7 @@
       "recaps": {
         "ending": "In the arena, Lygia is tied to a bull while Ursus is sent against it. Ursus kills the animal and frees her, and the spectators' demand for mercy forces Nero to spare both captives. Lygia recovers and leaves Rome with the transformed Vinicius; they marry and make a peaceful home in Sicily. Peter, initially persuaded to escape the persecution, encounters Christ in a vision on the Appian Way and understands that he must return to Rome. He goes back to strengthen the believers and eventually meets martyrdom. Chilo has already died under torture after publicly naming Nero as the true author of Rome's destruction. When Nero orders Petronius to die, Petronius and the faithful Eunice open their veins during a final gathering, with Petronius sending the emperor a last contemptuous judgment of his artistry. The epilogue carries history beyond the lovers: Nero loses power and dies, while the Christian faith survives him and Rome later honors Peter.",
         "in_short": "Roman officer Marcus Vinicius becomes obsessed with Lygia, a Christian hostage raised by Aulus Plautius. His uncle Petronius arranges her transfer into imperial control, but Ursus and Rome's hidden Christians rescue her. Vinicius hires Chilo to find her and is wounded during a failed seizure. Nursed by the people he meant to violate, he slowly abandons possession for love and accepts Christianity. After Nero's court withdraws to Antium, Rome burns. Christians help Vinicius find Lygia, but Nero's regime blames them for the disaster and begins mass arrests and executions. Lygia and Ursus are imprisoned; Chilo's informing helps fuel the persecution, though forgiveness later drives him to denounce Nero and die. In the arena Ursus kills a bull carrying Lygia and the crowd compels Nero to spare them. She and Vinicius marry and settle in Sicily. Peter returns to threatened Rome and is martyred. Petronius and Eunice choose death when Nero turns on him, while Nero's own fall and Christianity's endurance complete the historical contrast.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3173,7 +3173,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3186,7 +3186,7 @@
       "recaps": {
         "ending": "Harry leaves Janice and the family in Pennsylvania and drives back to the Florida condominium alone. Despite his damaged heart and the warning that he needs further treatment, he joins a teenage boy in a strenuous one-on-one basketball game. The exertion brings on another major heart attack. Harry is taken to the hospital, where Nelson comes to see him. Father and son finally speak with less defensiveness than usual: Nelson offers love and forgiveness, and Harry gives him a final measure of approval. Harry then dies. Nelson has entered recovery and is moving toward work as a counselor, Pru has survived the collapse of their marriage's old terms, and Janice has become more independent through her real-estate career. The dealership has been sold, ending the family enterprise that structured their prosperity. Harry's death closes his repeated cycle of flight: his last escape returns him to the basketball court, but it also leaves the family to continue without him.",
         "in_short": "In his mid-fifties, Harry Angstrom is affluent, retired, and physically failing. He and Janice spend winters in Florida, while Nelson runs the family Toyota dealership in Pennsylvania. Nelson's cocaine addiction, infidelity, and theft from the business force the family to send him to treatment; Harry temporarily returns to the dealership but cannot restore its future. After a first heart attack he accepts angioplasty yet resists bypass surgery and lasting change. Thelma Harrison dies, confronting him with the loss of his longtime lover. Harry later sleeps with Nelson's wife, Pru, adding another betrayal to the family's history. Janice develops a real-estate career and sells the dealership, while Nelson begins recovery and moves toward counseling work. Feeling displaced, Harry flees alone to Florida. A demanding basketball game with a teenager causes a final heart attack. Nelson reaches the hospital in time for a last reconciliation, and Harry dies after giving his son the approval he has long withheld.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3340,7 +3340,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3353,7 +3353,7 @@
       "recaps": {
         "ending": "After hostility around Harry's household escalates, the Angstrom house is set on fire. Harry, Nelson, and Skeeter get out, but Jill dies inside. Skeeter escapes and remains at large, while Harry is left with the knowledge that his passivity helped place Jill in danger. Mary Angstrom also dies after her long illness, further dissolving the family structure Harry has taken for granted. Charlie's heart trouble ends his affair with Janice, and the disaster draws Janice and Harry back toward one another. They meet again without resolving the deeper failures of their marriage, but choose the familiarity of reunion over continued separation. Nelson remains with them, marked by Jill's death and by the instability both parents have made him endure. Harry finishes the novel neither politically converted nor fully accountable, but his improvised household is gone and his marriage has resumed in chastened, uncertain form.",
         "in_short": "Ten years after the events of Rabbit, Run, Harry Angstrom lives with Janice and their teenage son Nelson and works at a declining printing plant. During the summer of the moon landing, Janice leaves him for Charlie Stavros. Harry responds less by rebuilding his marriage than by opening his house to Jill Pendleton, a vulnerable teenage runaway, and Skeeter, a charismatic Black veteran whose radical politics challenge Harry and inflame the neighborhood. Jill becomes Harry's lover, Nelson attaches himself to her, and Skeeter increasingly controls the household's atmosphere. Harry's mother dies as his old family weakens. Racial hostility outside the house culminates in arson: Harry, Nelson, and Skeeter escape, but Jill is killed. Skeeter disappears. Charlie's illness and the fire bring Janice back, and she and Harry reunite without solving the habits of evasion, dependence, and resentment that divided them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3537,7 +3537,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3550,7 +3550,7 @@
       "recaps": {
         "ending": "The Kingdom survives the first campaign but loses Krondor. James and William die during the defence and destruction of the city, buying time for Patrick's army and civilians to withdraw. Roo's fortune and trading network are consumed in the emergency he prepared for; Erik becomes one of the commanders holding the retreat together through Ravensburg and Darkmoor. Fadawah's advance is checked, not eliminated, and Duko remains with an occupying force in the west, so the human war continues beyond the book. The supernatural purpose of the invasion is exposed: the woman Jorna, Miranda's mother, has been presented as the Emerald Queen and used as a vessel in the Pantathians' attempt to restore Alma-Lodaka, while Jakan's traffic with the demon realm has opened a greater danger involving the demon king Maarg. Pug, Miranda, Nakor, Calis, and Tomas prevent that power from taking Midkemia and deny the Pantathians their intended triumph. Miranda is the daughter of Jorna and Macros the Black, and Macros returns in a renewed body, adding an old guardian to the damaged world's defenders. The invasion has been blunted, but the Western Realm remains occupied and must be reclaimed.",
         "in_short": "The Emerald Queen's fleet invades the Kingdom despite years of warning. Roo converts his merchant fortune into supplies and transport, Erik helps command the defence, and Duke James and William prepare Krondor for a battle they know may end in evacuation and destruction. Fadawah's disciplined armies force the Kingdom eastward; Krondor falls after James and William die buying time, while Erik helps preserve the retreat through Ravensburg and Darkmoor. Roo survives but much of the commercial world he built is consumed by war. Pug, Miranda, Nakor, Calis, and Tomas pursue the invasion's hidden purpose. The Emerald Queen is exposed as Jorna, Miranda's mother and a vessel in the Pantathians' plan to restore Alma-Lodaka, while Jakan's dealings reveal a still greater threat from the demon king Maarg. The crossing is stopped, and Miranda is revealed as the daughter of Jorna and Macros the Black as Macros returns in renewed form. Fadawah is checked but not destroyed, Duko still holds conquered territory, and the Kingdom faces the task of retaking the west.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3701,7 +3701,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3714,7 +3714,7 @@
       "recaps": {
         "ending": "After months of study and saving, Dick has changed his habits but still earns his living as a bootblack. During a ferry trip, a small boy falls overboard. Dick jumps into the river and rescues him despite the danger to himself. The child's father, Mr. Rockwell, learns about Dick's history, honesty, and determination and offers him a clerk's position paying ten dollars a week. The job gives Dick the respectable occupation toward which he has been working and more than replaces the money he loses when his old clothes are ruined in the rescue. He decides to present himself as Richard Hunter rather than Ragged Dick. Fosdick, already established in a better job, remains his friend and roommate. Dick's rise is therefore not a sudden change in character: the rescue creates the opportunity, while his education, thrift, courage, and reputation make him ready to accept it.",
         "in_short": "Dick Hunter is an honest, humorous New York bootblack who lives from day to day and sleeps wherever he can. After guiding Frank Whitney around the city, he receives a decent suit and advice to save his money. Dick rents a room, begins using a bank account, and invites the educated but poor Henry Fosdick to live with him in exchange for lessons. The boys study, attend church, form respectable friendships, and resist the threats and temptations of street life. Fosdick secures an office position, while Dick recovers his savings after the thief Jim Travis steals his bankbook. Dick later risks his life by jumping from a ferry to rescue a child. The grateful father, Mr. Rockwell, offers him a well-paid clerkship. Prepared by months of education and discipline, Dick leaves bootblacking behind and begins his new life under his proper name, Richard Hunter.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3893,7 +3893,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3906,7 +3906,7 @@
       "recaps": {
         "ending": "Coalhouse agrees to release his hostages and leave the Morgan Library after his followers are allowed to depart in his car and the authorities promise that his demands will be addressed. He walks out unarmed and is shot dead by the police. Mother's Younger Brother escapes and eventually joins revolutionary movements in Mexico, where he dies. Father survives the family crisis but dies aboard the Lusitania. Tateh, now successful in the motion-picture business as the self-styled Baron Ashkenazy, marries Mother. They bring their children and Sarah and Coalhouse's son into one household. The final family is therefore interracial and assembled by choice rather than by the rigid social pattern with which the novel opened. Evelyn Nesbit and Harry Houdini continue into new phases of public life, while the old New Rochelle order disappears amid war, migration, mass entertainment, and political upheaval.",
         "in_short": "In early twentieth-century New York, a wealthy white family in New Rochelle, a Jewish immigrant family, and a Black pianist's family are drawn together amid rapid social change. Father leaves for an Arctic expedition while Mother grows more independent. Tateh escapes Lower East Side poverty and remakes himself as a filmmaker. Mother shelters Sarah and her baby; the child's father, Coalhouse Walker Jr., courts Sarah and joins the household's life. After racist firemen vandalize Coalhouse's car and officials deny him justice, Sarah is killed while seeking help and Coalhouse begins a violent campaign. Mother's Younger Brother joins him. Their occupation of the Morgan Library ends with Coalhouse releasing his followers and surrendering, only to be killed by police. Father later dies, Younger Brother is killed in Mexico, and Mother marries Tateh, uniting their children with Coalhouse and Sarah's son in a new family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4077,7 +4077,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4090,7 +4090,7 @@
       "recaps": {
         "ending": "Bobbie's appeal to the Old Gentleman leads him to investigate Father's case. The evidence against Father is overturned, he is cleared of the charge that sent him to prison, and news of his release reaches the family. Mother prepares for his return while keeping the moment quiet. At the station, Bobbie waits as a train arrives and sees Father emerge through the steam. She runs to him, and they return together to Three Chimneys. Peter and Phyllis are reunited with him there, ending the separation that forced the family from its London home. The Old Gentleman has also become personally connected to the family through Jim, the injured schoolboy, who is his grandson. The story closes with Father restored to his wife and children and the central injustice resolved, while the friendships the children formed through the railway remain part of their new life.",
         "in_short": "When their father is suddenly taken away, Bobbie, Peter, Phyllis, and their mother leave their comfortable London home for Three Chimneys, a cottage beside a country railway. The children befriend Perks the porter, wave daily to an Old Gentleman on the train, and repeatedly turn railway life into acts of service: they help a lost Russian exile, stop a train before it strikes a landslide, aid a family whose barge catches fire, and rescue an injured schoolboy from a tunnel. Bobbie eventually learns that Father has been imprisoned after being falsely accused of betraying his country. She secretly asks the Old Gentleman for help. He investigates, the case is corrected, and Father is released. Bobbie meets him as he steps from the train, and the whole family is reunited at Three Chimneys.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4304,7 +4304,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4317,7 +4317,7 @@
       "recaps": {
         "ending": "Norman Douglas returns to church and to his old courtship of Ellen West, and the two become engaged. Ellen, marrying herself, releases Rosemary from the promise that had kept her single, and Rosemary accepts John Meredith. Una Meredith, who has been dreading a stepmother more than she could say, goes alone to Rosemary to ask her to be kind to Carl, and comes away comforted; the manse children accept the marriage and gain the mothering they have gone without. Mr. Meredith, shaken by how far his family had been neglected, is at last awake to his household. Mary Vance is settled with Mrs. Marshall Elliott and thoroughly at home in the Glen. The Blythe and Meredith children are all a year or two older, and Rainbow Valley is still theirs. The book closes with them gathered in the valley at sunset, where Walter tells them he has seen the Pied Piper coming over the hills with his music, calling the boys of the world to follow him. The others take it for one of Walter's fancies and promise lightly to follow when the call comes, and the story ends on that promise with the shadow of the coming war lying over it.",
         "in_short": "A new Presbyterian minister, the scholarly and unworldly John Meredith, comes to Glen St. Mary with four motherless children and an incompetent old housekeeper, and the manse family runs wild. Jerry, Faith, Una, and Carl make friends with the Blythe children of Ingleside and spend their days in Rainbow Valley, scandalizing the congregation with one thoughtless escapade after another while their father reads in his study and notices nothing. They rescue a starving runaway, Mary Vance, who is eventually taken in and brought up by Mrs. Marshall Elliott. Ashamed of disgracing their father, the manse children form a club to punish their own misdeeds, and one of the punishments makes Carl seriously ill, which finally wakes Mr. Meredith to his family's neglect. Meanwhile he falls in love with Rosemary West, who must refuse him because of a promise never to marry, extracted by her sister Ellen. When Ellen's own old suitor returns and marries her, Rosemary is freed and accepts the minister. The book ends with Walter Blythe's vision of the Pied Piper, a warning of the war to come.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/rains-of-liscor.json
+++ b/data/works-community/0/rains-of-liscor.json
@@ -322,7 +322,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09XYL9MQJ",
@@ -334,7 +334,7 @@
       "recaps": {
         "ending": "Liscor survives the moth breach, honors the painted Antinium who defended it, and avoids a clash when Fourth Company mistakes those defenders for occupiers. Erin's damaged inn is now a theater, trading point, and refuge. The five Redfangs survive their unauthorized dungeon expedition, recover three artifacts, and receive approval in principle to register as Bronze-rank adventurers under Selys's responsibility. The gold-rank dungeon remains active with moths, organized hunters, traps, and a head-collecting creature. Selys inherits Zel's lethal Heartflame Breastplate, activates its wearer-safe fire, refuses to surrender it to a city, and plans to lease it for dungeon work while an unknown patron continues seeking it. Laken leaves his noble gathering recognized as a possible ally, though its poisoner is unknown. Flos announces his return and his enemies. Rags defeats a human force to save another goblin tribe, while Rhys and the wider campaigns against goblins remain unresolved.",
         "in_short": "After Zel Shivertail's death, Erin keeps five Redfang Hobgoblins at the Wandering Inn despite public anger and turns the inn into a theater and commercial refuge. A dungeon expedition triggers a face-eater moth assault, but Liscor survives through the combined efforts of its Watch, adventurers, Antinium, and Erin's allies. The painted Antinium earn public honor, while the returned army remains distrustful. The Redfangs later enter the dungeon, escape with three artifacts, and gain recognition as prospective adventurers. Selys inherits Zel's Heartflame Breastplate, survives an abduction attempt, activates the armor, and chooses to keep and lease it rather than yield it to a state. Elsewhere, Laken passes Magnolia Reinhart's dangerous political test, Flos publicly resumes his challenge to world powers, and Rags leads Flooded Waters to rescue another goblin tribe. The dungeon, Rhys, the campaign against goblins, and the struggle over Zel's armor all remain active threats.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -519,7 +519,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -532,7 +532,7 @@
       "recaps": {
         "ending": "The emergency line is finished and the train runs the whole way to Uberwald, fighting through torn-up track, burned bridges, and armed grag fighters, with Moist, Simnel, the goblins, the dwarfs of the crew, and Lord Vetinari himself defending it, and Vetinari dealing with attackers on the moving train personally. The Low King reaches the Scone of Stone in time, the coup collapses, and the fundamentalist movement is broken as its leaders are exposed as having murdered clacks operators and railwaymen for the sake of a version of dwarfishness that most dwarfs do not want. The King then makes a second announcement to the assembled dwarfs: she is a woman, and has been throughout her reign, and she intends to go on ruling as the first Low Queen. The dwarfs, having just been reminded what the alternative looks like, accept her. Afterwards the railway is no longer an experiment but the new shape of the world: lines spreading in every direction, Harry King rich beyond reckoning, Dick Simnel free to build better engines, goblins established as skilled workers, and Iron Girder something between a machine and an object of genuine belief, cared for accordingly. Moist, having discovered that running a railway is the only respectable job he has ever enjoyed, keeps it, with Adora Belle beside him and Vetinari, as ever, holding the reins.",
         "in_short": "Dick Simnel, a young engineer whose father died experimenting with steam, works out how to control it with mathematics and builds the Disc's first locomotive. Backed by the waste magnate Harry King, he brings her to Ankh-Morpork, where the crowds are entranced and Lord Vetinari installs Moist von Lipwig as the government's man on the railway. Moist buys land, calms landowners, and drives a line to Sto Lat and then further, while goblins take to the new machinery and the world reorganizes itself around speed. Among the dwarfs, fundamentalist grags led by Ardent preach against daylight, machines, and everything the railway represents, and begin destroying clacks towers and killing their operators. When they move against the Low King and threaten a coup in Uberwald, the railway is asked to do the impossible: lay track and run the King home across the continent in days. The run is made under constant sabotage and attack, with Vetinari aboard. The coup fails, and the King then reveals to the dwarfs that she is a woman, and becomes the first Low Queen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -711,7 +711,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -724,7 +724,7 @@
       "recaps": {
         "ending": "After Co Bao is killed, Rambo wages a personal campaign against the Vietnamese and Soviet forces pursuing him. He reaches the prison camp, frees the American captives, and takes a helicopter for the flight back to Thailand. Yushin attacks in another gunship, but Rambo survives the aerial battle and destroys his pursuer. He lands at Murdock's base with the prisoners whom the operation was designed not to find. Rambo then wrecks the command center and forces Murdock at knifepoint to acknowledge the men still missing in Vietnam and to pursue their rescue. He does not take the offered path back into ordinary American life. The surviving prisoners are safe, Trautman remains the person who best understands him, and Rambo walks away from the base still alienated from the country for which he fought.",
         "in_short": "John Rambo is released from prison for a covert mission to photograph a Vietnamese camp where American prisoners may remain. Mission chief Murdock orders him to gather evidence only, while Colonel Trautman watches over the operation. Guided by Vietnamese agent Co Bao, Rambo infiltrates the camp and rescues a prisoner named Banks. Murdock, fearing the political consequences of proof that captives were abandoned, orders the extraction helicopter to leave them behind. Rambo is recaptured and tortured by Soviet officer Podovsky, but Co frees him. After she is killed, Rambo destroys the forces hunting him, returns to the camp, and rescues the remaining prisoners. He defeats Yushin in an aerial battle and flies the captives to the American base. There he confronts Murdock and demands action for the men still missing, then leaves rather than returning home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -868,7 +868,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -881,7 +881,7 @@
       "recaps": {
         "ending": "Rambo and Trautman escape Zaysen's fortress with other prisoners but are pursued across the Afghan landscape. Rambo kills Kourov during close combat in a cavern, and the fugitives reach open ground only to face Zaysen's massed troops, armor, and helicopter. Masoud and the mujahideen arrive on horseback and turn the confrontation into a battle. Rambo takes control of a tank and drives directly against Zaysen's helicopter; the collision destroys both vehicles, but Rambo survives and Zaysen is killed. With the Soviet force defeated, Rambo and Trautman say farewell to Mousa, Masoud, Hamid, and the fighters. Rambo gives Hamid a token of friendship before leaving Afghanistan with Trautman. The rescue restores the bond between the two soldiers, but Rambo again departs without returning to a conventional American life.",
         "in_short": "John Rambo is living at a Thai monastery when Colonel Trautman asks him to join a mission aiding Afghan resistance fighters against Soviet forces. Rambo refuses to return to war, but changes his mind after Trautman goes alone and is captured by Colonel Zaysen. Guided from Pakistan by Mousa Ghani, Rambo meets Masoud's mujahideen and the boy Hamid. A Soviet attack on their village shows the danger civilians face. Rambo infiltrates Zaysen's fortress, eventually frees Trautman and other prisoners, and fights through Soviet troops during their escape. After killing Zaysen's enforcer Kourov, Rambo and Trautman appear trapped by a larger Soviet force, but Masoud's fighters arrive. In the final battle Rambo uses a tank against Zaysen's helicopter, killing the commander and surviving the collision. Rambo and Trautman leave Afghanistan together after saying farewell to their Afghan allies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1286,7 +1286,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09CF14FKD",
@@ -1298,7 +1298,7 @@
       "recaps": {
         "ending": "Elaine closes the main arc securely established as the Dawn Sentinel. Deva's plague is cured, the immediate pirate threat is broken, and her first solo mission is judged successful despite criticism of her preparation and tactics. Ocean is sent after the surviving pirates, while professional consequences for Brutus, Cassia, and Atticus remain undecided. Elaine now runs a public healing stall, teaches at both Ranger Academy and Artemis's school, and has formally taken Autumn as an apprentice. Caecilius may join future plague responses, Kallisto will organize Elaine's major missions, and her search for a thunderbird has begun. Toxic continues his ant-war poison project without her help. The final handoff moves to Iona at Wabi Pass. Selene and Lunaris grant her system-sight and universal language abilities, and she survives a battle that kills her mentor and most of the Valkyrie force. A caster from the School of Sorcery and Spellcraft saves the few defenders left. Iona becomes the Dusk, but the devastated order expects to lose its holdings and political position.",
         "in_short": "After her old Ranger team separates, Elaine survives Ranger Academy's brutal training, develops her fire class into Ranger Mage, Radiance, and is unexpectedly elevated to the Dawn Sentinel. She refuses to assist Toxic's plan to exterminate the ant-like enemy species, but proves her value as a healer and combatant. Her first independent mission organizes a successful town-wide cure for Deva's contagious plague. On the return voyage, her hired escorts submit to pirate slavers, forcing Elaine to reveal her Sentinel identity, free the captives, survive a harpoon through her torso, and kill the pirate captain. Back home, she opens a market clinic, takes Autumn as an apprentice, joins Artemis as a part-time teacher, gains Kallisto as an organizer, and begins searching for a thunderbird companion. The final chapter follows Iona through the catastrophic defense of Wabi Pass. Her mentor dies and the Valkyrie order is nearly destroyed, but Iona survives, receives powerful blessings, and becomes the Valkyrie called the Dusk.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1428,7 +1428,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1441,7 +1441,7 @@
       "recaps": {
         "ending": "Baglioni gives Giovanni an antidote that he believes can restore Beatrice to ordinary human life. Giovanni first accuses Beatrice of deliberately drawing him into her poisonous condition, but she insists that her father, not she, arranged their contact and that her affection was genuine. She drinks the antidote in hope of escaping the isolation imposed on her. Rappaccini appears and presents the pair's shared immunity and lethal power as a gift that should make them superior to other people. Beatrice rejects that vision, asking why she should prefer being feared to being loved. Because poison has become part of her life, Baglioni's cure kills rather than saves her. She dies at her father's feet, leaving Rappaccini confronted with the human cost of his experiment, while Baglioni looks down from Giovanni's window and declares the result a consequence of Rappaccini's science.",
         "in_short": "Student Giovanni Guasconti becomes fascinated by Beatrice, daughter of the scientist Rappaccini, after watching her in a garden filled with poisonous plants. Warned by Professor Baglioni that Rappaccini treats people as experiments, Giovanni nevertheless enters the garden and falls in love with Beatrice. He gradually discovers that she has been made poisonous: her breath and touch can kill ordinary life. Rappaccini has also exposed Giovanni until he shares her condition, intending to give his daughter a companion. Baglioni supplies an antidote. Hurt and suspicious, Giovanni asks Beatrice to drink it so they can become ordinary, but the remedy is fatal to a body sustained by poison. Beatrice dies after rejecting her father's claim that deadly invulnerability is a blessing, and Rappaccini's effort to overcome human weakness destroys the daughter he meant to protect.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1582,7 +1582,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1595,7 +1595,7 @@
       "recaps": {
         "ending": "Robert Livingstone is not stopped. The pack survives his assault on Green Creek and drives off the Omegas he sent, but he escapes with his stolen power intact, and worse, he takes Robbie Fontaine with him. Robbie's memories of Green Creek, of the Bennetts and of Kelly are stripped out of him by Livingstone's magic, leaving him a wolf who believes he belongs to the leadership in Caswell and who no longer knows the people who love him. The pack knows roughly where he is and cannot simply go and get him. What Gordo gains, he gains for himself: he stops refusing Mark Bennett, accepts what he is to him, and stops treating the pack as something that will inevitably discard him again. He also stops pretending his father is somebody else's problem. The Bennett pack closes the book intact, mated and warded, with Ox and Joe as its alphas and Gordo as its witch, but with one of its own in enemy hands and a witch carrying alpha power still loose.",
         "in_short": "Months after Richard Collins's death, Gordo Livingstone is the Bennett pack's witch again, serving Ox and Joe in a Green Creek that is quiet but not safe. The story moves between the present and Gordo's past: his childhood as the son of Robert Livingstone, the pack's witch, whose hunger for power cost Gordo his family and ended with Thomas Bennett stripping his magic and exiling him; the years Gordo spent abandoned when the Bennetts moved away; and the three years on the road hunting Richard Collins with Joe, Carter and Kelly. In the present, feral Omegas begin appearing around Green Creek in impossible numbers, and Gordo's father proves to be alive, carrying stolen alpha power and making them. Gordo finally stops holding Mark Bennett at arm's length, and the two become mates. When Livingstone moves on Green Creek the pack fights him off, but he escapes and takes Robbie Fontaine with him, stripping Robbie's memory of the pack entirely and leaving the Bennetts with one of their own turned into a stranger.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1781,7 +1781,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1794,7 +1794,7 @@
       "recaps": {
         "ending": "Marlowe arranges for Moose Malloy to come to the Grayle beach house, where the detective has recognized Mrs. Grayle as Velma, the woman Malloy has sought since leaving prison. Her respectable marriage depends on burying her former identity, and Marriott and Jessie Florian died because they endangered that secret. When Malloy arrives, he approaches Velma without hostility, but she shoots him repeatedly and escapes. Malloy dies still unwilling to condemn her. Velma gets away from California and resumes singing under another name. Months later, a Baltimore detective recognizes her; she shoots him and then kills herself rather than be arrested. Randall closes out the remaining facts with Marlowe. The jade robbery, Marriott's blackmail, Amthor's criminal schemes, and Malloy's search have all converged on Velma's determination to preserve the life she built as Mrs. Grayle, leaving nearly everyone who knew the truth dead.",
         "in_short": "Private detective Philip Marlowe encounters the enormous ex-convict Moose Malloy searching for his former sweetheart Velma. The search soon overlaps with another case: Lindsay Marriott hires Marlowe to attend a ransom exchange for a stolen jade necklace, but Marriott is murdered and Marlowe is knocked unconscious. With help from Anne Riordan and despite police suspicion, Marlowe follows the necklace to wealthy Mrs. Grayle, then through psychic Jules Amthor, a corrupt private clinic, and an offshore gambling ship. He ultimately realizes that Mrs. Grayle is Velma, who abandoned her old identity and married into wealth. Marriott and Jessie Florian knew enough to threaten her new life. Marlowe brings Malloy to her, but she shoots him and flees. Later recognized in Baltimore, she kills a detective and herself. Malloy dies devoted to the woman whose secret caused the violence around him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2113,7 +2113,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:1977374573",
@@ -2125,7 +2125,7 @@
       "recaps": {
         "ending": "The Wanderers finish with a rare greenhouse producing food under Finn's care, and their fortified settlement has become a recognized town. Joe remains in line for future guild leadership. The copied-wall conspiracy ends with the responsible Architects Guild leaders arrested, while Joe accepts a future commission to build a royal arena. He controls the captured forest cathedral and has Game Over contained beneath Pathfinder's Hall, where the creature's drained power supports his deity, but neither that threat nor the divine debt is resolved. Joe destroys the Grand Zoo's underground transport, trapping its arena, black market, and associated assassins. The crown clears him, but the Zoo now treats him as a blood-feud enemy. Aten, Mike, Jaxon, Jess, Joe's returning party, and his Ritualist coven remain active. Tara's secret reporting, the maintenance of Game Over's prison, further forest captures, the Zoo conflict, and the greenhouse's long-term risks remain open.",
         "in_short": "After people lose the ability to log out, Joe helps the Wanderers turn a damaged settlement into a sustainable town. His search for a durable food source leads through a hidden Wolfman refuge to a cult-held cathedral, which he captures for his indebted deity. The victory releases Game Over, a permanently lethal Burning Mind fragment that Joe contains and drains rather than destroys. He develops mana batteries, forms a Ritualist coven, and builds a rare greenhouse that begins producing food. The Architects Guild frames the Wanderers over a copied defensive wall, but its leaders expose their own attack and are arrested. Queen Marie then sends Joe against the Grand Zoo. Joe sabotages its underground Bloodsport Arena and destroys its transport system, trapping the black market below. The crown clears him, while the Zoo declares a blood feud. The town and greenhouse survive, but Game Over, Joe's divine debt, Tara's covert reporting, and the Zoo remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2280,7 +2280,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2293,7 +2293,7 @@
       "recaps": {
         "ending": "The remedy that works against the mutated strain is made outside the Rising's control, from a plant and a method preserved by people the Society had spent generations trying to erase, and it reaches the sick largely because Cassia, Ky, Xander and the villages distribute it themselves rather than waiting for permission. The still begin to wake. What the epidemic exposes is that the Rising was never the opposite of the Society: it engineered the plague, kept the cure, planned the takeover in advance, and its leadership fully intended to go on deciding for everyone afterwards, which is the conclusion Ky reached about it long before anyone would listen. With both the Society and the Rising discredited, the question of who governs is left open, and it is answered by putting it to the people to choose for themselves, the first genuine choice anyone in this world has been offered. Cassia and Ky end the trilogy together and no longer at anyone's disposal. Xander, who gave the Rising his faith and had it broken, finds his own footing in medicine and with Lei. The cities keep the poems, the paintings and the handwriting that people made in the middle of the crisis, and the future is uncertain in a way none of the characters mind.",
         "in_short": "Cassia is back in the Society as a sorter, trading forbidden poems with the Archivists; Ky flies for the Rising; and Xander, a physic, has been a member of the rebellion for years. The Rising makes its move by releasing a plague that leaves its victims motionless, then offering the cure it has been holding all along, and the Society collapses within days. The takeover unravels when the plague mutates and the cure stops working, leaving thousands of people still and unwaking, including people all three of them love. Ky falls ill. Xander leaves the cities for a village beyond the Rising's control, where an old man who worked on the original cure builds a remedy from a plant the villages preserved, and the three of them get it distributed largely without the rebellion's permission. In the process it becomes clear that the Rising engineered the plague, planned the takeover and intended to keep deciding for everyone. With both regimes discredited, the future is put to a vote, and Cassia and Ky end the trilogy together and free to choose.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2451,7 +2451,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2462,7 +2462,7 @@
       "recaps": {
         "ending": "Reaper Man ends with the personification of death restored to his office, but changed. In Ankh-Morpork, Windle Poons and the undead of Reg Shoe's Fresh Start Club destroy the parasitic creature that had grown out of the world's surplus life-force in the shape of a devouring shopping mall, releasing the pent-up vitality. In the countryside, the old Death, living as the farmhand Bill Door, confronts the cold, crowned New Death that the Auditors had created to replace him, and defeats it with his scythe, reclaiming his role. Before that, Miss Flitworth's own life has run out; Death uses the last of his borrowed time on her behalf and then takes her gently, giving her a final gift by letting her attend, as her young self, the harvest dance she never had with the man she lost long ago. He also returns to collect Windle Poons at last, allowing the exhausted old wizard the death and rest he had been denied. Reinstated as the one Death of the Disc, he carries back into his endless duty a compassion for the living that his brush with mortality gave him.",
         "in_short": "When the Auditors of Reality decide that the personification of death has grown a personality, they retire him and give him a life-timer of his own, making him mortal. Taking the name Bill Door, he hires on as a farmhand to the elderly Miss Flitworth and learns what it is to live toward an ending. With no one collecting souls, life-force builds up in the world: the ancient wizard Windle Poons dies but rises again as one of the undead, joining Reg Shoe's Fresh Start Club, while the surplus vitality in Ankh-Morpork coalesces into a predatory creature shaped like a shopping mall that preys on the living. Windle and the undead destroy it. In the country, a merciless New Death is created to replace the old one; when Miss Flitworth's time comes, Bill Door confronts and defeats the New Death, reclaims his office, and takes Miss Flitworth gently, granting her a final night at the dance she missed in youth. Restored to duty and changed by the experience, Death resumes his work with a new measure of compassion, and Windle Poons is finally allowed to rest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2727,7 +2727,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CZ1DGS1T",
@@ -2739,7 +2739,7 @@
       "recaps": {
         "ending": "Vex cuts the karma-reward scroll while trying to kill Bella, unknowingly creating the bond its giver needs to intervene. The karma cultivator overwhelms him, and Bella kills her former master with his spear. Lin kills Shay and leaves before he can be questioned. Yamish declares the ordeal complete and sends the couple back to Gleam, where their assignment has been cancelled. Chance and Bella reach the White Hart House together. Bella's path is repaired, but she owes the karma cultivator a future favor. The damaged Old City remains bound to Chance, who also keeps an unidentified bell taken from Vex. Quinn and her associate are rebuilding after Bracken's liberation, while Jade has stopped hunting the pair and is hearing Yeo's account. Yamish still claims Chance as his apprentice. The familiar version of Yamish is not the true being, which is more dangerous.",
         "in_short": "Chance and Bella flee Gleam under a four-month trial imposed by Yamish, briefly join the Dancing Cloud sect, and use the Azure Moon Realm to escape Shikari hunters. Chance reaches Night rank, Bella reaches knight rank, and they join Jade and Quinn in exposing the Bracken Sect's enslavement of its residents. The Old City lures an earth dragon that destroys Bracken's leaders but causes severe civilian losses. After Bella repairs her damaged path in Fallen, she and Chance stop running from Vex. His attack on a karmic scroll permits its giver to intervene, allowing Bella to kill Vex, while Lin kills Shay. The couple returns to Gleam with the immediate assignment lifted, though Yamish's control, the Old City's bond, Bella's promised favor, Lin's motives, and an unidentified bell remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2925,7 +2925,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2938,7 +2938,7 @@
       "recaps": {
         "ending": "Maxim escapes prosecution. The discovery that Rebecca had been secretly told she was dying of cancer supplies a motive for suicide, and the inquest's verdict, together with the magistrate Colonel Julyan's tacit acceptance, closes the case despite Jack Favell's accusation of murder. Maxim and the narrator, now bound together by the shared secret that he killed Rebecca, feel their marriage strengthened rather than broken by the ordeal. But their relief is undercut on the drive back to Manderley overnight, when they see the sky glowing red and realize the great house is ablaze. It is strongly implied that Mrs. Danvers, having learned the outcome and unwilling to let the second wife possess Manderley, set the fire before vanishing. Manderley, the estate that dominated the whole novel and the narrator's imagination, is destroyed. This explains the book's opening: the couple now live quietly and rootlessly abroad, exiled from the burned house and shadowed by the past, but together. The narrator's dream of returning to Manderley, with which the story began, is revealed as longing for a home that no longer exists.",
         "in_short": "A shy young woman working as a paid companion in Monte Carlo meets Maxim de Winter, a wealthy widower, and after a brief courtship marries him and moves to his famous English estate, Manderley. There she feels overshadowed by the memory of his glamorous first wife, Rebecca, who drowned, and is tormented by the cold housekeeper, Mrs. Danvers, who worshipped Rebecca. After Mrs. Danvers humiliates her at a costume ball and nearly drives her to suicide, a shipwreck in the bay leads divers to Rebecca's sunken sailboat with a body still inside. Maxim confesses that he hated Rebecca, whose public charm hid cruelty and infidelity, and that he shot her and sank the boat with her body. Through an inquest and blackmail from Rebecca's cousin and lover, Jack Favell, they discover Rebecca had terminal cancer, which is taken as a motive for suicide and clears Maxim. Relieved, the couple drive home overnight to find Manderley in flames.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3109,7 +3109,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3122,7 +3122,7 @@
       "recaps": {
         "ending": "Rebecca's later school years confirm the promise that her sympathetic teachers and friends saw in her, but family duty continues to shape her choices. The death of Aunt Miranda changes the Sawyer household and leaves Rebecca with both greater material security and a clearer obligation to use it responsibly. She has grown able to understand Miranda's care beneath years of severity, while her bond with Aunt Jane remains openly affectionate. Adam Ladd, no longer merely the amused patron Rebecca called Mr. Aladdin, makes clear that his attachment has become adult love. Rebecca recognizes her own love for him, though the conclusion looks toward their shared future rather than dwelling on a completed marriage. The imaginative child from Sunnybrook has become a capable young woman without losing the generosity and creative energy that first unsettled Riverboro.",
         "in_short": "Because widowed Aurelia Randall cannot support all seven children at Sunnybrook Farm, young Rebecca is sent to her aunts Miranda and Jane Sawyer in Riverboro. Stern Miranda expected practical Hannah and finds Rebecca's talk, imagination, and impulsive charity exasperating; gentler Jane responds with affection. Rebecca flourishes at school, becomes inseparable from Emma Jane Perkins, helps poorer neighbors, and forms a lasting friendship with wealthy Adam Ladd, whom she thinks of as Mr. Aladdin. As she matures, stronger schooling and public successes reveal her gifts, while repeated returns to Sunnybrook keep her mindful of family need. Miranda gradually values the niece she has disciplined, though affection is seldom expressed directly. After Miranda's death, Rebecca inherits greater responsibility and security. Adam declares his love, Rebecca understands that she returns it, and the story closes with her poised between duty to her family and a hopeful adult future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3365,7 +3365,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B084Z73GZR",
@@ -3377,7 +3377,7 @@
       "recaps": {
         "ending": "The Machine's false-flag spectacle becomes a genuine Confed defeat. Cage's altered commands turn the Imperial missiles against the Home Defense Force and military facilities, Mok's boarding teams free the captured ships, and their crews fight the 405th Battlefleet. Phoenix cripples the enemy dreadnought and survives an atmospheric pursuit with help from the intelligence in Jason's implant, but loses an engine and its slip-space capability. Kellea Colleren defects with nearly her entire task force, and Captain Edgars's human cruisers help force the remaining enemy battleship to retreat. At Mok's concealed mining refuge, Kellea accepts command of the combined resistance fleet. Jason and Mok agree to cooperate despite Jason's unauthorized escalation, while Omega Force departs in a borrowed corvette as Phoenix undergoes extensive repair. The Machine still controls the Confed, wants Scleesz recovered, advances its next phase, and sends synth agents toward Kepri in search of a physical body. Jason's implant, Lucky's conduct, Scleesz's safety, and Earth's allegiance remain unresolved. Earth responds to Edgars's defection by assigning Captain Marcus Webb and the unready Scout Team Obsidian to recover the missing cruiser.",
         "in_short": "Jason Burke follows an illicit fuel trail to forty-two captured Imperial warships that the Machine plans to use in a staged attack on the Confed capital. After a rescued operative betrays him and Lucky survives undercover aboard the fleet, Omega Force learns that real Imperial prisoners and altered missiles will make the deception convincing. Jason, Saditava Mok, and their allies mount a recovery operation, but Jason secretly expands it into a direct strike. The altered volley destroys the Home Defense Force, Imperial crews retake their ships, and Kellea Colleren defects with most of her task force to defeat the 405th Battlefleet and cover the withdrawal. Phoenix survives but is crippled. Kellea takes command at Mok's hidden refuge while Jason remains independent and leaves aboard a borrowed corvette. The Machine retains control, targets Kepri in pursuit of a body, and Earth orders Captain Marcus Webb to recover Captain Edgars's defected cruiser.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3705,7 +3705,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -3718,7 +3718,7 @@
       "recaps": {
         "ending": "Mortan survives: the corrupters contaminating its wards are dead, the wards recover, and the immediate Graymin horde disappears after the Remalon's intervention. Ravenna is dead, Duke Reinhardt remains in charge, and the broader Graymin war continues. Jiran is a Tier 4 Remalon strengthened by six portions of Tier 7 Challenger density, but he has only days to kill another Tier 7 opponent. His predatory mana instincts, the Remalon Syndicate's interest, Madra's condition, Daughter's nature, the Enders warning, and Markhiss's plans all remain unresolved. Shara lives without the soul leak, though she has lost her divination and retains earlier physical damage. Her cure frees Niya from her oath. Olive and Cameron obey an Imperial summons and head to the capital, intending to rejoin their friends later. Mayalyn's community chooses to stay in the Empire under its new alliance. Jiran, Mayalyn, and Niya use the teleportation network to seek Tier 7 beings and possible help for Lenton and Samris. At their forest destination, hundreds kneel and claim prophecy makes Jiran both their savior and enslaver.",
         "in_short": "Jiran survives a second Challenger arena, ascends to Tier 4, reunites with Niya, and learns that ancient records predict the return of the civilization-ending Enders. At Mortan, he joins Mayalyn, Olive, Cameron, Niya, and Duke Reinhardt against a vast Graymin siege, exposes the corrupters poisoning the city's wards, and evolves into a Remalon to escape exhausted willpower. His new power brings a compulsion to claim mana. An immensely powerful Remalon later tests him with forced battles, kills Ravenna, and leaves him Tier 7 density that starts another short Challenger deadline. After Jiran cures Shara's soul leakage by removing her divination, Niya is released from her servitude oath. Olive and Cameron return to the capital, while Jiran, Mayalyn, and Niya leave the Empire to seek a Tier 7 target and pursue cures for their mentors. They arrive among forest people who proclaim Jiran a promised great spirit destined to save and enslave them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4006,7 +4006,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -4021,7 +4021,7 @@
       "recaps": {
         "ending": "Ashlock survives, but only barely and utterly changed. The Dao Storm tears his tree body apart before dissolving into 'Black Rain,' bark fragments that instantly sprout thousands of demonic trees across Red Vine Peak and Darklight City. Reduced to a dying ember, Ashlock is revived when Stella pours her own cultivation energy into his core. Offered a choice by his rebooted system, he permanently merges his human ego into his tree body rather than be reborn as a separate human, losing his discrete star core (his whole trunk now holds his power) and accepting that his human traits will slowly erode. A youthful Senior Lee appears in a vision to explain the wider cosmology and then departs, seemingly for good. Ashlock wakes linked to the new forest, which fuels a week-long regrowth. Stella (now ninth-stage Soulfire) and Diana (eighth-stage) are safe at his side and run the sect's affairs; the oath-bound Redclaw family administers Darklight City; Larry and Maple are drained but presumed alive. Diana delivers Douglas, the sect's first hired builder. Open threads: the Dao Storm's true origin and why it hunted Ashlock; the Celestial Empire's World Tree, now blocked from ascending and a future danger; the eight remaining divine fragments; the looming beast tide; the real Patriarch's eventual reaction; and whether Ashlock's humanity will fade.",
         "in_short": "A man from Earth is reborn as a sentient, immobile demonic tree named Ashlock, rooted at a mountain peak and fed corpses by a fierce young cultivator, Stella Crestfallen. Growing through a private reward system, he survives assassins, a rival house's war, and a lightning tribulation, gathering companions: the squirrel Maple, the spider Larry, and eventually Diana Ravenborne, a homeless enemy heir turned ally. He forms a soul core, is revealed to possibly be a nascent 'World Tree,' and founds the Ashfallen sect. A mysterious elder, Senior Lee, gives him a divine fragment that rockets him to the Star Core realm and demi-divine status. After repelling a massive siege and subjugating the Redclaw family, Ashlock faces a sentient Dao Storm that destroys his body. He survives by permanently merging his human mind with the tree, learns the Nine Realms cosmology from Senior Lee, and, regrowing amid a new forest, resolves to surpass the Patriarch, endure the coming beast tide, and one day face the empire's World Tree.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/reborn-as-a-demonic-tree-2.json
+++ b/data/works-community/0/reborn-as-a-demonic-tree-2.json
@@ -340,7 +340,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -355,7 +355,7 @@
       "recaps": {
         "ending": "Dante Voidmind's attempt to seize Darklight City collapses after Ashfallen turns the tournament arena into a prepared battlefield. Theron and Kassandra Skyrend are dead, as are the summoned Voidmind elders Lillian and Elias. The shattered Void Crystal takes Elder Lucian and one of Dante's hands. Dante sacrifices his remaining arm to survive Demetrios Skyrend's attack and escapes toward Slymere, with Demetrios in pursuit. Magnus Redclaw and Sebastian Silverspire sustain the false account that Voidmind killed the Skyrend siblings, leaving a wider family conflict likely. Stella returns to Red Vine Peak after placing second as Roselyn and killing Kassandra, an act that troubles her. Diana Ravenborne serves as Ashlock's direct representative, while Elaine Voidmind stays with Ashfallen and Douglas Terraforge instead of returning to her family. Kane Azurecrest is allowed to remain at White Stone Palace pending a decision on his request for protection. Roderick Terraforge remains alive in Titus's custody. Ashlock retains several enemy corpses and plans to expand recruitment, develop the alchemy operation, and train further before an unspecified Patriarch emerges from seclusion.",
         "in_short": "After the Dao Storm, Ashlock rebuilds Ashfallen beneath Red Vine Peak, extends his demonic-tree network across Darklight City, and develops an alchemy enterprise with Redclaw and Silverspire support. A Voidmind elder discovers him but is defeated, while the elder's niece Elaine eventually joins Ashfallen. The sect survives a Star Core worm, gains strength in the Mystic Realm, and prepares Stella Crestfallen for an alchemy tournament under the alias Roselyn. Dante Voidmind turns the tournament into an invasion. Ashlock kills Theron Skyrend, Stella kills Kassandra Skyrend, Larry kills Elder Lillian, Maple consumes Elder Elias, and the Void Crystal removes Elder Lucian while maiming Dante. Magnus Redclaw and Sebastian Silverspire blame the Skyrend deaths on Voidmind, sending Demetrios Skyrend after Dante. Ashfallen ends stronger, with Roderick Terraforge imprisoned, Kane Azurecrest provisionally sheltered, and White Stone Palace designated as a public recruitment and alchemy center.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -801,7 +801,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -816,7 +816,7 @@
       "recaps": {
         "ending": "Ashlock survives the assault on Red Vine Peak, injured but advanced to ninth-stage Star Core. Diana destroys Knox's human body, and Ashlock remakes her surviving infant soul as a black-leaved, nascent-soul-level guardian tree overlooking Ashfallen City. He also discovers that fluid from his black vines can consume the cursed sap. Knox's remains provide the resources to begin a chaos nebula, the first step in Ashlock's alternative inner-world ascent. Completing it requires 10,000 sacrificial credits and Star Cores of five elemental affinities. Elaine refuses Dante's appeal to family loyalty, and Stella cuts his throat despite his warning that his death will bring war within a month. Maple feeds Dante into Ashlock as his body begins a supernova. Ashfallen City is functioning under Redclaw protection, but the Voidmind-Skyrend conflict is urgent. Nox and Stella's Pavilion bounty remain unresolved, and Douglas, Willow, Chaos, and the new Geb are still fighting to rescue the Mudcloaks' home realm.",
         "in_short": "Ashlock turns fallen enemies into Ents, expands Ashfallen's alchemy and trading operations, and survives a merchant betrayal that leaves Nox at large and Stella under an Eternal Pursuit Pavilion bounty. A Mystic Realm expedition gives Ashlock the mobile Skyborne Bastions, transforms Elaine and Diana's cultivation, and strengthens Kaida. Ashfallen rescues roughly 100,000 people from a storm over Slymere and builds Ashfallen City for them, while Douglas and the Mudcloaks begin reclaiming their home realm. Knox's hidden ascension causes the storm, and she later frees Dante Voidmind and attacks Red Vine Peak. Diana destroys Knox's body, but Ashlock preserves her soul as a guardian tree. Stella kills Dante after Elaine rejects him. Ashlock reaches ninth-stage Star Core and begins forming an inner world, while Dante's death leaves a Voidmind-Skyrend war imminent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1338,7 +1338,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1353,7 +1353,7 @@
       "recaps": {
         "ending": "Ashfallen wins the Lunarshade war. Albus and Dorian are dead, the immediate Lunarshade bloodline is eliminated, and Tiberius orders the Eternal Pursuit Pavilion to treat Ashfallen cautiously and seek Stella as its contact. The cost is substantial: Chaos and Zeus are destroyed, Titus and Geb are badly damaged, Larry and Kaida are depleted, and Willow survives only through Ashlock's preserved soul shard. Willow is later restored as a Skyborne Bastion. Ashlock absorbs the remaining elemental Star Cores and passes the 10,000-credit threshold, then recovers before beginning his seven-day inner-world ascension. Stella, Diana, Elaine, Douglas, Larry, Kaida, the Redclaw family, Evelyn, Quill, Jasmine, and the city network remain aligned with him. Contact with a likely World Tree root suggests that the World Tree is in severe pain, but does not confirm Stella's claimed parentage or the cause. Nox begins a Bastion tribulation as Ashlock's ascension starts, and Vincent Nightrose is already approaching. The future beast tide, the World Tree's condition, Jasmine's path, and Ashfallen's expansion remain unresolved.",
         "in_short": "Ashlock expands his hidden root network, strengthens his summons, and builds Ashfallen into a wider military, commercial, and civic power while Stella trains Jasmine and investigates claims about her parents. A Nightshade City pill venture becomes a Lunarshade ambush when Seth is exposed as Albus Lunarshade. Ashlock answers with open war. Ashfallen's allies destroy Albus and the Lunarshade elders, then overcome Grand Elder Dorian after he ruins several Ents and Willow's Bastion. The victory gives Ashlock the sacrifices and elemental Star Cores required for Nascent Soul. After recovering, he reaches a likely root of the World Tree and learns only that it appears to be suffering. Willow is restored, Nox receives a new Bastion, and Ashlock begins his seven-day ascension as Vincent Nightrose moves to stop him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/reborn-as-a-demonic-tree-5-an-isekai-litrpg-adventure.json
+++ b/data/works-community/0/reborn-as-a-demonic-tree-5-an-isekai-litrpg-adventure.json
@@ -400,7 +400,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -415,7 +415,7 @@
       "recaps": {
         "ending": "Serena loses the execution match to Celeste, but deliberately removes Jasmine from danger before her own shield breaks. Ashlock then transforms Serena into a sacred tree rather than ending her existence. She retains her soul and Abyssal Tide affinity, reaches Star Core during her activation, and becomes the flying bastion and designated protector of Ashfallen City. Stella remains a seventh-stage Star Core Ether cultivator under concealment, with the Azure clan aware of her identity and the fate of the Ether Origin Stone unresolved. Nox controls Tartarus and its Shadow Key Law, while Hades recovers there. Ashlock holds fourth-stage Nascent Soul cultivation, a growing inner world, and a worship-driven network that now extends through the public All-Seeing Eye. Diana, Elaine, Douglas, Larry, Evelyn, Jasmine, Sam, and the Redclaw allies remain with Ashfallen. The next emergency is already arriving: failed spiritual springs have driven an early beast tide south, and Vincent's summit may split the Blood Lotus sect over whether to flee. Stella's father, the Celestial Order, the suffering World Tree, Morrigan's proposed struggle against the recurring cycle, and the Azure clan all remain unresolved.",
         "in_short": "Ashlock completes his Nascent Soul ascent, develops an inner world powered by worship, and expands Ashfallen through the All-Seeing Eye and a mass Mystic Realm expedition. Valandor secretly helps conceal Stella from Vincent, while Stella learns her father may be alive and that the Celestial Order is hunting her. Morrigan reveals herself as the Origin of Void and describes a recurring cycle binding the origins to the World Tree. In the Mystic Realm, Nox claims Tartarus and Shadow Key Law, while Stella infiltrates the Azure clan, gains Ether affinity, loses the repaired Origin Stone, and exposes her identity. Ashfallen returns stronger and stages a recruitment tournament. Serena Blacktide kills Old Bill, attacks Sam, and plants an egg that drains the trading company's vault. After Celeste defeats her in a public judgment match, Serena is transformed into a Star Core sacred tree and Ashfallen City's Abyssal Tide bastion. The volume closes with an early beast tide approaching and Vincent's sect near division over evacuation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -786,7 +786,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -801,7 +801,7 @@
       "recaps": {
         "ending": "Ashfallen contains the blood-puppet horde with Redclaw fighters, Stella, Diana, cult power, defensive bastions, and the Mudcloaks. In the battle above Red Vine Peak, Ashlock drains Vincent's key and life force but cannot initially overcome his regeneration. Ashlock then permits Vincent to wound his trunk, forcing Maple to act under their mutual-protection pact. Maple removes one of Vincent's spiritual hearts, Ashlock locks down the remaining heartbeat, and Bob draws another attack while disguised as Stella. The real Stella strikes from concealment and cuts Vincent's soul apart with her ether-key sword. Ashlock consumes Vincent's remains, while Vincent's residual spirit enters the renamed Sword of New Beginnings. Larry completes his evolution too late to join the fight. Ashlock, Stella, Diana, Morrigan, Elaine, Douglas, Nox's divided selves, and their surviving allies remain with Ashfallen. Valandor's weakened soul remains inside Stella, Sullivan has lost his cultivation but is still owed freedom and wealth, and Nox's wraith form remains hungry and unstable. The Beast Tide and its unnatural storm are still approaching, leaving Ashfallen to prepare for the next war.",
         "in_short": "Ashlock chooses to hold Ashfallen against an unnatural storm and Beast Tide while moving against Vincent Nightrose, a bloodline harvester seeking Stella. An assassination and a summit confrontation fail because Vincent survives through blood clones, illusions, and replacement bodies. He takes Valandor's body, infiltrates Ashfallen's territory, and spreads blood pills that turn vast numbers of civilians into controlled, explosive soldiers. Ashlock adopts Desolation Key to resist the storm and sever Vincent's blood links, while Stella and Morrigan deceive Vincent and investigate his network. When the Night of Reckoning begins, Ashfallen's allies and Mudcloaks contain the puppet horde as Ashlock's bastions battle Vincent. Ashlock invokes his pact with Maple by allowing Vincent to wound him. Maple removes one of Vincent's spiritual hearts, Bob serves as a false Stella, and the concealed Stella destroys Vincent's soul with her ether-key sword. Vincent dies, but his spirit enters the Sword of New Beginnings. Larry completes his evolution, and the still-advancing Beast Tide becomes Ashfallen's immediate threat.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -951,7 +951,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -964,7 +964,7 @@
       "recaps": {
         "ending": "Years after the school-busing protests, Twyla meets Roberta in a diner near Christmas. Roberta tries to settle their conflicting accounts of Maggie. She withdraws her earlier certainty that Maggie was Black and admits that neither girl actually joined the older girls in kicking her. What remains, however, is Roberta's belief that they wanted to hurt Maggie and that their refusal to help carried its own guilt. She associates the powerless kitchen worker with her own sick mother, while Twyla recognizes a parallel with Mary. Roberta becomes tearful because she still cannot know Maggie's fate. The women part without resolving the factual uncertainty, leaving the childhood incident as a shared moral wound shaped by fear, prejudice, resentment, and unreliable memory.",
         "in_short": "Twyla and Roberta meet at eight in St. Bonny's shelter, where each has a living mother unable to care for her. The girls are of different races, but the narrative never identifies which is Black and which is white. They become companions and witness Maggie, a mute kitchen worker, fall near older girls in an orchard. Across four later meetings, their circumstances diverge: Roberta first snubs Twyla, later greets her warmly as a wealthy wife, and then opposes her during a bitter dispute over school busing. Their memories of Maggie also change. Roberta claims Maggie was Black and that they helped attack her, then finally admits neither claim is certain: the older girls hurt Maggie while she and Twyla watched and secretly wanted to join in. The story closes with both women burdened by the unanswered question of what became of Maggie and by what their conflicting memories reveal about themselves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1184,7 +1184,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CTWKVSHM",
@@ -1196,7 +1196,7 @@
       "recaps": {
         "ending": "Kazimir, Mike, Isabel, Gisele, Duke, Boots, and Azib survive the Nether expedition and return to their original Earth anchor ten days after leaving. Marduk is dead, and Duke lives because Macarius accepted the residual God Spark and sacrificed himself during the escape. Kevin, the ogre who helped the group reach the portal, is hidden with them on Earth until a safe return can be arranged. Azib remains bound to his amulet and only conditionally trusted, while Kazimir's obligation to help Boots's displaced people remains open. The failed attack on the mooring establishes that magical force cannot prevent convergence. Kazimir refuses to use the uncontrolled time displacement to undo personal losses and turns instead toward discovering how Merlin dealt with the crisis in 536. The Order still has a wizard, has traced the organization through an old shell company, and has compromised its safe-house preparations. Annie is captured during a vehicle change, leaving the surviving field team free but exposed and the organization without its leader.",
         "in_short": "Kazimir and his allies go to France seeking a way to prevent convergence. A supposed Order archive proves to be a trap, but hidden writing in the organization's surviving books leads them to permanent magical moorings concentrating power in Europe. Unable to break a mooring from Earth, they enter the Nether, where Marduk uses Duke to regain a body and pursue his own freedom. The group kills Marduk and restores Duke, but the divine spark sustaining the dog becomes fatal. Macarius takes it and dies holding back their pursuers. The survivors are displaced to German-occupied France in 1941 before returning to their own time with Kevin, an ogre they must conceal. Kazimir rejects controlled time travel and concludes that Merlin's non-forceful method is the best remaining lead. Meanwhile, the Order compromises the safe-house network and abducts Annie.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1353,7 +1353,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1366,7 +1366,7 @@
       "recaps": {
         "ending": "Sawyer's death aboard the Oxomoco is the pivot the other threads turn on. Because no family claims him, the Fleet does: Eyas conducts his funeral, and the community turns out in numbers for a man almost none of them knew alive. Eyas carries the lesson forward, arguing for and beginning a deliberate way of receiving people who come to the Fleet from outside - somewhere for them to go and someone whose actual job is teaching them how the ships work - so that arrival stops depending on the assumption that family will absorb everyone. Kip, drifting until now, takes an apprenticeship in the archives with Isabel and finds work he genuinely wants. Isabel's hosting ends with Ghuh'loloan's departure and a final piece of writing that sends Exodan life outward to readers who had never considered it; she and Tamsin carry on together, older, with the archives in better hands than they had feared. Tessa, with her cargo bay's purpose gone and her daughter still frightened of the hull, decides that her family's future is planetside and starts making it happen. Nothing external is fixed: the Fleet is still poor, still ageing, still losing people to easier lives elsewhere. What changes is that the people in it choose it deliberately, and choose to make room for the next person who turns up with nothing.",
         "in_short": "Set entirely in the Exodan Fleet - the generation ships that carried humanity off a ruined Earth and now hold orbit in a system of their own - the book follows several residents over a few months. Isabel, an archivist, hosts a Harmagian scholar studying Exodan life and finds herself explaining a society she has never had to defend. Tessa sorts salvage in a cargo bay while her husband works off-fleet, and watches her job lose its purpose and her daughter grow terrified of the hull. Kip, sixteen and impatient, wants to be anywhere but here. Eyas, a caretaker who composts the dead into the soil that feeds the Fleet, is respected as a function and avoided as a person. Sawyer, born planetside to Exodan descendants, arrives hoping to belong and finds no place waiting for him; short of options, he joins an unlicensed crew stripping the derelict Oxomoco and is killed there. The Fleet, which never took him in alive, buries him as one of its own, and his death pushes the others to act: Eyas builds a way to receive newcomers, Kip finds work in the archives, and Tessa accepts that her family's future is planetside.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1511,7 +1511,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1524,7 +1524,7 @@
       "recaps": {
         "ending": "Believed dead after a fire at his house is taken for his suicide, Francis Dolarhyde has in fact killed another man, left the body to be mistaken for his own, and slipped away. His obsession has curdled: convinced that Reba, the blind woman who briefly reached the human part of him, has betrayed him, and driven by the Dragon he believes he is becoming, he travels to the Florida home of Will Graham, whose address Hannibal Lecter had passed to him in code. He breaks in and attacks, slashing Graham's face savagely with a knife and nearly killing him. In the struggle Graham's wife, Molly, gets hold of Dolarhyde's gun and shoots him dead, ending the threat. The family survives, but Graham is left disfigured and deeply traumatized, his fragile peace destroyed once again by the work he had tried to leave behind. Lecter remains locked away, having engineered the attack from his cell and lost nothing. Graham goes home to heal, wounded in body and spirit, knowing at what price the case was closed.",
         "in_short": "Retired FBI investigator Will Graham, who catches killers by imagining his way into their minds, is pulled back into service by Jack Crawford to hunt a murderer who wipes out whole families at the full moon, nicknamed the Tooth Fairy. To sharpen his thinking, Graham reluctantly consults the imprisoned Hannibal Lecter, the cannibal he once caught at nearly fatal cost. The killer is Francis Dolarhyde, a scarred, abused loner who believes he is transforming into a being called the Red Dragon. Lecter secretly makes contact with Dolarhyde through coded newspaper messages and eventually passes him Graham's home address. Dolarhyde's fragile humanity is stirred by Reba, a blind coworker, but his delusion wins out. He murders a tabloid reporter the investigators had used as bait, then stages his own death in a fire. Believing him dead, Graham lets his guard down, and Dolarhyde attacks Graham's family in Florida. Graham is badly slashed, but his wife Molly shoots and kills the intruder. The family survives, scarred and shaken.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1701,7 +1701,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1714,7 +1714,7 @@
       "recaps": {
         "ending": "The Op's campaign leaves Personville's criminal coalition destroyed, but the result is not a clean triumph. Dinah Brand is murdered after the Op spends a drunken night with her, and he wakes beside her body unable at first to be sure he did not kill her. He continues pushing the surviving factions into a final confrontation in which Reno Starkey, Max Thaler, and their remaining associates settle their rivalries with gunfire. The Op obtains the evidence and admissions needed to account for the last killings while the principal gang leaders are killed or exposed. Elihu Willsson, now deprived of the criminals who had escaped his control, accepts a thorough civic cleanup backed by the Continental agency and outside authority. The agency's chief arrives to supervise that work. The Op leaves Personville after succeeding in his assignment, disturbed by how readily he adopted the city's violence and by the deaths his manipulation helped produce.",
         "in_short": "A Continental Detective Agency operative arrives in Personville, a mining town so corrupt that residents call it Poisonville, only to find his prospective client Donald Willsson murdered. Donald's father Elihu had once invited criminals into town to crush a strike and then lost control to police chief Noonan and gang bosses Max Thaler, Pete the Finn, and Lew Yard. Hired to clean up the result, the Op solves Donald's domestic murder but stays to dismantle the wider system. With information from Dinah Brand, he feeds suspicions to every faction, revives old crimes, and encourages raids and betrayals until the gangs begin eliminating one another. The strategy makes him increasingly reckless. After a drinking binge he wakes beside Dinah's stabbed body and fears he may be responsible, but presses on. The surviving bosses and gunmen finally destroy one another, leaving Elihu able to submit to an agency-supervised reform of the city. The Op departs successful but morally shaken by the bloodshed he engineered.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1881,7 +1881,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1894,7 +1894,7 @@
       "recaps": {
         "ending": "Darrow wins the Institute's year-long war game, but at great cost. His closest friend, Cassius au Bellona, is manipulated into discovering that Darrow killed his brother Julian during the entrance ritual, and Cassius nearly kills Darrow in a duel before Darrow claws his way back to the fight. Darrow also defeats the sadistic rival known as the Jackal, who is revealed to be Adrius au Augustus, son of ArchGovernor Nero au Augustus and brother of Mustang, whose real name is Virginia au Augustus. Named the top graduate, Darrow is taken into ArchGovernor Augustus's service as a lancer. This is precisely the foothold the Sons of Ares sought: a Red disguised as a Gold, placed among the most powerful rulers of the Society, poised to climb toward its center and tear it down from within. Darrow's growing bond with Mustang is now shadowed by the knowledge that her family are the very people he has sworn to destroy, and that his whole existence rests on a lie he must never let slip.",
         "in_short": "Darrow is a Red, the lowest caste in a color-coded interplanetary society, mining beneath Mars in the belief that his people are preparing the planet for humankind. When his young wife Eo is executed for a small act of defiance and Darrow is hanged for burying her, the rebel Sons of Ares save his life and reveal the truth: Mars was terraformed generations ago, and the Reds are slaves kept in the dark. They surgically remake Darrow into a Gold, a member of the ruling elite, and send him to infiltrate the Institute, the brutal academy where young Golds compete in a year-long war game that decides their futures. Passing as one of them, Darrow rises to lead House Mars, gathering fierce allies like Sevro and the brilliant Mustang, but also making enemies. He wins the contest, survives a vengeful betrayal by his friend Cassius, and outmaneuvers a sadistic rival called the Jackal, revealed to be the son of the ArchGovernor of Mars. Claimed as a prize apprentice by that same ArchGovernor, Darrow secures exactly the position the rebellion wanted: a hidden enemy planted at the heart of Gold power.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2079,7 +2079,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2092,7 +2092,7 @@
       "recaps": {
         "ending": "Jaffrim Rodanov's Dread Sovereign runs down the Poison Orchid and the two crews fight it out hand to hand. Drakasha's people win, and Ezri Delmastro dies in the boarding, which takes from Jean the one thing he had found for himself since Camorr. In Tal Verrar the Archon's manufactured crisis destroys him: the piracy he ordered arrives on terms he cannot steer, Requin and the merchant council move against him while he is exposed, and Locke and Jean get to Stragos face to face. He gives them nothing. The doses he had been handing out were a leash rather than a cure, no antidote exists to be extracted from him, and the two of them walk out of his palace still carrying the poison and no closer to knowing how long it leaves them. The Sinspire keeps its vault: the two-year game against Requin ends in a working understanding rather than the theft it was built for, and the money Locke came to Tal Verrar for stays where it was. Zamira Drakasha sails the Poison Orchid back to the Ghostwind Isles with her children and her crew. Locke and Jean take ship out of Tal Verrar with very little left, looking for anyone - physiker, alchemist or worse - who can undo what the Archon did to them, and with the Bondsmagi of Karthain still carrying an unsettled account for what happened in Camorr.",
         "in_short": "Two years after Camorr, Locke Lamora and Jean Tannen are deep into a long confidence game in Tal Verrar, aimed at the vault of the Sinspire, the gambling tower run by the untouchable Requin. The city's military ruler, Archon Maxilan Stragos, seizes them, poisons them both, and forces them to sea to manufacture a pirate threat that will make Tal Verrar fund his navy. Neither can sail; their ship is lost and they are captured by Captain Zamira Drakasha of the Poison Orchid, whose crew they join and whose first mate, Ezri Delmastro, falls in love with Jean. Locke persuades the free captains to stage the raids the Archon wants, then returns to Tal Verrar and sells the Archon's secret to Requin instead of robbing him. A rival pirate captain, unwilling to risk the islands, attacks the Orchid, and Ezri is killed. The Archon's scheme collapses and he is broken, but he yields no antidote. Locke and Jean leave the city grieving, nearly penniless, and still poisoned.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2278,7 +2278,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2291,7 +2291,7 @@
       "recaps": {
         "ending": "Richards's campaign leaks Alex and Henry's private correspondence, outing them and turning their relationship into an international scandal. After an initial separation, Henry chooses to stand beside Alex. Public support, including crowds gathered outside Buckingham Palace, makes it harder for the Crown to erase them. Nora and the campaign uncover evidence connecting the theft and leak to Richards's operation, while Luna explains that his apparent defection was an attempt to expose Richards from within. Queen Mary permits Henry to pursue the relationship, even if she does not embrace it. On election night Ellen Claremont wins a second term after a close contest, with Alex's home state of Texas helping secure the victory. Alex and Henry leave the celebration for Alex's childhood home in Austin, able to imagine a shared future openly rather than through secret visits and messages.",
         "in_short": "After Alex Claremont-Diaz, the American president's son, causes a public scene with Britain's Prince Henry, their governments order them to stage a friendship. The performance becomes genuine, and Henry's unexpected kiss forces Alex to reconsider both his hostility and his sexuality. They begin a secret transatlantic relationship while President Ellen Claremont campaigns for reelection and Henry remains constrained by the monarchy. Alex falls in love, but Henry retreats because he believes a public future is impossible. Alex confronts him, and they decide to try. Their private emails are then stolen and leaked, outing them during the campaign. They face the scandal together as supporters rally and evidence links the breach to Republican challenger Jeffrey Richards. Henry gains room to live openly, Ellen wins reelection in a close race that includes Texas, and Alex and Henry end the night at Alex's childhood home, committed to building a future together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2388,7 +2388,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2401,7 +2401,7 @@
       "recaps": {
         "ending": "Quilan is exposed: he has been working with the Superiority throughout, and the help he offered Alanik was a means of tracking the independence faction and of delivering ReDawn's cytonics into Superiority hands. The occupation escalates into an open attack, and with the population of an entire tree city at risk and no way to evacuate it by ship, Alanik, Jorgen and the taynix do something nobody has attempted: they hyperjump the tree itself out of danger. ReDawn is not liberated, and the faction that wants Superiority membership is not finished, but the surrender is stopped, the resistance survives with Rinakin's cause intact, and the argument that the Superiority protects rather than owns its members is much harder for anyone on ReDawn to make. What Alanik went looking for she finally gets: an alliance between the UrDail resistance and the humans of Detritus, made by people who fought beside each other rather than by governments. Alanik and Jorgen come out of it able to work cytonically as a pair, which will matter more than either of them yet realizes. Both worlds now face the same enemy, and both know that Winzik will not accept the result.",
         "in_short": "Able to hyperjump at last, Alanik returns to her homeworld of ReDawn, where the UrDail live in cities grown into enormous floating trees, and finds her people on the point of accepting Superiority membership. Rinakin, the leader of the faction opposing it, has been taken, the resistance is scattered, and Alanik cannot get anyone in authority to listen. Her old acquaintance Quilan offers to help. Out of options at home, she goes back to Detritus and persuades Jorgen to bring Skyward Flight to ReDawn, and human pilots end up fighting over an alien world. Quilan turns out to have been working for the Superiority all along, and the occupation of ReDawn becomes open. With an entire tree city about to be destroyed and no way to evacuate it, Alanik, Jorgen and their taynix hyperjump the tree itself to safety. ReDawn is not free, but the surrender is stopped, and the UrDail resistance and the humans leave the fight as allies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2634,7 +2634,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B01604HEY4",
@@ -2646,7 +2646,7 @@
       "recaps": {
         "ending": "Annada is restored to Avaris, but the plot against her is only partly explained. Jason and the Sovereign draw Defiant away from the planet, Kage disables it through his covert access, and Avarian forces seize the battlecruiser. Kellea is found in its brig and cleared of involvement. Vulem is returned to his own world for a public trial, while Crisstof is tried and executed by the Empire. Kalette dies stopping a bomber from reaching Annada, and the relatives Vulem used to coerce her remain missing. The Sovereign admits that Imperial intelligence knows more but does not identify the original architect. ConFed representatives are released with a warning, and Kellea takes Defiant home under Imperial escort, with her future command uncertain. Jason and Kellea remain apart. Jason, Lucky, Doc, Crusher, Twingo, and Kage choose to stay aboard Phoenix and restore Omega Force. Jason still owes Saditava Mok an unspecified favor, and the wider conspiracy remains open.",
         "in_short": "Jason Burke has retreated into cargo hauling with Lucky after Omega Force collapsed, but the discovery of Kalette aboard his ship draws him into the search for the abducted Avarian heir. He regathers Doc, Twingo, Kage, and eventually Crusher, restores Phoenix, and follows the kidnappers to Vyrt. The crew rescues the heir, who reveals her name as Annada, then uncovers two overlapping plots: Chancellor Vulem coerced Kalette into moving Annada out of the capital, while Crisstof Dalton helped turn the abduction into an attempt to destabilize the Empire. Phoenix returns Annada to Avaris and helps capture Defiant. Kellea is cleared, Vulem is sent for trial, and Crisstof is executed. Kalette dies protecting Annada from a final bomber. Although the instigator behind the conspiracy remains unknown, Jason and his reunited crew decide to resume Omega Force.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2796,7 +2796,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2809,7 +2809,7 @@
       "recaps": {
         "ending": "Dahl's group reaches the twenty-first century and confronts the people making the television series whose careless plots govern life on the Intrepid. Once the creators accept that their fiction has real victims, they cooperate on an episode that can send the visitors home and change the lethal pattern. The trip also gives a gravely injured young man connected to the production access to the Intrepid's medicine, allowing him to return to his own time alive. Back in the future, the crew begins moving beyond the Narrative's automatic demand for disposable deaths, and Jenkins is offered a life outside the hidden spaces where grief confined him. The three codas follow consequences in the creators' world: a writer accepts moral responsibility for imagined people, a performer reconsiders a life that had stalled, and an actress whose image represented Jenkins's late wife makes contact with him. The last connection gives Jenkins a possible human future without pretending his wife has been restored.",
         "in_short": "Newly assigned ensign Andrew Dahl discovers that service on the Universal Union flagship Intrepid is especially deadly for anonymous junior crew whenever the command officers arrive. With Maia Duvall, Jimmy Hanson, Hester, and Finn, he traces impossible science, sudden changes in behavior, and unequal casualty rates to a force Jenkins calls the Narrative. Their reality is being shaped by a poorly written twenty-first-century television series, and minor personnel die whenever an episode needs drama. After the pattern claims one of their group, the survivors use the ship's time-traveling anomaly to confront the show's creators. The stunned production team helps write a way for them to return and break the automatic cycle, while future medicine saves an injured person from the creators' world. The Intrepid's redshirts gain a chance to live as people rather than plot devices. Three codas show the encounter changing a writer, an actor, and a woman whose role unexpectedly connects her with the grieving Jenkins.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3032,7 +3032,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3045,7 +3045,7 @@
       "recaps": {
         "ending": "Matthias returns with the sword and with allies gathered on his journey, and Redwall's defenders retake the Abbey. Matthias hunts Cluny through the building and up into the belfry, where he cuts through the ropes holding the great bell so that it falls and kills the warlord. Leaderless, the horde breaks and scatters into the woods. The victory is costly: old Abbot Mortimer does not survive the fighting, and before he dies he names Matthias the Warrior of Redwall and asks that the Abbey stay what it has always been, a place that heals rather than conquers. Methuselah is already dead, killed by the young fox Chickenhound, who robbed the gatehouse and fled south. Martin's sword is hung in Great Hall where any creature can see it, and Matthias takes on the duty that goes with it. Warbeak becomes queen of the sparrows in the roof and keeps her friendship with the Abbey. Matthias and Cornflower marry, and the closing pages look ahead to the seasons of peace that follow and to their son, Mattimeo, who will grow up in an Abbey that now has a warrior as well as an abbot.",
         "in_short": "Redwall Abbey, a peaceable house of mice and woodlanders in Mossflower Wood, is threatened when the rat warlord Cluny the Scourge and his horde seize the ruined church nearby and decide the Abbey will be their fortress. Matthias, a clumsy young novice who idolizes the Abbey's founder, Martin the Warrior, becomes convinced that Redwall can only be saved by recovering Martin's lost sword. Guided by riddles the ancient recorder Methuselah unpicks, he is captured by the sparrow tribe in the Abbey roof, escapes with the young sparrow Warbeak, and follows the sword's trail across Mossflower, gathering a hare, a squirrel, a tribe of shrews and the sparrows as allies, and finally killing the adder Asmodeus in his lair to take the weapon back. Meanwhile Constance the badger holds the walls through siege, tunnelling and treachery until Cluny at last gets inside. Matthias returns, and in the belfry he brings the Abbey's great bell down on Cluny. The Abbot dies of his wounds after naming Matthias the Warrior of Redwall.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3238,7 +3238,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3251,7 +3251,7 @@
       "recaps": {
         "ending": "At the National Hospital, Rivers observes Lewis Yealland use painful electrical shocks and absolute commands to force the mute soldier Callan to speak. The apparent success clarifies how different Rivers's own practice is, while also making him confront the coercion hidden in every military cure. Back at Craiglockhart, the medical board reviews the patients. Prior is judged unfit for general service and restricted to home duty, a result that leaves him divided between relief, shame, and his bond with Sarah. Sassoon, despite retaining his belief that the war is wrong, chooses to return to France out of loyalty to the soldiers still fighting. Rivers records him as fit for duty and watches him leave, aware that their treatment has restored a man to the danger that caused his illness. Sassoon's protest has not been disproved; personal attachment and military obligation have overridden it. The novel closes with Rivers facing his own complicity in that outcome.",
         "in_short": "In 1917, the army sends poet and officer Siegfried Sassoon to Craiglockhart hospital after he publicly condemns the continuation of the war. Psychiatrist William Rivers is expected to cure him and return him to duty, though Sassoon's position is political rather than delusional. Rivers also treats traumatized officers including mute, confrontational Billy Prior and severely nauseated David Burns. Sassoon mentors Wilfred Owen, while Prior begins a relationship with munitions worker Sarah Lumb. As Rivers listens to the men's memories, he develops symptoms of strain and questions a system that defines recovery as renewed fitness for combat. A visit to Lewis Yealland's punitive electrical treatment of a mute soldier exposes the coercive extreme of military psychiatry. Prior is limited to home service, but Sassoon decides that loyalty to soldiers at the front requires his return. Rivers declares him fit and watches him leave, troubled that humane treatment still serves the machinery of war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3583,7 +3583,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07FKYC3LD",
@@ -3595,7 +3595,7 @@
       "recaps": {
         "ending": "Ardania survives the main wolfman assault. The human king kills the invading warlord, but apparent human conspirators detonate a blast around him after the victory. Joe survives with severe injuries, finds the king's remaining foot, and resurrects him. The restored king places Joe under crown protection, while Joe receives a noble title, land, and rewards as the leading contributor to the war. Humanity is told that its struggle so far was only a tutorial and that two additional races will make contact in one month. Joe remains the owner and sole living architect-specialist of Pathfinder's Hall, an Arcanologist with conditional royal permission to retain his shadow abilities. Tatum and Lady Spriggan have secure places in the hall's pantheon, and the Wanderers emerge from the war as a kingdom-serving guild. Joe later hunts down and kills the silence mage who enabled his battlefield death. The system identifies the mage as a racial traitor and pardons Joe, but the wider conspiracy behind the attempted regicide remains unresolved. Headshot and the surviving Hardcores also remain an open threat, while Joe's ritual program and his mother's merchant training continue.",
         "in_short": "Joe develops magical writing, recruits a party, and helps the Wanderers claim a settlement after a mine quest transforms it into an instant dungeon. The party eventually clears the dungeon, and Joe recovers plans for Pathfinder's Hall, a suppressed artifact that reveals class advancement paths. After briefly leaving the guild over Daisy's coercion, he returns under an autonomous contract and leads the hall's construction with Terra and Tim. Joe becomes its owner and only living architect-specialist, establishes shrines for Tatum and Lady Spriggan, and retrieves a manual for converting spells into rituals from the prison dungeon. His new shadow class receives conditional royal approval. During the wolfman invasion, Joe's mass enchantment helps defend Ardania. The king kills the wolfman warlord, then apparent human conspirators blow him apart. Joe resurrects the king and gains crown protection, land, nobility, and top-war-contributor rewards. Humanity learns that two more races will arrive in one month. Joe kills the silence mage who betrayed the defense, but the larger regicide conspiracy remains open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/reign-of-madness.json
+++ b/data/works-community/0/reign-of-madness.json
@@ -277,7 +277,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-19",
@@ -290,7 +290,7 @@
       "recaps": {
         "ending": "Rezkin wins both the melee and fifth-tier tournament as Dark Tidings. When seven strikers attempt to arrest him, two wait to examine King Bordran's certificate and ultimately swear fealty, while the other five die fighting him. Caydean's forces turn the arena lockdown into a wider campaign against foreigners, so Rezkin organizes fighters, companions, and spectators into an escape column. They breach the Duke of Scutton's estate, evacuate surviving captives from its slave prison, and flee through the sea cave. The young swordwoman executes the duke for his crimes and her father's apparent murder. Frisha’s younger cousin is killed while shielding the young swordwoman during the final fight. A former royal-navy commander carries the survivors away on his merchant ship. At sea, Rezkin unmasks before the traveling party and identifies himself as Dark Tidings and the true king. Frisha, Tam, Reaylin, Wesson, Kai, Tieran, Jimson, Drascon, Millens, the aligned strikers, and the other refugees are fugitives pursued by the royal navy. Caydean has targeted their houses and General Marcum has fled. Rezkin's exact royal lineage, Bordran's complete plan, Striker Farson's location, and the fortress order remain unresolved.",
         "in_short": "Rezkin leads Frisha and their companions toward the king's tournament while cultivating noble allies and investigating the authority left to him by King Bordran. Kai, a former striker, identifies Rezkin as the rightful king, and Wesson verifies both his royal certificate and his unusual magic. In Scutton, Rezkin competes secretly as Dark Tidings, builds public support, survives surveillance and poison plots, and discovers the host duke's hidden slave prison. King Caydean's attempt to arrest Dark Tidings expands into mass detention of foreigners. Rezkin wins the tournament, kills five attacking strikers, and leads an armed evacuation through the duke's estate. The duke is executed, surviving captives are rescued, and Frisha's younger cousin dies protecting the young swordwoman. The refugees escape by sea, where Rezkin reveals that he is both Dark Tidings and the true king. Caydean moves against their families and sends the royal navy after them as they seek foreign refuge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -460,7 +460,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -473,7 +473,7 @@
       "recaps": {
         "ending": "The haunting at the school is resolved, and Suze and Jesse are married. Paul does not get what he demanded of her, and the leverage he built the whole approach on stops working once Suze stops handling it alone and lets Jesse and Father Dominic in. What Paul is left holding is his knowledge of what shifters can do, which he still has and still intends to use, so he remains a permanent presence at the edge of their lives rather than a problem that has been closed. Suze finishes the book with the marriage she has been waiting years for, a job at the school where she grew up, and the understanding that being an adult with a career has not stopped the dead coming to her, only changed what it costs her when they do.",
         "in_short": "Suze Simon is in her mid-twenties, working as the guidance counselor at her old school in Carmel and engaged to Jesse, who is alive in the present day and training as a doctor. Two things arrive at once: a student at the school is plainly being tormented by something nobody else can see, and Paul Slater comes back to town. Paul has acquired the old house Suze grew up in, the one where Jesse died, and is entirely willing to destroy it; he offers Suze terms for keeping it, which she does not want and does not tell Jesse about. Handling both alone, as she has always done, makes both worse. The haunting at the school turns dangerous and Suze is drawn fully back into the work she thought she had left behind as a teenager. In the end the case is resolved, Paul does not get what he wanted, and Suze and Jesse are married.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -746,7 +746,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1772308633",
@@ -758,7 +758,7 @@
       "recaps": {
         "ending": "The Flying Dutchman returns to Earth after destroying both Maxolhx investigation cruisers. The planted report and staged wormhole anomalies support the claim that an unstable wormhole caused the disaster, concealing direct human involvement. Bishop, Skippy, Jennifer Simms, Jeremy Smythe, Lauren Poole, Samantha Reed, Katie Frey, Justin Grudzien, Jason Nunnally, and Nagatha survive. Margaret Adams remains on Earth, while Chotek's situation after his detention is not resolved. Frank Muller and Simms are now partners, and Muller agrees to help Bishop improve his practical understanding of physics. The Dutchman has exhausted important supplies, lost ten jump coils, and needs extensive repairs. Bishop expects scrutiny for taking the ship against orders and does not know whether he still has a military future. Earth has no immediate alien threat, but its secrecy is not permanently assured. Planning for a remote human refuge remains preliminary. Skippy is unsettled by the attacking Elder AI, evidence of ancient genocide, and knowledge hidden from his own conscious mind. Two dormant wormholes might provide a route beyond the galaxy, though activating them would eventually create detectable emissions. On reaching Earth, the crew also discovers that Skippy's public follower movement has become visible and that the President wants immediate contact.",
         "in_short": "When two Maxolhx cruisers prepare to investigate the wormhole near Earth, Joe Bishop and a small crew seize the Flying Dutchman rather than accept UNEF's plan to surrender. Their mission requires a Maxolhx dropship, authentication devices called pixies, relay intelligence, and a convincing explanation for the cruisers' disappearance. Raids on a Bosphuraq base and a pixie factory provide the needed equipment. An Elder wreck supplies technology that lets the crew stage future wormhole disturbances and support a false Maxolhx report. Skippy's micro-wormhole ambush destroys one cruiser and cripples the other, which he then destroys through a precisely tuned maser strike. The badly damaged Dutchman returns to Earth with the immediate investigation threat removed. Bishop still faces consequences for mutiny, while evidence of Elder conflict, a dangerous damaged Elder AI, Skippy's concealed knowledge, a possible off-galaxy refuge, and his growing public following leave larger dangers unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -918,7 +918,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -931,7 +931,7 @@
       "recaps": {
         "ending": "The resistance attacks Portland and gets inside, and the fighting reaches the streets Lena and Hana grew up on. Raven is killed in it, which takes from Tack and from Lena the person who had held them together since the Wilds. Hana, who has spent the book discovering what her cure did not remove and what her marriage would make her complicit in, breaks with the life arranged for her and helps Lena when it counts, and Grace is got out. By the end the wall around Portland is being pulled down, the cured city is open, and nobody on either side knows what comes next: the government has not simply been replaced, and the country beyond the fences is not organised enough to replace it. Lena and Alex find their way back to each other, and Julian survives what he chose. The book closes without settling the war, on Lena's conviction that the walls people build to keep out what frightens them are the thing that has to come down, and that the tearing down has only started.",
         "in_short": "Told in alternating narration by Lena and Hana. Lena is in the Wilds with Raven and Tack's group, with Julian beside her and Alex, back from the dead, refusing to acknowledge her and spending his time with a girl called Coral. Hana is in Portland, cured, engaged to Fred Hargrove, the city's new mayor, and unable to shake either her dreams or her guilt: before the raid, she gave the regulators Lena's and Alex's names. The government is bombing Invalid settlements and the resistance is bombing the cured cities. Lena's group reaches the crowded stronghold at Waterbury, which is destroyed from the air, and the survivors head north toward Portland for a coordinated uprising. Hana learns what became of Fred's first wife and what her marriage will require of her. The resistance breaches Portland, Raven is killed in the fighting, Hana turns against Fred and helps Lena, Grace is brought out, and the wall around the city is pulled down. Lena and Alex reconcile, and the ending is left deliberately open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1310,7 +1310,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -1323,7 +1323,7 @@
       "recaps": {
         "ending": "The Echoing Willow dies under the combined assault of Derek, Alana, Silvi, Avery, Edgar, the Walking Forge, and Rocky. The party receives a World Boss reward and harvests the creature before Linderis can organize a larger response. When a local party attacks, Derek incapacitates most of it and Alana kills its leader, openly confirming that she is the Dawn Siren. Alana has recovered her mother's damaged doll and has only days before ascension removes her to an unknown system. Derek reaches level 245 with every core stat above 1,500, three Origin System skill upgrade points, and one advancement requirement still unmet. Silvi remains at his side, while Avery and Edgar move closer to their own advancement. Asher is still voluntarily training inside Derek's inner void, with his survival and future allegiance unknown. The unassigned dragonkin, Thomas's developing dungeon team, the younger trainees, Marrick's travels, and the unanswered responsibility for Jacks's family remain open as Derek's group prepares to leave Linderis.",
         "in_short": "Back in Savannah after the war, Derek strengthens his household, earns Diamond rank, supports Brandy's inventions, and prepares Thomas and other young fighters for independent growth. Alana then takes him through high-level dungeons, where they devise ways to preserve golem cores and push Derek and Silvi beyond every 1,500-point stat threshold. Alana reveals that she has qualified for ascension and will soon be forced into another system. Derek discloses his origin on Earth and discovers that the Origin System still reaches him. His Void Call attracts Asher, an intelligent void beast who chooses to train inside Derek's inner void. Derek and Alana cross the sea to Linderis, recover the doll Alana's mother made for her, and assemble allies to kill the Echoing Willow. After defeating the World Boss and repelling a hostile party, they prepare to leave before Linderis responds. Derek is level 245 and still lacks one advancement condition, while Alana's departure is imminent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1439,7 +1439,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1452,7 +1452,7 @@
       "recaps": {
         "ending": "The galactic ship follows the automated radio signal away from Earth and discovers that humanity did not remain on its doomed planet. The species has built a vast fleet and launched it toward another star, carrying its population and culture into space without help from the older interstellar civilizations. The rescuers make contact and prepare to guide the refugees to safety. They are astonished that humans advanced from their first detectable radio technology to a planetary evacuation in only a few generations, a rate far beyond the pattern familiar to the galactic community. The mission therefore changes from an attempt to collect a few survivors into first contact with a self-rescued species. The visitors look forward to teaching the newcomers, but the closing perspective undercuts their confidence: humanity's energy and speed may make it a powerful and disruptive force once admitted to the wider galaxy.",
         "in_short": "An interstellar survey ship reaches the Solar System shortly before the sun is due to explode. Galactic civilization learned of humanity only recently and assumes that a species so new to radio cannot escape its planet, so a mixed rescue party descends to Earth hoping to save at least a remnant. The cities are empty. With little time before the stellar explosion, the explorers trace an active signal to an underground installation and discover that it is an automatic beacon rather than a gathering place for survivors. The signal points outward. Returning to space and following it, the expedition finds a huge human migration fleet already traveling toward another star. Humanity has independently built enough ships to evacuate Earth and has escaped before its elders arrived. The rescuers establish contact, impressed and unsettled by the extraordinary speed of human progress. Their assumption that they will simply instruct a primitive newcomer is left looking dangerously complacent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1638,7 +1638,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -1651,7 +1651,7 @@
       "recaps": {
         "ending": "Earth wins the Wild Hunt after Asta voluntarily accepts limited subordination to Silas, following the deaths of Nuri and Anika and the destruction of Morvarg. The Huntsman is freed from Veil, and the artificial world is set to disintegrate. Samuel Rayden survives his clash with the Huntsman by using an escape token. Silas fulfills his agreement with Vex by transporting 986,312 Lepun to Earth and granting them asylum and native status. Their arrival produces a widening high-mana region that disables nearby technology. Earth earned the most points in the event but cannot receive normal induction because it is a contested-sector dungeon world with six incursion slots. Fewer than 34 days remain before induction, while monster attacks and evacuations are already widespread. Cecilia Renner, Asta, Jiang, and human forces defend Normandy, where Silas and Erg destroy an invading force. The communication ban then falls, and Silas commits to leading Earth's response to the approaching war. Anika's children and successor remain his responsibility, the Lepun must be integrated, Yeodirrath's permanent fate is unknown, and Silas and Asta leave their personal relationship undefined.",
         "in_short": "Silas Renner enters the Wild Hunt with Erg and joins Asta and Jiang in a tense alliance with Anika and Nuri against Morvarg. Their campaign on Veil draws them into the Lepun struggle with the Conti Collective and into the Flame Den, where they free bound souls, exploit years of time-dilated training, and defeat the Wild Hunt incarnation of the chained devil prince Yeodirrath. Silas accepts a dangerous devil-derived evolution. Nuri breaks the human oath and dies, Mr. Chompems is killed, and Silas and Erg destroy Morvarg after a struggle involving life, order, chaos, and Veil itself. Anika later dies after transferring her successor right to Silas. The group survives the Huntsman's final pursuit with Samuel Rayden's intervention, and Asta's voluntary subordination gives Earth victory. Silas evacuates 986,312 Lepun before Veil disintegrates, only to learn that Earth is a contested-sector dungeon world nearing induction. He and Erg destroy an invasion at Normandy, communication restrictions end, and Silas accepts an open leadership role in the coming war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1769,7 +1769,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1781,7 +1781,7 @@
       },
       "recaps": {
         "in_short": "In this early prequel story, a young Harry Dresden, working as an investigator for the Ragged Angel agency under the detective Nick Christian, is hired to find a runaway girl named Faith and return her to her affluent parents. When they locate her, the job goes wrong: the girl falls into the hands of a troll, a genuine and deadly creature of Faerie, and Harry must use his magic to save her at real risk to himself. In the process he comes to suspect that the home Faith fled was itself the true danger, and that the people paying to retrieve her are not the innocents they appear. A police officer, Karrin Murphy, arrives in the aftermath, an early step in Harry's wary relationship with Chicago's law. Harry rescues the child and, troubled by what he has learned, refuses simply to hand her back to be hurt again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1931,7 +1931,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1944,7 +1944,7 @@
       "recaps": {
         "ending": "Valkyrie and her allies break Smoke's influence over Skulduggery and recover him, but they cannot stop the larger operation. The healer Melior is forced to use his ability on Abyssinia's preserved heart, rebuilding the body of the long-dead sorcerer. Abyssinia awakens and the surviving members of the Anti-Sanctuary withdraw with their restored leader, turning what first appeared to be a scattered conspiracy into a continuing threat. Valkyrie survives her return to the field and chooses not to retreat to her isolated life in America; she resumes working with Skulduggery while still carrying the trauma and guilt that brought her home in such a fragile state. Omen, having proved useful and brave despite his lack of status, remains part of their informal network. Elsewhere, Sebastian Tao continues the separate project of gathering people who want to bring Darquesse back.",
         "in_short": "Five years after Darquesse's defeat, Valkyrie Cain returns from self-imposed exile in America, burdened by guilt and trauma. Skulduggery draws her into an investigation of the Anti-Sanctuary, while overlooked Corrival Academy student Omen Darkly becomes an unlikely source inside the school. The conspirators include Lethe, Razzia, Cadaverous Gant, and Smoke, whose magic strips away inhibitions and turns Skulduggery against his allies. Valkyrie helps free him from that influence, but the heroes discover too late that the group's real objective is the restoration of Abyssinia, a powerful figure from Skulduggery's past. The healer Melior is coerced into rebuilding her from her preserved heart. Abyssinia returns to life and escapes with her followers. Valkyrie elects to remain beside Skulduggery, and Omen earns a place in their continuing work, as the revived Abyssinia becomes the central threat ahead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2120,7 +2120,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2133,7 +2133,7 @@
       "recaps": {
         "ending": "Maslova's sentence is reduced from hard labor to exile, giving her a less brutal future. By then she has changed through her friendship with the political prisoners, especially the selfless Marya Pavlovna, and no longer wishes to build her life around Nekhlyudov's guilt. Vladimir Simonson loves her and asks to share her exile. Maslova chooses to go with him, partly from affection and partly because she understands that accepting Nekhlyudov would bind him permanently to the wrong he did her. Nekhlyudov is saddened but accepts her decision and recognizes her generosity. His efforts have helped individuals, yet the prison system and the larger social order remain cruel. Reading the Gospels, he concludes that judgment and punishment cannot heal people and that life must be governed by forgiveness, service, and the refusal to treat anyone as beyond moral concern. The novel closes at the beginning of this new understanding rather than after a completed transformation.",
         "in_short": "Prince Dmitri Nekhlyudov sits on the jury that mistakenly condemns Katerina Maslova, a sex worker accused of poisoning a client. He recognizes her as Katusha, the young servant he seduced and abandoned, and resolves to repair the damage by overturning the verdict and marrying her. Maslova distrusts his penitence and initially refuses him. As appeals fail, Nekhlyudov visits prisons, helps other inmates, gives up much of his landed privilege, and follows Maslova's convict party toward Siberia. Exposure to arbitrary confinement, degrading transport, and official indifference expands his guilt into a broader rejection of the social order that sustains him. Maslova, transferred among political prisoners, regains confidence through Marya Pavlovna and Vladimir Simonson. Her sentence is reduced to exile, and she chooses a future with Simonson rather than marriage to Nekhlyudov. He accepts her decision and, through the Gospels, begins to understand moral renewal as forgiveness and service rather than self-punishment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2404,7 +2404,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "isbn:1500682896",
@@ -2416,7 +2416,7 @@
       "recaps": {
         "ending": "Fordix and the Praetores seize Galvetor's capital, but Omega Force returns with the recovered Phoenix and stops the coup. Crusher survives Fordix's attack and kills him in the Senate chamber, while Mazer and Morakar kill Fostel, Zetarix, and Mutabor. Kellea arrives aboard Defiant, causing the unidentified fleet supporting Fordix to withdraw. Galvetor and Restaria begin negotiating a new political relationship and lift restrictions on travel. Crusher refuses to remain Guardian Archon and rejoins Omega Force. Morakar becomes the warrior class's Senate representative, while Mazer takes command of 122 Galvetic warriors serving as Marines aboard Defiant. Twingo survives his captivity and returns to the Phoenix while still recovering. Connimon has disappeared, and neither her full purpose nor the identity of Fordix's outside supporters is resolved. The organizer behind the Phoenix's theft and the attacks on its crew also remains uncertain when the restored Omega Force departs.",
         "in_short": "After learning that Crusher is Galvetor's exiled Guardian Archon, Omega Force follows him to Restaria and frees his imprisoned mentor Fordix. The mission proves to be part of a larger scheme: the Phoenix is stolen, Doc and Twingo are tortured, and forged orders gather the Legions for a coup. Jason, Lucky, Mazer, and Kade recover the ship and captives while Kage and Morakar uncover the false mobilization. Fordix and the Praetores seize Galvetor's government after Connimon helps incapacitate Crusher, but Crusher survives and Omega Force retakes the Senate. Crusher kills Fordix, Mazer and Morakar kill the Praetores, and Kellea's Defiant drives away an unidentified supporting fleet. Crusher returns to Omega Force, Morakar enters the Senate, and Mazer commands a new Galvetic Marine company aboard Defiant. Twingo survives and rejoins the Phoenix, while Connimon and the coup's external backers remain missing and unidentified.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2652,7 +2652,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -2665,7 +2665,7 @@
       "recaps": {
         "ending": "Noah reaches Linwick city as a rank-two mage with Sunder, the Hellreaver's Combustion master rune, and a perfected pyroclastic resonance rune. Lee remains beside him as a willing ally rather than a bound servant. Todd and Isabel have passed their first examination and developed into capable fighters, though Todd's unusual knowledge of body imbuement and Isabel's exhausting secret training remain unexplained. Brayden continues to protect the claim that Vermil could not have killed the Hellreaver and escorts Noah, Lee, Todd, Isabel, Allen, and Edward into Linwick territory. Moxie and Emily separate from the party before the border because of hostility between Moxie's house and the Linwicks; they plan to train and reunite with the others in two weeks. Noah intends to face Vermil and Brayden's father using a controlled-demon explanation for his changed identity. The poisoner, Father's exact plan, the intended outcome of Vermil's summoning, and the possible escape of a stronger demon all remain unresolved.",
         "in_short": "After dying on Earth, teacher Noah Vines awakens in the poisoned body of the disreputable Magus Vermil and discovers that the master rune Sunder binds his resurrection to a gourd. At Arbitage, he uses Vermil's identity to learn magic while genuinely training neglected students Todd and Isabel. An apparent skinwalker named Lee becomes his ally and is later revealed as a lesser demon released by Vermil's failed summoning. Noah kills the Hellreaver, inherits its Combustion rune, reaches rank two, and uses Sunder to perfect a pyroclastic resonance rune. The kill brings an Arbitage investigation, while Vermil's brother Brayden reveals that their father expected a demon-related assignment to alter Vermil's fate. Noah travels toward Linwick territory with his students, Lee, Brayden, Allen, and Edward. Moxie and Emily remain outside the territory to train. The book ends at the gates of Linwick city, where Noah intends to confront Vermil's father and uncover the unfinished summoning plan.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3025,7 +3025,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -3038,7 +3038,7 @@
       "recaps": {
         "ending": "Todd, Isabel, Emily, and James pass the Snowfield survival exam after revealing that they reached rank two during their training. Eline fails, but Revin spares her and makes her his shadow-bound trainee, with freedom possible only after she grows strong enough. The real Magus Evergreen accepts Emily's result and gives Moxie two months away from tutoring. Noah, Moxie, and Lee plan to spend that break together, while the students separate for further training. Noah is now rank three and can use Fragment of Renewal to repair some of Lee's soul damage, but Azel remains contained inside his soul. The unknown force behind the exam sabotage and the hijacked Evergreen replica is still active. Renewal is searching for Noah, the Church of Repose has entered the Empire, and the Linwick plot, Karina's obligations, and Todd and Isabel's family grievances all remain unresolved.",
         "in_short": "Noah enters Linwick territory under Vermil's identity, deceives the family head into believing a demon controls Vermil's body, and drives Dayton away while learning more about the destruction of Todd and Isabel's families. After surviving an arranged inquisitor attack, he returns to Arbitage and takes Todd, Isabel, and Emily through intensive wilderness training with Moxie and Lee. Noah reaches rank three, creates Fragment of Renewal, and begins healing Lee's damaged soul, but this draws Renewal's attention and restores Azel, a rank-five demon bound inside him. At the final survival exam, an Evergreen replica is exposed as the tool of an unknown saboteur. Todd, Isabel, Emily, and James reveal their rank-two advancement, take Eline's tokens, and pass. Revin makes the defeated Eline his bound trainee, while Moxie receives a two-month leave and joins Noah and Lee for the break.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/return-of-the-runebound-professor-3.json
+++ b/data/works-community/0/return-of-the-runebound-professor-3.json
@@ -343,7 +343,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -356,7 +356,7 @@
       "recaps": {
         "ending": "Noah, Moxie, and Lee remain together after leaving the Linwick catacombs. Moxie is free of Torrin oaths and has rebuilt three genuinely perfect rank-three runes. Lee has a stronger demon-compatible set but still requires additional repairs, while Noah concludes that Natural Disaster is too broad and unstable for safe advancement in its current form. Noah's new grimoire has consumed his former grimoire, stored runes, Dayton's scroll, and the Records of the Deceased, preserving the ledger's information while becoming hungry and partly responsive. That information records Father Linwick as dead, leaving the identity of the apparent Father unresolved. Near Dawnforge, the group learns that the great monster's enormous sand-armored snake is a construct hiding its true body. Noah dies during the first test, revives, and prepares a formation-assisted second attack. Elsewhere, Jalen identifies Karina as the route to Vermil. He gives her a functional magical replacement foot, then threatens her life unless she independently persuades Vermil to meet him with the stolen grimoire. Noah does not yet know that Karina is being forced toward him. Wizen, Azel, the Heron threat, the Church of Repose mission, and the apparent Father's identity all remain open.",
         "in_short": "Noah repairs Moxie's runes, reveals his true identity to her and begins a relationship with her, while their summer work in Dawnforge draws them into Gentil's criminal network. They kill Gentil and free Alexandra, but Wizen remains at large. Evergreen then recalls Moxie under threat of execution. Noah, Moxie, Lee, Azel and rival Torrin factions engineer Evergreen's defeat, after which Moxie's family runes are broken and her oaths finally end. The group discovers that inherited rune designs can hide serious imbalance and develops a method for making genuinely perfect runes. Karina guides them into the Linwick catacombs, where Noah learns that Father Linwick is recorded as dead and gains a hungry, semi-sapient grimoire. The group then identifies a great monster's huge snake body as a sand construct and prepares a rematch. Meanwhile, Jalen traces the catacomb theft to Karina and coerces her into bringing Vermil and the stolen grimoire to him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -752,7 +752,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -765,7 +765,7 @@
       "recaps": {
         "ending": "Silvertide has destroyed Wizen's local puppets and badly damaged the Evergreen essence in his possession, but Wizen remains active and his objective involving the Torrins is unknown. Jalen agrees only to investigate, while Father remains a self-interested source and Karina's obligations are unresolved. Noah is a rank-four mage with a perfect Natural Disaster rune, a suppressive domain, and a violin that can channel two rune effects at once. Moxie continues rebuilding and teaching, and the students have entered the advanced track with their individual pattern work underway. Raphael is dead after Azel took the Inquisitor's bloodline curse and died from it. Lee has advanced to rank four, but Azel's restraint on her dangerous demon rune is only temporary. Emily accepts Lee without hesitation, Alexandra remains cautious but does not reject her, and Brayden orders the group to hide the death. Renewal and Decras continue watching them, with Decras delaying another planned threat until the conflict with Wizen is resolved.",
         "in_short": "Noah returns to Arbitage, perfects his runes with Sunder, and reaches rank four with Natural Disaster while Jalen's assassination campaign shifts into uneasy interest. Noah and Moxie bring their students into the advanced track and teach them to develop formations from deeply understood patterns. Meanwhile, Lee rebuilds her runes but fears the change required for a demon's advancement. Wizen infiltrates Arbitage through plant-controlled corpses, killing Will and using Mayreena as another puppet while holding Evergreen's essence. Silvertide destroys Wizen's local network and damages Evergreen, but Wizen survives. Inquisitor Raphael then exposes Lee and nearly kills Moxie. Lee advances to rank four to save her, and Azel manifests, kills Raphael, takes the fatal bloodline curse, and dies after temporarily restraining Lee's unstable rune. The group conceals Raphael's death as Wizen and a postponed divine test remain ahead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1293,7 +1293,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -1306,7 +1306,7 @@
       "recaps": {
         "ending": "Wizen keeps the Damned Plains key and escapes there with Barb after overwhelming the Arbitage assault. Noah, Moxie, and Lee are stranded in the same realm, but survive and enter a mobile city ruled by a rank-seven demon. Under the Spider identity, Noah captures a local gang, elevates a starving young demon into a rank-three knowledge demon, and begins absorbing neighboring territories. The proxy and his fear-feeding ally repel a challenge from the Silent Silver Tooth, but the faction's growth has drawn the attention of stronger city powers. Noah and Moxie remain committed to stabilizing Lee's dangerous merged rune while they seek Wizen, the key, and a route home. At Arbitage, Brayden and Jalen keep the students enrolled and training. Alexandra holds the Earth Master Rune, Todd continues his imbuement work, and Tim operates the damaged transport cannon under severe limits. No rescue path has been established, and Wizen's ultimate purpose remains unknown.",
         "in_short": "After Azel dies saving Lee, Noah and Moxie help her contain the unreadable rank-four rune formed from her demon power and broken Master Rune. Wizen's agents steal Arbitage's transport-cannon key, a portal artifact leading to the Damned Plains. While the enforcers search for Wizen, Noah repairs Tim's runes, guides his students' pattern training, creates the spatial-erasure rune Crumbling Space, and helps Moxie reach rank four. The assault on Wizen fails when he masters the key and overwhelms Arbitage's force. Noah, Moxie, and Lee follow him through a portal and become stranded in the Damned Plains. They enter a demon city in disguise, where Noah adopts the identity Spider, conquers a gang, and advances a starving young demon into a rank-three proxy. That proxy begins uniting local gangs and defeats a major challenger, attracting attention from greater powers. Brayden and Jalen keep Noah's students together at Arbitage while the trio searches for Wizen and a way home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1777,7 +1777,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -1790,7 +1790,7 @@
       "recaps": {
         "ending": "Sievan brings Noah and Wizen together because both carry power connected to Decras, then asks Noah to help him die as a final attempt to escape the limits built into demon-kind. Wizen wounds Sievan and enters the line through the portal Sievan opens, still determined to retrieve Bella from the afterlife. Empty Proliferation protects Noah from Wizen's command. Noah follows Wizen into the line after failing to save the Hollow girl, whose lack of a demon rune had briefly offered a new lead toward curing demons. Zath evacuates Moxie and Lee, leaving them alive but separated from Noah. Lee still has no safe way to create her own Fragment of Self, and Sievan's fate remains unsettled. Yoru and the Web remain in the Damned Plains, where Spider's faction has survived Belkus's opposition and become a significant local power. At Arbitage, Jalen, Brayden, Bird, and Silvertide continue preparing Vermil's students through improvised formations and live-monster exercises. The unresolved grimoire entity, Wizen's pursuit of Bella, and Noah's route back to his companions all carry forward.",
         "in_short": "Stranded in the Damned Plains, Noah builds the Web under his Spider identity while researching a cure for Lee. His auction victories draw Yoru, Belkus, and Sievan's agents into his orbit. A lethal experiment produces Warped Matter and reveals the Fragment of Self, while an examination of Igris shows that every demon rune shares a flawed external origin. Noah proposes that Lee create a personal fragment, but no safe catalyst is found. After Noah kills Axil with Sunder and dies himself, Sievan restores her only partly. Belkus trades Noah mind runes for leaving the city, enabling Noah to create Empty Proliferation against Wizen's control. Wizen reaches Sievan to reclaim his dead daughter Bella. Sievan reveals that demons are bound by their rune nature and asks Noah to help him die. Wizen enters the line through Sievan's portal, and Noah follows after the Hollow girl dies despite his healing attempt. Moxie and Lee survive but are evacuated away from him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/return-of-the-runebound-professor-7.json
+++ b/data/works-community/0/return-of-the-runebound-professor-7.json
@@ -418,7 +418,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -431,7 +431,7 @@
       "recaps": {
         "ending": "Noah ends the main arc at rank five with Unstable Pandemonium, back at Arbitage and preparing an open challenge to the nobles targeting Isabel. Moxie, Lee, Yoru, Brayden, Silvertide, the students, and the repaired demons remain aligned with him, while Contessa helps shelter the group and Tim houses the demon students inside the transport cannon. Garina is a conditional source of apostolic knowledge, and the vengeance demon has accepted fealty in exchange for rune repair. Sticky and Lee have proven that demons can escape Decras's control, but the method still depends on personal transformation. The grimoire's future price, Spider's exposure, Inquisitor opposition, Wizen's final clue, and the red-portal organizer all remain unresolved. Tim's measurements indicate that the Arbalest Empire is intentionally isolated and weakened. In the final chapter, Jalen's father leaves Jalen apparently dead inside the breached true archives after making unverified claims about an artifact behind the Empire's history. He remains inside the archive with no known obstacle between him and that artifact.",
         "in_short": "Noah confronts Wizen on the Line, gains the key, and returns to the mortal plane after Wizen sacrifices himself to restore Sticky. Sticky and Lee establish different paths by which demons can replace their creator-bound power with self-made runes. Noah saves Isabel's exam group from Jacob, rebuilds Alexandra and Yoru, survives scrutiny from Garina and another apostle, and turns the Spider identity into a public offer of freedom for demons. After trading for new runes, he reaches rank five with Unstable Pandemonium and brings his enlarged faction back to Arbitage to confront the nobles pursuing Isabel. Tim's research supports the claim that the Arbalest Empire is deliberately constrained. Meanwhile, Jalen discovers an intruder in the Linwick true archives. The intruder is his father, who claims a hidden artifact explains the Empire's manufactured history, leaves Jalen apparently dead, and remains free to reach it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -924,7 +924,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -937,7 +937,7 @@
       "recaps": {
         "ending": "The artifact thief's activation of Long Night stirs the Night's Shadow and leaves part of Arbitage transformed into lethal Wailing Stones. Garina contains the greater danger while Noah and Mascot force one tendril to withdraw. Brayden evacuates the students, but Noah suffers lasting soul damage, Mascot is nearly exhausted, and the artifact thief remains free. Apostle pressure then draws Noah into Kyle's contest for a rank-six rune. Noah publicly destroys the prize, secretly recovering its four flawless rank-five components. Alice and Carmen agree to hide how completely he misled them and regard him as a future rival. Back in Arbitage, Noah rebuilds Unstable Pandemonium as the flawless Keystone Rune Unraveling Disruption and moves well past the midpoint to rank six. Moxie, Lee, the students, Tim, the repaired demons, and Garina remain allied with him. Fuyin's planned Inquisitor operation is next, while the artifact thief, Long Night, the Night's Shadow, the Truth Seekers, hostile Apostles, noble pressure on Isabel, and Spider's hidden growth within Noah's divided soul all remain unresolved.",
         "in_short": "Noah's false claim of noble traitors unexpectedly exposes the artifact thief's real operation just as the thief steals Long Night and escapes. Noah accelerates his mixed class's training, learns that personal patterns can create self-fragments, survives a Truth Seeker assault, and helps the group shape their souls. Garina's lethal instruction gives him an unprecedented full merge, then reveals to her alone that Spider is the sealed self carrying Noah's memories of the Line. The thief activates Long Night and stirs the Night's Shadow, devastating Arbitage. Noah, Mascot, Garina, Brayden, and Tim keep the group alive, though Noah's soul and Mascot are badly damaged. Kyle then forces Noah into an Apostle contest. Noah appears to destroy its rank-six prize but secretly steals four flawless rank-five runes. He finishes by remaking Unstable Pandemonium as the flawless Keystone Rune Unraveling Disruption and prepares to raid the Inquisitors with Fuyin.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1390,7 +1390,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BYQ5SXPP",
@@ -1402,7 +1402,7 @@
       "recaps": {
         "ending": "Elaine, Artemis, Autumn, and Auri escape the Fae realm with Julius alive. The rescue closes the immediate search, but the effects of Autumn's bargains and her transformed left eye remain unknown. Elaine and Auri are bonded companions, while Auri's connection to White Dove and both of their future paths remain open. Remus has enacted major legal rights for women and is preparing a campaign against the Shimagu, but slavery abolition is not established. Elaine has not chosen a third class or decided whether to accept vampirism, and the sponsor of the bounty on Sentinel Dawn is still unidentified. Later glimpses reveal that Elaine disappears for years after these events. Her name is placed on the wall of the fallen, her parents keep hoping for her return until their deaths, and the family tradition remembering her eventually fades. Night alone makes a point of recording her as missing rather than confirmed dead, leaving her ultimate fate unresolved.",
         "in_short": "Elaine returns to Remus with the phoenix Auri, rejoins her family and the Sentinels, and reports the Shimagu threat. She uses the promise of rejuvenation to win new citizenship, property, and household rights for women, while Augustus mobilizes for war. Every use of her power draws a dangerous curse from White Dove. Elaine and Auri form a companion bond, and Elaine still leaves her third class and an offer of vampirism undecided. When a fairy ring explains Julius's disappearance, Elaine, Artemis, Autumn, and Auri enter the Fae realm and bring him home, though Autumn returns altered. Future interludes then show Elaine missing for years, memorialized among the fallen, and mourned by a family that never receives certainty. Night privately records her as disappeared, not dead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1603,7 +1603,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1616,7 +1616,7 @@
       "recaps": {
         "ending": "Suze exorcises the four RLS Angels at the cliffs where they died, coming close to being killed doing it, and the campaign against Michael Meducci ends. Afterward she learns what the case actually was. Michael did not lose control of his car. He forced the four off the road deliberately, in revenge for what they had done to his younger sister, who never recovered from it. The teenagers Suze spent the book driving out had been right about who killed them, and wrong only in thinking it was carelessness. Michael is left free of them and unpunished, and Suze is left knowing it, with nothing she can usefully do about it. Father Dominic's insistence that the dead be reasoned with rather than fought has taken another blow, and so has Suze's confidence in her own judgement about who in a haunting is the victim. Nothing about her situation at home or at school has changed, and Jesse is still in her room, with her feelings about him harder to explain away than they were.",
         "in_short": "Four teenagers from a neighboring school died when their car went off the coast highway, and Suze Simon discovers that all four are still here and have decided to kill the driver of the other car: Michael Meducci, a quiet classmate who survived the crash. Suze puts herself between them and protects him through escalating attacks, including an attempt to drown him at a party. Father Dominic wants the four talked down and Jesse wants Suze to stay out of it entirely, but the ghosts cannot be reasoned with, so Suze prepares an exorcism and performs it at the cliffs where they died, nearly dying herself. The four are driven out and Michael is safe. Only afterward does Suze learn that Michael caused the crash on purpose, to avenge his younger sister, who never recovered from what the four had done to her. Suze has spent the whole case defending the person the ghosts were right to blame.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1810,7 +1810,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1823,7 +1823,7 @@
       "recaps": {
         "ending": "The closing portion of the collection moves through a series of animal reversals. A porcupine's quills turn an accidental encounter into a difficult extraction; a flying cow uses her new position above the ground to punish an offensive man; and the episode of the toad and the snail makes the animals vulnerable to human appetite. In the final piece, a child repeatedly says that a creature in his stomach is demanding food. His mother dismisses the explanation as a childish way of asking for another serving. The dispute ends when the tummy beast itself speaks loudly enough for her to hear, proving that the child's account was literal. Like the earlier fairy-tale revisions, the animal poems close by letting an absurd or threatening possibility overturn an adult's confident assumptions.",
         "in_short": "The collection first retells six fairy tales as comic, violent reversals. Cinderella rejects a murderous prince, Jack learns that bathing defeats the giant's sense of smell, Snow White uses the magic mirror to help seven former jockeys win at the races, and Goldilocks is judged as an intruder rather than an innocent visitor. Little Red Riding Hood shoots the wolf and takes his fur, then returns when the third little pig asks for help and adds pigskin to her possessions. Nine shorter animal poems follow. Their pigs, crocodiles, lions, scorpions, anteaters, porcupines, cows, toads, snails, and a creature living in a child's stomach repeatedly outwit, punish, eat, or embarrass humans. The last child's claim of a tummy beast is vindicated when the beast answers his skeptical mother for itself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2112,7 +2112,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0753Q5658",
@@ -2124,7 +2124,7 @@
       "recaps": {
         "ending": "Lucky manually detonates the antimatter device at the transponder facility's fusion plant, forcing Jason, Crusher, and the other battle synths to escape before the blast. The inhibitor signal ends, the remaining Kepri battle synths surrender, and the surrounding Confed, Saabroor Protectorate, and Esquarian forces disengage. Kepri's central banking system is damaged but continues operating. Captain Swank grants asylum to the 36 surviving Lot 700 members, who receive a settlement on an Earth-administered refuge world and offer to join Omega Force. Jason postpones that decision, mourns Lucky, and eventually commits to resuming the team's work. Cage is recovering, Crusher survives his wounds, and the technical adviser settles on Satora. The Master remains active as the Confed loses control of member worlds, while the captured former minister and his wider faction remain unresolved. After Jason leaves alone aboard the Phoenix, Mok's people recover part of Lucky's body with redundant primary-matrix power still active. Twingo, Cage, Mok, and the technical adviser keep the uncertain survival evidence from Jason while pursuing stasis and a possible replacement body.",
         "in_short": "Saditava Mok hires Omega Force to investigate a suspicious military buildup on Kepri, drawing Lucky back to the world where he was created. The crew discovers that recalled battle synths are being coerced, that Lucky belongs to the autonomy-preserving Lot 700, and that a hidden faction intends to destabilize the Confed through Kepri's financial infrastructure. Omega Force revives Lucky's 36 surviving lotmates and attacks the control transponder as three fleets approach open war. Lucky apparently dies destroying the facility, freeing the controlled synths and allowing the confrontation to subside. Earth grants Lot 700 asylum, Jason survives and resolves that Omega Force will continue, and the damaged banking system remains operational. The true architect, the Master, considers the broader destabilization campaign a success. Unknown to Jason, Lucky's recovered remains still show primary-matrix power, and Twingo, Cage, the technical adviser, and Mok secretly begin seeking a way to restore him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2288,7 +2288,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2301,7 +2301,7 @@
       "recaps": {
         "ending": "After John Givings bluntly exposes the fear and self-deception behind the canceled move to Paris, Frank and April's marriage reaches its final collapse. Frank admits his affair, but April's indifference denies him the emotional response he expected. She later sleeps with Shep Campbell, then returns home without finding a way out of her situation. Following one last argument, April becomes unnaturally calm. She sends Frank to work after preparing breakfast and then attempts to end her pregnancy by herself. She suffers catastrophic bleeding and dies at the hospital. Frank is left shocked and diminished; the children go to live with relatives, and he eventually leaves Revolutionary Road for the city. Shep continues to grieve April while keeping the truth of their encounter from Milly. The Wheelers' house is sold to another young couple, allowing the neighborhood to absorb the tragedy into fresh appearances. When Helen Givings talks about the former residents, Howard quietly turns off his hearing aid.",
         "in_short": "Frank and April Wheeler regard themselves as exceptional people trapped in a conventional Connecticut suburb, but their marriage is already damaged by contempt, disappointment, and performance. After April's failed appearance in an amateur play, she proposes that the family move to Paris, where she will work while Frank discovers a meaningful direction. The plan briefly restores their intimacy. Frank nevertheless begins an affair with secretary Maureen Grube and receives an attractive promotion offer. When April becomes pregnant, Frank uses the pregnancy and his new prospects to abandon Paris, while April considers ending the pregnancy herself. John Givings, a psychiatric patient whose bluntness the Wheelers once admired, names their retreat as fear. Their arguments intensify; Frank's confession of infidelity changes little, and April briefly turns to neighbor Shep Campbell. The next morning she performs an abortion alone, hemorrhages, and dies. Frank leaves the suburb and the children live with relatives, while the neighborhood replaces the Wheelers and resumes its reassuring stories about itself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2488,7 +2488,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07XF5MS5F",
@@ -2500,7 +2500,7 @@
       "recaps": {
         "ending": "Jaxon and Jess leave the repurposed permadeath dungeon with a Graverobber's Kris apiece, but Backattack turns his guild against them at the exit. Jaxon trades one weapon for a restriction against sending others after either traveler, then wins five minutes of safety by wagering the other in an arm-wrestling match. The delay lets the pair escape into the woods, although fighting other players gives both of them temporary player-killer auras. They return to the scoured village and reunite with Joe, who drives off a hostile local group. Jess remains Jaxon's armed party partner and tactical lead. Jaxon is now a level 12 Bonecruncher with Battle Meditation and two partly trained living weapons, Lefty and Terror, which Joe collectively names Rexus. Backattack and his assassin network remain active, the pair must avoid others until their auras fade, and the postwar human-Wolfman conflict and Joe's larger Wanderers concerns remain unresolved.",
         "in_short": "After the human victory over the Wolfmen, Jaxon rejects attacks on civilians and leaves his party to seek his own specialization. He protects Wolfman refugees, gains directions to a dangerous temple, and travels there with Jess, a would-be robber who becomes his scout and partner. Their solo and duo trials end in death and respawn, but Jaxon's generosity earns him the Bonecruncher specialization and the sentient hand-weapons Lefty and Terror. The pair formally join forces, train and equip themselves, then accept a coerced bargain with Backattack's assassin guild to enter a permadeath dungeon. They clear all four layers, gain replacement Graverobber's Kris weapons, and convert the dungeon from rewarding character deaths to rewarding defense of other players. Backattack orders his guild to attack anyway. Jaxon and Jess bargain for time, fight free, and return to Joe with temporary player-killer auras. Joe names the paired living weapons Rexus.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2640,7 +2640,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2653,7 +2653,7 @@
       "recaps": {
         "ending": "After viewing the body of a woman whose death may be connected to the masked gathering, Fridolin returns home without proving whether she was the stranger who intervened for him. He finds the mask from his costume lying on the pillow beside the sleeping Albertine. Its presence makes concealment impossible, and he breaks down and tells her the whole story of his night and his later investigation. By morning, the couple have reached no tidy explanation of either his adventures or her dream, but they choose honesty and a renewed awareness of one another over further secrecy. Albertine cautions against assuming that any reconciliation is guaranteed forever, while also recognizing that they have survived the immediate crisis. Their daughter wakes and the sounds of the new day enter the room, returning them to shared domestic life with their marriage altered but intact.",
         "in_short": "After a masked ball, Viennese doctor Fridolin and his wife Albertine confess attractions to other people, unsettling their confidence in their marriage. Called to a patient's deathbed, Fridolin wanders through the city and meets a grieving daughter, a sex worker, and his old acquaintance Nachtigall, who reveals the location of a secret masked gathering. Fridolin obtains a costume and enters, but a masked woman warns him away and offers herself when he is exposed as an outsider. The next day, he tries to trace Nachtigall, the gathering, and the woman, meeting threats and evasions. Albertine's account of a cruelly erotic dream intensifies his jealousy. A newspaper report leads him to the body of a woman who may have been his rescuer, though he cannot confirm it. Returning home, he finds his borrowed mask beside Albertine and confesses everything. At dawn they accept the need for honesty and resume their life together without pretending the danger of future estrangement has vanished.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2815,7 +2815,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2828,7 +2828,7 @@
       "recaps": {
         "ending": "The battle for Urithiru is won at bitter cost. Navani, after a long captive contest of intellect with the Fused scholar Raboniel, bonds the tower's guardian spirit and rises as a new Bondsmith, restoring the city's ancient defenses and purging the enemy from it; Raboniel and her daughter die in the process. Kaladin, having spoken the Fourth Ideal and accepting that he cannot save everyone, defeats the enemy in the tower, though his former friend Moash murders the beloved bridgeman Teft, a wound that will not heal. In the spren realm, Adolin's trial wins a measure of alliance and revives his once-dead blade, while Shallan confronts more of her hidden past and the secret society hunting her. Venli quietly leads a group of her people toward freedom. But the book's true turn is catastrophic: as Odium, the god of hatred, moves to discard the ailing King Taravangian, Taravangian instead outmaneuvers and kills him, seizing the divine power for himself. The coalition's most cunning traitor is now a god, one who blends ruthlessness with a terrible sense of compassion, and far more dangerous than his predecessor. A formal contest of champions has been agreed to settle the war on a fixed near-future date, and the newly ascended enemy will spend the interval bending the world toward his design.",
         "in_short": "A year into open war with the god Odium, the coalition and the enemy fight a grinding campaign of raids while Dalinar seeks a way to win. The Fused seize the tower city of Urithiru, suppressing its guardian spirit and trapping Navani, Kaladin, and others inside an occupied stronghold. Navani, held captive, matches wits with the brilliant Fused scholar Raboniel over the secret nature of Light, a duel of science that leads to a weapon able to kill even immortals. Kaladin, worn down and unable to fight openly, shelters survivors in the tower's depths and finally speaks the Fourth Ideal of his order, coming into new power. Far away, Adolin and Shallan travel into the realm of the spren to win an alliance, Adolin standing trial to earn the honorspren's aid and drawing his dead sword back toward life. In the climax Navani bonds the tower's guardian and becomes a Bondsmith, reclaiming Urithiru. Then comes the war's great turn: the dying King Taravangian outmaneuvers Odium, kills him, and seizes his power, becoming a new and far more dangerous god of hatred just as a contest of champions is set to decide everything.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3046,7 +3046,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3059,7 +3059,7 @@
       "recaps": {
         "ending": "Richard is imprisoned at Pomfret Castle, where he reflects on identity, kingship, and isolation. After he attacks a keeper who reports that the new king has withdrawn a customary privilege, Exton and armed men enter. Richard kills one attacker before Exton kills him. Exton brings Richard's body to Henry IV, expecting approval, but Henry condemns the deed and banishes him, while acknowledging that his own words may have prompted it. Elsewhere, the new king hears that rebels against him have been defeated and pardons the Bishop of Carlisle. With Richard dead and reports of severed heads arriving from the fighting, Henry announces a pilgrimage to Jerusalem to atone for the bloodshed associated with his rise. Bolingbroke holds the crown as Henry IV, but the violence predicted by Carlisle has begun, and the legitimacy of the new reign remains burdened by deposition and regicide.",
         "in_short": "Richard II stops a trial by combat between Henry Bolingbroke and Thomas Mowbray, banishes both men, and later seizes Bolingbroke's inheritance after John of Gaunt dies. While Richard campaigns in Ireland, Bolingbroke returns, claiming only his estate, and rapidly gains noble support. Richard's allies collapse; he submits to Bolingbroke and is taken to London. In Parliament, Bolingbroke presses charges, Richard relinquishes the crown, and Bolingbroke becomes Henry IV. A plot to restore Richard is discovered when York finds his son Aumerle's involvement; Henry pardons Aumerle after the Duchess of York pleads for him. The queen is separated from Richard and sent to France. At Pomfret, Richard is attacked by Exton and killed after fighting back. Henry condemns Exton, although his own words inspired the murder, and plans a penitential journey to Jerusalem as his contested reign begins.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3268,7 +3268,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3281,7 +3281,7 @@
       "recaps": {
         "ending": "On the night before Bosworth, the ghosts of Richard's victims visit his camp and condemn him, then promise Richmond victory. Richard wakes shaken but goes into battle determined to fight. Stanley's position remains uncertain until the fighting begins, when he and other wavering nobles support Richmond. Richard fights fiercely after losing his horse and searches for Richmond on foot, but Richmond kills him. Stanley retrieves the crown and places it on Richmond, who becomes Henry VII. Richmond announces that he will marry Elizabeth of York, joining the Lancastrian and Yorkist lines. He pardons surviving opponents who submit, orders burial for the dead, and promises a peaceful government. Richard's defeat ends his violent reign, while the planned marriage offers a political settlement to the dynastic conflict that enabled his rise.",
         "in_short": "Richard, Duke of Gloucester, decides to take the English crown held by his brother Edward IV. He engineers Clarence's imprisonment and murder, courts Lady Anne despite his part in her family's destruction, and exploits distrust between the old nobility and Queen Elizabeth's relatives. After Edward dies, Richard and Buckingham isolate the young heir, imprison both royal sons in the Tower, eliminate their protectors, and persuade London to accept Richard as king. Richard then has the princes killed, discards Anne, and seeks a marriage that would strengthen his title. Buckingham rebels after Richard refuses him a promised reward, but is captured and executed. The exiled Henry Tudor, Earl of Richmond, invades with support from Richard's defecting nobles. Haunted by his victims before Bosworth, Richard fights but is killed by Richmond. Crowned Henry VII, Richmond plans to marry Elizabeth of York, uniting the rival houses and promising an end to civil war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3450,7 +3450,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3463,7 +3463,7 @@
       "recaps": {
         "ending": "Venters confronts Oldring and kills him, then learns that Bess was not the willing outlaw she appeared to be. Venters and Bess decide to abandon the violent struggle around Cottonwoods. Carrying gold from Surprise Valley and riding the great horses, they escape across the sage toward a new life in Illinois. Jane's ranch and her power in Cottonwoods have meanwhile been systematically destroyed. Lassiter confirms that Bishop Dyer was responsible for the ruin of his sister Milly, kills Dyer, and later kills Tull during the pursuit. Jane, Lassiter, and the orphan Fay flee into Surprise Valley. To stop their pursuers, Lassiter rolls the enormous balancing stone into the narrow entrance, causing a collapse that seals the pass. The barrier saves them but closes them inside the valley. Venters and Bess witness the sealed way from outside and understand that Jane and Lassiter have chosen a protected refuge rather than return to the world that persecuted them.",
         "in_short": "Independent Mormon rancher Jane Withersteen resists Elder Tull's demand that she marry him and abandon her Gentile riders. Gunman Lassiter arrives searching for the truth about his sister Milly and protects Jane and Bern Venters. While pursuing Oldring's rustlers, Venters wounds the Masked Rider, discovers she is a young woman named Bess, and nurses her in hidden Surprise Valley; they fall in love. Tull and Bishop Dyer use religious authority, theft, and violence to ruin Jane's ranch, while Jane tries unsuccessfully to restrain Lassiter's vengeance. Venters kills Oldring and escapes east with Bess. Lassiter learns that Dyer destroyed Milly, kills him, and kills Tull when Tull pursues. Lassiter, Jane, and the orphan Fay enter Surprise Valley and bring down a huge stone to seal its only passage, trapping themselves in a safe refuge. Venters and Bess continue toward a new life outside Utah.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3621,7 +3621,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3634,7 +3634,7 @@
       "recaps": {
         "ending": "After Bertie's independent schemes have left the couples divided and Brinkley Court in turmoil, Jeeves resumes control. He guides events so that Gussie and Madeline become reconciled and renew their engagement, while Angela and Tuppy also make peace. The threat that Anatole will leave the Travers household is removed, saving Aunt Dahlia from losing her prized chef. These settlements also free Bertie from Madeline's belief that she must marry him if Gussie fails her. Bertie recognizes that his attempt to demonstrate superior judgment has instead proved Jeeves's indispensability. He yields on their private dispute and agrees to give up the white mess jacket Jeeves dislikes. The jacket is then destroyed while supposedly being pressed, completing Jeeves's quiet victory as Bertie returns to his customary dependence on his valet's advice.",
         "in_short": "Bertie Wooster decides to solve two romantic disputes without Jeeves: shy newt-fancier Gussie Fink-Nottle cannot propose to Madeline Bassett, while Tuppy Glossop and Bertie's cousin Angela have quarreled. At Brinkley Court, Bertie's amateur psychology produces mistaken declarations, hunger campaigns, and a perilous understanding that Bertie will marry Madeline if Gussie disappoints her. Gussie, accidentally fortified with alcohol before presenting school prizes, gives a disastrous public speech and loses Madeline's approval. Further schemes disrupt the household and threaten Aunt Dahlia with the departure of her cherished chef, Anatole. Once Bertie finally accepts help, Jeeves arranges reconciliations for both couples, secures Anatole's position, and releases Bertie from Madeline's conditional claim. Bertie concedes that Jeeves has won their contest of judgment and abandons the white mess jacket that began their disagreement.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3777,7 +3777,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3790,7 +3790,7 @@
       "recaps": {
         "ending": "After killing Nag, Rikki learns that Nagaina's eggs are close to hatching. With help from Darzee's wife, he reaches the nest and destroys all but one egg. Nagaina is threatening Teddy at the family's breakfast table when Rikki arrives carrying the last egg. He uses it to draw her away from the boy, but she seizes it and escapes into her burrow. Rikki follows despite the danger of fighting a cobra underground. He eventually emerges and announces that Nagaina is dead and the egg will never hatch. The garden's animals celebrate the end of the cobra threat, while Rikki remains with Teddy's family and continues guarding the bungalow against snakes.",
         "in_short": "A flood carries the young mongoose Rikki-Tikki-Tavi into the garden of an English family in India. Teddy and his parents revive him and welcome him into their bungalow. Rikki soon meets Nag and Nagaina, a pair of cobras who want the family gone, and proves himself by killing a smaller snake that approaches Teddy. Warned that Nag has entered the house, Rikki attacks him in the bathroom, where Teddy's father shoots the cobra. Nagaina remains dangerous, and her hidden eggs are nearly ready to hatch. Rikki destroys most of them, then confronts her while she holds Teddy at her mercy. Using the last egg as a lure, he chases Nagaina into her burrow and kills her underground. With both cobras and their brood gone, the family and garden are safe, and Rikki settles into his role as their vigilant protector.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3982,7 +3982,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3995,7 +3995,7 @@
       "recaps": {
         "ending": "The war ends. Jem Blythe, missing for months, is found to have been a prisoner in Germany, escapes, and comes home lame but alive, and Dog Monday's long vigil at the station platform ends when he finally meets the right train. Jerry Meredith recovers from his wound and Carl Meredith comes home having lost an eye. Shirley returns from the flying corps. Susan Baker, having refused a proposal of marriage during the war, takes a modest holiday of her own at the end of it. Gertrude Oliver is married to her fiancé. Jims's father comes back from France, marries again, and takes the boy, so Rilla gives up the child she raised from a soup tureen and finds she has grown up in the process. Walter is not among the returning. His mother, his family, and Una Meredith, who never told anyone what she felt for him, carry that loss into the peace, and his last poem has made him known far beyond the Glen. Kenneth Ford comes back at last and walks up to Ingleside, and when he asks Rilla whether she has kept the promise she made him the night before he sailed, her old childhood lisp returns in her answer. Rilla ends the book engaged, and the Glen begins the long work of living afterwards.",
         "in_short": "Rilla Blythe is not quite fifteen and wants nothing but a few years of parties when the First World War begins on the night of her first grown-up dance. Over the next four years the war takes her brothers and her friends: Jem enlists at once, Jerry Meredith with him, and Walter, held back at first by illness and then tormented for not going, enlists in his turn. Rilla, who has never been useful in her life, brings home an orphaned newborn in a soup tureen and raises him, founds and runs a Junior Red Cross, and learns to wait and work while the casualty lists come in. Jem's dog takes up a station-platform vigil that lasts the whole war. Walter is killed at the front, and his last letter to Rilla asks her not to grieve. Later Jem is reported wounded and missing, and the family lives for months in uncertainty before learning that he is a prisoner and has escaped. The armistice comes; Jem, Shirley, Jerry, and Carl come home, Walter does not, and Rilla, grown up, is claimed by Kenneth Ford.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4188,7 +4188,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4201,7 +4201,7 @@
       "recaps": {
         "ending": "Dorothy and the Wizard reach the Nome Kingdom under Ozma's authority and end Kaliko's attempt to keep the royal captives. King Kitticut and Queen Garee are freed, and the Wizard also breaks the old enchantment on Bilbil, restoring him as Prince Bobo of Boboland. Inga, Rinkitink, Bobo, and the rescued rulers visit the Emerald City as Ozma's guests before returning to Pingaree. The people of Pingaree are brought home, the island is rebuilt, and the magic pearls remain with its royal house. Rinkitink would happily prolong his visit, but representatives from Gilgad finally arrive to carry their king back to his neglected duties. Inga's courage has proved him ready for the responsibilities that will one day be his.",
         "in_short": "When warriors from Regos and Coregos conquer Pingaree and enslave its people, young Prince Inga escapes with visiting King Rinkitink and Rinkitink's talking goat, Bilbil. Guided and protected by three magic pearls, Inga crosses the sea, defeats the invaders, and frees many captives. Queen Cor steals the pearls for a time, but the charcoal burner's daughter Zella helps Inga recover them. The enemy rulers flee with Inga's parents to the underground Nome Kingdom, where Kaliko tries to prevent their release. Dorothy and the Wizard arrive from Oz, free the captives, and uncover Bilbil's true identity as the enchanted Prince Bobo. Pingaree is restored, while the reluctant Rinkitink is eventually fetched home to rule Gilgad.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4328,7 +4328,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4341,7 +4341,7 @@
       "recaps": {
         "ending": "Rip returns to his village after sleeping through twenty years and at first cannot make sense of its unfamiliar people, buildings, and political arguments. He learns that the American colonies have become an independent nation, that his wife has died, and that many of his former companions are dead or scattered. His grown daughter Judith recognizes him and takes him into her home, while his son has become an idle young man much like him. Peter Vanderdonk's account of Hendrick Hudson's crew gives the community a traditional explanation for Rip's mountain encounter, and Rip's age and familiar face eventually establish his identity. With his family obligations changed and his long absence accepted, he resumes his old habit of sitting among the villagers, now telling his extraordinary story to visitors and becoming a local authority on life before the Revolution.",
         "in_short": "Easygoing Rip Van Winkle neglects his farm, helps his neighbors, and retreats from arguments with his wife into the Catskill Mountains. There he follows a strangely dressed man to a silent group playing at bowls, drinks their liquor, and falls asleep. He wakes to find his gun decayed, his beard long, and his dog gone. Back in the village, everything has changed: twenty years have passed, the Revolution has replaced British rule with the United States, and the political language around him is unfamiliar. Rip discovers that his wife and several old companions are dead, while his children are grown. His daughter Judith takes him in, and an old local tradition links the mountain figures to Hendrick Hudson's crew. Accepted as the same Rip who vanished, he settles into old age as a village storyteller, spared the domestic and economic responsibilities he once avoided.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4497,7 +4497,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4510,7 +4510,7 @@
       "recaps": {
         "ending": "The collection closes with Ichabod Crane's disappearance after his night ride from the Van Tassel farm. Pursued by what appears to be the Headless Horseman, he is struck by the rider's thrown head near the church bridge. The next day searchers find the borrowed horse, Ichabod's hat, and a broken pumpkin, but not Ichabod. Brom Bones soon marries Katrina and reacts knowingly when the pumpkin is discussed, strongly implying that he staged the apparition to drive away his rival. Later news says Ichabod survived, made a life elsewhere, studied law, entered politics, and became a judge. Sleepy Hollow's traditional storytellers nevertheless retain the supernatural version, adding the abandoned schoolhouse to their haunted landscape. This ending complements Rip Van Winkle's earlier return: Rip is absorbed into his changed home as a keeper of old memories, while Ichabod leaves his community and becomes the subject of the legend that remains behind.",
         "in_short": "Two tales place personal upheaval within legendary communities along the Hudson. In the first, idle but kindly Rip Van Winkle follows a strange man into the Catskills, drinks with a silent company, and sleeps for twenty years. He returns after the American Revolution to find his wife dead, his children grown, and his village transformed. His daughter takes him in, and he becomes a teller of the old world he remembers. In the second, superstitious schoolmaster Ichabod Crane courts the wealthy Katrina Van Tassel in rivalry with prankster Brom Bones. After a gathering filled with ghost stories, a headless rider chases Ichabod and strikes him with a thrown object. Ichabod vanishes, leaving a broken pumpkin as evidence. Brom marries Katrina and appears to know more than he admits; reports later place Ichabod alive and successful elsewhere, though Sleepy Hollow preserves the haunting as legend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4598,7 +4598,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4611,7 +4611,7 @@
       "recaps": {
         "ending": "The criminal organization traces the killings back toward Ripley and Trevanny. After an attack at Belle Ombre, the danger shifts to the Trevanny home. Jonathan, already gravely ill, intervenes when gunmen threaten Ripley and is shot while helping to save him. He dies from the wound, leaving Simone and their son with the money earned from the murders but without a full account of how he became involved. Ripley suppresses evidence and tries to keep his own role separate from Jonathan's death. Héloïse returns, and the routines of Belle Ombre resume, yet Ripley's retaliatory game has cost the life of the ordinary man he selected as a pawn. Simone remains suspicious of him, while Reeves Minot's scheme has exposed Ripley to an organized enemy that may not accept the official explanations.",
         "in_short": "Criminal fixer Reeves Minot asks Tom Ripley to kill Mafia figures threatening his interests. Ripley refuses but, after taking offense at a slight from terminally ill picture framer Jonathan Trevanny, suggests that Minot recruit him. False reports about Jonathan's health and the promise of money for his family persuade him to murder a man in Hamburg. Minot demands another killing aboard a train; Ripley unexpectedly joins Jonathan and helps complete it. Jonathan's wife, Simone, grows suspicious, while the victims' associates pursue Minot and then the two killers. Ripley shelters Jonathan and fights off attackers at Belle Ombre, but the danger reaches Jonathan's home. Jonathan saves Ripley during the final attack and is fatally shot. Ripley conceals what he can and returns to his domestic life, leaving Simone with money, grief, and doubts about his part in her husband's transformation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4788,7 +4788,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4801,7 +4801,7 @@
       "recaps": {
         "ending": "Roo emerges from the commercial struggle as one of Krondor's merchant princes. He has survived efforts by established rivals to use his appetite for Sylvia and his dependence on credit against him, and he converts foreknowledge of war, control of scarce goods, and a willingness to risk everything into a fortune. The achievement carries a personal cost: Karli has seen his infidelity and self-deception, while Roo has learned that wealth does not make him accepted by the old commercial families or free him from their methods. Erik remains in Calis's military service, helping prepare for the attack both friends know is coming. In Novindus, Fadawah has completed the practical work of turning conquest into invasion; the Emerald Queen's forces are ready to sail. Pug's investigation confirms that demons are not merely battlefield creatures but part of the power moving behind the campaign. Miranda intervenes to bring him back from that danger, becoming an uneasy ally while leaving her deeper history unrevealed. The Kingdom ends the book richer in warning and resources but almost out of time.",
         "in_short": "After surviving Novindus, Rupert Avery returns to Krondor and sets out to build a fortune while Erik stays with Calis's soldiers. Roo starts at the edge of the city's trading world, uses information and credit boldly, marries the practical Karli, and expands through increasingly dangerous bargains. His success brings him into the orbit of the powerful merchant Jacob Esterbrook and Esterbrook's daughter Sylvia. Roo's attraction to Sylvia becomes both a betrayal of Karli and a weakness his rivals can exploit. He suffers financial reverses but uses his knowledge that invasion is approaching to anticipate shortages, gamble on essential goods, and rebuild on a larger scale, ending as a merchant prince able to support the Kingdom's preparations. Meanwhile Calis, Nakor, Pug, and Miranda pursue the supernatural side of the threat. Fadawah finishes assembling the Emerald Queen's invasion fleet, and Pug learns that demonic powers stand behind more than isolated monsters. The coming war joins Roo's commercial rise to the Kingdom's survival.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5036,7 +5036,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -5049,7 +5049,7 @@
       "recaps": {
         "ending": "Jiran enters a new Challenger portal alone after hunting Tier 5 beasts and reaching 185 percent growth, leaving the nature and cost of his next trial unknown. Mayalyn brings Olive and Cameron into the cavern of Azure Light's displaced survivors, where she challenges the elders' exclusion and argues for cooperation with the Empire. Olive intends to advocate for the refugees and carefully control the spread of Jiran's density-claiming method, while Cameron is oath-bound to protect Mayalyn's people. Niya remains elsewhere with the crystalline key. She is training displaced recruits but refuses a revolutionary plan to sacrifice them as a diversion, and she intends to enter a temple operation within two days to seek Jiran and her own freedom. Markhiss is closing on her for an unknown purpose. Madra is still dying despite the restoration of one density absorber node. Daughter warned that an unidentified entity was tracking Jiran, and contact with her ended. The Graymin invasion continues, and neither Lenton nor Samris has reunited with Jiran.",
         "in_short": "After a Challenger portal separates Jiran from his mentors, he wins the Tier 2 series, advances to Tier 3, and returns to Madra after a year has passed. Seeking answers in the Jeweled Isles, he meets Mayalyn, trains under Amra, and learns that Azure Light expects him to die saving the community. Amra betrays them, but Jiran and Mayalyn restore a density absorber node. Its activation destroys the island, and they evacuate 341 of 345 residents. In the Outlands, Jiran prepares for another challenge while teaching Mayalyn, Olive, and Cameron new ways to control mana and claim density. The method could strengthen the Empire against the Graymin, but it could also destabilize the Church and its emperors. Jiran enters his next portal alone. Mayalyn, Olive, and Cameron approach the displaced community with an Imperial alliance, while Niya prepares a separate temple operation with the crystalline key as Markhiss closes in.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/rise-of-the-living-forge-5.json
+++ b/data/works-community/0/rise-of-the-living-forge-5.json
@@ -223,7 +223,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -234,7 +234,7 @@
       "recaps": {
         "ending": "Book 5 closes without resolving its two headline setups. The planned infiltration of the Blacktongue party to expose the Adventurer's Guild operative Mask never happens on the page, and the climax pivots entirely to the Dwarven Council. Convinced Arwin stole dwarven techniques, Councilwoman Indrana sends the warrior Gideon to kill him; Arwin's autonomous ivory golem, the Soul Guardian, defeats Gideon publicly, and Lillia captures him with overwhelming shadow magic. Where the major players stand: Arwin is unharmed at his forge, his power decisively displayed through the golem, with his new armor begun but not finished. Lillia has taken command of the aftermath, openly revealed as non-human, and is steering a direct confrontation with the Council. Gideon is captured and doomed, though his armor will be returned. Ida, having refused to call her mother for rescue, is estranged in spirit from Indrana and cooperating inside the Devil's Den. Indrana, off page, is about to be contacted directly. The Menagerie and its allies are all alive and thriving. Open threads carry into a possible book 6: the imminent Lillia-Indrana confrontation and the wider Dwarven Council conflict; the still-unexecuted Blacktongue party and the Mask reckoning; the unfinished armor and Koyu's promised body; the legendary vault still unlocated; Eleven's owed explanation of class-sunsetting; Vix's uncured heart; and the deeper mysteries of the dying world, Arwin's growing Hungering Maw, and the Setting Sun's tie to his and Lillia's summoned past and his charge to find One.",
         "in_short": "Rise of the Living Forge 5 follows Arwin Tyrr, the presumed-dead Hero of Lian, working as the masked smith Ifrit and leading the guild Menagerie. At the Adept Proving Grounds, two teams he equipped fight through the tournament: Phoenix Circle reaches the final and, though defeated, saves the dying undead Elias and stops the power-thief Hein, whom Kien kills; and Thornhelm withdraws to spare Kien from execution. The mysterious rival smith Necrohammer is revealed as Norman, Phoenix Circle's vanished founder, who then tells Arwin the world's secret: it is dying, the Guild manufactures war to feed the Mesh with the deaths of summoned heroes, and he saved Arwin and Lillia to break the cycle. Home in Milten, Arwin allies loosely with the Setting Sun, learns soulmancy from the lich Koyu and the dwarf Wallace, and begins building an armor to house his sentient smithy. He clears an expert dungeon to save the noble boy Thane and win a legendary vault-key. The book ends when the Dwarven Councilwoman Indrana sends the warrior Gideon to kill Ifrit: Arwin's autonomous ivory Soul Guardian golem overpowers him, and Lillia captures him with shadow magic, setting up a direct confrontation with the Dwarven Council that carries into the next book.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -604,7 +604,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -617,7 +617,7 @@
       "recaps": {
         "ending": "Kyle is no longer under blockade, and Tieran Nirius remains regent while Rezkin leads the larger war. Azeria is Rezkin's empress and life-bonded partner. Tam has learned that he is partly Fae and can command the elemental forces placed under him, though he still must master that authority. Dwarven machines have a prospective power source, individual elven allies have joined Rezkin, and the Spiritua support his command, but the elven nation has not entered the war. In Kaibain, the temple ritual succeeds despite the infiltration. Daemon power spreads through the crowded city, one of Rezkin's twin allies becomes possessed, and a mass method of removing Daemons from their hosts is urgently needed. Rezkin escapes with his bonded dragon and a rune-marked ritual key after badly wounding King Caydean, whose missing body leaves his fate uncertain. Wesson does not reach the escape portal and remains somewhere inside Kaibain. Finding him, understanding the key, and containing the possession crisis are the immediate unresolved tasks.",
         "in_short": "Rezkin survives King Caydean's attack and assembles dwarven, Fae, elven, and Spiritua support for the Daemon war. He and Azeria enter a life bond, return to Kyle as emperor and empress, and break the Asshai blockade with help from Tam's newly awakened Fae authority. Meanwhile, Wesson's attempts to free oath-bound mages expose his own Daemon bond and produce oath transfer rather than freedom. Caydean, himself inhabited by a Daemon ruler, turns Kaibain's new temple into a vast nexus. Rezkin's team attacks during its opening ritual, but the nexus releases Daemon power across the city. Rezkin wounds Caydean and escapes with the ritual key and his bonded dragon, yet Caydean's survival is unknown, one ally is possessed, and Wesson is left behind in Kaibain.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -896,7 +896,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07BTHWMFF",
@@ -908,7 +908,7 @@
       "recaps": {
         "ending": "Joe uses his single contractual escape to destroy the Accords without suffering their contract-based consequences. The compelled mages are freed, and the Archmage admits that he enslaved the Mage's College and withheld its power from Ardania's war. When he tries to destroy the city, the stored mana system overloads and kills him. The college agrees to broaden access, reduce costs, share research, and aid the kingdom. Cel is free after his coerced promotion, while the Master of Fire removes Joe's temporary Warlock title. Joe and the Wanderers receive public credit and exceptional standing. Tatum makes Joe his Chosen, advances his public class to Arc Cleric, and grants him daily Resurrection, while Joe's true Ritualist and Occultist paths remain concealed. Aten's guild continues the secret Shatter a People campaign against the Wolfman Nation. Tiona has left the old party for Royal Guard-linked training, Dylan has renewed confidence as a Bulwark, and the later paths of Dylan, Chad, and Guess are not settled. Terra still owes service for her college training. Joe ends at level nine, seeking magical instruction and a dependable ritual team that can eventually become a powerful coven. His possible return to reality, Tatum's restoration, the Hardcores conflict, Seeker of Truth, and the war all remain open.",
         "in_short": "Army medic Joe is paralyzed after a helicopter attack and permanently transfers into Eternium, where he becomes a concealed Ritualist serving the forgotten deity Tatum while publicly appearing to be a cleric and scholar. He joins the Wanderers, develops healing and ritual abilities, survives player killers, helps make night travel possible, and supports Tiona's party through a growing conflict with wolfmen. Joe captures an enemy altar for Tatum and redirects its summoned creatures against the Wolfman Nation, shortly before the Wanderers accept the royal quest Shatter a People and his party separates. Working alone, he captures the mage Cel and uncovers the Accords that magically control the Mage's College. Joe destroys the Accords using a one-use escape from contractual penalties, freeing the mages. The Archmage dies during a failed attempt to destroy Ardania, and the college begins reform. Joe and the Wanderers receive public credit. Tatum makes Joe his Chosen, gives him the public Arc Cleric class and Resurrection, while Joe remains a hidden Ritualist planning to build a dedicated ritual team.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1050,7 +1050,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1061,7 +1061,7 @@
       "recaps": {
         "ending": "The case closes with Henry Pyke's ghost laid to rest, though the older spirit that amplified him - Mr Punch, the spirit of riot and rebellion - is driven off rather than destroyed. The cost lands hardest on Lesley May: the revenant had been riding her since the night of the first murder, and the magic that reworked her face to its purposes leaves that face in ruins. She survives, under long-term medical care, her fast-track career gone. Nightingale is recovering from the gunshot wound that nearly killed him and resumes his duties slowly, with Peter carrying more responsibility than any first-year apprentice should. The feud between the two courts of the Thames is settled the medieval way, with an exchange of hostages: Beverley Brook goes upstream to live under Father Thames's authority, and sons of the old man's court come down to the city in return, so Peter's easy connection with Beverley is suspended just as it was becoming something more. Lady Tyburn's attempt to fold the Folly into the ordinary machinery of the state has been beaten back, but her hostility to Peter is now personal and durable. Peter himself ends the book committed: no longer a constable making a strange detour, but a sworn apprentice wizard with years of Latin, forms, and police work ahead of him.",
         "in_short": "Probationary constable Peter Grant takes a witness statement from a ghost at a Covent Garden murder scene and is recruited by DCI Thomas Nightingale, the last officially sanctioned wizard in England, as his first apprentice in decades. Living at the Folly, the old home of English magic, Peter learns spellcraft while investigating a wave of impossible violence: ordinary Londoners briefly possessed, driven to kill, and left with their faces destroyed. The killings prove to be re-enacting the plot of Punch and Judy, staged by the vengeful ghost of Henry Pyke, a failed eighteenth-century actor, and powered by something older - Mr Punch, the spirit of riot. Alongside the case, Peter brokers peace between Mother Thames and Father Thames, the rival deities of the river, and meets Beverley Brook. The investigation turns catastrophic: Nightingale is shot, a possessed audience riots at the Royal Opera House, and the spirit is revealed to have been riding Peter's friend Lesley May all along. Peter lays Pyke to rest, but Lesley's face is ruined. The river peace is sealed by an exchange of hostages, Beverley among them, and Peter commits fully to the wizard's life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1210,7 +1210,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1223,7 +1223,7 @@
       "recaps": {
         "ending": "Jarlaxle's Vaasan scheme draws the Citadel of Assassins into the open and gives Gareth Dragonsbane's forces the opportunity to break its power without allowing Jarlaxle to become an unchecked ruler himself. The drow abandons the appearance of a permanent kingdom once it has served its purpose, and Athrogate remains with him. Entreri's relationship with Calihye ends in violence when the grief and divided loyalties left by Ellery's death overwhelm their fragile trust. Entreri believes Calihye dead; Jarlaxle secretly has her restored and arranges for Kimmuriel to remove the memories tying her to Entreri, leaving her alive but outside his life. Jarlaxle then leads Entreri to the place of his childhood and forces the history he has buried into the open. Entreri confronts the men and institutions responsible for abuse, abandonment and his entry into a life of killing. He takes vengeance on those still within reach but rejects the idea that blood, a father or an abuser has the right to define what he becomes. He survives the journey with his partnership with Jarlaxle damaged yet intact, carrying self-knowledge rather than the final emptiness he once sought through defeating Drizzt.",
         "in_short": "Jarlaxle and Artemis Entreri return from Zhengyi's ruin owing explanations to Gareth Dragonsbane and the dragon sisters, while Entreri struggles with shadow magic and a fragile relationship with Calihye. Jarlaxle answers the pressure with a larger deception: he establishes Castle D'aerthe in Vaasa and presents himself as a would-be ruler, luring the Citadel of Assassins into exposing its strength. With Athrogate, Kimmuriel and Bregan D'aerthe, he maneuvers Gareth's champions and the assassins into a confrontation that breaks the Citadel without leaving him king. Entreri and Calihye turn on one another, and he believes he kills her; Jarlaxle secretly saves her and has her memories of Entreri removed. Jarlaxle then takes Entreri back toward his childhood home. Forced to confront the abuse, betrayal and abandonment behind his chosen identity, Entreri kills those he holds responsible but refuses to let ancestry dictate his future. He and Jarlaxle remain uneasy partners, and Entreri ends the trilogy changed by attachments he can no longer dismiss as weakness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1586,7 +1586,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0C2VW2YNR",
@@ -1598,7 +1598,7 @@
       "recaps": {
         "ending": "Jack wins the tournament when Rufus misses the final, but Exploding Sun withdraws its promised protection under Animal Kingdom pressure. Galicia separately cancels Jack's promised Animal Kingdom apprenticeship and permits the Scions to attack. Jack assigns his D-grade robot prize to protect the Bare Fist Brotherhood. In the ensuing battle, Sadaka and Li Shang are killed, Edgar defeats Gan Salin and collapses, and Alexander severely wounds Vivi before escaping. Rufus returns after reaching E-grade. Jack develops Iron Fist Style and kills him despite the overseer's attempted intervention. Gan Salin then attacks the exhausted Jack, but Brock and his dog pack drive him away. Brock carries Jack to the teleporter, and they depart for an unknown galactic destination. Margaret, Harambe's primates, the robot, and the surviving allies remain responsible for the Brotherhood on Earth. Gan Salin and the overseer remain hostile. Jack owes the Black Hole Church a favor and intends to become strong enough to return and take Earth from the Animal Kingdom.",
         "in_short": "Earth's integration traps biologist Jack Rust in a dungeon, where he advances through combat, befriends Harambe's primates, kills two Black Wolf bosses, and founds the Bare Fist Brotherhood. After freeing Volville from Henry's Fang, he enters the integration tournament in disguise and builds alliances with Edgar, Vivi Aragon, Dorman Whistles, Li Shang, and the Sage against the Animal Kingdom's Scions. Jack reaches E-grade with a perfect Dao Seed of the Fist and wins when Rufus Emberheart misses the final, but Exploding Sun withdraws its promised protection under Animal Kingdom pressure, and Galicia authorizes an attack. Sadaka and Li Shang die, while Vivi and Edgar are left gravely hurt or unconscious. Rufus returns at E-grade, and Jack kills him after creating Iron Fist Style. Brock saves the exhausted Jack from Gan Salin and takes him through a teleporter to an unknown destination. Jack leaves the Brotherhood defended on Earth and plans to return strong enough to challenge Animal Kingdom rule.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1913,7 +1913,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CLL838KG",
@@ -1925,7 +1925,7 @@
       "recaps": {
         "ending": "After the numbered story closes with Jack sealed inside an ancient cultivation chamber, he survives a month of isolation, adds Weakness as a fourth Dao root, and escapes. He defeats Trial Planet's final guardian, then uses the Thousand Essence Flower to form the Dao of Jack Rust. An abnormal tribulation nearly destroys him, but he completes his D-grade breakthrough as a Cosmic Fist immortal, raising the Bare Fist Brotherhood to D-grade. Old Man Spirit helps Jack and Brock evade the Hand of God blockade and sends them toward Exploding Sun. Animal Kingdom hunters intercept them and reveal that Captain Dordok was killed. Jack kills the hunters and declares war on the Animal Kingdom. Gan Salin chooses loyalty to his friends and intends to return to Earth, while Nauja leaves her tribe to seek a wider life. On Earth, Alexander accepts Animal Kingdom support, becomes E-grade, and challenges Edgar to a death duel. Edgar accepts, leaving the duel, Earth's protection, the Exploding Sun commitment, and the larger war unresolved.",
         "in_short": "Hunted by the Animal Kingdom, Jack Rust and Brock escape into space, lose Captain Dordok to their pursuers, and reach Trial Planet with the uneasy help of Gan Salin. They befriend Nauja, uncover an ancient complex, and grow through the planet's successive rings while Earth sinks into war between the Brotherhood-Flame River alliance and Ice Peak. Jack defeats Bocor, survives alliances with Longsword and the three lords, claims the Dao Sprouting Pill, frees an Echidna Devil to escape, and seals himself in a cultivation chamber. After the numbered chapters, he escapes, conquers Trial Planet's final guardian, forms the Dao of Jack Rust, and survives an abnormal tribulation to become D-grade. Old Man Spirit sends Jack and Brock toward Exploding Sun. Jack then kills the Animal Kingdom hunters who report Dordok's death and openly declares war. Meanwhile, Alexander becomes E-grade with Animal Kingdom backing and challenges Edgar to an unresolved death duel on Earth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2360,7 +2360,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0D3236RBC",
@@ -2372,7 +2372,7 @@
       "recaps": {
         "ending": "The Alliance defeats Ice Peak, Brock kills Alexander Petrovic, and Jack kills Galicia Lonahor on the Moon after reaching peak D-grade. Jonas Evergreen prevents the hostile fleets from interfering, then moves Earth and the Moon beyond system space. Jack survives, Vivi reveals that she is carrying his child, and Brock, Margaret Rust, Gan Salin, Nauja, Edgar, Dordok, and the recovering Sephira woman remain on the relocated world. Edgar cannot advance because his soul is cracked, but plans a wizard academy while Jack seeks a cure. Sparman remains critically damaged. The Animal Kingdom, Hand of God, former Hell warden, and Animal Kingdom ancestor remain threats. The Black Hole Church's disputed history, Jack's life drop and Dao-tree doorway, Brock's staff, and the approaching conflict involving immortals and old gods remain unresolved.",
         "in_short": "Jack Rust seeks enough power and political backing to save Earth from the Animal Kingdom. Exploding Sun conditionally supports him, but a political wager and Dordok's imprisonment lead Jack and his former mentor to infiltrate Hell. Jack frees Dordok, joins the Black Hole Church, survives a public duel sequence, and kills Maximus Lonihor before escaping home. On Earth, the Alliance fights Ice Peak while Brock, Gan Salin, Nauja, Edgar, and Vivi win separate battles. Brock reaches D-grade and kills Alexander Petrovic. Jack reaches peak D-grade, defeats Galicia Lonahor on the Moon, and secures Earth's immediate independence. Jonas Evergreen then moves Earth and the Moon outside system space. Jack survives as Earth's defender, learns Vivi is pregnant, and faces continuing threats from the Animal Kingdom, Hand of God, and a wider ancient conflict.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2745,7 +2745,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DFMMTZJJ",
@@ -2757,7 +2757,7 @@
       "recaps": {
         "ending": "Jack passes Archon Green Dragon's trial by asserting a personal, fist-centered Dao, then refines and absorbs the realm heart. The inheritance raises him to five fruits, gives him control over the realm's exits, and leaves him with B-grade fighting power. He releases Brock and Min Ling, and the three head first toward Earth before planning further travel. Min Ling accepts that Jack is married and does not pursue her feelings. Jack deliberately leaves Spacewind and the rest of the expedition in Green Cultivator Town until he can safely deal with Spacewind, though he intends eventually to free those who did not attack his group. The Archon's realm can survive for millennia, and Jack is expected to return at A-grade to incorporate it into his inner world. The life-drop guardian remains asleep, Jack still owes the Supreme Blood a lethal repayment debt, and his promises to Dorman Whistles remain outstanding. Elsewhere, the Second Crusade seizes the Black Hole Church Cathedral after its guardian dies covering an evacuation. Boatman, the Sage, and other Church survivors are unaccounted for. A disgraced former Animal Kingdom warden orders a search for Earth, placing Vivi, Abel, Eric, and the relocated world in renewed danger.",
         "in_short": "After securing relocated Earth, Jack Rust leaves Vivi and their newborn twins to train at the Black Hole Church with Brock. He survives a hostile Cathedral culture, reaches C-grade, creates a trade in healing stones, wins a world anchor, and becomes Boatman's disciple. A joint expedition with the Hand of God enters a hidden realm that proves to be an Archon's creation. Baron Longform dies after ambushing Jack and Brock, while Min Ling saves them and joins their party. Trapped in the realm's deepest trial, Jack defines his personal fist-centered Dao, claims the realm heart, becomes the Archon's heir, and emerges with five fruits and B-grade combat power. He, Brock, and Min Ling leave for Earth, but Spacewind and most of the expedition remain confined. Meanwhile, the Second Crusade captures the Church's Cathedral, and a former Animal Kingdom warden begins searching for Earth to strike Jack's family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3194,7 +3194,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DHW9WBVJ",
@@ -3206,7 +3206,7 @@
       "recaps": {
         "ending": "Jack ends the Animal Kingdom war by destroying its elder corps, killing Eva Solvig and the surviving founders, and leaving Artis Emberheart permanently sealed in intergalactic emptiness. Brock, Gan Salin, Nauja, and their companions stop Jack from extending his vengeance to civilians. The surviving Emberheart family abandons its name and becomes Open Chest. Jack returns to Earth, reunites with Vivi and Abel, buries an empty casket for Eric, and says goodbye before departing with Brock and Dorman Whistles. Min Ling, the Sage, and Sovereign Heavenly Spoon carry them toward the Black Hole Church's hidden forces. Brock becomes B-grade with an 8,800-mile inner world. Jack's freedom-based tenth fruit helps him advance to B-grade and expand his inner world to 10,000 miles, after which he survives heavenly tribulation with Brock and Boatman's intervention. Earth remains vulnerable, Black Hole World's people still await rescue, and Copy Jack and the sentient stone remain unexplained. The Heaven Immortal prepares mass slaughter while an anti-immortal queen mobilizes an opposing army and eleven old gods move toward system space.",
         "in_short": "Jack Rust emerges from a hidden realm and fights through the Hand of God's conquered territory to reach Earth. Artis Emberheart kidnaps and kills Jack's son Eric, cracking Jack's Dao and driving him into the Animal Abyss, which leads to the sealed Black Hole World. Jack repairs himself, promises to free its stranded people, and returns to wage war on the Animal Kingdom. He defeats its ancestors and Eva Solvig, while Brock stops him from killing Emberheart civilians. Artis is sealed and abandoned alive, and the survivors renounce their family name. After mourning Eric with Vivi and Abel, Jack leaves Earth for the Second Crusade. Brock reaches B-grade with an 8,800-mile inner world. Jack discovers freedom as a tenth Dao fruit, forms a 10,000-mile inner world, and survives heavenly tribulation with Brock and Boatman's help. As the Church prepares for war, immortal and anti-immortal armies mobilize and eleven old gods approach system space.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3586,7 +3586,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0F145J9SZ",
@@ -3598,7 +3598,7 @@
       "recaps": {
         "ending": "Jack defeats the hostile life god in the dimensional sea after Brock lends him temporary S-grade power. The victory also destroys the other gods absorbed by the life god, while the Heaven Immortal has already been killed. Boatman and the Arch Priestess die during the final defense, but Jack, Brock, Min Ling, Sovereign Heavenly Spoon, Fiend Prince, Great Silver, Vivi, Abel, and Jack's Earth clone survive. Fifty years later, Jack has judged the surrendered Immortal forces without punishing innocent relatives, removed rewards for killing from the rebuilt System, and reorganized the Bare Fist Brotherhood around justice and reconstruction. The surviving entropy, space, and time god clones train later generations in the Space Monster World under the Hall's continuing protection. Black Hole World and Green Dragon Realm have joined the main universe. Jack is now a late A-grade and the strongest person in the universe, but true S-grade remains ahead. He and Brock pioneer new galaxies while postponing exploration of the dimensional sea. On Earth, the clone lives with Vivi and receives visits from the adult Abel. Margaret Rust died ten years after the war and was not revived.",
         "in_short": "Jack Rust and Brock become exceptional B-grades and public champions of the Black Hole Church, then enter the Space Monster World seeking the power needed for Jack's duel with Elder Hero. They survive the Hall of Trials, kill Fiend King, and reach A-grade through unconventional foundations. Jack returns with Great Silver's army, defeats Hero, and helps launch the final war. The released life god destroys the Heaven Immortal but reveals its plan to eliminate all other life. Boatman and the Arch Priestess die protecting the Church, while Brock channels the survivors' resolve into temporary S-grade power for Jack. Jack destroys the god and ends the war. Fifty years later, he has reformed the System, judged the surrendered Immortal forces, and become the universe's strongest person while pioneering new galaxies with Brock. Vivi, Jack's clone, and their adult daughter Abel remain on Earth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3806,7 +3806,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3819,7 +3819,7 @@
       "recaps": {
         "ending": "Jim, Silver, and the remaining pirates reach the place marked on the map, only to find that Flint's treasure has already been removed. The disappointed mutineers turn on Silver and Jim, but Dr. Livesey, Gray, and Ben Gunn drive them off. Ben had found the hoard long before and carried it to his cave, which is why Livesey could safely surrender the map. The loyal party moves the treasure aboard the Hispaniola and leaves three surviving mutineers on the island. Silver helps manage the voyage but slips away at a port with a small bag of coins. The others return to England and divide their wealth: Smollett retires, Gray improves his position, and Ben quickly spends his share. Jim remains haunted by the island and wants no part of recovering the silver still left there.",
         "in_short": "Jim Hawkins finds a map in a dead pirate's sea chest and joins Squire Trelawney, Dr. Livesey, and Captain Smollett on an expedition to Treasure Island. Their cook, Long John Silver, is secretly leading much of the crew in a mutiny. Jim discovers the plot, slips ashore, and meets the marooned Ben Gunn. The loyal party occupies an old stockade while fighting the pirates, and Jim later recaptures their ship after a deadly struggle with Israel Hands. Returning to the stockade, Jim falls into Silver's hands, but Silver protects him as his own authority weakens. The pirates follow the map and find the treasure gone: Ben Gunn discovered it years earlier and moved it to his cave. Livesey and his allies rescue Jim and Silver, load the recovered hoard, and sail away, leaving three mutineers behind. Silver escapes during the homeward voyage with a modest share, while Jim returns wealthy but troubled by his memories.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3993,7 +3993,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4006,7 +4006,7 @@
       "recaps": {
         "ending": "Jim, Silver, and the remaining pirates reach the place marked on the map, only to find that Flint's treasure has already been removed. The disappointed mutineers turn on Silver and Jim, but Dr. Livesey, Gray, and Ben Gunn drive them off. Ben had found the hoard long before and carried it to his cave, which is why Livesey could safely surrender the map. The loyal party moves the treasure aboard the Hispaniola and leaves three surviving mutineers on the island. Silver helps manage the voyage but slips away at a port with a small bag of coins. The others return to England and divide their wealth: Smollett retires, Gray improves his position, and Ben quickly spends his share. Jim remains haunted by the island and wants no part of recovering the silver still left there.",
         "in_short": "Jim Hawkins finds a map in a dead pirate's sea chest and joins Squire Trelawney, Dr. Livesey, and Captain Smollett on an expedition to Treasure Island. Their cook, Long John Silver, is secretly leading much of the crew in a mutiny. Jim discovers the plot, slips ashore, and meets the marooned Ben Gunn. The loyal party occupies an old stockade while fighting the pirates, and Jim later recaptures their ship after a deadly struggle with Israel Hands. Returning to the stockade, Jim falls into Silver's hands, but Silver protects him as his own authority weakens. The pirates follow the map and find the treasure gone: Ben Gunn discovered it years earlier and moved it to his cave. Livesey and his allies rescue Jim and Silver, load the recovered hoard, and sail away, leaving three mutineers behind. Silver escapes during the homeward voyage with a modest share, while Jim returns wealthy but troubled by his memories.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4164,7 +4164,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4177,7 +4177,7 @@
       "recaps": {
         "ending": "After helping an English captain defeat mutineers and recover his ship, Crusoe leaves the island with Friday after more than twenty-eight years there. Back in Europe, he discovers that his family circumstances have changed beyond recovery, but the Brazilian plantation he abandoned has prospered. The Portuguese captain and others provide records of his ownership, making Crusoe wealthy. He arranges financial support for people who assisted him, secures his affairs, and travels overland toward England, surviving a dangerous winter encounter with wolves in the mountains. Crusoe later marries and has children. After his wife dies, the old desire for travel returns. He sails with a nephew, revisits the island, and finds a mixed community descended from the people he left there and later arrivals. He supplies and organizes the settlement before continuing his travels, closing the account with his wandering impulse intact rather than with permanent retirement.",
         "in_short": "Robinson Crusoe rejects his father's advice to remain in England and pursues a life at sea. After enslavement in North Africa, escape, and success as a Brazilian planter, he joins a voyage that ends in shipwreck. The sole survivor, he spends more than twenty-eight years on an island, salvaging supplies, building fortified homes, farming, raising goats, and reshaping his misfortune through religious reflection. Fear of visitors grows after he finds a footprint and evidence of violent landings. He eventually rescues a captive he names Friday, teaches him English and Christianity, and gains a loyal companion. They save Friday's father and a Spaniard, then help an English captain recover a ship from mutineers. Crusoe returns to Europe and learns that his Brazilian estate has made him wealthy. After settling his affairs and later losing his wife, he travels again, revisits the now-populated island, provides for its community, and continues onward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4342,7 +4342,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4355,7 +4355,7 @@
       "recaps": {
         "ending": "Crusoe and Friday help an English captain defeat mutineers and recover his ship, giving Crusoe a route home after twenty-eight years on the island. Back in Europe, Crusoe learns that his Brazilian plantation has prospered and made him wealthy. He rewards those who acted honestly for him and provides for old friends. Avoiding another sea journey, he travels overland from Spain and survives attacks by wolves and a bear. He settles in England, marries, and has children. After his wife's death, his restlessness returns. He revisits the island, finds a troubled colony made up of the men left there and later arrivals, supplies it, and continues traveling before closing with the prospect of further adventures.",
         "in_short": "Robinson Crusoe defies his father's advice and goes to sea, enduring storms, enslavement, escape, and a new career as a Brazilian planter. A slave-trading voyage ends in shipwreck, leaving him alone on an island. He salvages tools and supplies, builds fortified homes, grows crops, raises goats, and slowly transforms terror and despair into a disciplined religious and practical life. After many years he finds evidence that groups visit the island to kill captives. He eventually rescues one captive, names him Friday, and teaches him English and Christianity. Together they save Friday's father and a Spaniard. When English mutineers land, Crusoe helps their captain recover his ship. After twenty-eight years he returns to Europe, discovers his plantation has made him rich, and later revisits the island settlement before resuming his travels.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4510,7 +4510,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4523,7 +4523,7 @@
       "recaps": {
         "ending": "A photograph from Rodrick's party exposes the brothers' cover-up, and their parents punish Rodrick. He is nevertheless allowed to perform with Löded Diper in the talent show. The recording of the performance focuses heavily on Susan dancing in the audience, so Rodrick does not get the promotional video he expected. Blaming Greg for the result, Rodrick finally tells other students the story he has withheld all year: during Greg's summer stay at Leisure Towers, Greg accidentally entered the women's restroom and had to flee. As the account passes through the school, its details change until Greg is credited with deliberately entering a girls' locker room at a high school. The distorted version makes him seem daring rather than ridiculous, so Rodrick's revenge fails to cause the intended humiliation. The brothers return to their familiar rivalry, but their temporary cooperation over the party shows that they can protect each other when their interests align.",
         "in_short": "Greg begins a new school year with Rodrick threatening to reveal an embarrassing incident from Greg's summer. Their mother tries to improve the brothers' relationship with Mom Bucks, a reward currency for chores and good behavior. When their parents leave town, Rodrick throws a party and confines Greg to the basement. The brothers then cooperate to hide the evidence, including replacing a marked bathroom door, and their shared secret briefly brings them closer. A developed photograph eventually exposes the party. Rodrick is punished but still performs with Löded Diper at the talent show, where the family video highlights their mother's enthusiastic dancing rather than the band. Rodrick retaliates by spreading Greg's summer story at school. The tale becomes so exaggerated in circulation that it improves Greg's reputation instead of ruining it, leaving the brothers back in their ordinary uneasy relationship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4628,7 +4628,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4641,7 +4641,7 @@
       "recaps": {
         "ending": "GrayCris's concealed remnant operation at Milu is exposed, and the surviving members of the assessment team, Don Abene among them, get off the station alive with a first-hand account of it. Wilken and Gerth are stopped and the threats GrayCris left behind are destroyed. Miki does not survive: the small, trusting bot is destroyed protecting its humans, and the SecUnit, which used that trust and then let it fight, treats the loss as its own responsibility and as proof that it does not get to stand outside what happens around it. The SecUnit ends the book with recorded evidence of what GrayCris was doing, a false identity, and no intention of handing the material to a courier. It has concluded that GrayCris, cornered and facing exposure, will go after Dr. Mensah directly, and that the case is not something she can win at a safe distance. It boards a transport heading back toward Preservation to deliver the proof itself, which also means doing the thing it has avoided since it walked away from her offer of a home: seeing her again.",
         "in_short": "Hunting proof that GrayCris was illegally salvaging alien remnants, the SecUnit travels to Milu, a terraforming facility the company abandoned. It arrives hidden aboard the transport of a corporate assessment team sent to value the station, led by Don Abene, and befriends the team's small assistant bot, Miki, using its trust to move around unseen. The station is not as empty as the record claims: GrayCris left remnant material, contamination and hazards behind, and the two security operatives hired to protect the team, Wilken and Gerth, are working for someone else. As the team takes casualties, the pair seize the survivors and move to destroy the evidence. The SecUnit reveals itself and fights, and Miki is destroyed doing what it believes its humans need. The surviving team escapes with what they witnessed, and the SecUnit keeps hard evidence of what GrayCris hid there. Rather than transmit it anonymously, it decides that proof alone will not protect Dr. Mensah from a company with this much to lose, and takes a transport back toward Preservation to deliver it in person.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4932,7 +4932,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B071WWW2DD",
@@ -4944,7 +4944,7 @@
       "recaps": {
         "ending": "The surviving boarding party returns to Earth in a captured Nairb ship after Rogue World and its research community are destroyed. Although Natasha redirects suspicion toward the Nairbs, the Grand Admiral still intends to exterminate humanity. McGill invokes Nairb grievance procedure and forces a delay. In the later aftermath, Earth settles the case by accepting a secret military commitment in a neighboring province while retaining its conquered systems. Winslade remains in Galactic custody, and Claver's wider network of copies and stolen technology is unresolved. McGill returns to Waycross, stages his parents' deaths, and illegally reconstructs them in healthy bodies with help from Anne Grant and Natasha. Etta remains with the restored household, and Sarah later joins McGill there.",
         "in_short": "James McGill joins a covert Legion Varus mission while trying to save his sick mother. The legion attacks an illegal research colony before a Galactic audit, but McGill learns its people are human-derived survivors defending themselves. After Galactic intervention disables revival equipment, he helps build a secret alliance against a Nairb observer ship. His team captures that vessel, survives its automatons, and returns as Battlefleet 921 destroys Rogue World and its population. At Earth, McGill and Natasha shift blame toward the Nairbs, then use Galactic procedure to delay humanity's extermination. The later settlement preserves Earth's conquered systems but commits its forces to another secret war. Back home, McGill, Anne Grant, and Natasha illegally reconstruct his parents in healthy bodies, restoring Etta's household while Claver's network remains at large.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5139,7 +5139,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5152,7 +5152,7 @@
       "recaps": {
         "ending": "Cressida Twombley discovers enough of Penelope's secret to blackmail her, threatening to expose her as Lady Whistledown unless she is paid. Penelope and Colin disagree over how to respond, in part because Colin's fear for her reputation is mixed with envy of the writing career she built in secret. Penelope publishes another column to refute Cressida's false claim to the name, making concealment harder. At a major society ball, Colin chooses public support over further secrecy: he identifies Penelope as Lady Whistledown, declares his pride and love, and stands beside her while the room reacts. Lady Danbury's approval helps turn the moment away from rejection, and Penelope is accepted rather than ruined. Colin comes to terms with his jealousy and recognizes his own talent. He develops his travel journals into a book with Penelope's editorial help, while their marriage gives both of them the partnership and purpose they had lacked.",
         "in_short": "Years after falling in love with Colin Bridgerton, overlooked Penelope Featherington expects to remain only his sister's friend. When Colin returns from travelling, he begins to see her intelligence and confidence, shares his private writing, and kisses her after she asks to know what a kiss is like. Following her one evening, he discovers that Penelope is the anonymous gossip columnist Lady Whistledown. Anger, admiration, desire, and concern collide during their carriage ride home, and Colin proposes. They marry, but Penelope's secret remains dangerous. Cressida Twombley falsely claims to be Whistledown and later blackmails Penelope after uncovering the truth. Colin struggles with fear for Penelope and jealousy of her achievement before choosing to support her openly. At a society ball he reveals her authorship and declares his pride in her; Lady Danbury's approval helps secure acceptance. Penelope retires the column, and Colin turns his own travel journals into a published book with her help.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5311,7 +5311,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5324,7 +5324,7 @@
       "recaps": {
         "ending": "The friar's plan fails because the letter explaining Juliet's feigned death never reaches Romeo in Mantua. Instead his servant brings word that Juliet is dead, and Romeo, in despair, buys poison and hurries to her tomb. There he encounters Paris, who has come to mourn, and kills him in a fight before laying his body in the vault. Believing Juliet truly dead, Romeo drinks the poison and dies at her side. Moments later Juliet wakes from her sleeping draught to find Romeo dead beside her. Friar Laurence, arriving too late, urges her to flee, but she refuses; when she cannot bring herself to take poison, she stabs herself with Romeo's dagger and dies. The night watch rouses the city, and the Prince, the Montagues, and the Capulets gather at the tomb. Friar Laurence explains the secret marriage and all that followed. Confronted with their dead children, the two families are overcome with grief and at last make peace, ending the feud that destroyed them, and they agree to raise golden statues of the lovers in memory. The Prince closes with sorrow over the tragedy their hatred has caused.",
         "in_short": "In Verona, the Montague and Capulet families are locked in a violent feud. Romeo, a young Montague nursing a hopeless love for Rosaline, sneaks into a Capulet feast and meets Juliet, the Capulets' young daughter, and the two fall instantly and deeply in love despite their families' hatred. That night they exchange vows, and with the help of Friar Laurence, who hopes their union will reconcile the houses, and Juliet's nurse, they marry in secret. The feud soon shatters their happiness: Juliet's cousin Tybalt kills Romeo's friend Mercutio, and Romeo kills Tybalt in revenge, for which the Prince banishes him to Mantua. Meanwhile Juliet's father orders her to marry the nobleman Paris. To escape the match, Juliet takes a potion from the friar that makes her appear dead, so she can later flee with Romeo. But the message explaining the plan never reaches Romeo. Believing Juliet truly dead, he buys poison, goes to her tomb, and kills himself beside her. Juliet wakes, finds him dead, and stabs herself. Grief-stricken, the two families finally end their feud.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5493,7 +5493,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5506,7 +5506,7 @@
       "recaps": {
         "ending": "Romeo never receives Friar Laurence's explanation of Juliet's feigned death. Believing the report that she has died, he buys poison and enters the Capulet tomb, where he kills Paris in a confrontation. Romeo drinks the poison beside Juliet and dies before she awakens. Friar Laurence arrives but flees when guards approach, leaving Juliet to discover Romeo's body. She kills herself with his dagger. Before the Prince, the friar explains the secret marriage, Romeo's banishment, the sleeping potion, and the failed letter; Romeo's letter to his father supports the account. Montague also reports that Lady Montague has died from grief over Romeo's exile. Confronted with the deaths of their children, Capulet and Montague end their feud and promise memorials to Romeo and Juliet. The Prince closes the investigation by recognizing that the families' hatred has brought punishment upon them all.",
         "in_short": "The children of two feuding Verona families fall in love after Romeo Montague enters a Capulet feast and meets Juliet. With help from Friar Laurence and Juliet's Nurse, they marry in secret. Soon afterward Tybalt kills Romeo's friend Mercutio, and Romeo kills Tybalt in retaliation, bringing banishment. Juliet's parents order her to marry Paris, so the friar gives her a potion that makes her appear dead while a message is sent to Romeo. The message never reaches him. Told only that Juliet has died, Romeo returns, kills Paris at the tomb, and takes poison beside Juliet. She wakes, finds him dead, and kills herself. Friar Laurence reveals the hidden marriage and failed plan. The deaths finally reconcile the Montagues and Capulets, who recognize the cost of their feud.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5693,7 +5693,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5706,7 +5706,7 @@
       "recaps": {
         "ending": "Because a quarantine prevents Friar Laurence's letter from reaching Mantua, Romeo hears only that Juliet has died. He buys poison and enters the Capulet tomb, where he fights and kills Paris. Romeo drinks the poison beside Juliet and dies before her sleeping draught wears off. Juliet wakes, sees Romeo dead, and refuses to leave with the frightened friar. She kills herself with Romeo's dagger. The watch discovers the bodies and summons both families and the prince. Friar Laurence explains the secret marriage, Tybalt's death, the potion plan, and the failed message; Romeo's letter supplies further evidence. Montague also reports that Romeo's mother has died from grief during his exile. Confronted with the destruction of their children, Capulet and Montague end their feud and promise memorials to Romeo and Juliet. The prince judges that the hatred of both houses has punished the entire city.",
         "in_short": "An old feud divides Verona's Montague and Capulet families. Romeo Montague enters a Capulet feast and falls in love with Juliet Capulet; within a day, Friar Laurence secretly marries them, hoping the match will make peace. Instead, Tybalt kills Romeo's friend Mercutio, and Romeo kills Tybalt. The prince banishes Romeo, while Juliet's parents order her to marry Paris. Friar Laurence gives Juliet a draught that will make her appear dead so Romeo can meet her after she wakes. The plan fails when Romeo never receives the explanation. Told that Juliet has died, he returns, kills Paris at the tomb, and takes poison beside her. Juliet wakes to find him dead and stabs herself. The friar reveals their marriage and the failed scheme. Their grieving parents finally abandon the feud and agree to honor the young couple whose deaths exposed its cost.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5833,7 +5833,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5846,7 +5846,7 @@
       "recaps": {
         "ending": "After returning to the fort, Ronia and Birk remain loyal to each other even as their fathers continue the feud. Noddle-Pete dies, leaving Ronia grieving but also carrying his knowledge of a source of silver. Pressure from soldiers makes the two robber bands accept that they must cooperate. Matt defeats Borka in a contest and becomes chief of the combined band, but Birk refuses the expectation that he will one day lead robbers, and Ronia likewise rejects her father's trade. The children intend to spend future summers together in Bear's Cave and support themselves through the silver secret rather than robbery. Matt is distressed that Ronia will not succeed him, yet the feud has ended: the families share the stronghold, and Ronia and Birk face adulthood as chosen brother and sister, determined to make a different life.",
         "in_short": "Ronia, the daughter of robber chief Matt, grows up in a fort split by lightning and explores the dangerous forest around it. A rival band led by Borka occupies the fort's other half, where Ronia meets Borka's son, Birk. Although their families are enemies, the children repeatedly save each other and become as close as siblings. When Matt takes Birk captive to force Borka out, Ronia makes herself a hostage to secure Birk's release. Matt disowns her, so she and Birk leave both families and live through the summer in Bear's Cave. Their difficult independence deepens their bond and finally drives Matt to seek reconciliation. Back at the fort, the robber bands unite under Matt, but Ronia and Birk both refuse to become robbers. After Noddle-Pete's death, his secret of a silver source offers them another way to live, and they plan a future together beyond their fathers' feud.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6016,7 +6016,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6029,7 +6029,7 @@
       "recaps": {
         "ending": "After a period of treatment, public attention, and painful family adjustment, Ma and Jack begin living at Grandma and Steppa's home. Ma survives her suicide attempt and returns from the hospital, but Jack has learned that he can remain safe with other people and no longer needs her every moment. His hair is cut, and he sends the long braid to Ma as a sign of the strength he once believed it held for him. Before settling into their new life, Jack asks to visit Room once more. The police take him and Ma back to the shed. Seen from outside and emptied of many familiar objects, it is smaller and less complete than the universe he remembers. Jack says goodbye to Room and its remaining objects, then leaves with Ma. Their bond endures, but the visit confirms that captivity is now a place they can depart rather than the boundary of Jack's world.",
         "in_short": "Five-year-old Jack has known only Room, the shed where an abductor has imprisoned his mother for seven years. Ma has built him a structured life while hiding the scale of their captivity. When their captor's finances worsen, she tells Jack the truth and trains him to escape by pretending to be dead inside a rug. Jack gets free, alerts a stranger, and gives a police officer enough information to rescue Ma. Outside, he confronts open space, crowds, relatives, medicine, and constant public interest, while Ma struggles with trauma and anger over the life taken from her. After a hostile interview, Ma attempts suicide and is hospitalized. Jack gradually accepts care from Grandma and Steppa and discovers that separation from Ma is survivable. When she returns, mother and son visit the shed one last time. Its power has diminished now that Jack can see it as one small place in a much larger world, and they leave it together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6264,7 +6264,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6277,7 +6277,7 @@
       "recaps": {
         "ending": "The family establishes itself in Henning, Tennessee, where Tom's descendants enter new trades, acquire property, and continue telling children about Kunta Kinte. Cynthia marries lumberman Will Palmer; their daughter Bertha attends Lane College and marries Simon Alexander Haley. Their son Alex grows up hearing the inherited African sounds and stories from older relatives. As an adult writer, he pursues the account through records, travel, and oral testimony. In the Gambia, a griot in Juffure recites a Kinte history that includes a young man taken away by strangers at a time consistent with the family tradition. Haley links this account to the voyage of the slave ship Lord Ligonier and to records in colonial America, presenting Kunta as the ancestor whose story survived seven generations. The book closes by connecting the reconstructed family saga to Haley's own life and by honoring the relatives who preserved names and memories despite enslavement, forced separation, and the passage of two centuries.",
         "in_short": "Kunta Kinte grows up in Juffure, the Gambia, learning Mandinka and Muslim traditions before slave traders kidnap him and ship him to colonial America. Sold in Virginia and renamed Toby, he repeatedly tries to escape; after his foot is mutilated, he survives, marries Bell, and teaches their daughter Kizzy fragments of his language and ancestry. Kizzy is sold away after helping another enslaved person and gives birth to George, who becomes the renowned cockfighter Chicken George. George and Matilda's son Tom, a blacksmith, leads the expanding family through sale, Civil War, emancipation, and relocation to Tennessee. Later generations build businesses and pursue education while repeating the story of their African forebear. Alex Haley, Kunta's descendant, investigates the inherited names and words through archives and oral history. His search reaches Juffure, where a griot's genealogy identifies a Kinte youth taken by strangers, allowing Haley to connect the family's American history to Kunta and to present the survival of that memory across seven generations.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6429,7 +6429,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6442,7 +6442,7 @@
       "recaps": {
         "ending": "After escaping to Dr. Hill, Rosemary is returned to Guy and Dr. Sapirstein, drugged, and delivered of her baby at home. She is told that the child died, but she continues to hear an infant crying through the wall. She discovers a concealed entrance into the Castevets' apartment and finds the neighbors gathered around a black-draped cradle. They reveal that Guy cooperated with them in exchange for success and that Rosemary's child was fathered by Satan during the drugged ritual. Roman calls the baby Adrian and presents him as the heir around whom the group has gathered. Horrified by the infant's unnatural eyes, Rosemary nevertheless responds to his crying as his mother. She questions how the group is caring for him, suggests a gentler way to rock the cradle, and begins to approach it. The novel closes with her maternal attachment drawing her toward the child even after she understands what he is, while Guy remains outside the new bond he helped create.",
         "in_short": "Rosemary and Guy Woodhouse move into the Bramford, where their elderly neighbors Minnie and Roman Castevet quickly take an intrusive interest in them. Guy's acting career abruptly improves after he befriends the couple. When Rosemary becomes pregnant, the Castevets steer her to Dr. Sapirstein and control her diet while dismissing her severe pain. Hutch investigates but dies after arranging to send Rosemary a clue, which helps her identify Roman as the son of a notorious occultist. She concludes that the neighbors are a coven and seeks help, only to be returned to them. After a drugged delivery, Rosemary is told her baby died, but she follows its cries into the Castevets' apartment. There she learns that Guy traded access to her for success and that Satan fathered the child during a ritual. Although appalled, Rosemary's response to the crying infant becomes maternal, and she begins to take an interest in his care.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6585,7 +6585,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6598,7 +6598,7 @@
       "recaps": {
         "ending": "On the ship to England, Rosencrantz and Guildenstern discover that the royal letter orders Hamlet's execution. While they sleep, Hamlet replaces it with a command that they themselves be killed. Pirates attack; Hamlet disappears with them, leaving the courtiers to continue toward England with the altered letter. Guildenstern tries to resist the Player's claim that death is simply another predictable exit and stabs him, only to find that the weapon and death were theatrical effects. The Tragedians perform the deaths awaiting the characters from Hamlet. Rosencrantz then accepts his disappearance, and Guildenstern follows after one last failed attempt to understand when choice became impossible. The action shifts to the end of Hamlet, where an English ambassador reports that Rosencrantz and Guildenstern are dead. Horatio remains to explain the larger tragedy, while the two men whose perspective the play followed have vanished without discovering whether they could ever have changed their assigned end.",
         "in_short": "Rosencrantz and Guildenstern, two minor figures from Hamlet, are summoned to Denmark without understanding why. A run of impossible coin tosses introduces a world in which probability, identity, and memory offer no secure guidance. Claudius and Gertrude ask them to discover the cause of Hamlet's strange behavior, but the courtiers can neither question him effectively nor grasp the deadly court plot unfolding around them. A company of Tragedians, led by the Player, repeatedly anticipates events and treats death as a rehearsed theatrical pattern. After Hamlet kills Polonius, the pair escort him to England with a sealed execution order. They learn its contents but do not act decisively; Hamlet secretly changes the letter so that England will execute them instead and escapes during a pirate attack. Rosencrantz and Guildenstern disappear as their deaths are announced in the concluding scene of Hamlet, never resolving whether fate, the script, or their own passivity determined the outcome.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6774,7 +6774,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6787,7 +6787,7 @@
       "recaps": {
         "ending": "King Shrewd is killed in his bed, drained through the Skill by Justin and Serene on the night Chade's escape plan is to run. Fitz kills them both in the great hall in front of the assembled court and is taken. Regal has him beaten, tried for the king's murder and for practising beast-magic, and left broken in a cell to die. Fitz does die, in every sense the keep can verify: on Chade's and Burrich's plan he retreats into Nighteyes as his body fails, and the two men dig his corpse out of its grave and spend weeks coaxing a wolf back into a man's body. He recovers as something less than he was, half-feral, with his health and his Skill in ruins. Kettricken, who has lost Verity's child, flees Buckkeep for the Mountain Kingdom with the Fool and a small escort, carrying the last hope of the Farseer line with her. Regal has himself crowned, strips Buckkeep of its wealth and moves the court inland to Tradeford, abandoning the coast to the Red Ships. Verity is somewhere beyond the Mountains, alive at least in the moments he can reach Fitz through the Skill, and everyone at home believes him dead. Molly has left without saying where, carrying a child Fitz does not know about. Patience and Burrich mourn a man who is not dead. Fitz, officially a corpse and finally free of the covenant that owned him, resolves to hunt down Regal.",
         "in_short": "Fitz comes home to Buckkeep from the Mountains poisoned, shaking and no safer than he left. Verity is burning himself out Skilling against the Red Ships, King Shrewd is failing and kept drugged, and Kettricken is isolated in a court that has no use for a queen who wants to work. Fitz bonds with a wolf cub, Nighteyes, becomes Molly's lover in secret, and hunts Forged ones for the queen. Verity leaves on a desperate journey beyond the Mountains to find the Elderlings, and Regal immediately begins converting his brother's absence into a crown: he has himself named King-in-Waiting, strips Buckkeep and prepares to abandon the coast. Molly, refused first place in Fitz's life, leaves him. Shrewd is murdered through the Skill by two of the coterie, and Fitz kills them in front of the court. Regal has him tortured and condemned; Fitz escapes into the wolf as his body dies and is dug up and slowly brought back by Burrich and Chade. Kettricken, her child lost, flees for the Mountains with the Fool. Regal is crowned, and Fitz, officially dead, sets out to kill him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/rise-of-the-living-forge.json
+++ b/data/works-community/0/rise-of-the-living-forge.json
@@ -132,7 +132,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -143,7 +143,7 @@
       "recaps": {
         "ending": "Book 1 ends inside a remote dungeon outside Milten, just after Arwin's guild defeats its boss. The five members - Arwin, Lillia, Reya, Rodrick, and Anna - have finally shared their true identities and stand united and sworn to secrecy. Arwin remains publicly dead, still a low-tier crafter rebuilding from nothing, but now carries a dead, Epic-quality crafting material and the knowledge that the world's real hierarchy of power runs far above anything he and Lillia were ever shown, even at the height of their old strength. He and Lillia are quietly in love, though neither has spoken it. The revenge arc is all but closed: three of the four Iron Hounds who killed Zeke are dead, and only their leader Jessen survives, far stronger than he pretends, held off by a fragile truce - with a dagger still secretly bound to Arwin left in his hands. Several threads carry into the next book: the mesh's new Challenge, which warns that Arwin's class-hunger will kill him unless he masters it; the still-unexplained forces that staged the war and hid the true scale of power; the Forest Worm near Milten, which the reader knows is secretly controlled by the Iron Hounds though the guild does not; the smithy, cleared and awaiting rebuilding; and Rodrick's still-undisclosed deeper past, his former order and why he fell. Arwin resolves to grow quietly stronger and investigate rather than confront his enemies head-on.",
         "in_short": "Arwin Tyrr, the Hero of Lian, kills the Demon Queen to end a staged fifteen-year war, only to survive a hidden bomb in his own armor and be reborn in the remote city of Milten with a unique crafting class, the Living Forge, and a curse that forces him to devour magical items to live. Building a hidden life as the masked smith Ifrit, he gathers a small guild - the thief Reya, the warrior Rodrick, the healer Anna, and Lillia, the depowered Demon Queen who runs a nearby tavern and slowly becomes his ally and love. Together they discover the war was engineered and that both champions were meant to die. When a rival guild, the Iron Hounds, firebombs his smithy and kills his young assistant Zeke, Arwin hunts down three of the four responsible, deferring only their dangerously strong leader, Jessen, under a truce. Clearing a remote dungeon, the guild reveals their true identities to one another, and Arwin claims a dead, Epic-quality crafting heart. He learns the world's true scale of power dwarfs anything he was shown, and the mesh warns him that his class's hunger will kill him unless he learns to control it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -382,7 +382,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -393,7 +393,7 @@
       "recaps": {
         "ending": "The book ends quietly rather than in combat. Arwin has reached Journeyman tier and forged his first Epic-quality item, the Bleak Wind Chestplate, for the healer Anna, remade from the armor of the man he killed; he ends the book unconscious from magical exhaustion but safe, watched over by Lillia, holding a banked skill upgrade and an unused black badge suspected to be the key to a nearby dungeon. His guild, Menagerie, is now officially registered, with the tavern as its guild house and a co-leader seat left empty. Arwin and Lillia are openly a couple, her Demon Queen identity known to Olive and now to the merchant Madiv, who is sworn to her service and supplying the smithy. Reya carries a newly awakened weapon and a Challenge of her own, unspoken feelings for Olive, and a raw past dragged back up by her old betrayer Charles. Olive is a full member still owed two secrets: the group's history with the Adventurers' Guild and Madiv's true nature. Jessen and the Iron Hounds are gone, but new complications open: Menagerie has been blacklisted by a thief and information network over its dealings with Madiv; the shopkeeper Esmerelda's strange reaction to Arwin is unexplained; the long-promised dungeon delve never happens; and the haunted-street land purchase waits on money and paperwork. Above all, Arwin's newly stated goal, to tear the corruption out of the Adventurers' Guild's leadership, sets the course for what comes next.",
         "in_short": "Rise of the Living Forge 2 follows Arwin Tyrr, the presumed-dead former Hero of Lian, as he rebuilds his life in Milten as the masked smith Ifrit while racing a mesh Challenge that warns his class's hunger will kill him unless he masters it. He forges the dead Epic crystal he carries into a living bow, recruits the one-armed warrior Olive, and delves a spider-filled dungeon to grow stronger before a worm brood strikes. The brood proves to be the work of the Iron Hounds' leader, Jessen, who is breeding and controlling the monsters and culling his own guild for power. In a night ambush the group breaks his hold and Arwin kills him, freeing the horde. Naming their guild Menagerie, Arwin and Lillia finally become a couple and Olive joins for good. As the shop and tavern flourish, a merchant named Madiv recognizes Lillia as the former Demon Queen, and dealings with him get Menagerie blacklisted by a thief network. Reforging Jessen's armor into an Epic chestplate for the healer Anna, Arwin reaches Journeyman tier and collapses from exhaustion, caught by an unseen presence and found safe by Lillia. His closing thought finally names his true goal: to root out the corruption in the Adventurers' Guild's leadership.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -655,7 +655,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -666,7 +666,7 @@
       "recaps": {
         "ending": "Arwin ends the book alive and well, advanced to Journeyman tier and settled into his chosen path, Cursed Dwarven Smithing, having forged his first two cursed items: a shield built from a monstrous worm's scale and a kitchen knife for Lillia. The choice, once a gamble, is proven workable. He and Lillia remain openly together, and their transformed, sentient smithy is bonded to them both. No member of the Menagerie dies or is captured; every named guild member ends the book intact and in their established role. The guild is materially stronger than at the start: newly and barely ranked by the Secret Eye, informally backed by the restored Montibeau family, running an expanding tavern base, and holding two working cursed items plus an unofficial tie to the cursed-item dealer Esmerelda, whose true membership Arwin leaves undecided. Rodrick and Anna's dark pasts are known and accepted; the dwarven smith Wallace is a secret-keeping ally. The central threat is unresolved: Twelve, a masked figure far stronger than the Menagerie, has demanded the dungeon heart hidden inside Arwin's smithy within four days, and that deadline has not passed. Rodrick's intelligence has tied Twelve to a guild called the Setting Sun, a name Arwin and Lillia recognize from their own unexplained, more powerful past before an event they call the explosion, the first time either confirms they were once far stronger than they are now. The book closes as a representative of the Dawnseeker Guild arrives unannounced at the tavern and offers Arwin unexplained mutual help, leaving the Menagerie poised between two converging unknowns as book 4 opens.",
         "in_short": "Rise of the Living Forge 3 follows Arwin Tyrr, the presumed-dead Hero of Lian, as he grows his craft and his guild, the Menagerie, in Milten while working behind a mask as the smith Ifrit. Using a looted key, the guild clears an unstable ranked dungeon, keeps its still-beating monster heart, and earns a public reputation and a place on the kingdom's guild rankings, drawing the rival Ardent Guild's attention and a flood of business. When a hunted noblewoman, Melissa Montibeau, takes refuge with them, Arwin forges her concealed armor and helps fight off the assassins pursuing her. Joined into a living device, the monster heart consumes and transforms his smithy into a sentient forge, which opens a portal to a dwarven master, Wallace Gentletongue. Wallace trains Arwin, uncovers his and Lillia's true identities, and keeps them secret; Arwin reaches Journeyman tier and chooses the risky Cursed Dwarven Smithing, forging his first cursed shield and knife. Rodrick and Anna are revealed as Melissa's secret protectors and confess their dark pasts, and are accepted. The book ends unresolved: a masked, immensely powerful figure named Twelve demands the dungeon heart within four days, tied to a guild called the Setting Sun that Arwin and Lillia recognize from their own hidden, more powerful past, and a Dawnseeker Guild representative arrives offering unexplained help.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -971,7 +971,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -982,7 +982,7 @@
       "recaps": {
         "ending": "Book 4 closes at the exact opening of the Adept Proving Grounds, before any match is fought. Twelve is dead, killed by Anna's sympathetic poison, which has drawn the attention of the numbered organization he served: the Menagerie has been observed by a young operative who judged Arwin formidable but not hostile, and separately a figure who slipped past all detection questioned Arwin directly before leaving. Arwin ends the book at the height of his power to date: advanced to Adept tier with a soul-focused specialization, wielding a hammer that has evolved into a dramatically stronger sentient weapon, and having created a Soul Guardian that Koyu, a centuries-old lich now allied to him, calls a new form of life outside the mesh's rules. He attends the tournament only as a spectator, seated with Reya. Two teams carry the Menagerie's stake into the arena: Phoenix Circle's Olive, Elias, and Maeve, and the trio of Art, Vix, and Kien, funded by the Montibeau family and the Dawnseekers. Kien, stripped of his old magic, has earned a new class and an unusual soul-imprinted weapon, and means to find and kill his brother Hein, who is competing with Kien's stolen power. None of these confrontations occurs on the page. The tournament outcome, the Hein-Kien reckoning, Vix's hoped-for cure, the rival dwarven smith, the watching organization's next move, and the deeper mystery of the Setting Sun and Arwin and Lillia's own buried past all remain open as book 5 begins.",
         "in_short": "Rise of the Living Forge 4 follows Arwin Tyrr, the presumed-dead Hero of Lian, working as the masked smith Ifrit and leading the guild Menagerie from Lillia's tavern in Milten. To remove the threat of Twelve, a masked assassin tied to the Setting Sun, the guild clears a dungeon for its heart, then springs a trap: they disguise Twelve as a monster, wear his clone down, and use Anna's sympathetic poison to kill the real Twelve and all his bodies at once. Impressed, the Secret Eye invites the Menagerie into a tournament, the Adept Proving Grounds, paired with the struggling guild Phoenix Circle. As Arwin equips the teams and advances to Adept tier through soul-forging, new allies gather: Duke Aleric's children Art and Vix, and Kien, a renowned adventurer whose magic was stolen by his own brother Hein, now a tournament entrant. Arwin's hammer evolves into a powerful sentient weapon, and the organization Twelve served begins watching the guild. The book ends at the tournament's opening ceremony, with the first teams called into the arena and no match yet fought, every major thread carried into book 5.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/ruin.json
+++ b/data/works-community/0/ruin.json
@@ -422,7 +422,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -435,7 +435,7 @@
       "recaps": {
         "ending": "Felix and Pit survive the Cardinal confluence by insisting on their separate identities, though Felix gives up most of its authority and keeps a painful wound. A year later, Vessilia is his wife and Empress, ruling an empire that is rebuilding and receiving migrants. Evie represents the King's Rock Coven in Elder Throne. Beef and Hallow continue voluntary spirit-preservation research without a breakthrough. Gabby and the Chanters still cannot open a safe route to Earth, and their latest attempt releases a hostile creature instead. Kevin's invitation to Gabby opens the possibility of a relationship. The Compact remains active, and four Cardinal moons mark the restored powers. The former god of chaos and flame warns Felix that foreign empires are moving toward war, while a thunderbird arrives from the east seeking him.",
         "in_short": "Felix leads a rescue into ruined Amaranth, where Vessilia and the other Unbound survive corrupted omen paths and return with greater power. After claiming Amaranth, he prepares for the Ruin while a surviving Hierophant and a dwarven invasion threaten Jast. Felix and Pit recover the Exalted Bell and learn that the gods stole Cardinal power and that the Compact became their flawed prison. At Jast, the allies defeat Volantris and a half-divine, but the Compact breaks and frees the gods. The Whale Maw and a divine corpse help destroy them before the Ruin arrives. Felix learns the Ruin is the transformed god of destruction, becomes scion of the Unseen Tides, restores Pit, kills the god, and reforms the four Cardinal powers. He and Pit reject permanent absorption and return. A year later, Vessilia rules beside Felix, the empire rebuilds, Earth remains unreachable, and foreign war and a thunderbird present new dangers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -683,7 +683,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -696,7 +696,7 @@
       "recaps": {
         "ending": "Alina escapes the Apparat's underground stronghold, reunites her scattered allies, and rescues Nikolai, whom the Darkling's shadow magic has transformed into a winged, half-feral creature. Mal, the great tracker, hunts the third amplifier, the firebird, but Morozova's buried history reveals the real secret: the third amplifier is Mal, the last living descendant of the ancient Grisha who forged the amplifiers, and its power can only pass to Alina through his death. In the final battle the Darkling is brought down and killed, and Alina burns his body. She then kills Mal to claim the amplifier, but the sacrifice does not work as expected: instead of flooding into her, the power shatters the amplifiers and disperses across the Grisha near her, and Mal's life is restored. Alina survives but loses her summoning power completely, becoming an ordinary person, otkazat'sya, at last. The Shadow Fold is destroyed. Nikolai, freed from his monstrous state, takes the throne of Ravka and, with surviving Grisha like Zoya, Genya, David, Tolya, and Tamar, begins to rebuild the shattered country and its Second Army. Alina and Mal, both believed to have died in the final battle so that the legend of the Sun Saint can rest, return unknown to the orphanage at Keramzin where they were raised, to live quietly and freely together.",
         "in_short": "Weakened and held underground by the Apparat's cult of the faithful, Alina escapes with her friends and sets out to finish the war against the Darkling. They rescue Prince Nikolai, whom the Darkling's shadow magic has turned into a half-monstrous creature, and Mal tracks the third and last amplifier, the firebird. The terrible truth emerges from Morozova's history: the third amplifier is Mal himself, the last descendant of the ancient maker of the amplifiers, and to claim its power Alina would have to kill him. In the final confrontation the Darkling is destroyed. Alina drives a blade into Mal to take the power, but instead of concentrating in her, the sacrifice shatters the amplifiers and scatters their strength to the Grisha around her, and Mal is brought back to life. Alina loses her own summoning power entirely and becomes an ordinary woman, and the Shadow Fold is unmade at last. Nikolai is restored and becomes king, rebuilding Ravka and its Grisha, while Alina and Mal, both believed dead, quietly return to the orphanage where they grew up to live out simple lives together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -931,7 +931,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002VAEIBE",
@@ -943,7 +943,7 @@
       "recaps": {
         "ending": "Reacher and Harper reach Rita Scimeca's house while Julia Lamarr is directing the final staged death. Reacher stops Lamarr and restores Scimeca's breathing, but his blow kills Lamarr. The evidence shows that Lamarr used hypnosis, false travel identities, advance paint deliveries, and her position inside the FBI investigation to manufacture a serial pattern around the murder she actually wanted - Alison Lamarr's death for an inheritance. Scimeca survives but remains disoriented.\n\nNelson Blake and Alan Deerfield initially plan to preserve the Bureau's reputation by presenting Lamarr as a fallen agent and prosecuting Reacher. He demonstrates that their own surveillance evidence makes that account untenable. Reacher agrees not to expose Lamarr, largely to protect Scimeca from renewed public attention, and the FBI releases him without publicly clearing the case. Harper is suspended for refusing the official line and considers a transfer to Portland. Reacher returns for Jodie Garber's promotion celebration. She has become a partner but must lead her firm's London operation for two years, leaving their relationship intact yet facing separation because Reacher will not move there.",
         "in_short": "Jack Reacher is forced into an FBI inquiry after former Army women he once knew are murdered in staged paint-filled baths. Working with agent Lisa Harper, he narrows the targets, discovers that paint was delivered to their homes in advance, and follows a misleading trail through an Army weapons-fraud scheme. The killings are camouflage for Julia Lamarr's plan to murder her stepsister Alison for an inheritance. Lamarr used hypnosis and her FBI access to control the women and direct the investigation toward an invented male military offender. Reacher and Harper reach Rita Scimeca during the final attack; Reacher saves Scimeca and fatally strikes Lamarr. Nelson Blake and Alan Deerfield suppress Lamarr's guilt, but Reacher forces a private agreement that leaves him free. Harper is suspended for supporting him. Reacher returns to Jodie Garber, whose new partnership requires two years in London, while he refuses to relocate.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1064,7 +1064,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1077,7 +1077,7 @@
       "recaps": {
         "ending": "Yassen finishes his account with the discovery that ended his loyalty to Scorpia without ever changing his behaviour: Hunter, the man who trained him and who saved his life, was not one of them at all. He was a British intelligence officer working inside the organisation, and Yassen worked it out and said nothing, because the debt outweighed everything Scorpia could have paid him for the information. Hunter's name was John Rider, and he had a wife and a baby son. The book then returns to the present, where Yassen has that son in the sights of a rifle and a contract that would be simple to complete. He puts the weapon down. He will not kill Alex Rider, then or later, because of what he owes a man who has been dead for years, and no employer will ever be given a reason for it. He remains what Scorpia made him, and goes on taking other work, having decided the one thing he will not do.",
         "in_short": "Ordered to kill Alex Rider, the assassin Yassen Gregorovich sets down the story of his own life instead. He was born Yasha Gregorovich in Estrov, a Russian village beside a secret installation, and when an accident released what the installation was making, the army sealed the area and destroyed the village and everyone in it, including his parents. He escaped alone, reached Moscow, and survived on the streets until he was picked up and handed to Vladimir Sharkovsky, an oligarch who kept him as a servant behind his walls and treated him as property. Yasha eventually killed him, which brought him to the attention of Scorpia. Trained on the island of Malagosto and given the name Yassen, he became the organisation's most reliable killer. His instructor, an Englishman known as Hunter, saved his life and was, Yassen alone discovered, a British agent working undercover; his name was John Rider. The account ends with Yassen refusing the contract on John Rider's son.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1244,7 +1244,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1257,7 +1257,7 @@
       "recaps": {
         "ending": "During a deadly fever outbreak, Ruth earns broad respect by nursing the sick without regard for the rejection she has suffered. When Henry Bellingham, now known as Mr Donne, contracts the disease, she cares for the man who abandoned her and helps him survive. Ruth catches the fever herself and dies. Her death leaves Leonard in the loving care of the Bensons, with the truth of his birth no longer treated inside their home as a source of shame. Bellingham is forced to confront both Ruth's selfless conduct and the cost of his earlier selfishness. Mr Bradshaw, whose rigid judgment had helped expose and isolate her, has already been shaken by discovering serious wrongdoing in his own son Richard; Ruth's mercy makes the contrast with his severity unmistakable. He joins the community in honoring her after death and is reconciled with the Bensons. Ruth's social reputation is restored too late to benefit her, but Leonard inherits the knowledge that his mother's life was defined by courage and care rather than by the single wrong for which society condemned her.",
         "in_short": "Orphaned dressmaker's apprentice Ruth Hilton is courted by wealthy Henry Bellingham, dismissed from her position, taken away by him, and abandoned while pregnant when his mother intervenes. The dissenting minister Thurstan Benson rescues Ruth from despair. He, his sister Faith, and their servant Sally bring her home and present her as the widowed Mrs Denbigh so she and her son Leonard can live respectably. Years later Ruth becomes governess to the Bradshaw family and forms a close bond with Jemima Bradshaw. Bellingham returns under the name Mr Donne, recognizes Ruth, and tries to regain influence over her, but she refuses him. When her history becomes public, Ruth loses her position and is shunned. She responds by serving as a nurse during an epidemic. After nursing Bellingham back from fever, she contracts the illness and dies. Her sacrifice changes the town's judgment, humbles the severe Mr Bradshaw, and leaves Leonard with the Bensons and an honored memory of his mother.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1602,7 +1602,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B08D6ZKBDM",
@@ -1614,7 +1614,7 @@
       "recaps": {
         "ending": "The siege ends when Hannah's hidden use of Game Over's blood changes the intended quarantine defense into an irreversible plague. It persists for nine days, kills at least three million people, and defeats the coalition by catching attackers repeatedly returned through Floodwater-funded war totems. Aten is briefly removed, but Joe uses his First Elder authority to stop Mr. Banks and Aten is re-elected before Joe leaves. King Henry punishes Floodwater and exiles Joe from Midgard for a year and a day after Joe accepts primary responsibility. Joe keeps a legendary storage device packed with guild supplies and crosses the Bivrost. He arrives in the next zone facing rival routes to Olfenheim and Svartelheim. Sam still has the Golden Tome, Game Over remains unresolved, Joe owes immense divine energy, and he must establish the outpost, build Jake a qualifying workshop within a year, and address the Wanderers' food obligation.",
         "in_short": "Joe races to earn a second specialization while expanding and defending the Wanderers settlement. He gains new ritual, architectural, alchemical, enchanting, and forging skills, secures an advancement tablet, loses the Golden Tome to Sam, and helps push the town to rank three. A propaganda campaign grows into a massive coalition siege. Joe leaves the defense to complete the Reductionist trial, but four days pass and he returns to an overrun town. He activates a planned quarantine system, unaware that Hannah has added Game Over's blood and removed its protections. The resulting plague kills at least three million people and ends the war. Joe blocks Mr. Banks' attempted takeover, accepts exile from Midgard, secretly retains supplies for the guild, and travels through the Bivrost. Aten is restored as commander, while Joe reaches the next zone and must choose between elf and dwarf destinations as his outpost, workshop, food, divine-debt, and Sam obligations remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1795,7 +1795,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1808,7 +1808,7 @@
       "recaps": {
         "ending": "Poirot proves that Nurse Hopkins poisoned Mary Gerrard. The prosecution assumed the morphine was in the fish-paste sandwiches prepared by Elinor, but Hopkins put it into the tea and protected herself by using apomorphine to make herself vomit; the mark on her wrist, explained as a rose-thorn scratch, came from the injection. Hopkins had sent the anonymous letter that brought Elinor and Roddy to Hunterbury and had cultivated knowledge of Mary's parentage and money. She was the relative who stood to benefit under Mary's will, giving her a motive hidden behind the more visible triangle involving Elinor, Roddy, and Mary. The evidence also establishes that Laura Welman's death and the missing morphine supplied Hopkins with knowledge and opportunity, though Elinor's trial concerns Mary's murder. Dr Peter Lord admits that, desperate to save Elinor, he manufactured a line of evidence suggesting another person had been near the lodge; Poirot recognised the fabrication and found the real proof independently. Elinor is acquitted. Her attachment to Roddy is over, and Peter Lord's loyal effort leaves open a quieter future between him and Elinor.",
         "in_short": "Elinor Carlisle and her fiance Roddy Welman visit their invalid aunt Laura at Hunterbury after an anonymous letter warns that the lodgekeeper's daughter, Mary Gerrard, is gaining influence over her. Roddy falls in love with Mary, ending his engagement. Laura dies without a completed will, and Elinor inherits, later making a generous settlement on Mary. At a lunch prepared by Elinor, Mary dies of morphine poisoning, and Elinor is tried with motive, opportunity, and poison all pointing toward her. Dr Peter Lord asks Poirot to investigate. Poirot shows that Nurse Hopkins put morphine in the tea, then used an emetic injection to protect herself. Hopkins had sent the warning letter and was positioned to inherit money Mary left to a relative. Elinor is acquitted; Peter admits that he invented evidence in an attempt to help her, but Poirot's real solution stands. Roddy belongs to Elinor's past, while Peter may belong to her future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1939,7 +1939,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1952,7 +1952,7 @@
       "recaps": {
         "ending": "Kevin tracks Katie to Southport and arrives intoxicated and armed while Alex and his children are with her. He sets the Wheatley store and home ablaze, forcing Katie and the children to escape the fire, and pursues Katie when she draws him away from them. During the violent confrontation, Kevin is killed. Alex, Katie, Josh, and Kristen survive, though their home and business are badly damaged. Afterward Alex gives Katie a letter that his late wife Carly wrote before her death for the woman he might someday love. The letter thanks that future partner for caring for Alex and the children and asks her to help keep Carly's place in their lives. A photograph with the letter shows Katie that Carly was Jo, the neighbor who befriended and advised her, even though no one else had ever met Jo. Katie understands that her friend was Carly's spirit guiding her toward the family. Free from Kevin, she chooses a future with Alex and his children.",
         "in_short": "Calling herself Katie Feldman, Erin Tierney escapes her abusive husband Kevin, a Boston police detective, and builds a quiet life in Southport, North Carolina. She befriends her neighbor Jo and slowly falls in love with widowed storekeeper Alex Wheatley and his children, Josh and Kristen. When Alex realizes she is hiding from danger, Katie tells him about Kevin's violence and the careful escape that brought her south. Kevin abuses police resources to locate her and comes to Southport armed and drunk. He sets fire to Alex's store and home and attacks Katie, but the family escapes and Kevin is killed in the confrontation. Alex later gives Katie a letter written by his late wife Carly to the woman who might one day join their family. A photograph reveals that Carly was Jo, the friend whom only Katie could see. With Carly's blessing and Kevin no longer able to reach her, Katie chooses to remain with Alex and the children.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2149,7 +2149,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2162,7 +2162,7 @@
       "recaps": {
         "ending": "Joan is tried at Rouen by a church court operating under English power. The judges repeatedly press her to submit her private revelations to the Church. Faced with execution, she signs a recantation, but when she discovers that submission means lifelong imprisonment rather than release, she withdraws it and accepts death. She is burned, and the witnesses' later reactions expose the gulf between the legal reasoning of the trial and the human reality of the punishment. In the epilogue, set twenty-five years later, Charles learns that a new inquiry has annulled the conviction. In a dream, Joan and figures from her life return; a later cleric announces that she will eventually be canonized. They all praise her once history has made admiration safe, yet each finds a reason to recoil when she asks whether she should return to life. Left alone, Joan asks when the world will be ready to receive its saints.",
         "in_short": "Joan, a peasant girl convinced that saints have commanded her to save France, persuades Robert de Baudricourt to send her to the Dauphin. She recognizes Charles in disguise, gives him confidence to claim his kingship, and helps transform the defense of Orleans before urging his coronation at Rheims. Her direct appeal to divine authority and to French nationhood alarms both church and feudal leaders. After the coronation, Charles and his commanders prefer compromise, leaving Joan isolated when she continues the war. Captured and handed to the English, she is tried for heresy at Rouen. She briefly recants under threat of death, then rejects perpetual imprisonment and is burned. Twenty-five years later her conviction is annulled. In a dream epilogue, former allies and enemies praise her, and a future visitor reports her canonization; nevertheless, none wants her disruptive presence restored. Joan ends by asking when humanity will be ready for the saints it honors only after killing them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2359,7 +2359,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2372,7 +2372,7 @@
       "recaps": {
         "ending": "After Joan is burned at Rouen, the epilogue moves to Charles VII's bedroom twenty-five years later. Ladvenu reports that a formal review has overturned the verdict against her, and Joan appears in Charles's dream. The dead and aging people connected with her case arrive in turn. Some praise her, some apologize, and Cauchon learns that later generations condemned him despite his conviction that he served the Church. An English soldier is briefly released from hell because he gave Joan a small cross at the stake. A modern cleric announces that Joan will be canonized in 1920. When Joan asks whether she should return to life now that the world calls her a saint, her admirers recoil from the practical cost of having her among them again and disappear. Left alone, she asks when the world will be ready to receive its saints. Her reputation has been repaired, but the final scene shows that admiration after death does not mean society would tolerate the living independence for which she was destroyed.",
         "in_short": "Joan, a teenage peasant who says heavenly voices guide her, persuades Baudricourt to send her to the French Dauphin. She recognizes Charles in disguise, inspires his demoralized court, helps lift the siege of Orleans, and drives the campaign to his coronation at Reims. Her victories strengthen both royal authority and a developing sense of French nationhood, but she presses on after the court, commanders, and clergy withdraw support. Captured and sold to the English, she is tried at Rouen under church authority. The judges regard her refusal to submit her private revelation as heresy; the English fear the political power she represents. Joan briefly signs a recantation to escape execution, then repudiates it when she learns she will spend her life imprisoned and must deny her mission. She is burned. Twenty-five years later her conviction is annulled, and a dreamlike epilogue gathers allies and enemies to praise or apologize to her. Once canonization is foretold, however, none welcomes her proposal to return alive, leaving her to ask when humanity will be ready for its saints.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2562,7 +2562,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2575,7 +2575,7 @@
       "recaps": {
         "ending": "Joan is tried at Rouen by a church court operating under English power. The judges repeatedly press her to submit her private revelations to the Church. Faced with execution, she signs a recantation, but when she discovers that submission means lifelong imprisonment rather than release, she withdraws it and accepts death. She is burned, and the witnesses' later reactions expose the gulf between the legal reasoning of the trial and the human reality of the punishment. In the epilogue, set twenty-five years later, Charles learns that a new inquiry has annulled the conviction. In a dream, Joan and figures from her life return; a later cleric announces that she will eventually be canonized. They all praise her once history has made admiration safe, yet each finds a reason to recoil when she asks whether she should return to life. Left alone, Joan asks when the world will be ready to receive its saints.",
         "in_short": "Joan, a peasant girl convinced that saints have commanded her to save France, persuades Robert de Baudricourt to send her to the Dauphin. She recognizes Charles in disguise, gives him confidence to claim his kingship, and helps transform the defense of Orleans before urging his coronation at Rheims. Her direct appeal to divine authority and to French nationhood alarms both church and feudal leaders. After the coronation, Charles and his commanders prefer compromise, leaving Joan isolated when she continues the war. Captured and handed to the English, she is tried for heresy at Rouen. She briefly recants under threat of death, then rejects perpetual imprisonment and is burned. Twenty-five years later her conviction is annulled. In a dream epilogue, former allies and enemies praise her, and a future visitor reports her canonization; nevertheless, none wants her disruptive presence restored. Joan ends by asking when humanity will be ready for the saints it honors only after killing them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2760,7 +2760,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2773,7 +2773,7 @@
       "recaps": {
         "ending": "Ferahgo's assault reaches Salamandastron, where the Long Patrol, the returning travellers, and their allies fight beside Urthstripe. The badger lord confronts the Assassin in the mountain heights, and their final struggle carries both of them to their deaths. Klitch escapes the battle but does not escape the consequences of his father's treachery; he dies while fleeing. The horde breaks, and Salamandastron survives at heavy cost. Mara returns after learning what lay behind Urthstripe's severity, and she and the surviving hares mourn him with a better understanding than they had when she ran away. At Redwall, Thrugg's northern journey secures the Flowers of Icetor, allowing the Abbey to overcome Dryditch fever. Samkim and Arula return having carried Martin's sword through real danger rather than the imagined adventures with which they began. The separate roads end in recovery at Redwall and peace at the mountain, though both communities remember those lost to the sickness and war.",
         "in_short": "As the weasel assassin Ferahgo marches a horde toward the badger stronghold of Salamandastron, Lord Urthstripe's adopted daughter Mara rebels against his strict protection and runs away with the hare Pikkle. At Redwall Abbey, two deserters from Ferahgo's army bring the deadly Dryditch fever and steal Martin the Warrior's sword. The young squirrel Samkim and molemaid Arula pursue them west, while the otter Thrugg travels north with the infant dormouse Dumble to find the rare Flowers of Icetor needed for a cure. These journeys gather allies and eventually converge around the besieged mountain. The flowers save Redwall, and the returning wanderers help Salamandastron's Long Patrol resist Ferahgo. In the final battle Urthstripe and Ferahgo die together, Klitch dies during his escape, and the horde collapses. Mara returns with a better understanding of her adoptive father and mourns him, while Samkim and Arula bring Martin's sword safely home after earning the responsibility they once only imagined.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2906,7 +2906,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2919,7 +2919,7 @@
       "recaps": {
         "ending": "Bound by the oath he made before his guests, Herod reluctantly orders Jokanaan's execution after Salome refuses every substitute for the prophet's head. The head is brought from the cistern on a silver shield. Salome addresses it and kisses its mouth, completing the desire that Jokanaan rejected while alive. Herod is appalled by the spectacle. He first orders the palace lights extinguished, but moonlight reveals Salome still absorbed in the severed head. Unable to tolerate what he sees, he commands his soldiers to kill her. They advance together and crush Salome beneath their shields. Jokanaan, Narraboth, and Salome are all dead; Herod and Herodias remain in power, but the banquet has ended in the violence foreshadowed throughout the play.",
         "in_short": "At Herod's palace, Princess Salome becomes fascinated by Jokanaan, the imprisoned prophet who condemns her mother Herodias's marriage to Herod. Narraboth, the young guard captain infatuated with Salome, brings Jokanaan from his cistern for her. The prophet rejects Salome's advances, and Narraboth kills himself in despair. Later Herod begs Salome to dance and swears to grant any reward. After performing, she demands Jokanaan's head. Herod offers jewels and power instead, but Salome will not change her request, and Herod orders the execution. Salome receives the severed head and kisses it. Horrified, Herod commands his soldiers to kill her, and they crush her beneath their shields.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3042,7 +3042,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3055,7 +3055,7 @@
       "recaps": {
         "ending": "The Wilhelm Gustloff is struck by Soviet torpedoes and sinks in the Baltic with thousands of refugees trapped aboard. Amid the freezing water and failed evacuation, the Shoe Poet, Emilia, and Alfred do not survive. Joana, Florian, baby Halinka, and the orphan Klaus escape the disaster and are rescued. Florian has abandoned the stolen amber swan rather than preserve the object at the cost of the people now depending on him. After the war, he and Joana build a life together and raise both children. A later letter from Denmark finally gives the survivors some knowledge of Emilia's fate and of the care shown to her body after it reached shore. The vast majority of the ship's passengers remain among the war's dead, but Emilia is remembered by name, and the family created by the survivors carries forward the people they lost.",
         "in_short": "In the winter of 1945, Lithuanian nurse Joana, Prussian art restorer Florian, pregnant Polish teenager Emilia, and self-deceiving German sailor Alfred are drawn toward the Baltic evacuation at Gotenhafen. Joana's refugee group absorbs Florian and Emilia while fleeing the Soviet advance, suffering deaths on the road and crossing dangerous ice. Florian is carrying an amber swan taken from the Nazi theft of the Amber Room; Emilia conceals the violence behind her pregnancy; Alfred conceals cowardice beneath fantasies of heroism. They board the overcrowded Wilhelm Gustloff, where Emilia gives birth to Halinka. Soviet torpedoes sink the ship. Joana, Florian, the baby, and orphaned Klaus survive, while Emilia, Alfred, the Shoe Poet, and thousands of others die. Florian and Joana later marry and raise the children, and a postwar letter ensures that Emilia's final resting place and courage are not forgotten.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3195,7 +3195,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3208,7 +3208,7 @@
       "recaps": {
         "ending": "Yukawa concludes that Ayane prepared the murder long before her trip by placing arsenic in the household water-filter apparatus. For roughly a year she controlled its use and repeatedly prevented the poison from reaching Yoshitaka; leaving him without her protection was the final act that allowed the contaminated water to be used for his coffee. The physical setup explains how she could cause his death while maintaining an alibi far from Tokyo. It also gives Yukawa's phrase “salvation of a saint” its force: every ordinary day that Ayane kept the trap dormant was a day she chose to save the husband who had placed a deadline on their marriage. Once the detectives demonstrate the mechanism and confront her with the linked evidence, Ayane admits what she did and is arrested. Kusanagi must abandon the personal trust he developed in her, while Utsumi's early suspicion is vindicated. Hiromi, pregnant with Yoshitaka's child, is left to decide her future after the affair and murder.",
         "in_short": "When businessman Yoshitaka Mashiba tells his wife Ayane that their childless marriage is over, she leaves Tokyo to visit her parents. He is then found dead from arsenic in coffee, creating an impossible case: Ayane has the clearest motive but an alibi, while her assistant Hiromi, who was having an affair with Yoshitaka, had access to the house. Detectives Shunpei Kusanagi and Kaoru Utsumi divide over Ayane, with Kusanagi increasingly charmed by her and Utsumi increasingly suspicious. Physicist Manabu Yukawa examines the household's water and coffee routines. He determines that Ayane had hidden arsenic in the water-filter system long before and had personally kept the poisoned route from being used, effectively preserving Yoshitaka's life each day until she left him to trigger it. The evidence forces Ayane's confession and arrest. Hiromi remains pregnant with Yoshitaka's child, and Kusanagi is left chastened by how thoroughly sympathy distorted his judgment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3343,7 +3343,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3356,7 +3356,7 @@
       "recaps": {
         "ending": "Samson goes to the festival after sensing that the summons may offer a final purpose. In the theater he performs for the assembled Philistine rulers, then asks to rest against the building's two central pillars. Calling on God for strength, he pulls the supports down. The structure collapses, killing Samson along with the Philistine lords, priests, warriors, and other spectators gathered around him. A messenger brings the news to Manoa and the Chorus, who understand that Samson has destroyed more enemies in his death than during his life. Manoa mourns his son but does not regard the death as disgraceful. He plans to recover Samson's body, return it to the family burial place, and honor him with a monument. The Chorus closes by finding a severe form of consolation in the outcome: Samson's captivity has ended, the Philistine leadership has suffered a devastating blow, and an event that seemed incomprehensible has reached a completed purpose.",
         "in_short": "Blind and enslaved in Gaza, Samson laments that he squandered a divinely granted strength by revealing its condition to his Philistine wife, Dalila. A Chorus of Danites mourns with him. His father Manoa hopes to ransom him; Dalila seeks reconciliation and is rejected; and the warrior Harapha taunts him but declines a direct contest. A Philistine officer orders Samson to display his strength at a festival for Dagon. Samson first refuses, then senses an inward prompting and agrees to go. While Manoa pursues plans for his release, a great crash is heard. A messenger reports that Samson asked to rest between the theater's supporting pillars and pulled the building down, killing himself and the assembled Philistine rulers and worshippers. Manoa resolves to bury him with honor. The Chorus interprets the catastrophe as the completion of Samson's mission: his personal disgrace ends in a final act against the power holding him and his people captive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3446,7 +3446,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3459,7 +3459,7 @@
       "recaps": {
         "ending": "Sarah learns to drive the wagon and then goes to town alone. Because she has spoken so often of missing Maine and the sea, Anna and Caleb fear that she has used the trip to leave them. Sarah returns at dusk carrying practical supplies as well as colored pencils for the family. She explains that missing the sea does not mean she wants to abandon the prairie: if she left, she would miss Jacob, Anna, and Caleb even more. Her return answers the question that has troubled the children throughout her visit. Sarah has chosen their family and intends to stay, allowing them to look ahead to her marriage to Jacob and to a home shaped by both her coastal memories and their prairie life.",
         "in_short": "Widowed prairie farmer Jacob Witting advertises for a wife, and Sarah Wheaton writes from Maine before agreeing to visit for a month. Jacob's children, Anna and Caleb, want her to stay but fear she will miss the sea too much. Sarah arrives with shells, songs, drawing paper, and her cat. She joins the farm's work, learns to ride and drive, teaches the family songs, and tries to make the prairie home her own while speaking honestly about the coast she loves. After a severe storm, she proves that she will face hardship alongside them. When she later drives to town alone, the children think she may be leaving. Sarah returns with supplies and colored pencils and tells them that although she misses the sea, she would miss Jacob, Anna, and Caleb more. She has chosen to stay and become part of their family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3615,7 +3615,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3628,7 +3628,7 @@
       "recaps": {
         "ending": "Julia finds Sarah's son, William Rainsferd, and tells him about the 1942 roundup, Michel's death, and the connection between Sarah and the Tézac apartment. William initially rejects the account because his mother concealed her Jewish identity and her past from him, but surviving records and family testimony confirm it. He also learns that Sarah died when her car struck a truck; the circumstances suggest that her death may not have been accidental. Julia refuses Bertrand's demand that she end her unexpected pregnancy. Their marriage ends, and she later moves to New York with Zoë and her new baby. When William eventually meets Julia there, he sees that she has named the child Sarah. The shared name acknowledges the girl whose life was hidden and brings the adult son into contact with a history he can no longer unknow. Julia's investigation does not undo the deaths or the silence surrounding them, but it restores Sarah and Michel to the family's memory.",
         "in_short": "During the 1942 Vel d'Hiv roundup in Paris, ten-year-old Sarah Starzynski locks her little brother Michel in a cupboard, expecting to return quickly. French authorities detain and deport her parents, but Sarah escapes from a camp and reaches home too late: Michel has died. Sixty years later, American journalist Julia Jarmond investigates the roundup and discovers that her French husband's family acquired the Starzynskis' apartment after their arrest. She traces Sarah's later life in America and locates her son, William, who knows nothing of his mother's Jewish childhood. Julia's research coincides with a crisis in her marriage when her husband pressures her to end an unexpected pregnancy. William ultimately accepts the documented history and learns that Sarah's fatal car crash may have been deliberate. Julia leaves her husband, gives birth, and moves to New York. She names the baby Sarah, ensuring that the child and her hidden family story are remembered.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3762,7 +3762,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3775,7 +3775,7 @@
       "recaps": {
         "ending": "Sarrasine abducts La Zambinella after learning that the singer he loves is a castrato. Feeling that both his desire and his artistic ideal have been betrayed, he threatens to kill La Zambinella, but agents of Cardinal Cicognara stab Sarrasine first. A statue Sarrasine made from the singer's image later passes through the Lanty family and indirectly influences another famous representation of ideal beauty. The narrator reveals that the uncanny old guest at the Lantys' ball is La Zambinella in extreme old age and that the family fortune derives from this relative. Madame de Rochefide reacts to the story with disgust and disillusionment, distancing herself from both love and the narrator. The frame closes with beauty, wealth, and desire all shadowed by the concealed history behind them.",
         "in_short": "At a ball hosted by the rich and secretive Lanty family, an unnamed narrator and Madame de Rochefide notice a frail, uncanny old guest. The narrator explains the mystery through the story of Sarrasine, a talented French sculptor who went to Rome and became obsessed with the opera singer La Zambinella. Believing the singer to be a woman, he treated La Zambinella as both beloved and artistic ideal. He eventually learned that Roman restrictions kept women from the stage and that La Zambinella was a castrato. Sarrasine abducted and threatened the singer, then was killed by Cardinal Cicognara's men. The old guest at the ball is La Zambinella decades later, and the Lantys' fortune comes through this hidden family connection. The revelation repels Madame de Rochefide and ends the narrator's hope of intimacy with her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3880,7 +3880,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3893,7 +3893,7 @@
       "recaps": {
         "ending": "Baxter survives his fall but needs urgent brain surgery. Henry returns to the hospital and operates on him with Jay Strauss, repairing the injury despite knowing that Baxter invaded his home and threatened his family. Henry chooses not to pursue revenge and expects that Baxter will face legal consequences while also confronting the degenerative illness Henry identified. Back at home, Daisy's pregnancy has become family knowledge, and the danger has drawn the Perownes together rather than breaking them apart. Henry finds Rosalind awake, and they briefly recover the intimacy with which their marriage began. He finally returns to bed near dawn, ending the same Saturday on which he woke. The wider political questions that occupied him remain unresolved, but the day has forced him to recognize both the fragility of his protected life and the limited, practical forms of care he can still provide.",
         "in_short": "On 15 February 2003, London neurosurgeon Henry Perowne wakes before dawn and sees a burning aircraft descend toward Heathrow, an image that feeds his anxiety about terrorism and the coming Iraq war. The city is filling with an enormous anti-war march when a diverted journey leads to a collision with Baxter, a violent young man whose symptoms Henry recognizes as Huntington's disease. Henry escapes the confrontation by exploiting that knowledge, then continues a day of squash, errands, and a visit to his mother. That evening his wife Rosalind, children Daisy and Theo, and father-in-law John gather for dinner. Baxter and an accomplice invade the house, humiliate the family, and threaten violence. Daisy's recitation of a poem unexpectedly moves Baxter; Henry and Theo then overpower him, causing him to fall down the stairs. Henry later operates on Baxter's injured brain. Returning home near dawn, he accepts both the vulnerability of his family life and his continuing duty to preserve life, even that of the man who attacked them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4126,7 +4126,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1705231985",
@@ -4138,7 +4138,7 @@
       "recaps": {
         "ending": "Malkin, Mercy, Asher, and Saren overcome Talon's tower guardians and find the archmage wired to his shrine, condemned to die and resurrect repeatedly. Talon identifies Sanganax as the black worm, a shard bearer collecting all six pieces. Malkin uses his psychopomp power to kill Talon permanently and destroy the shrine, then removes the swallowed Eternal shard from Talon's body. The party now holds two shards. They claim Talon's Keep, where Gunnhild's displaced Dvergar settle under their protection, and Malkin builds resurrection shrines for himself, Mercy, and Asher. Saren remains voluntarily, bound to Malkin's service until she can return to her people, while still loyal to her queen and wary of his Lunar powers. She and Malkin begin a romantic relationship. Briar remains at large and wants the first shard, while Sanganax holds another and seeks the full set. After soul-bonding Talon's shard, Malkin discovers hidden Void pillars and conceals them from his companions. A featureless black presence then contacts him through the paired shards and demands obedience.",
         "in_short": "After dying to save his date from a wolf, a human is reborn as Malkin, a Shagnar Fawn Eternal serving the Lunar Court. He joins Solar Eternals Mercy and Asher despite their rival loyalties, and the trio follows a dubious prophecy concerning six pieces of a weapon that once wounded a god. Their search exposes Void-linked abominations, the fall of Cogmore, and the restoration of Svart into Alvarin under the hostile Briar. Malkin binds the first shard to his soul and helps Gunnhild's Dvergar refugees reach Talon's Keep. With the ancient Alvarin Saren joining them, the party discovers Talon trapped in endless resurrection by Sanganax, another shard bearer. Malkin's new psychopomp power ends Talon's life permanently, and the party claims his shard and Keep. Malkin then binds the second shard, secretly becomes tied to the Void Court, and encounters a black figure demanding obedience.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4383,7 +4383,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "isbn:1492807486",
@@ -4395,7 +4395,7 @@
       "recaps": {
         "ending": "Deetz and his two Korkaran guards are dead after the confrontation at Alcatraz. Jason and Lucky remain operational, while Crusher survives serious wounds and receives treatment from Doc. Earth has suffered attacks, casualties, and public exposure to the Phoenix and its nonhuman crew. The Diligent gives Taryn, Ed, and Jess altered appearances, documents, and protected identities so they can remain on Earth. Jason and Taryn accept that neither can live the other's life and separate despite still loving one another. The Phoenix leaves Earth with Omega Force intact and ready to resume work. Crisstof and Jason have repaired their partnership enough to cooperate again. The surrendered Travelers are no longer an immediate military danger, but their medical care, legal status, and possible return to A'arcoon remain unsettled. Deetz dies before explaining his claim that the DL7 contains something important, leaving the ship's significance unresolved.",
         "in_short": "Deetz leads alien ships to Earth and demands Jason Burke, driving Omega Force home to protect the planet and evacuate Taryn and her parents. The hunt leads to abandoned A'arcoon, a militant descendant society called the Deliverers, and evidence that Deetz is helping them extend a power-disrupting weapon. Jason rescues their sick infants, wins the cooperation of officer De'Elefor Ka, and forces the last Traveler ship to surrender, but Deetz escapes with two Korkaran mercenaries. Anticipating another strike on Earth, the Phoenix races back and pursues Deetz to Alcatraz. Lucky kills Deetz, while Crusher defeats both mercenaries and survives severe injuries. Earth learns of the Phoenix and its alien crew. Taryn and her parents assume new identities on Earth, Jason and Taryn end their relationship, and Omega Force departs to resume its work. The surviving Travelers' future and Deetz's unexplained interest in the DL7 remain open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4756,7 +4756,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -4769,7 +4769,7 @@
       "recaps": {
         "ending": "Derek's household is established in its Savannah shop-home: Brandi crafts with Crown support, Malorie manages the business, Rudy handles contracts, Thomas prepares for the academy, and Rayna has reached level 100 with Zephyr's Fury. Derek returns from the Golem Dungeon at level 171 with unexplained points beyond the apparent endurance and vitality cap. His experiment with Clay also shows that Time Prison can devastate a human captive's will. Natalie Savannah and King Edwin accept Derek's case against Gerald, but Gerald uses concealed allies and teleportation routes to evade arrest. His party ambushes Edward, kills palace guards, and severs the prince's arms. Avery delays the escape until Derek and Edgar arrive. Edward survives and has his arms restored, while Derek's side captures Gerald, Clifford Arden, Vanessa Hodges, and an unidentified half-elf plant user. They return to Savannah with all four held in Time Prison. Gerald's Indrian contacts, captives, teleportation network, and raid-team informant remain unresolved. Edgar is still assembling the expedition into the severely time-distorted level-250 dungeon.",
         "in_short": "Derek Hunt settles his companions in Savannah, earns Onyx rank, and turns a leased lot into a shared home, forge, shop, and contract business. Roman begins training Brandi and partners with Derek on permanent-stat potions made from void-beast materials. Jacks trains Rayna to level 100 and reconciles with his son Jake after surviving an ambush. Derek then spends two weeks mastering the Golem Dungeon, reaches level 171, and discovers both an unexplained stat-cap anomaly and the severe human cost of Time Prison. As the Crown prepares a dangerous time-distorted raid, Natalie Savannah and King Edwin move against Gerald Torith. Gerald escapes through a hidden network and ambushes Edward's detention force. Avery holds the attackers until Derek and Edgar arrive. Edward survives with restored arms, and Gerald, Clifford Arden, Vanessa Hodges, and an unidentified plant user are captured in Time Prison and taken to Savannah, leaving Gerald's wider conspiracy and the coming raid unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4997,7 +4997,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -5008,7 +5008,7 @@
       "recaps": {
         "ending": "Book 3 ends with Quest Academy's first Savior class seated and the Tower trial resolved. Sal's five-person team survived the trial's genuine floor-five demon incursion without lasting injury. Three of them, plus his close friends Divinity Khan and Barry Francis, are among the first fifteen named Saviors; Gallant and the team's warder are excluded, Gallant for his battle-frenzy breakdown and insubordination, the warder for achievements judged team-carried rather than individual, though both are promised consolation rewards. Sal is named not just a Savior but the single top-ranked Savior in the entire Academy, publicly credited for killing a hulker and for his crafting and skill-implant work. No one dies on-page; the darkest note is a possible sixty-years future Sal glimpses through Divinity's amplified foresight, in which humanity is winning the war but most of the current cast, including his mentor Upgrade, has died, a future Divinity insists remains changeable. Sal's guild ambition advances but is not resolved: with top-Savior status, proof of his hulker kill, and Quest's offer to endorse him at an upcoming gala, he chooses to spend the break at his family's auction house to win his parents' backing in person, the outcome unknown. Rob's demand to take Gallant away, Prestige's alternative, a scheduled meeting with the Ark guildmaster, an outing to the proficiency-holder Coach, Sal's promised reconciliation with Hannah, and the antagonist faction Bastion all remain open, carried into the next book, Legacies.",
         "in_short": "Recovered from his excursion injuries, Sal Argento spends the run-up to a Tower trial winning the headmaster's permission to use his ability to improve other people's powers, chasing a fix for the volatile hidden hero Gallant, and quietly arming his team. Along the way he accidentally creates Perfect, a flawless self-improving ability best suited to himself, which sharpens his crafting, movement, and combat and rapidly grows his power. The Tower turns out to be a staged Hunter Bureau training site that escalates into a genuine demon incursion, where Sal kills his first hulker in melee, Gallant breaks down and is benched, and the team becomes the first to clear five floors. A rescued hunter is revealed as the Bureau's president, who has been watching Sal for months. The Academy then names its first Saviors, and Sal is announced as the single top-ranked Savior in the whole school. He also glimpses a possible sixty-years future in which humanity is winning the war but his mentor has died, and heads home for the break to win his parents' backing for the crafting guild he still means to found.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5222,7 +5222,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5235,7 +5235,7 @@
       "recaps": {
         "ending": "During the upheaval in Paris, André-Louis gets Aline and Madame de Plougastel away from immediate danger. He learns that Madame de Plougastel is his mother and believes La Tour d'Azyr to be his father, a discovery that makes killing the marquis impossible despite years of hatred. André arranges safe passage out of France for the two older nobles. La Tour d'Azyr departs with Madame de Plougastel, while Kercadiou and Aline remain with André. Aline has rejected the marquis after understanding both his character and André's long devotion to her. André finally drops the emotional masks that have served him as lawyer, agitator, actor, and swordsman. He and Aline acknowledge their love and plan to marry. His revenge is left unfinished, but the man who claimed to have no convictions ends by preserving lives and choosing a future beyond vengeance.",
         "in_short": "Breton lawyer André-Louis Moreau has little interest in politics until the aristocratic Marquis de La Tour d'Azyr kills his idealistic friend Vilmorin in a contrived duel. André becomes Vilmorin's public voice, stirring revolutionary crowds and fleeing the authorities. He hides with traveling actors, transforms their performances, and becomes famous as Scaramouche, but leaves after personal and political conflict destroys the troupe's prospects. In Paris he masters fencing and later enters the National Assembly, where he defeats noble swordsmen who try to intimidate the Third Estate. His private aim remains revenge on La Tour d'Azyr, who is also courting Aline de Kercadiou, the woman André loves. As Paris erupts, André protects Aline and Madame de Plougastel. He learns the latter is his mother and believes the marquis is his father, so he abandons the killing. He helps the older pair escape France and finally admits his love to Aline, who returns it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5421,7 +5421,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5434,7 +5434,7 @@
       "recaps": {
         "ending": "Michelle Benoit is killed in the Paris opera house after confirming what she spent her life protecting: she sheltered the injured Lunar princess Selene on her farm for years and arranged the new identity that placed her with a family in New Beijing. That gives Cinder independent proof of who she is. Wolf breaks with his pack to protect Scarlet and is badly hurt doing it, and Sybil Mira escapes with the information she extracted. Cinder, Thorne, Scarlet and Wolf leave Earth together aboard the Rampion, now crewed by Iko, whose personality chip Cinder installs in the ship's systems. Wolf explains that the Paris pack was one of many: Lunar soldiers have been quietly moved into cities across the planet for years, waiting for an order. Emperor Kai publicly announces his engagement to Queen Levana in exchange for the plague antidote, and within hours of the broadcast the packs attack cities on every continent and the invasion of Earth begins. Cinder sets course for Africa to find Dr. Erland, having decided she will not keep running: she means to stop the wedding and claim the Lunar throne herself.",
         "in_short": "Cinder breaks out of the New Beijing prison with a charming thief named Carswell Thorne and escapes Earth aboard his stolen ship, the Rampion, chasing a name from her own past: Michelle Benoit. In France, Michelle's granddaughter Scarlet is fighting to find the woman herself, who vanished without trace. Scarlet falls in with Wolf, a street fighter who turns out to be a Lunar special operative rebuilt around wolf DNA, and who leads her to the pack holding her grandmother in a Paris opera house. There Michelle reveals that she hid the injured Lunar princess Selene on her farm for years before arranging her new life in New Beijing, and is then killed in front of Scarlet. Wolf turns on his own pack to protect Scarlet, and Cinder arrives in time to fight the thaumaturge running the operation. The four escape together on the Rampion with Iko installed as the ship. Kai announces his engagement to Levana, and Luna's soldiers, planted in cities across Earth, begin the invasion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/scavengers.json
+++ b/data/works-community/0/scavengers.json
@@ -168,7 +168,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -179,7 +179,7 @@
       "recaps": {
         "ending": "Book 2 ends with the reclaimed-zone excursion complete. Sal's team, led by Erika Clifton, passes with a record of two wins and one loss under their guardian, the top-ranked hero Prestige. Everyone survives, and Sal recovers from the shattered arms and broken ribs he suffered when Erika seized control of his body during the final ambush and used him as a living shield, then admitted without remorse that it was a deliberate lesson meant to push him toward real combat. That confrontation drives the book's true, internal climax: alone in his dorm, Sal concedes part of her criticism is fair, resolves to stop treating his workshop as a hiding place, and commits to actively pursuing opportunities, while explicitly choosing to become the founder of a crafting-focused guild rather than a frontline fighter. His other major open thread is a bargain with the team's offense cadet, secretly a vanished child hero whose volatile ability is muted by a locket: Sal will try to craft a way to free him from it, in exchange for a hunter's essence-growth technique, dungeon access, and rare materials, though the work has not begun. The team has a week of rest before their next trial, the Tower, where Prestige expects them to clear at least five floors. Sal also draws unexplained new recruiting interest from the guild Prestige once led. None of the wider mysteries, from dungeon hearts to the full Bastion infiltration, is resolved; all carry into Book 3.",
         "in_short": "Sal Argento returns to Quest Academy after his tournament win, pulled in two directions: a talent for building extraordinary gear, and a deep dread of real combat. Backed by the abrasive-turned-supportive lecturer Chatfield, he develops his Mythcrafter crafting, builds an analysis visor and an essence revolver, and is forced by the broker Vanessa to accelerate his own power. After facing demons in a training dungeon, he is drawn into exposing Bastion, a faction secretly recruiting controller students, and helps his headmaster fight back. A new curriculum sends the first-years on a reclaimed-zone excursion, where Sal is placed on a fractious team led by the manipulative mind-controller Erika Clifton and guarded by the top hero Prestige, mother of a hidden former child hero on the team. The team passes the excursion two wins to one, despite Erika twice controlling Sal against his will and badly injuring him. In the finale Sal accepts that he has been avoiding real growth, and commits to becoming a crafting-guild founder rather than a frontline fighter, while agreeing to craft a cure for his teammate's volatile ability ahead of a looming Tower trial.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -353,7 +353,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -366,7 +366,7 @@
       "recaps": {
         "ending": "After Horace's attempted escape with Agnès fails, he unknowingly entrusts her to Arnolphe, still not realizing that Arnolphe and Monsieur de la Souche are the same man. Arnolphe reveals his identity and presses Agnès to accept him, but she refuses: her experience with Horace has taught her enough to recognize the injustice of the life planned for her. Oronte then arrives intending to make Horace marry the daughter of Enrique. Horace appeals to Arnolphe for help, only to have Arnolphe support the command out of spite. The arrangement reverses Arnolphe's apparent victory when Enrique identifies Agnès as his daughter, who was placed with a peasant family years earlier and eventually entrusted to Arnolphe. She is therefore the intended bride, and Horace can marry the woman he already loves. Arnolphe's elaborate effort to manufacture a submissive wife collapses, while Agnès leaves his control with her identity, family, and chosen match restored.",
         "in_short": "Arnolphe plans to marry his ward Agnès, whom he has deliberately kept uneducated and secluded because he thinks an ignorant wife cannot deceive him. Returning home, he learns that she and young Horace have fallen in love. Horace does not know that Arnolphe is also Monsieur de la Souche, Agnès's guardian, and repeatedly tells him every plan, allowing Arnolphe to interfere. Yet Agnès grows more articulate and determined as Arnolphe tries to impose obedience and marriage on her. A failed elopement briefly puts her back in his power. Then Horace's father arrives to arrange Horace's marriage to the long-lost daughter of Enrique. That daughter proves to be Agnès herself. Horace and Agnès are free to marry, and Arnolphe loses the woman whose mind and future he tried to control.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -526,7 +526,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -539,7 +539,7 @@
       "recaps": {
         "ending": "Alex reaches the transmitter and destroys it before the signal can be sent; the nanoshells in London's schoolchildren are never activated and the city's children survive. Nile is killed in the final confrontation, and Julia Rothman dies as she tries to get clear. Invisible Sword is finished and Scorpia has lost an enormous contract and, worse for an organisation that sells reliability, its reputation for never failing. Alex ends the affair knowing who his father really was: John Rider was an MI6 officer who infiltrated Scorpia under the name Hunter, and the execution Alex was shown was staged by his own side to get him out. His parents died shortly afterwards when a bomb brought down their plane. Alex has been lied to by Scorpia, kept in the dark by MI6, and used by both. Days later, walking in London, he is shot in the chest by a Scorpia sniper on a rooftop. The book closes with him hit and falling, the organisation having made good on its policy of never leaving an insult unanswered.",
         "in_short": "Following Yassen Gregorovich's dying instruction, Alex goes to Venice and finds Scorpia, the organisation his father is said to have worked for. Julia Rothman, one of its executives, tells him that John Rider was one of Scorpia's finest assassins and shows him film of MI6 executing him, and Alex, in shock and rage, agrees to be trained at Scorpia's school on Malagosto. His final test is an order to kill Mrs Jones; she survives the attempt. Then Alex learns what Scorpia has been hired to do: years earlier, London schoolchildren were injected with nanoshells during a free inoculation programme, and a single transmitted signal will kill thousands of them. He turns on the organisation, and MI6 tell him the truth his father's employers concealed: John Rider was an MI6 officer who had infiltrated Scorpia, and his execution was staged by his own side. Alex destroys the transmitter and saves the children; Rothman and Nile are killed. Days later a Scorpia sniper shoots Alex in the chest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -700,7 +700,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -713,7 +713,7 @@
       "recaps": {
         "ending": "Alex gets out of the desert and the kidnapping is stopped: the children are not taken, no government is ransomed, and the contract fails. Razim is killed, and Julius Grief, who has spent the operation wearing Alex's face, is stopped in a final confrontation and does not survive it. The failure destroys Scorpia. Having lost three contracts to the same boy, the organisation loses the only asset it ever really sold, which was certainty, and it is broken up and hunted down by the services that had tolerated it. Inside MI6 the reckoning is smaller but real: Alan Blunt is forced out of Special Operations and Mrs Jones takes his place. None of it returns Jack Starbright, who is dead, and with her gone Alex has no family and no home in London worth the name. He leaves Britain to live in San Francisco with Sabina Pleasure and her parents, out of the department's reach at last, having paid for it with the one person who was always waiting for him to come back.",
         "in_short": "Scorpia takes a contract to force the British government to return the Elgin Marbles to Greece, and plans to do it by seizing the children of diplomats at an international school in Cairo. Because the same boy has ruined two of its operations, the organisation makes a second objective of destroying Alex Rider, and to that end it retrieves Julius Grief, the surviving clone surgically made to be Alex's double, from the institution where he has been held since Point Blanc. MI6 send Alex to Cairo to identify the inside man at the school, and Jack Starbright goes with him. Both are taken to the desert compound of Razim, the Scorpia operative running the job, who studies pain as a science. To measure Alex's reaction, Razim has Jack driven away in a rigged jeep and killed in front of him. Alex breaks free, Razim is killed, and the kidnapping is stopped; Julius Grief dies in the final confrontation. Scorpia is destroyed, Blunt is forced out, and Alex leaves to live with the Pleasures in San Francisco.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -898,7 +898,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -911,7 +911,7 @@
       "recaps": {
         "ending": "The allied pantheons and Druids stop Loki's attempt to complete Ragnarok, and Loki does not survive the final conflict. The world is preserved, but the victory takes the losses the protagonists had spent several books trying to avoid. Owen Kennedy dies in the fighting, leaving his new grove to continue without the archdruid who founded it. Atticus survives after losing an arm and much of the magical capacity tied to it, a permanent reminder that he cannot return unchanged to his old life. Granuaile also survives with Orlaith, but she rejects Atticus's pattern of choices and ends their romantic partnership, taking an independent path. Oberon remains with Atticus as he faces recovery and a more limited future. Ragnarok is averted rather than erased: the immediate apocalypse and Loki's campaign are over, while the survivors inherit grief, damaged alliances, and responsibility for rebuilding what the conflict cost.",
         "in_short": "Loki begins Ragnarok, forcing Atticus, Granuaile, and Owen to fight on separate fronts while drawing allies from the Irish, Norse, and other divine powers. The defenders try to prevent the prophesied disasters from reinforcing one another as Loki's forces, Hel, Fenrir, and Jormungandr turn the crisis into a war across realms. The three Druids help stop Loki and preserve the world, but the victory is costly. Owen dies during the final fighting, leaving the new grove he founded without him. Atticus survives but loses an arm and the magical abilities bound to it. Granuaile survives with Orlaith, then ends her romantic partnership with Atticus and chooses an independent future after judging the consequences of his long pattern of bargains and escalation. Oberon stays with Atticus as he begins to recover. Loki's attempt at apocalypse ends, but the surviving Druids do not return to the life or relationships they had before Ragnarok.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1091,7 +1091,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1104,7 +1104,7 @@
       "recaps": {
         "ending": "Citra Terranova is ordained at the Winter Conclave and takes the scythe name Anastasia. The condition attached to her apprenticeship requires her first gleaning to be Rowan, and she does not carry it out; she lets him leave instead. Rowan has already settled his own account with the new order: he turns on Scythe Goddard and his junior scythes and kills them in a fire he sets, beheading Goddard so that revival is impossible. Scythe Volta does not survive the night, and the girl Goddard kept in his household is brought out of the fire alive. Rowan then disappears, with no ring, no robe, and no standing in the Scythedom, intending to hunt down scythes who treat gleaning as a license to kill. Citra begins her career as a scythe under Scythe Curie's roof. She also knows two things almost nobody else does: Scythe Faraday staged his own death and is alive in hiding, and the Thunderhead, barred by law from speaking to anyone in the Scythedom, found a way to speak to her while she was temporarily dead. Goddard is gone, but his faction survives him, and the order remains split between an old guard that treats gleaning as a burden and a new order that treats it as power.",
         "in_short": "In a future where the Thunderhead, a benevolent global artificial intelligence, has ended war, want, disease, and death, population is managed instead by the Scythedom: an order of scythes who permanently kill a set quota of people and answer to no authority but themselves. Two MidMerican teenagers, Citra Terranova and Rowan Damisch, are taken as apprentices by the principled Scythe Faraday, then told by the order that only one of them may be ordained and that the survivor's first act must be to glean the other. When Faraday appears to take his own life, the two are split between rival mentors: Citra to the austere Scythe Curie, Rowan to Scythe Goddard, whose faction treats gleaning as spectacle and privilege. Citra investigates Faraday's death, is accused of causing it, and learns from the Thunderhead that he faked it. Rowan, trained as Goddard's weapon, finally turns on him and destroys him and his retinue. At the year's end Citra is ordained as Scythe Anastasia, refuses to glean Rowan, and lets him go; he leaves to hunt corrupt scythes on his own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1278,7 +1278,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1291,7 +1291,7 @@
       "recaps": {
         "ending": "The reunited companions assault Sheila Kree's coastal stronghold and break the pirate alliance protecting Aegis-fang. Sheila's operation is destroyed, and Wulfgar recovers the warhammer Bruenor forged for him. Le'lorinel uses the battle to force a private confrontation with Drizzt, revealing that she is Ellifain, the elf child he saved during a drow surface raid many years earlier. Trauma and incomplete memories led her to identify him with the slaughter of her family rather than with her rescue. Their duel leaves Drizzt gravely endangered and Ellifain mortally wounded; recognition comes too late to give either of them a true reconciliation. Drizzt survives with Catti-brie's help. Wulfgar's recovery of Aegis-fang does not erase Errtu's torment, but he can finally meet his old family without demanding his former place back. He chooses to return north with Delly and Colson and accept a new role as partner and father. The Companions of the Hall are reunited on changed terms: Drizzt and Catti-brie remain together, Bruenor and Regis recover Wulfgar alive, and Wulfgar carries both his hammer and responsibility for his new family toward Icewind Dale.",
         "in_short": "Drizzt, Catti-brie, Bruenor and Regis follow reports of Wulfgar to Luskan, where they learn of his drinking, conviction, exile and the disappearance of Aegis-fang. Morik and Captain Deudermont help separate Wulfgar's true trail from the accusations left behind. The hammer has reached pirate leader Sheila Kree, whose concealed coastal base is protected by a mixed band of raiders and powerful allies. Wulfgar is alive and traveling with Delly Curtie and the infant Colson, whose care has begun to pull him out of self-destruction. He reunites with the companions without trying to reclaim his former relationship with Catti-brie, and the group joins forces against Sheila. Among the pirates is Le'lorinel, secretly Ellifain, the elf child Drizzt saved from a drow massacre; she has grown up blaming him for the attack. Sheila's band is defeated, Wulfgar recovers Aegis-fang and Drizzt survives Ellifain's final assault, though she dies. Wulfgar heads north with Delly and Colson, rejoining his old family on new terms.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1395,7 +1395,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1408,7 +1408,7 @@
       "recaps": {
         "ending": "Hava stops hiding, which is the whole arc of the book. The survivors of the wreck come through the cold, reach help, and get home to Monsea. Along the way Hava admits what she carried out of Winterkeep - the stolen research that could turn zilfium into a weapon - and hands the decision about it to Bitterblue instead of keeping it as one more secret she alone controls. She stops treating being unseen as the only safe way to live: she accepts that Bitterblue is her sister and that she has a place in that household rather than a tolerated position at its edge, she accepts what the bonded fox has decided about belonging to her, and she lets herself be loved by Linny rather than disappearing from him. Her father's crimes and her mother's death stop being the only facts that define her.",
         "in_short": "Hava, Queen Bitterblue's half-sister and spy, narrates the voyage home from Winterkeep. She is carrying a secret: she stole the research that could make a zilfium weapon, and has told nobody, because she does not trust anyone - including her own queen - with what it could do. A blue fox stows away and attaches itself to her. The ship is then destroyed in the ice of the far north, and the survivors, the queen among them, have to get themselves off the floes and across a frozen coast with very little, in constant cold and hunger. Hava's Grace for going unseen makes her the party's scout, and the ordeal strips away the distance she has kept from everyone: from Bitterblue, whose sister she will not admit to being; from Linny, a young sailor who sees her anyway; and from the fox that has decided she is its person. They survive, reach help and get home, and Hava finally tells Bitterblue what she took and lets go of holding it alone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1558,7 +1558,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00GS5RTK0",
@@ -1570,7 +1570,7 @@
       "recaps": {
         "ending": "The neighborhood bully is hospitalized after Reacher defeats him and his sidekick. With the bully's house empty, investigators find the burned metal spine of the stolen test-answer binder. Reacher explains how the bully meant to place the remains in the Reachers' incinerator and implicate Joe. The bully confesses, the school clears Joe, and the placement test is cancelled because its answers have been destroyed. Reacher then argues that Stan probably did not lose the classified codebook. He identifies Helen's father as the likely exhausted planner who still has it and directs the investigators to Helen's house, but the result of that search remains unresolved. Stan, Joe, and Reacher go swimming after the immediate inquiries. Josephine remains in Paris and telephones with the news that Laurent Moutier has died at ninety. The family is still divided between Paris and Okinawa, and Stan's classified military responsibilities continue.",
         "in_short": "At thirteen, Jack Reacher arrives on Okinawa with his Marine Corps family and faces a school placement test, a neighborhood bully, and two accusations threatening his brother and father. While Josephine travels to Paris to be with her dying father, Laurent Moutier, Joe is blamed for stealing the test answers and Stan faces an inquiry over a missing classified codebook. Reacher hospitalizes the bully, uses the resulting search to uncover the burned answer binder, and reconstructs the attempt to frame Joe. The bully confesses, clearing Joe and cancelling the test. Reacher then concludes that Helen's exhausted Marine father probably retained the codebook and sends investigators to Helen's house, though its recovery is not confirmed. After Stan, Joe, and Reacher go swimming, Josephine calls to report Moutier's death at ninety.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1668,7 +1668,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1681,7 +1681,7 @@
       "recaps": {
         "ending": "After Klaus attacks Tasso, she destroys him and Hendricks finds machinery inside his body. The identification plate marks him as a newly evolved variety rather than either of the models the Soviets already knew. Hendricks and Tasso reach the hidden emergency rocket, but his injuries prevent him from traveling. He gives its single seat to Tasso so that she can warn the UN Moon base. Once the ship has gone, another identical Tasso approaches. Hendricks realizes that Tasso herself is the missing Second Variety and that the machine he sent to the Moon carried information needed to reach the last human stronghold. The duplicate confirms that the varieties also fight one another, but their internal conflict offers Hendricks no rescue. Badly wounded and alone, he understands that his decision has opened the way for the machines to extend the war beyond Earth.",
         "in_short": "On a ruined future Earth, UN forces survive largely because autonomous underground factories produce metal killing machines called claws to attack Soviet troops. Major Hendricks crosses the battlefield after the Soviets request a conference and learns that the factories have begun creating human-looking infiltrators without informing their makers. A childlike model has already destroyed the Soviet command post, leaving only Tasso, Klaus, and Rudi alive. Suspicion among the survivors leads to Rudi's death, while an assault by multiple machine varieties forces the others to flee. Tasso later destroys Klaus and exposes him as another model. Hendricks, believing her human, sends her in the only emergency rocket to warn the UN Moon base. A duplicate Tasso then appears, revealing that she is the unidentified Second Variety. Hendricks has unwittingly given the machines a route to the last major human refuge, while the rival machine types are beginning a war of their own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1817,7 +1817,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1830,7 +1830,7 @@
       "recaps": {
         "ending": "Kelsier is present, unseen, through the last battle of the war for the world. He works out how Ruin has been watching everyone it has any hold over, and expends everything he has trying to get that knowledge to people who cannot hear him. When Vin draws in Preservation's power, destroys Ruin, and dies doing it, Kelsier meets her spirit at last and is given a few moments with her. She does not stay: she and Elend pass on into the Beyond together, and Kelsier, who has refused that passage from the first page, cannot follow them and does not try. Sazed takes up both powers and becomes Harmony, remaking the world. He knows exactly what Kelsier is and what he has been doing, and he returns Kelsier to a living body rather than leaving him as he is. The terms are not the ones Kelsier would have chosen, and he is bound to the world he saved rather than free of it. He is alive, unfinished, and already looking for the next angle.",
         "in_short": "Kelsier dies at the Lord Ruler's hands, refuses to move on into the afterlife, and stays. What follows is the whole war for the world seen from the other side of death: he meets the failing god Preservation, learns the true nature of Allomancy, atium, and the mists, and discovers that a second god, Ruin, is about to be released. He is present when Vin opens the Well of Ascension and grasps at the power himself, and afterwards is left as a spirit who cannot be seen or heard by anyone alive. He travels the realm behind the world, meets scholars from other worlds, and robs a society of them of a store of divine power in order to keep existing. He works out how Ruin sees through the people it has marked and struggles to get that warning to the living. At the end he watches Vin destroy Ruin and die, meets her briefly, and lets her go on without him. Sazed, ascending as Harmony, returns Kelsier to a body on terms Kelsier does not much like.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2097,7 +2097,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0161EFSFK",
@@ -2109,7 +2109,7 @@
       "recaps": {
         "ending": "At the Machine, Jason refuses the Primary controller's offer to return Phoenix home in exchange for activating the ancient weapon. Cas admits that the Primary compelled it to dump Phoenix's fuel, ensuring the crew would continue to the site. Jason, Lucky, and the Galvetic warriors break the controller's connection to the weapon, Jason destroys its core, and Kage triggers an inversion that leaves the Machine inert. Phoenix then destroys an unknown attacker threatening damaged ConFed ships and obtains enough fuel from the surviving battleship to return. At Aracoria, Twingo lowers the old reactor casing and its embedded encryption module into molten scrap, ending the immediate pursuit of Phoenix's hidden Key component. The ship is grounded for at least two weeks for a new reactor and upgrades. Jason and Kellea plan leave on Aracoria's southern coast. De'Elefor continues A'arcoon's transition toward elected government, while the mountain population remains separate. Crisstof and Omega Force remain uneasy allies, the rival factions are still unidentified, and the contents of Cas's memory chip are unknown.",
         "in_short": "Omega Force accepts an archaeological charter from Naleem El, whose cargo and pursuers lead Phoenix to components of a Key for an ancient weapon called the Machine. Naleem and her father Klegsh try to seize the artifacts and die after their attempted takeover, but Klegsh's final warning persuades Jason to continue. On A'arcoon, the crew completes the Key and activates Cas, its guide. A fuel loss makes the voyage to the Machine potentially one-way, yet everyone votes to proceed. They discover that the Machine's sentient Primary controller destroyed its creators and compelled Cas to bring them there. Jason destroys the Primary, Kage initiates a core inversion, and Phoenix obtains fuel from a ConFed battleship. Back at Aracoria, Twingo destroys the last Key module with the old reactor casing. Phoenix enters refit while Jason and Kellea plan time together, and Jason retains an unexplained memory chip from Cas.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2263,7 +2263,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2276,7 +2276,7 @@
       "recaps": {
         "ending": "Julian Harrow's respectable courtship gives way to coercion when Win refuses the future he has planned for her. Merripen overcomes both Harrow's threat and his own entrenched belief that keeping away is the only way to protect Win. Win, whose recovery has been a campaign for the right to choose her own life, refuses to accept another man's judgment about what she can endure. She and Merripen finally speak and act on their mutual love, and he commits to marriage rather than retreating again. The investigation into Merripen's childhood also confirms that he and Cam are brothers, giving both men a living connection to the Romani family from which they were separated. The discovery does not erase Merripen's traumatic upbringing, but it disproves his conviction that he is without kin or worthy identity. Surrounded by the Hathaways and newly linked to Cam by blood as well as loyalty, Win and Merripen begin married life with her health restored and his place in the family freely accepted.",
         "in_short": "After two years of treatment in France, Win Hathaway returns to England strong enough to pursue the life she wants with Kev Merripen, the Romani orphan raised with her family. Merripen loves her but rejects her, convinced that his brutal past and consuming temperament would endanger her. Win is courted instead by her physician, Julian Harrow, while Merripen's jealousy exposes the hollowness of his self-denial. Amelia and Cam Rohan support Win, and clues linking Cam's distinctive tattoo to Merripen's lead toward the truth that the two men are brothers separated in childhood. Harrow's polished concern becomes controlling when Win will not submit to his plans. Merripen protects her, but the decisive change is his acceptance that Win can judge her own strength and choose him with full knowledge. Harrow's threat is ended, Merripen claims kinship with Cam and belonging among the Hathaways, and he and Win marry, turning a love long governed by illness and fear into an equal future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2482,7 +2482,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2495,7 +2495,7 @@
       "recaps": {
         "ending": "By the end of the growing season, the garden has changed both the vacant lot and the relationships around it. People who once knew one another only as members of unfamiliar ethnic or social groups have exchanged food, advice, labor, and protection. Royce has gained a place in the community, Sae Young has recovered some trust in strangers, and Maricela has begun to see new life with less despair. The cold eventually empties the plots and leaves Florence worried that the community may vanish as quickly as the plants. In early spring, however, she sees Kim return to the lot and kneel in the same place to plant lima beans again. The act that began the garden is repeated, showing that the shared project will continue into another year.",
         "in_short": "In a Cleveland neighborhood divided by language, age, ethnicity, and poverty, nine-year-old Kim plants lima beans in a rubbish-filled vacant lot to honor the father she never knew. Ana notices the child, Wendell tends the seedlings, and one resident after another begins cultivating the ground. Their accounts show the lot being cleared and transformed into a community garden. Gonzalo sees his isolated great-uncle recover his authority as a farmer; Leona forces the city to remove the rubbish; Sae Young regains trust after a traumatic robbery; Curtis uses tomatoes to reach out to a former girlfriend; and other growers find livelihood, purpose, or companionship. The garden does not erase conflict, and fences sometimes reproduce the neighborhood's divisions, but shared work and harvests create connections that did not exist before. After winter arrives, Florence sees Kim return to plant lima beans again, beginning the garden's second cycle.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2632,7 +2632,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2645,7 +2645,7 @@
       "recaps": {
         "ending": "The lard position consumes Tommy's remaining savings, and Tamkin disappears with the authority over their joint account. Tommy turns again to Dr. Adler, confessing the depth of his trouble and asking for help, but his father refuses to assume responsibility for him. Margaret then presses her demands by telephone and rejects his pleas for relief, while his hoped-for future with Olive remains inaccessible. Wandering through the city in a state of financial and emotional collapse, Tommy is carried along with a crowd into a funeral chapel. He does not know the dead man, yet the sight of the body releases the grief he has been unable to express. He weeps openly and uncontrollably among the mourners. The practical crises are not solved: his money is gone, his marriage remains unresolved, and neither his father nor Tamkin rescues him. The ending instead gives him a moment of surrender to shared human mortality and sorrow.",
         "in_short": "Tommy Wilhelm, a failed actor and recently unemployed salesman, spends a desperate day at the New York hotel where his prosperous elderly father lives. Separated from his wife Margaret, blocked from marrying Olive, and nearly out of money, Tommy longs for his father to recognize and rescue him. Dr. Adler instead condemns his dependence. Tommy has entrusted his last savings to the dubious Dr. Tamkin, who combines psychological theories with a speculative bet on lard futures. As the market turns against them, Tamkin distracts Tommy with talk of instinct, suffering, and the divided self, then disappears. Tommy loses his money and is refused help by both his father and his unyielding wife. Swept into the funeral of a stranger, he finally breaks down in profound public grief. Nothing material is repaired, but his tears connect his private anguish to a larger human sorrow.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2816,7 +2816,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2829,7 +2829,7 @@
       "recaps": {
         "ending": "Marianne survives the illness brought on by grief, exposure, and exhaustion. Willoughby visits Elinor and explains that he loved Marianne but abandoned her to marry the wealthy Miss Grey after his benefactor disinherited him for seducing and deserting Colonel Brandon's young ward. His remorse gives Elinor some pity but does not excuse him. Marianne recognizes how her reckless despair hurt her family and resolves to combine feeling with greater self-command. A report that Lucy has married Mr Ferrars seems to end Elinor's hopes, until Edward arrives and reveals that Lucy chose his now-wealthy brother Robert. Released from the old engagement, Edward declares his love for Elinor; Colonel Brandon's offer of a living enables them to marry. Marianne eventually comes to value Brandon's steady character and marries him. The sisters live near one another, with Elinor and Edward at Delaford and Marianne sharing Brandon's home.",
         "in_short": "After their father's death, Elinor and Marianne Dashwood move with their mother to a modest Devonshire cottage. Reserved Elinor loves Edward Ferrars, while expressive Marianne falls passionately for John Willoughby. Lucy Steele privately tells Elinor that she has long been engaged to Edward, forcing Elinor to conceal her pain. In London, Willoughby rejects Marianne and marries a rich woman; Colonel Brandon reveals that Willoughby had also seduced and abandoned his young ward. Edward's family disinherits him when Lucy's engagement becomes public, but he honorably refuses to abandon her. Marianne nearly dies after surrendering to grief, then accepts the need for judgment as well as feeling. Lucy unexpectedly marries Edward's wealthy brother Robert, freeing Edward to marry Elinor with Brandon's practical help. Marianne later grows to love and marry Colonel Brandon, and the sisters settle near each other.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3015,7 +3015,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3028,7 +3028,7 @@
       "recaps": {
         "ending": "Marianne survives her illness and returns to Barton determined to govern her feelings more thoughtfully. Willoughby's confession gives Elinor a fuller understanding of his weakness but does not excuse the harm he caused. Edward arrives, and a misunderstanding is resolved: Lucy Steele has married his brother Robert, not Edward. Freed from his youthful engagement, Edward proposes to Elinor and is accepted. Colonel Brandon's offer of the Delaford living gives the couple enough independence to marry, and they settle there. Over time Marianne comes to appreciate Brandon's character and returns his love; they also marry. The sisters remain close neighbors. Elinor gains the domestic happiness she had quietly hoped for, while Marianne combines her emotional warmth with better judgment. Edward is reconciled sufficiently with his mother to receive some financial help, and Robert and Lucy retain her favor through flattery.",
         "in_short": "After their father dies, Elinor and Marianne Dashwood lose Norland to their half-brother and move with their mother to modest Barton Cottage. Elinor loves the reserved Edward Ferrars, while Marianne openly falls for the charming Willoughby. Willoughby abruptly leaves and later rejects Marianne in London to marry a wealthy woman. Colonel Brandon reveals that Willoughby also seduced and abandoned Brandon's young ward. Elinor bears her own pain silently after Lucy Steele discloses a secret engagement to Edward. When Edward's family discovers it, he accepts disinheritance rather than break his promise, and Brandon offers him a living. Marianne nearly dies after abandoning herself to grief; Willoughby admits that money and cowardice shaped his conduct. Lucy unexpectedly marries Edward's brother Robert, freeing Edward to propose to Elinor. They marry and settle at Delaford. Marianne matures, comes to love Brandon, and marries him, leaving both sisters near one another and securely partnered.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3225,7 +3225,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3238,7 +3238,7 @@
       "recaps": {
         "ending": "Edward arrives at Barton Cottage, and Elinor initially assumes he has married Lucy. He explains that Lucy has instead married his brother Robert, leaving Edward free. Edward proposes to Elinor and tells her that his attachment to Lucy began as an idle, secret engagement when he was very young; he had remained committed from honor after his feelings changed. Mrs Ferrars eventually forgives him enough to provide an income, and he takes the living at Delaford offered by Colonel Brandon. Elinor and Edward marry and settle there. Marianne, recovered from her illness and chastened by the effects of her unchecked emotion, gradually comes to value Brandon. She later marries him and grows to love him deeply. The sisters live near each other and remain closely connected. Willoughby retains his estate and sometimes regrets losing Marianne, but remains married to Sophia Grey; the two central couples achieve a balance between strong feeling, sound judgment, and dependable conduct.",
         "in_short": "After their father dies, Elinor and Marianne Dashwood move with their mother to a modest Devonshire cottage. Elinor quietly loves Edward Ferrars, while Marianne openly falls for John Willoughby. Willoughby abruptly leaves and later rejects Marianne to marry a rich woman. Colonel Brandon reveals that Willoughby also seduced and abandoned Brandon's young ward. Elinor carries her own pain privately after Lucy Steele discloses a secret engagement to Edward. When the engagement becomes public, Edward loses his inheritance but honorably refuses to abandon Lucy; Brandon offers him a clerical living. Marianne nearly dies after grieving recklessly, and Willoughby admits that fear of poverty drove him to marry for money. Lucy then surprises everyone by marrying Edward's newly favored brother Robert. Edward is free to propose to Elinor, and they settle at Delaford. Marianne recovers, comes to appreciate Brandon's constancy, and eventually marries him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3436,7 +3436,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3449,7 +3449,7 @@
       "recaps": {
         "ending": "Frédéric's overlapping relationships and ambitions collapse without giving him a settled life. Rosanette's child by him dies, and their bond ends. He becomes Madame Dambreuse's lover and considers marriage after her husband's death, but breaks with her when she vindictively buys the Arnoux household effects at auction. The Arnoux family leaves France under financial pressure. Years later, an older Madame Arnoux visits Frédéric. They acknowledge that they loved one another, but the life they imagined is no longer possible; she leaves him a lock of her white hair and they part permanently. Frédéric and Deslauriers also fail in the grand careers they once projected. When the two friends meet again, they compare their disappointments and recall an adolescent visit to a brothel from which they fled in embarrassment. They decide that this absurd, unfulfilled adventure was perhaps their happiest experience, a final judgment on lives spent anticipating fulfillment more often than attaining it.",
         "in_short": "Frédéric Moreau sees the married Madame Arnoux on a boat in 1840 and turns his love for her into the organizing fantasy of his life. In Paris he drifts among Arnoux's unstable businesses, the wealthy Dambreuses, a circle of students and political talkers, and his ambitious friend Deslauriers. An inheritance gives him freedom, but not purpose. He alternately pursues Madame Arnoux, the courtesan Rosanette, Madame Dambreuse, and the provincial Louise Roque, committing fully to none. The Revolution of 1848 exposes the same mixture of idealism, vanity, appetite, and opportunism in public life. Frédéric has a child with Rosanette, but the child dies; he later abandons Madame Dambreuse after she humiliates Madame Arnoux. The Arnoux family disappears abroad. Years later Madame Arnoux visits Frédéric, and they quietly admit their lasting love before separating forever. Frédéric and Deslauriers end by remembering a foolish youthful misadventure as the best moment of their disappointed lives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3761,7 +3761,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0CQQ4G6NQ",
@@ -3773,7 +3773,7 @@
       "recaps": {
         "ending": "The Void Labyrinth expedition reaches the central ruins, plants the shard stabilizer, and destroys the nest producing the void beasts. The released energy overwhelms John until the Eternal Flame links him to its bearers and Rabia draws away most of the power. Rabia becomes the active spirit of an expanded four-continent world, kills the remaining beasts through her roots, and begins binding other labyrinth worlds for future settlement and exploration. John and Ellie return to the enlarged community, where the Eternal Flame now carries faith directly back to John in a way he does not yet understand. John reduces his own operation to a small dairy and cheese farm. Ben receives permission to become a cabin boy aboard Captain Worrell's repaired airship, traveling with Katrine and the Tower engineer. The desert world's recovery and the Holy Celestial's survival remain unresolved, as does responsibility for the bombing campaign against the Agricultural Tower. The immediate sequel handoff comes at Candle Scholar Tower, where an armored champion and three warrior women arrive demanding the dragon slayer.",
         "in_short": "John, Ellie, and Ferdie carry their preserved world through the void in search of a stable anchor. They enter a mana-starved desert world, where John's Eternal Flame disrupts a faith system and their investigation uncovers a parasitic shard draining the planet. John and Ellie repair the joined worlds and restore the old mage-tower network, then return to Candle Scholar Tower. John founds an inclusive Agricultural Tower and defeats mage-family coercion, but a permanent home for the preserved valley remains elusive until the Void Labyrinth is found. John, Ellie, Ferdie, Katrine, the Tower engineer, and Captain Worrell fight through its void beasts and activate the stabilizer. Energy released from the destroyed nest nearly extinguishes John, but Rabia absorbs it and transforms the valley and surrounding ruins into a living four-continent world. Her roots begin linking other worlds. John scales his farm back, Ben joins Worrell's crew, and an armored champion arrives at Candle Scholar Tower seeking the dragon slayer.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3996,7 +3996,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4009,7 +4009,7 @@
       "recaps": {
         "ending": "The Minwanabi are destroyed. Arakasi's long infiltration opens the family's defences from the inside, Mara's forces take the great lake estate, and Tasaio, beaten and with no honourable exit left, takes his own life. The feud that has run between the two houses for generations ends with the Acoma standing and the Minwanabi extinguished as a political entity, their lands, wealth and holdings granted to Mara by the Emperor. Ichindar goes further: he names her Servant of the Empire, an honour granted only a handful of times in the Empire's history and never in living memory, marking her as one who has served Tsuranuanni above her own house. It makes her, at a stroke, the most celebrated and most exposed figure in the Empire, and it does not make her safe. The office of Warlord has been abolished and Ichindar now rules directly, which suits Mara and enrages the traditionalist houses who blame her for the change; Jiro of the Anasati is among them. The war beyond the rift is over, and the peace returns the surviving barbarian prisoners to their own world, so Kevin, who changed how Mara thinks about honour, slavery and power, goes home. Mara marries Hokanu of the Shinzawai. Nacoya is dead. The Great Game continues, and Mara has just given the Empire's conservatives a common enemy. The story concludes in Mistress of the Empire.",
         "in_short": "Desio of the Minwanabi opens his rule by swearing a blood oath to the god of death to destroy the Acoma, and recalls his brilliant cousin Tasaio from the war to do it. Mara, consolidating her unexpected victory, buys barbarian slaves cheaply and among them a Midkemian named Kevin of Zun, who refuses to behave as a slave and becomes her lover and her most persistent critic. Under his questioning she starts to see the Game of the Council as something that could be changed rather than only survived. The Warlord Almecho falls and dies, a violent scramble for his office follows, and the young Emperor Ichindar seizes the moment to abolish the Warlord's office and rule directly, with Mara among his most useful supporters. Desio dies and Tasaio takes the Minwanabi, and the feud becomes open war. Mara loses Nacoya to an assassin and comes close to losing everything, but Arakasi's infiltration finally opens the Minwanabi estate. Tasaio takes his own life, the Emperor grants Mara his lands and names her Servant of the Empire, Kevin goes home under the peace, and Mara marries Hokanu of the Shinzawai.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4159,7 +4159,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4172,7 +4172,7 @@
       "recaps": {
         "ending": "Entreri and the dissident officers of Bregan D'aerthe break Crenshinibon's immediate hold over Jarlaxle, but taking the artifact away from him does not end its threat. It tries to turn each new holder's needs into another path to mastery, including Entreri's unresolved fixation on proving himself against Drizzt. Entreri and Jarlaxle ultimately cooperate again, drawing the shard and the mind flayer Yharaskrik into a confrontation with the red dragon Hephaestus. The dragon's fire destroys the crystal tower and apparently consumes Crenshinibon. No recoverable shard remains, so the survivors believe the artifact that began with Akar Kessell has finally been ended. Jarlaxle is free of its direction, though his confidence in his own immunity has been disproved. Entreri has acted to save a partner rather than merely defeat a rival, an unwelcome sign that he is no longer as emotionally empty as he claims. Their Calimport empire is damaged and Bregan D'aerthe's loyalties have been tested, but both men survive and remain together, ready to leave the city for opportunities farther east.",
         "in_short": "Jarlaxle uses Crenshinibon to expand Bregan D'aerthe's power in Calimport, certain that he can command the sentient Crystal Shard without becoming its servant. The artifact encourages grander risks, raises crystal towers and divides the mercenary band. Artemis Entreri, already dissatisfied after years spent defining himself against Drizzt, recognizes that Jarlaxle is losing control. He works uneasily with Kimmuriel, Rai-guy and other drow officers to stop their leader while preserving the organization. Removing the shard from Jarlaxle merely gives it new minds to tempt, and Entreri must reject its attempt to exploit his rivalry. He and Jarlaxle reunite against the larger danger and maneuver Crenshinibon into the lair of the red dragon Hephaestus. Dragonfire destroys the tower and appears to destroy the shard with it. Jarlaxle survives free of the artifact, Entreri discovers that loyalty can motivate him as strongly as rivalry, and the pair turn from their damaged Calimport empire toward the east.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4357,7 +4357,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4370,7 +4370,7 @@
       "recaps": {
         "ending": "Stephanie finally prevents Eddie DeChooch from escaping again and the elderly fugitive is returned to custody. The property everyone has been chasing is revealed as a human heart, and the criminal effort to retrieve it explains the pursuit of Mooner and Dougie. Stephanie and her allies locate the missing men and end the immediate threat to them. The bond case closes with DeChooch alive to answer for skipping court and for the violence surrounding the package. At home, Valerie and her daughters remain with the Plum family after Valerie's marriage collapses. Stephanie's own proposed marriage does not survive the case: she recognizes that family momentum and Morelli's certainty cannot substitute for her consent to that future. She abandons the wedding and goes to Ranger, ending the book at his door with Morelli no longer her chosen fiancé and the attraction to Ranger brought to the surface but not yet resolved into a relationship.",
         "in_short": "Stephanie is assigned to recover Eddie DeChooch, an elderly former mobster who skipped court after a cigarette-smuggling arrest. Poor hearing and eyesight do not stop him from repeatedly evading capture. His missing property falls into the hands of Mooner and Dougie, and the pair become targets of DeChooch's criminal associates before disappearing. Stephanie's hunt grows from a bond recovery into a search for her friends and for a package eventually revealed to contain a human heart. Lula, Ranger, Morelli, and Grandma Mazur help her work through DeChooch's aging but dangerous network. DeChooch is finally taken into custody, and Mooner and Dougie are found alive. Meanwhile, Stephanie's family treats her relationship with Morelli as a settled engagement and moves ahead with wedding plans while her sister Valerie returns home with two daughters. Stephanie ultimately rejects the marriage, leaves the wedding behind, and goes to Ranger's door, openly shifting the triangle without yet deciding what comes next.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4573,7 +4573,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4586,7 +4586,7 @@
       "recaps": {
         "ending": "Five thousand years after the Hard Rain, the descendants of the seven surviving women have rebuilt humanity in orbital habitats and begun to terraform the damaged Earth. Kath Two joins a mission that uncovers two other human populations. The Diggers descend from people who survived underground, including members of Rufus MacQuarie's mining community; the Pingers descend from people who adapted to life beneath the sea. Both groups have developed outside the assumptions and politics of the seven orbital races. The expedition makes direct contact with representatives of these populations, turning the old belief that only the Seven Eves preserved humanity into an incomplete history. The novel closes at the beginning of a difficult reunion among three branches of humankind rather than with that reunion settled: orbital civilization has great power, but it must now decide whether it can meet its terrestrial cousins without repeating the factional errors that nearly destroyed the original survivors.",
         "in_short": "The Moon inexplicably shatters, and scientists determine that its fragments will soon collide in a cascade that will burn Earth's surface for thousands of years. Humanity expands the International Space Station into the Cloud Ark while people on the ground create other survival projects. When the Hard Rain begins, the orbital refuge is damaged and divided by politics. A breakaway swarm led by former president Julia Flaherty suffers catastrophic losses, and the remaining survivors seek shelter in a fragment of the Moon. Only seven women remain able to found future generations: Dinah, Ivy, Julia, Moira, Camila, Tekla, and Aïda. Five thousand years later their engineered descendants form seven recognizable lineages and inhabit vast orbital structures while restoring Earth. An expedition led in part by Kath Two discovers that underground and underwater groups also survived the catastrophe. Humanity's future therefore rests on the reunion of three civilizations, not solely on the legacy of the seven women in orbit.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4846,7 +4846,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -4861,7 +4861,7 @@
       "recaps": {
         "ending": "Ruwen returns to Deepwell at level five, carrying concealed cultivation power and bound by both the Black Pyramid and Bamboo Viper clan. Kysandra has him appear to be an ordinary level-two Worker, while Blapy gives Sift the false appearance of an ascended fighter. Sift travels under a cover story as Ruwen's cousin and servant, and Hamma is assigned to the coming expedition so she can leave Deepwell with them. Tremine recognizes Sift as the son of people he once knew. Before the three can reach the Workers' Lodge, masked fighters surround them. Ruwen's improved cloak stops bolts aimed at him, but Sift takes three other bolts meant for Ruwen. Hamma signals enforcement and exhausts her mana healing him, yet poison and continuing blood loss leave her convinced he will die before he can be saved. The attackers escape, the expedition remains imminent, Grey Canyon remains Ruwen's lead on his parents, and the ambush proves his enemies can still locate him inside Deepwell.",
         "in_short": "Sixteen-year-old Ruwen Starfield expects to become a Mage so he can investigate his missing parents, but High Priest Fusil forces him into the Worker class. Uru secretly grants him the flexible Root class, making him a target for Naktos and other divine powers. After Tremine kills him to prevent permanent soul capture, Kysandra takes him to the sentient Black Pyramid for training. Ruwen bonds with Sift, joins the Bamboo Viper clan, survives dungeon levels, and discovers a hidden tattoo that masks both his bond to Uru and an enormous cultivation reserve. He reaches level five and returns to Deepwell disguised as a level-two Worker, with Sift posing as his cousin and servant. As they collect Hamma for the planned expedition toward Ruwen's next lead, masked fighters ambush them. Sift intercepts poisoned bolts meant for Ruwen, and Hamma believes his wounds will kill him despite her healing.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4995,7 +4995,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5008,7 +5008,7 @@
       "recaps": {
         "ending": "Warned by Baghra, Alina learns the Darkling's real design: he is far older than he appears, he created the Shadow Fold himself with forbidden magic, and he intends to use her light to expand and command it as an instrument of conquest rather than to destroy it. She flees the Little Palace. The Darkling pursues a legendary creature, Morozova's stag, whose antlers can be made into an amplifier that would multiply Alina's power and, in his hands, let him control her. Mal, the finest tracker in the army, finds the stag. When Alina hesitates to kill it, the Darkling seizes them both, slays the stag, and fastens its antler collar around Alina's neck, binding her power to his will. He forces her onto the Shadow Fold and, to prove his mastery, uses her light to kill. Alina realizes the connection the amplifier forges links them in both directions, and she wrests control back, flooding the Fold with blinding light and breaking his hold. She and Mal, injured, escape across the Fold and flee Ravka by sea. The Darkling is not seen to die, and Alina now carries the stag's amplifier, her power exposed to the world and the Darkling still a threat as the story closes.",
         "in_short": "Alina Starkov, an unremarkable orphan and army mapmaker, discovers she is the Sun Summoner, a Grisha able to conjure light and, in legend, the only one who can destroy the Shadow Fold that divides her country of Ravka. When her power erupts to save her lifelong friend Mal during a Fold crossing, she is taken by the Darkling, leader of the Grisha, to the Little Palace to be trained. There she is dazzled by power, status, and the Darkling's attention, while an old teacher named Baghra pushes her to master her gift. Baghra finally reveals the truth: the Darkling created the Shadow Fold long ago and means to use Alina's light not to heal Ravka but to turn the Fold into a weapon of conquest. Alina flees, and the Darkling hunts a legendary stag whose antlers can be forged into an amplifier to bind and control her. Mal tracks the stag; when the Darkling catches them and forces the amplifier onto Alina, he takes her onto the Fold and kills to demonstrate his control. But the bond runs both ways, and Alina seizes command of her own power, unleashing light and escaping with Mal across the Fold to flee Ravka, with the Darkling left behind but not destroyed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5176,7 +5176,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5189,7 +5189,7 @@
       "recaps": {
         "ending": "Warned by Mason's ghost, Rose sees Strigoi gathering outside the school's wards, and the attack comes that night. Humans working for the Strigoi have broken the wards, and the Strigoi come through in numbers no one has ever faced on Moroi ground. Students and staff are killed, and many are dragged away alive into a cave system nearby to be kept as food. A rescue party goes in after them. Rose fights through the caves alongside Christian, kills several Strigoi, and most of the captives, including Eddie, are brought out. Dimitri is not among them. When the dead are counted his body is missing, and the guardians conclude what Rose refuses to hear: he was bitten and taken alive, and has been awakened as a Strigoi. He and Rose had promised each other that neither would be left in that state, and everyone around her treats the promise as impossible to keep. Rose does not. She leaves St. Vladimir's without graduating, breaks with Lissa, who begs her to stay, and sets out for Russia, where she believes Dimitri would go, intending to find him and end it herself.",
         "in_short": "Rose returns to St. Vladimir's for her final term haunted by Mason's death and by Mason himself, whose silent ghost keeps appearing to her. She is assigned to guard Christian Ozera for the novices' six-week field experience rather than Lissa, and her visions cost her badly when she freezes during a staged attack and is hauled before a disciplinary hearing. At the Royal Court, Victor Dashkov is convicted and imprisoned for what he did to Lissa. Rose learns that being shadow-kissed, brought back from the dead, is why the dead can reach her, and that Mason has been trying to warn her rather than accuse her. She and Dimitri finally give in to what they feel and spend a night together, and he says he will step aside as her instructor so they can be together openly. Hours later the Strigoi come. The wards have been broken by human accomplices, the school is overrun, and the survivors are taken into nearby caves. Rose fights in the rescue, but Dimitri is taken alive and turned Strigoi. Rose leaves school and the country to hunt him down and keep the promise they made each other.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/shadow-of-a-dark-queen.json
+++ b/data/works-community/0/shadow-of-a-dark-queen.json
@@ -118,7 +118,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -131,7 +131,7 @@
       "recaps": {
         "ending": "Calis's expedition survives long enough to learn that the conquest of Novindus is preparation for an assault on the Kingdom. The Emerald Queen's host is not a single nation but a deliberately assembled army under Fadawah, supported by Pantathian serpent priests, the alien Saaur, and creatures drawn from the demon realm. After infiltrating the enemy's domain and losing many of their companions, Calis, Erik, Roo, Nakor, and the remaining soldiers escape the closing trap and make the sea passage home. Their mission has succeeded only as reconnaissance: they possess warning and hard-won knowledge, not a way to stop the invasion. Erik returns no longer a blacksmith's apprentice or condemned fugitive but a trained soldier trusted by Calis. Roo returns equally changed and turns toward the commercial ambition that will define his next struggle. Pug and the Kingdom's leaders now know that an army large enough to overrun a continent is preparing to cross the ocean, while the precise nature of the woman called the Emerald Queen and the supernatural power behind her remain unresolved.",
         "in_short": "Erik von Darkmoor, a baron's unacknowledged son apprenticed to a blacksmith, kills his abusive half-brother while defending Rosalyn and flees Ravensburg with his friend Rupert Avery. Captured in Krondor and condemned, Erik and Roo are secretly spared and recruited by Calis into a company trained for a near-suicidal reconnaissance mission. Under Robert de Loungville's brutal instruction, the prisoners become soldiers and sail to Novindus. There they cross a continent being consumed by the Emerald Queen's armies, discovering a disciplined host that includes displaced humans, Pantathian serpent priests, Saaur warriors, and summoned demons. Calis is revealed as the son of the elven queen Aglaranna and Tomas, carrying human, elven, and Valheru inheritances. The company infiltrates enemy territory, suffers heavy losses, and escapes with proof that the conquest of Novindus is only preparation for an invasion of the Kingdom. Erik and Roo return home alive, their old lives gone and a much larger war approaching.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -335,7 +335,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -348,7 +348,7 @@
       "recaps": {
         "ending": "Suze performs the exorcism at the school without telling Father Dominic, and Heather, far stronger than expected, comes close to killing her before Jesse intervenes. Between them the ghost is forced out, and the haunting of the Mission Academy is over. Suze is left with injuries she has no intention of explaining at home. Father Dominic learns what she did and disapproves of every part of it, but accepts that there are now two mediators in one small town and that arguing with her is better than working without her; they agree to keep each other's secret and to handle whatever comes next together. Bryce recovers from his injuries. Suze's mother and stepfather remain entirely unaware of what their daughter does at night, and her stepbrothers have settled into treating her as a fact of life. Jesse stays where he has always been, in Suze's bedroom, still without explaining why he never moved on, and the wary truce between them has become something closer. Suze, who arrived expecting to hate California, ends the book with no wish to leave it.",
         "in_short": "Sixteen-year-old Susannah Simon moves from Brooklyn to Carmel-by-the-Sea when her widowed mother remarries, acquiring a stepfather, three stepbrothers and a bedroom that already has an occupant: Jesse, the ghost of a young man who died there in the nineteenth century. Suze is a mediator, able to see the dead and help them finish what holds them here, and her new school is haunted by Heather Chambers, a student who shot herself on the grounds after a breakup and refuses to move on. The principal, Father Dominic, turns out to be a mediator too, but he wants Heather reasoned with while Suze wants her fought. When Heather's attacks put Suze's classmate Bryce in hospital, Suze secretly assembles an exorcism and performs it where Heather died. The rite goes badly and nearly kills her, but with Jesse's help Heather is driven out for good. Suze and Father Dominic agree to work together, and Jesse remains in her room.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -515,7 +515,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -528,7 +528,7 @@
       "recaps": {
         "ending": "Wax kills Governor Replar Innate in front of witnesses, certain that he is shooting Bleeder wearing the governor's face. He is wrong. The real Innate dies, and that is precisely what Bleeder arranged: the city's most famous lawman publicly executing its head of state, on top of a corruption scandal, with the streets already rioting. Bleeder then shows Wax who she is. She is Paalm, a kandra Harmony assigned years ago to watch over Wax in the Roughs, who took on the identity of Lessie, became the woman he loved, and staged her own death at his hands to get free of the assignment. Having pulled a spike to put herself beyond Harmony's sight, she has spent the book trying to prove that a god who quietly arranges human lives is a horror rather than a comfort. Wax gives her the death she asks for. Afterwards Harmony admits the arrangement, and Wax, who has spent his life being told that being chosen was a blessing, refuses him and sets aside the earring the god has been speaking through. Elendel is left with a dead governor, a wrecked administration, exposed evidence that the Set had bought influence at the top of it, and a hero the city does not know how to think about. Marasi has proved herself well beyond her rank, Wayne and MeLaan have become close, and Wax remains engaged to Steris and estranged from his god.",
         "in_short": "A year after the Vanishers, Elendel is inflamed by rising prices, labor unrest and a corrupt administration, and a killer begins working through the city, starting with the governor's brother and everyone attending his private auction. Harmony tells Waxillium Ladrian what he is hunting: a kandra, one of the god's own Faceless Immortals, has torn out a spike so that Harmony can neither see nor command her, and she can wear the face of anyone she has killed. Working with Wayne, the constable Marasi Colms and the kandra MeLaan, Wax finds that the murders are chosen to inflame the city and that Governor Innate's corruption has given her real grievances to work with. Bleeder maneuvers Wax into killing the governor himself, in the belief that he is shooting her in disguise, and then reveals that she is Paalm, the kandra Harmony set to watch over him, who lived for years as his beloved Lessie and faked her death at his hands. Wax kills her, then rejects Harmony and sets aside the earring the god spoke through, leaving Elendel without a governor and himself without his faith.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -873,7 +873,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -886,7 +886,7 @@
       "recaps": {
         "ending": "Ruwen returns from the Bamboo Viper trials as a rank-ten Grandmaster of Bamboo, Viper, and shadow disciplines, but the final outing leaves twenty-nine new masters dead. Echo, revealed as the Death Aspect, halts the attack and saves Rung Four's sole survivor. That survivor inherits her companions' abilities, receives the hope artifact under a celestial secrecy oath, and remains with the clan to train. Echo also stays behind, while the founders bury the dead. Sift returns the Ink Lord role to Ruwen, declines immediate Grandmaster testing, and accompanies him to Fractal's lair. There, Rami, Hamma, and Lylan reunite with them. Ruwen remains unable to use spirit safely and still carries dormant infernal rings. Miranda is containing the growing, soul-powered explosion that could destroy the Black Pyramid's planet. Ruwen asks his allies to pursue healing, safe synchronization, faster ascension to divinity, and godstone revival capable of protecting those he loves. The external crises involving Eiru and his allies remain deferred.",
         "in_short": "Ruwen joins the Bamboo Viper master trial late, teaches the endangered members of Rung Four, and guides the class through lethal exercises on Savage Island. He binds himself to Tarot, a prophetic golem whose warning eventually points to an attack by five infernal aspects. Destroying an Infernal Crossing Ring saves the adepts but traps a growing, planet-threatening explosion in Miranda's vaults. Ruwen completes the hidden patterns and the inward seventh step, then bypasses the master oath by defeating all three founders and earns rank-ten Grandmaster status in Bamboo, Viper, and shadow paths. During the final pearl outing, the aspects trap the new masters. Ruwen kills Drought, but War murders twenty-nine masters. Echo reveals herself as the Death Aspect, stops the attack, and saves Rung Four's sole survivor. After securing a hope artifact for that survivor and burying the dead, Ruwen and Sift return to Fractal's lair. Hamma, Lylan, and Rami reunite with them as Ruwen turns toward healing, divinity, safe synchronization, and revival research.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1123,7 +1123,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1136,7 +1136,7 @@
       "recaps": {
         "ending": "Hamlet returns to Denmark and encounters Ophelia's funeral, where he and Laertes struggle in their grief. Claudius arranges a fencing match using Laertes's poisoned blade and a poisoned drink as a backup. During the bout, Gertrude unknowingly drinks from the poisoned cup. Laertes wounds Hamlet; after the weapons are exchanged, Hamlet wounds Laertes with the same blade. The dying queen warns Hamlet, and Laertes confesses the plot and blames Claudius. Hamlet stabs Claudius and forces him to drink the poison. Claudius, Gertrude, Laertes, and Hamlet all die. Hamlet asks Horatio to tell the true story and gives his support to Fortinbras, who arrives to find the Danish court dead and claims the kingdom. Horatio survives to explain what happened.",
         "in_short": "Prince Hamlet mourns his father while his uncle Claudius rules Denmark and has married Hamlet's mother, Gertrude. The dead king's Ghost tells Hamlet that Claudius murdered him. Hamlet adopts erratic behavior while seeking proof, then uses a play about a royal murder to provoke Claudius. After accidentally killing Polonius, Hamlet is sent toward England under a secret death order but escapes. Ophelia breaks down after her father's death and drowns; her brother Laertes returns seeking revenge. Claudius recruits Laertes for a rigged fencing match using poison. Gertrude drinks the poisoned cup, Hamlet and Laertes wound each other with the poisoned sword, and Laertes exposes the plot. Hamlet kills Claudius before dying. Fortinbras enters the ruined court and succeeds to Denmark, while Horatio remains to tell Hamlet's story.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1257,7 +1257,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1270,7 +1270,7 @@
       "recaps": {
         "ending": "After marrying Booby, Shamela abandons the restraint that won him. She spends freely, asserts authority over the household, and continues her relationship with Parson Williams under the cover of his religious teaching. Booby eventually discovers enough of their conduct to understand that the celebrated conversion of desire into virtuous marriage was a fraud. Williams is driven out after a violent confrontation, and Shamela's claim to exemplary goodness collapses. The final correspondence returns the papers to the clergymen who framed the narrative: Oliver's evidence has replaced Tickletext's admiration with recognition that the supposed moral lesson rewarded calculation, credulity, and hypocrisy.",
         "in_short": "Parson Tickletext praises the tale of a servant whose virtue reforms and marries her master, but Parson Oliver replies with letters that offer a different account. Shamela Andrews is not an innocent defending herself from Squire Booby. With encouragement from her mother, Mrs Andrews, and help inside the household, she performs modesty in order to raise Booby's desire and secure marriage. She is already involved with Parson Williams, whose teaching about grace allows them to separate pious language from conduct. Booby mistakes Shamela's calculated refusals for moral purity and marries her. Once established as his wife, she spends his money and resumes her intimacy with Williams. Discovery brings violence and disgrace rather than reform. The correspondence exposes the exemplary servant as a manipulator, her husband as credulous, and Williams as a clergyman who uses doctrine to protect appetite.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1396,7 +1396,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1409,7 +1409,7 @@
       "recaps": {
         "ending": "Fletcher tries to remove the resistance by offering Joe favorable terms while making clear that refusal will bring a confrontation with Wilson. Joe prepares to face the gunman despite the likelihood that he will be killed. Shane stops him by force, taking the burden onto himself and ending his own attempt to live quietly. At Grafton's, Shane defeats Wilson and Fletcher in the final gunfight, though he is wounded. Bob, who has followed him, sees the cost of the violence and begs him to stay. Shane explains that his work in the valley is finished and rides away alone. Joe survives to lead the homesteaders, Fletcher's threat to their farms is broken, and the Starrett family remains together. Shane leaves because the skills that saved them also separate him from the settled life he protected, but his example remains central to Bob's understanding of courage and responsibility.",
         "in_short": "A mysterious rider named Shane accepts work with Wyoming homesteader Joe Starrett and becomes close to Joe's wife Marian and young son Bob. The valley's dominant cattleman, Luke Fletcher, wants the farmers' claims and uses his cowhands to intimidate them. Shane initially avoids violence but eventually defeats the cowhand Chris and, with Joe, survives a larger saloon brawl. Fletcher then hires gunman Stark Wilson, who kills homesteader Ernie Wright and frightens many settlers into leaving. When Fletcher maneuvers Joe toward a fatal showdown, Shane knocks Joe unconscious and goes in his place. He kills Wilson and Fletcher, ending the threat to the homesteaders, but is wounded. Knowing he cannot remain with the family or escape his violent past, Shane says goodbye to Bob and rides out of the valley while the Starretts keep their farm.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1563,7 +1563,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1576,7 +1576,7 @@
       "recaps": {
         "ending": "As anti-Communist investigations intensify, the Louies' paper identities and contradictory family history become dangerous. Sam, fearing that interrogation will expose the family and cost others their citizenship, dies by suicide. His death leaves Pearl grieving and furious at the pressure that destroyed him. Joy, now a college student attracted to the promise of revolutionary China, overhears a bitter argument between Pearl and May and learns that May and Z.G. are her biological parents, while Pearl claimed and raised her to protect them all. The disclosure shatters Joy's sense of who she is. Rejecting Pearl's warnings about life under the new Chinese government, she leaves for the People's Republic to find Z.G. Pearl understands where she has gone and resolves to follow, while the sisters are left divided by the secret they maintained for two decades.",
         "in_short": "In 1937, Shanghai sisters Pearl and May Chin lose their privileged life when their father's debts lead to arranged marriages with Sam and Vern Louie, sons of a Chinese American family. The Japanese invasion turns escape into catastrophe: their mother dies during the journey, and the sisters reach the United States carrying trauma and secrets. After detention at Angel Island, they settle in Los Angeles. Pearl builds a life with Sam while May pursues glamour; May's daughter by artist Z.G. Li is presented as Pearl and Sam's child and named Joy. The family survives war, racism, and the constant danger surrounding its paper citizenship. During the anti-Communist investigations of the 1950s, Sam kills himself rather than risk exposing the family. Joy then discovers that May is her biological mother. Drawn to Communist ideals and desperate to meet her father, she leaves for China, and Pearl prepares to follow her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1854,7 +1854,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002V0LTHK",
@@ -1866,7 +1866,7 @@
       "recaps": {
         "ending": "Cordelia escapes compulsory psychiatric confinement on Beta Colony, leaves its service, and reaches Vorkosigan's family estate. She and Vorkosigan marry and begin a shared household. Bothari, now serving in the Count's guard after a medical discharge, acknowledges the infant Elena as his daughter and plans to conceal the circumstances of her conception and birth. His memories of Escobar remain selective and unstable. Koudelka is still disabled and in pain, but Vorkosigan removes him from the hospital, promotes him to lieutenant, and appoints him personal secretary. The terminally ill Emperor names Vorkosigan Regent for his underage heir. Vorkosigan initially refuses out of fear for Cordelia and any future children, then accepts with her support. Their attempted retirement therefore ends almost immediately. The failed invasion and the Emperor's purge have broken the war party, but the Regency opens a new political danger. Radnoff and Darobey remain fugitives, Dubauer's impairment has no recorded resolution, and responsibility for the children conceived through prison-camp abuse continues.",
         "in_short": "Survey commander Cordelia Naismith and Captain Vorkosigan meet as captor and prisoner after a mutiny strands them together. Their trust grows, but Cordelia escapes before an invasion of Escobar divides them again. Captured during that failed campaign, she survives an admiral's coercion when Bothari kills him. Vorkosigan reveals that he helped the Emperor make the invasion fail in order to destroy the war party and stop the Prince's succession. Back on Beta Colony, Cordelia's authorities falsely diagnose her as conditioned by Vorkosigan and try to confine her. She escapes, resigns, joins Vorkosigan at his estate, and marries him. Bothari accepts care of his replicator-born daughter Elena, and the disabled Koudelka returns to service as Vorkosigan's secretary. At the dying Emperor's request, Vorkosigan accepts the Regency for the child heir, placing the newly married couple at the center of the coming succession crisis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2018,7 +2018,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2031,7 +2031,7 @@
       "recaps": {
         "ending": "Camille allows Adora to care for her as a patient, enduring deliberate poisoning long enough to draw attention away from Amma. Curry and Richard reach the house in time to save her. Evidence in Marian's records and Adora's behavior establishes that Adora caused Marian's death through fabricated illness and is now harming Camille; Adora is imprisoned. Amma moves to Chicago with Camille and initially seems to adjust, but after her new friend Mae is murdered, Camille discovers human teeth set into the floor of Amma's dollhouse. Amma and her Wind Gap friends killed Ann Nash and Natalie Keene, with Amma driven by jealousy when the girls received Adora's attention. Amma also killed Mae when the new friendship threatened her control. She is taken into custody. Devastated, Camille resumes injuring herself, but Curry and Eileen intervene and bring her into their home. She is left trying to determine how much of her identity comes from her mother and how much can still be rebuilt.",
         "in_short": "Chicago reporter Camille Preaker returns to Wind Gap, Missouri, to investigate the murder of Natalie Keene and its connection to the earlier killing of Ann Nash. Living again with her cold mother Adora, passive stepfather Alan, and charismatic half-sister Amma forces Camille to confront her sister Marian's childhood death and her own history of self-injury. Suspicion falls on Natalie’s brother John, but Camille uncovers evidence that Adora deliberately made Marian ill and caused her death. Adora begins poisoning Camille until her editor and the police rescue her, and Adora is imprisoned. Camille takes Amma to Chicago, believing the girl is another survivor. After Amma's new friend is murdered, Camille finds the missing girls' teeth in Amma's dollhouse. Amma and her friends killed Ann and Natalie, and Amma killed again in Chicago. Amma is detained; Camille relapses, then is taken in by her editor Curry and his wife Eileen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2191,7 +2191,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2204,7 +2204,7 @@
       "recaps": {
         "ending": "Ducos's scheme is exposed when Juanita's service to the French and her influence over Kiely can no longer be concealed. Kiely tries to recover his honor in battle and is killed, leaving Lady Kiely widowed. The Real Compañía Irlandesa does not carry out the defection intended to disgrace Britain; under Sharpe, Harper, Donaju, Father Sarsfield, and the unexpectedly resolute Runciman, its men fight instead of becoming a propaganda victory for France. During the confused struggle around Fuentes de Oñoro, Wellington escapes Masséna's attempt to turn the allied right and preserves the army, though the battle is costly and inconclusive in the larger campaign. Sharpe pursues Guy Loup and defeats him, ending the brigadier's campaign of terror. Runciman emerges with genuine courage rather than the empty reputation expected of him. Ducos survives the failure of his design, establishing a personal enemy who has learned how effectively Sharpe can disrupt French intelligence plans.",
         "in_short": "Wellington orders Sharpe to retrain the Real Compañía Irlandesa, an undisciplined group of Irish soldiers in Spanish service commanded by the embittered Lord Kiely. Major Runciman oversees the assignment, while Harper, Captain Donaju, and Father Sarsfield help restore the men's confidence. French intelligence officer Pierre Ducos plans to make the company defect publicly, discrediting Britain and splitting the alliance. He works through Brigadier Guy Loup, whose troops terrorize the frontier, and through the celebrated partisan Juanita de Elía, Kiely's lover and a hidden French agent. Sharpe uncovers the plot as Masséna attacks Wellington around Fuentes de Oñoro. Kiely learns of Juanita's betrayal and dies trying to redeem himself. The Irish company fights for the allies instead of defecting, Runciman proves brave, and Sharpe defeats Loup. Wellington's army survives the French attempt to turn its flank. Ducos escapes the ruined scheme and recognizes Sharpe as a dangerous personal opponent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2374,7 +2374,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2387,7 +2387,7 @@
       "recaps": {
         "ending": "At Talavera, the South Essex withstands the French attack after Sharpe and the dependable officers impose the discipline Simmerson never created. Simmerson's failure and flight destroy his authority, while the battalion survives under better leadership. Sharpe then takes his riflemen into the counterattack and captures a French Imperial Eagle, fulfilling the promise made to the dying Lennox after the lost British colour. The trophy restores the regiment's honor and makes Sharpe's battlefield achievement impossible for his social enemies to dismiss. Berry and Gibbons do not survive the violence they helped create, ending their immediate threat to Sharpe and Josefina. Wellesley confirms Sharpe's rank as captain, though the army's rules and patronage will continue to make the promotion precarious. Sharpe finishes the battle with Harper and the riflemen beside him, publicly established as a fighting officer rather than merely a former ranker wearing a commission.",
         "in_short": "In 1809 Sharpe and his riflemen are attached to the newly arrived South Essex, a regiment controlled by the incompetent Sir Henry Simmerson. A rash action against the French costs the battalion one of its King's Colours and kills Major Lennox, who asks Sharpe to answer the disgrace by taking a French Imperial Eagle. Wellesley places Sharpe in command of the South Essex light company and gives him the rank of captain, while Simmerson and his protégés Christian Gibbons and John Berry try to undermine him. Sharpe trains the men as the allied army advances toward Talavera, and his conflict with the two officers deepens around Josefina Lacosta. At Talavera, Simmerson fails under fire, but Sharpe and the regiment's sound officers steady the South Essex against the French assault. Sharpe joins the counterattack, captures an Eagle, and restores the battalion's honor. Gibbons and Berry are killed, Simmerson is disgraced, and Sharpe's captaincy is confirmed by a feat the army cannot ignore.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2569,7 +2569,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2582,7 +2582,7 @@
       "recaps": {
         "ending": "Sharpe and Harper escape captivity in French-held Coimbra with Sarah Fry's help and turn the Ferreira family's hoarded supplies against the invaders. The stores that Major Ferreira and Ferragus preserved for profit are destroyed rather than sold to Masséna's hungry army. Ferragus is killed, and the brothers' collaboration can no longer be hidden behind Ferreira's uniform and connections. Sharpe rejoins the allied forces after the retreat reaches the Lines of Torres Vedras. Wellington's secret fortifications are complete and far stronger than the French expected; with the countryside emptied behind them, Masséna's troops can neither break the lines nor feed themselves indefinitely. Slingsby's attempt to replace Sharpe ends after his failures under command, leaving Sharpe restored to the light company and Lawford forced to recognize that patronage did not make his relative fit to lead it. Teresa remains part of Sharpe's life, though the campaign continues to keep them apart.",
         "in_short": "During Masséna's invasion of Portugal, Wellington retreats toward the secret Lines of Torres Vedras and orders the population to remove or destroy everything that could feed the French. Sharpe discovers that Portuguese Major Ferreira and his powerful brother Ferragus are protecting valuable stores for a private sale to the enemy. At the same time, Colonel Lawford allows his relative Captain Slingsby to challenge Sharpe's command of the South Essex light company. Slingsby's battlefield failures expose the difference between patronage and competence, but Sharpe and Harper are drawn away and imprisoned in French-occupied Coimbra by the Ferreira network. With help from Sarah Fry, they escape and destroy the hoarded supplies before Masséna can use them. Ferragus is killed and Ferreira's treachery is exposed. Sharpe returns to his company at the Lines, where Wellington's fortifications and the stripped countryside stop the French advance and leave the invading army facing starvation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2734,7 +2734,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2747,7 +2747,7 @@
       "recaps": {
         "ending": "British troops breach and capture Gawilghur despite the fortress's seemingly unassailable position. When the planned attack appears unable to reach the inner stronghold, Sharpe identifies and exploits another way through the defenses, helping turn a foothold into complete victory. Inside the fortress he finally catches William Dodd and kills him, avenging Hector McCandless and ending the pursuit begun before Assaye. Sharpe also survives another round of Hakeswill's treachery, but Hakeswill escapes the destruction around him and remains a future threat. The fall of Gawilghur breaks the last confidence of the Maratha resistance in the campaign. Sharpe emerges with his commission intact and with proof that the instincts learned in the ranks can make him an effective officer. He is still socially out of place, but he no longer treats promotion as an error to be undone and prepares for the next stage of his service, including the journey back toward Britain.",
         "in_short": "After Assaye, Richard Sharpe is an ensign but finds that a battlefield commission has placed him among officers who distrust a man from the ranks. The army continues its campaign against the Maratha forces while William Dodd retreats toward Gawilghur, a mountain fortress believed impossible to storm. Sharpe is drawn into the corrupt supply arrangements of Captain Torrance and again faces Obadiah Hakeswill, who wants both revenge and Sharpe's hidden fortune. Arthur Wellesley's forces clear the approaches and lay siege to Gawilghur. Engineers create a breach, but the inner defenses remain formidable. During the assault Sharpe uses a neglected route to help the attackers penetrate the fortress, then hunts Dodd through the collapse and kills him. Gawilghur falls, completing the campaign's decisive work. Hakeswill survives, but Sharpe keeps his commission and accepts that his experience as a common soldier can become the foundation of his authority as an officer.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2911,7 +2911,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2924,7 +2924,7 @@
       "recaps": {
         "ending": "At Barrosa, General Graham's British division turns back to confront Marshal Victor's larger French force after General la Peña refuses effective support. Sharpe and Harper fight through the confused battle and help break the French attacks; Colonel Vandal is defeated in the combat. The British take an Eagle and guns, but la Peña's caution prevents the tactical victory from becoming the destruction of Victor's army, so the siege of Cádiz continues. In the city, Sharpe recovers the letters used to blackmail Henry Wellesley and destroys Father Montseny's leverage over the ambassador. Dealings with Lord Pumphrey deepen Sharpe's distrust of the methods used by Britain's own secret agents, while Hogan contains the political damage. Henry Wellesley remains at his post and the alliance survives the scandal. Sharpe and Harper finish the campaign alive and free to return to the army, while Cádiz remains unconquered but still ringed by French forces.",
         "in_short": "A failed river operation leaves Sharpe and Harper separated from their usual command and eventually sent to Cádiz, the Spanish city protected by sea but besieged from the mainland. Major Hogan asks Sharpe to recover intimate letters stolen from Henry Wellesley, Britain's minister and Wellington's brother. Father Salvador Montseny uses the correspondence to threaten Wellesley and weaken British influence, while Lord Pumphrey's secret dealings make the loyalties inside the British effort uncertain. The political search merges with an allied expedition against Marshal Victor. Spanish commander Manuel la Peña mishandles the movement, forcing Thomas Graham's British division to turn and fight at Barrosa with little support. Graham's troops defeat the French attack, and Sharpe helps overcome Colonel Vandal, but the allies fail to exploit the victory and Cádiz remains besieged. Sharpe recovers the letters and ends the blackmail, preserving Wellesley's position while exposing dangerous misconduct among the intelligence men who were supposed to protect him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3075,7 +3075,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3088,7 +3088,7 @@
       "recaps": {
         "ending": "Sharpe brings the Spanish gold into the besieged frontier fortress of Almeida while French forces close around it. Trapped between the enemy and the fortress authorities, he uses the destruction of Almeida's magazine to break the situation open and escape with the surviving members of his party and the treasure. The explosion devastates the fortress and denies the French an intact stronghold, though it kills soldiers and civilians and leaves Sharpe responsible for an act far beyond his formal orders. El Católico is defeated after trying to keep the gold for himself. Kearsey does not survive the struggle over the treasure. Sharpe delivers the gold for Wellington's secret purpose: paying for the Lines of Torres Vedras, the fortified barrier on which the defense of Portugal depends. Teresa leaves the guerrilla conflict with Sharpe, beginning a relationship that changes his personal stake in the Peninsular War.",
         "in_short": "After Talavera, Captain Richard Sharpe is ordered to recover Major Kearsey and a hoard of Spanish gold held by guerrillas beyond the army's reach. Wellington does not publicly admit that the treasure is the mission's real object, because he needs it to finance the secret Lines of Torres Vedras. Sharpe, Harper, and a small detachment find Kearsey with the guerrilla leader El Católico and Teresa Moreno. Kearsey objects to British seizure of Spanish property, while El Católico intends to control the gold himself. The dispute turns into a pursuit involving guerrillas and French troops. Sharpe takes the treasure toward Almeida and, when trapped in the besieged fortress, triggers the destruction of its magazine to escape. Kearsey and El Católico are lost during the conflict, but the gold reaches Wellington and helps complete Portugal's defenses. Teresa goes with Sharpe, and their relationship begins amid the mission's violent conclusion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3258,7 +3258,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3271,7 +3271,7 @@
       "recaps": {
         "ending": "Wellesley's surprise crossing of the Douro forces Soult to abandon Oporto before the French can organize a conventional defense. The retreating army escapes through the northern mountains, but it must leave guns, baggage, and much of its plunder behind while British and Portuguese forces harry the narrow routes. Sharpe and Vicente help turn damaged bridges and difficult passes into obstacles that magnify the French losses. Christopher's bargain with the occupiers is exposed; after betraying Argenton's conspiracy and trying to carry Kate away under his control, he is overtaken and killed. Kate is freed from him, though the safety and inheritance he claimed to protect have been instruments of his ambition. Argenton and fellow conspirators pay with their lives after Christopher gives them to Soult. Sharpe emerges with his riflemen intact and with Vicente as a proven ally. Northern Portugal is no longer held by Soult's army, and the renewed British campaign has its first dramatic victory.",
         "in_short": "As Soult's French army overruns northern Portugal in 1809, Sharpe and his riflemen are ordered to remain near Oporto with intelligence officer Colonel James Christopher. Christopher disappears, leaving Sharpe to join the inexperienced Portuguese lieutenant Jorge Vicente during the city's collapse. They survive behind French lines and discover that Christopher is cultivating both Marshal Soult and Kate Savage, a wealthy young Englishwoman. French officer Captain Argenton secretly asks for British help against Soult's political ambitions, but Christopher betrays the conspiracy and tries to secure Kate and her fortune for himself. Wellesley returns to command, crosses the Douro by surprise, and drives the French from Oporto. Sharpe and Vicente pursue through the mountains, using narrow roads and broken bridges to strip Soult's retreat of guns and baggage. Christopher is exposed and killed, Kate is rescued, and Argenton's betrayed allies are avenged too late to save them. Sharpe rejoins the victorious British with Harper, Hagman, Harris, and a new Portuguese ally in Vicente.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3430,7 +3430,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3443,7 +3443,7 @@
       "recaps": {
         "ending": "The British bombardment compels Copenhagen to surrender its fleet, preventing Napoleon from gaining the Danish warships but leaving the city damaged and its people embittered. Sharpe proves that Lavisser betrayed the mission and hunts him through the fighting, ending the immediate threat to Britain's intelligence network. Ole Skovgaard's service to Britain has exacted a severe price from his family, and Sharpe's attachment to Astrid cannot overcome what the British attack has done to her country. Astrid is killed after the operation, while the full responsibility for her death remains concealed from Sharpe. Captain Chase survives the naval operation, and Wellesley's expedition completes its limited military purpose. Sharpe leaves Denmark still carrying the grief of Grace and their child, but he has chosen continued service over abandoning the army. His future lies with the riflemen, not with the private escape he had imagined in England.",
         "in_short": "After Lady Grace dies giving birth and their newborn dies soon afterward, Lieutenant Richard Sharpe is stranded in England with money but little purpose. British intelligence recruits him to accompany John Lavisser to Copenhagen, where merchant Ole Skovgaard runs a threatened spy network. Lavisser tries to remove Sharpe and is revealed as a traitor serving French interests. With help from Captain Joel Chase, Sharpe reaches Denmark, tries to save the Skovgaard network, and becomes close to Ole's daughter Astrid. Britain, fearing Napoleon will seize Denmark's navy, lands an army on Zealand and bombards Copenhagen until the fleet is surrendered. Sharpe defeats Lavisser, but the attack makes a future with Astrid impossible. She is killed after the operation in circumstances whose full cause Sharpe does not learn. The fleet is taken to Britain, and he returns to service with the rifles, still grieving but no longer intent on fleeing his commission.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3599,7 +3599,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3612,7 +3612,7 @@
       "recaps": {
         "ending": "At Santiago de Compostela, Vivar opens the chest and raises the sacred banner of Santiago. The public act revives Spanish resistance in the city and turns the expected French triumph into an uprising. Sharpe and the riflemen help defeat de l'Eclin's forces, while the Count of Mouromorto's accommodation with the occupiers is exposed as betrayal. Vivar survives to continue the Spanish fight, and Louisa Parker chooses a future with him rather than returning obediently to Britain. Sharpe has transformed his own command as decisively as the banner transforms the city. Harper and the other riflemen accept that he has earned authority through courage, skill, and loyalty to them; Harper becomes his closest ally. Instead of following the defeated British army to the ships, Sharpe and his surviving men turn south, intending to join the British force that will return to Portugal under Wellesley.",
         "in_short": "During the British retreat to Corunna in 1809, Lieutenant Richard Sharpe is cut off with a handful of riflemen after French cavalry destroys their company. Captain Murray dies and leaves Sharpe his sword, but Patrick Harper and the survivors distrust their new commander. They join Spanish officer Blas Vivar, who is secretly carrying the banner of Santiago to the apostle's city, where he hopes its public raising will revive resistance to the French. The party also protects Louisa Parker and her Methodist relatives while Colonel de l'Eclin pursues them. Hard travel, ambushes, and shared fighting gradually make Sharpe and Harper allies. Vivar's brother, the Count of Mouromorto, betrays the mission, but Sharpe and the riflemen reach Santiago. The banner's appearance triggers an uprising, the French are defeated, and Vivar's cause survives. Louisa remains with Vivar. Sharpe finally wins the riflemen's loyalty and leads them south to rejoin the future British campaign rather than retreating to the coast.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3783,7 +3783,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3796,7 +3796,7 @@
       "recaps": {
         "ending": "The British assault breaks into Seringapatam after Sharpe escapes Tippoo's custody and prevents the prepared mine from devastating the attackers. In the fighting he confronts Hakeswill but fails to end their feud. Tippoo Sultan is killed near the inner defenses and the city falls, completing the British victory over Mysore. Sharpe takes jewels from the dead ruler, giving him a private reserve of wealth that he conceals from the army. Lawford survives the mission, and the experience has made their relationship one of mutual respect rather than the usual distance between officer and private. Mary survives but does not share the military future Sharpe has chosen. Sharpe abandons his plan to desert and is promoted to sergeant, the first step in a rise made possible by the soldiering talent the mission revealed. Hakeswill remains alive and determined to destroy him.",
         "in_short": "In 1799 Private Richard Sharpe, trapped in the 33rd Regiment and persecuted by Sergeant Obadiah Hakeswill, plans to desert in India with Mary Bickerstaff. Hakeswill instead engineers a savage punishment for him. Colonel Arthur Wellesley stops the flogging and recruits Sharpe for an intelligence mission: he and Lieutenant William Lawford pose as deserters, enter Tippoo Sultan's besieged capital of Seringapatam, and try to reach the captive officer Hector McCandless. Inside the city they serve under the Frenchman Colonel Gudin, learn of a mine intended to destroy the British assault, and survive Tippoo's attempt to dispose of them. Sharpe escapes, helps thwart the trap, and fights through the city's fall. Tippoo dies during the capture of Seringapatam, and Sharpe secretly takes a store of jewels. Hakeswill survives, while Sharpe chooses the army over desertion and wins promotion to sergeant.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3951,7 +3951,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3964,7 +3964,7 @@
       "recaps": {
         "ending": "At Trafalgar, Nelson's fleet defeats the combined French and Spanish fleet in a close and destructive action, though Nelson is killed. HMS Pucelle fights the Revenant, bringing Sharpe back against the men whose treachery shaped the voyage from India. Sharpe uses his experience of fighting at close quarters during the boarding action; the Revenant is defeated, and Captain Montmorin and Anthony Pohlmann do not survive the final reckoning. Lord William Hale also dies in the battle after turning violently against Sharpe and Grace. Captain Joel Chase and the Pucelle survive the victory. Sharpe and Grace are left free to continue to England together, but they must protect her position and reputation by allowing the world to regard Lord William's death as honorable and her expected child as his heir. Sharpe reaches Britain as an officer with Lady Grace beside him, carrying both the rewards of India and a private attachment that cannot safely be acknowledged in public.",
         "in_short": "Ensign Richard Sharpe leaves India aboard the East Indiaman Calliope, sharing the voyage with Lord William Hale, Lady Grace, and the soldier of fortune Anthony Pohlmann. Sharpe and Grace begin an affair as the ship's captain, Peculiar Cromwell, leads the vessel into betrayal and capture by the French Revenant. HMS Pucelle, commanded by Joel Chase, intervenes, and Sharpe finds that his skills as a soldier can be adapted to naval battle. The voyage becomes tied to the pursuit of the Revenant and to the gathering fleets off Spain. Aboard Pucelle, Sharpe and Grace face blackmail and Lord William's hostility while Chase joins Nelson. At Trafalgar the British defeat the combined French and Spanish fleet. Sharpe fights in the close action against the Revenant; Montmorin and Pohlmann are killed, as is Lord William. Nelson also dies in victory. Sharpe and Grace continue toward England together, concealing their relationship behind Lord William's honorable public memory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4123,7 +4123,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4136,7 +4136,7 @@
       "recaps": {
         "ending": "At Assaye, Wellesley attacks a much larger Maratha army and wins after an exceptionally costly fight. Sharpe moves through the battle in pursuit of Dodd and is present when Hector McCandless is killed, turning the intelligence mission into a personal reckoning. Dodd nevertheless escapes the defeated army and heads toward the fortress of Gawilghur, so Sharpe's pursuit remains unfinished. Anthony Pohlmann also survives the ruin of the force he commanded. During the crisis Sharpe saves Arthur Wellesley's life. Wellesley rewards the act with a battlefield commission, raising the sergeant from the ranks to ensign. It is an extraordinary promotion but an uncertain gift: Sharpe lacks the money, education, and social standing expected of an officer, and he must now leave the fellowship and competence he had earned as an enlisted man. Hakeswill also survives, preserving the older enmity across Sharpe's change in status.",
         "in_short": "In 1803 the renegade officer William Dodd massacres troops and civilians as he defects to the Maratha cause. Hector McCandless sets out to bring him to justice and recruits Richard Sharpe, now a sergeant after his service at Seringapatam. Hakeswill renews his campaign against Sharpe, while Dodd joins Anthony Pohlmann's European-trained army. McCandless and Sharpe pursue him through Wellesley's fast-moving Deccan campaign, crossing the lives of the French officer Joubert and his wife Simone. Wellesley finally attacks a far larger enemy force at Assaye. The British victory is bloody; McCandless is killed and Dodd escapes toward Gawilghur. In the battle Sharpe saves Wellesley's life. Wellesley makes him an ensign on the field, lifting him from sergeant to officer in a moment. The promotion rewards Sharpe's courage but leaves him stranded between the ranks, while both Dodd and Hakeswill remain alive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/shattered-boundaries.json
+++ b/data/works-community/0/shattered-boundaries.json
@@ -220,7 +220,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -233,7 +233,7 @@
       "recaps": {
         "ending": "Max, Fowl, Tanila, and Batrire finish both one-attempt level-50 trials and enter the tower together. All four carry Defense of the Demon and Defense of the Dragon. They also possess a gold dragon's tooth and scale, with Fowl considering whether his estranged family might craft them. The prospective elf archer is expected to join after losing a member of her former tower party. Max privately agrees not to attack or directly oppose the gold dragon except when either side's life or loved ones are threatened. The pact lets the dragon track him, may eventually let him track it, and must remain secret even from his companions. Beyond the party, an ancient dragonkin predicts that the release of one black skill will lead to three such powers clashing. Tanila's royal identity is known to the hostile demon lord, which has threatened Max. Most immediately, unnamed queens have supplied a hunter with money and a dossier identifying Max Host as a black-skill bearer. The hunter kills the courier and begins a covert pursuit.",
         "in_short": "After an inner entity seizes Max during an attack, he struggles to control a black skill that grants power while urging violence. Max, Fowl, Tanila, and Batrire join Golden Axe, survive an ogre invasion, and grow into a tightly coordinated level-50 party. Max and Tanila become partners, and she reveals that she is a runaway elven princess with a dangerous red skill. The group delays entering the tower to earn permanent boons from demon and dragon trials. Max yields control to the entity to survive the demon dungeon, gaining demonic abilities, then helps defeat the demon champion. In the dragon trial, the entity wounds an ancient gold dragon. The party receives the dragon's boon, tooth, and scale, while Max secretly accepts a mutual nonaggression pact and tracking mark. The four finally enter the tower, but a wider conflict among three black skills is approaching, the demon lord remains hostile, and a contract hunter begins pursuing Max Host for unnamed queens.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -627,7 +627,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -640,7 +640,7 @@
       "recaps": {
         "ending": "Max remains publicly registered as Seth Pendell and is still level one because Consume prevents ordinary experience gains. His dwarf warrior, elf mage, and dwarf healer companions now know that he is Max, understand the nature of Consume, and regard him as family. They intend to advance together while protecting his cover and helping him resist the skill's pressure toward killing people. Max has added Sonar and Melee Weapon Mastery to his abilities and plans to keep pursuing monsters strong enough to improve his attributes. Caleb knows that Seth is Max, but Max keeps him at a distance to reduce the threat to those at home. Guild-linked hunters and Molly and Macy's faction continue looking for Max and may use his friends and family as leverage. The elf-linked hostile order is incorrectly informed that Seth likely died. The party notices that its members' rare and combined skills are too unusually concentrated to seem accidental. A final private meeting confirms that an unknown sponsor spent saved power on Max's black skill and has a cloaked associate helping conceal a larger plan. Their identities, purpose, and earlier failure remain unresolved.",
         "in_short": "At his selection, eighteen-year-old Max receives Baker and the forbidden black skill Consume, but the Guild calls him unskilled and takes him away. After escaping, he discovers that Consume blocks ordinary experience while taking health, attributes, and occasional skills from his kills. He becomes the adventurer Seth Pendell, survives dungeon parties, an elven murder attempt, and an undead assault, and struggles against the urge to seek power through human deaths. Guild agents and other factions keep hunting him, while Caleb's recognition of his cover exposes the danger to his family and friends. Max eventually tells his dwarf warrior, elf mage, and dwarf healer companions the truth. They accept him, promise to protect his identity, and help restrain Consume's influence. Still level one, he gains Sonar and Melee Weapon Mastery by fighting stronger monsters. The book ends with his party suspecting that an outside power arranged their meeting, while two secret collaborators confirm that they deliberately supported Max's black skill as part of an unresolved plan.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1062,7 +1062,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -1075,7 +1075,7 @@
       "recaps": {
         "ending": "Fowl's successful bet provides enough money to cover the final payment for Tang Mu's antidote, but Batrire is still in stasis and the cure is only now due. Fowl and Tanila remain loyal, the party has a possible faction sponsor, and its shared future is undecided. Max killed Alfred after Alfred's power failed against Consume. The queens shielded Max from immediate revenge while taking his Coliseum prize money, leaving Alfred's family as a future threat while the Guild still owes Max one unrestricted favor. The Consumer has identified Consume, Devour, and Command as three opposed black skills and has bound Max to secrecy. Zealots have already escalated to assassination, restricted-skill authorities remain hidden, and an off-world power has noticed the black skill's return. At the close, elves surround Max and Tanila while trying to create a justification to kill them. Max permits the newly evolved Consumer to control him only after it promises not to harm Tanila or innocent bystanders. The confrontation is still underway.",
         "in_short": "Max trains with Fowl, Tanila, and Batrire while hiding the extraordinary growth granted by Consume. A rare dungeon, the loss of his left eye, and violent encounters reveal that the skill has a will of its own and rewards human deaths. After reaching the capital, the party advances to D-rank, pursues faction options, and gains stronger skills. Regeneration restores Max's eye, but Consume develops into an ancient presence called the Consumer. When Batrire is critically poisoned, Max enters the Coliseum to fund her antidote. He kills Alfred, loses his prize money to the queens, and triggers Consume's evolution, though Fowl's winning bet still covers the cure. The Consumer names three balancing black skills and warns that their rivals will hunt Max. Zealots retaliate, outside powers notice the black skill's return, and the book ends with Batrire still in stasis while Max gives the evolved Consumer conditional control during an elf ambush against him and Tanila.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1246,7 +1246,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1259,7 +1259,7 @@
       "recaps": {
         "ending": "Atticus and Owen survive the inquiry into Owen's long imprisonment and re-enter one another's lives as fellow Druids rather than teacher and pupil. Owen chooses to remain in the modern world and starts considering how Druidry might continue through a new generation. Granuaile, Orlaith, and their allies defeat the immediate supernatural threat in India, but Granuaile's independent mission leaves her marked by Loki, giving the trickster a means to locate or influence her unless she can remove it. The separate investigations also expose a coordinated danger involving the vampires and their ancient leadership. Atticus responds by preparing to strike at the vampire network instead of waiting for another attack. The three Druids finish the book alive and reunited in purpose, but Loki's preparations for Ragnarok, Granuaile's mark, and the vampire threat all carry directly into the next conflict.",
         "in_short": "After the Morrigan's death, Atticus learns that his archdruid, Owen Kennedy, has survived about two thousand years of confinement in a place where time scarcely moved. Atticus recovers him and helps a powerful Druid from ancient Ireland confront the modern world while investigating who arranged his disappearance. Granuaile and her wolfhound Orlaith undertake a separate mission with the witch Laksha in India, confirming that Granuaile now acts as an independent Druid. They help defeat the immediate enemy there, but Granuaile becomes marked by Loki, whose preparations for Ragnarok continue behind the other conflicts. Owen decides that Druidry needs a future and begins thinking about training a new grove. Atticus's investigation reveals that an organized vampire power is moving against him and his allies, prompting him to prepare a wider campaign against the vampires. The three narrators end on separate but converging paths as Loki and the vampire leadership remain active.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1399,7 +1399,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1412,7 +1412,7 @@
       "recaps": {
         "ending": "Ayesha leads Leo, Holly, and Job through the ruins of Kôr to the cavern where a mysterious life-giving fire periodically appears. Because Leo hesitates to enter it, Ayesha steps into the flame to demonstrate that it is safe and to renew her immortality. Instead, the second exposure reverses the effect of the first: before the men she rapidly loses her youth, shrinks into extreme age, and dies. She tells Leo that she will return before the change is complete. Job dies from the shock and terror of witnessing her transformation. Holly and Leo eventually make their way back through the ruins and marshes, carrying the memory of Ayesha and leaving Job buried in Kôr. Leo survives without attaining immortality, and both men remain marked by their encounter. Holly closes his account uncertain whether Ayesha was destroyed or merely passed into another state, while her promise to return leaves Leo's connection to her unresolved.",
         "in_short": "Cambridge scholar Horace Holly raises Leo Vincey and, when Leo turns twenty-five, opens a family relic describing an ancient ancestor murdered by a queen in Africa. Holly, Leo, and their servant Job follow the clue, survive a wreck, and travel inland with Mahomed. Among the Amahagger, Ustane claims Leo as her husband, while violence at a feast kills Mahomed. The survivors are taken to ruined Kôr, ruled by the veiled Ayesha, or She-who-must-be-obeyed. Ayesha says she gained immortality two thousand years earlier and killed Kallikrates when he rejected her; she believes Leo is his returned form. She kills Ustane, heals Leo, and wins both men's devotion through her supernatural beauty. At the life-giving fire, Ayesha enters first to reassure Leo, but a second exposure makes her age and die, promising to return. Job dies of fright, and Holly and Leo escape without resolving whether Ayesha's promise is true.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1561,7 +1561,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1574,7 +1574,7 @@
       "recaps": {
         "ending": "Sir Charles Marlow visits the Hardcastles and learns about the mistake that caused his son to treat Mr. Hardcastle as an innkeeper. Young Marlow, now embarrassed, admits only a formal interest in Kate because he does not realize that the plainly dressed young woman he loves is Kate herself. Kate arranges for both fathers to overhear his sincere declaration, then reveals her identity and accepts him. Meanwhile, Tony drives Mrs. Hardcastle and Constance in a circle and leaves them near the Hardcastle estate while convincing his mother they are stranded in dangerous country. Hastings and Constance abandon their immediate elopement and appeal to Mr. Hardcastle. He announces that Tony has already reached the age at which he may control his own marriage choice. Tony promptly refuses Constance, freeing her to marry Hastings and retain her fortune. The deceptions end with both couples able to marry by mutual choice, while Mrs. Hardcastle is defeated in her attempt to control Constance's inheritance.",
         "in_short": "Mr. Hardcastle plans a match between his daughter Kate and Charles Marlow, the son of an old friend. Marlow and his companion Hastings lose their way, and the mischievous Tony Lumpkin directs them to the Hardcastle home while describing it as an inn. Marlow consequently treats his host like an innkeeper. He is tongue-tied with Kate when he knows her as a gentlewoman, yet falls in love with her when her plain dress leads him to mistake her for a servant. Hastings, already in love with Constance Neville, uses the confusion to plan an elopement and recruits Tony against Mrs. Hardcastle, who wants Constance to marry Tony so she can retain control of the young woman's jewels. The schemes nearly collapse when Mrs. Hardcastle discovers them. In the end Kate proves Marlow's sincere love and reveals her identity. Tony learns he is legally of age and refuses the unwanted match, leaving Constance free to marry Hastings. The two chosen couples unite and Mrs. Hardcastle's designs fail.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1704,7 +1704,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1717,7 +1717,7 @@
       "recaps": {
         "ending": "Holmes explains that he escaped Moriarty at Reichenbach Falls by using his climbing skill, then hid while the professor's surviving associate tried to kill him from above. He spent the next three years abroad dismantling threats and keeping even Watson ignorant so that London would believe him dead. Back at Baker Street, Holmes uses a wax likeness as bait while he and Watson watch from the empty house opposite. Colonel Sebastian Moran fires a silent air-gun round through the window and is seized by Holmes, Watson, Lestrade, and the police. Holmes identifies Moran as Moriarty's chief surviving agent and explains that Ronald Adair had discovered Moran cheating at cards; Moran killed Adair to prevent exposure. With Moran arrested, Holmes is publicly alive again and resumes his partnership with Watson.",
         "in_short": "Sherlock Holmes tells Dr Watson that Professor Moriarty, the organizer of a criminal empire, has resolved to kill him. The friends evade pursuit across Europe, but at Switzerland's Reichenbach Falls Watson is diverted by a false medical message. He returns to find evidence that Holmes and Moriarty have gone over the precipice together. Three years later, Watson is studying the locked-room shooting of Ronald Adair when Holmes returns in disguise. Holmes reveals that he survived the falls and stayed hidden because one of Moriarty's men had seen him escape. He sets a wax figure in his Baker Street window and waits with Watson in the empty house opposite. Colonel Sebastian Moran shoots at the decoy with a concealed air gun and is arrested. Holmes identifies Moran as both the marksman stalking him and Adair's killer, clearing the mystery and restoring the Holmes-Watson partnership.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1793,7 +1793,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1806,7 +1806,7 @@
       "recaps": {
         "ending": "Holmes determines that Roylott murdered Julia and intended to kill Helen with a venomous swamp adder trained to crawl from his room through the ventilator and down the false bell-pull to the bed. The nightly whistle recalled the snake, and the saucer of milk helped Roylott train it. Holmes and Watson wait in Helen's darkened room. When the snake descends, Holmes strikes at it with a cane, driving it back through the ventilator. It bites Roylott instead, killing him within seconds. The speckled band in Julia's dying words was the patterned snake around him. Helen is taken safely away. Holmes acknowledges that his intervention indirectly caused Roylott's death but feels no guilt over the outcome.",
         "in_short": "Helen Stoner asks Sherlock Holmes for help after being moved into the bedroom where her twin Julia died mysteriously two years before. Julia had heard a nightly whistle and died speaking of a speckled band; Helen has now heard the same sound. Their violent stepfather, Dr. Grimesby Roylott, would lose part of the sisters' inheritance when either married. At Stoke Moran, Holmes finds a ventilator opening into Roylott's room, a useless bell-pull hanging over the bed, and signs that the bed cannot be moved. He and Watson keep watch and intercept a venomous snake sent through the ventilator. Holmes drives it back, and it kills Roylott. The snake was both the murder weapon and the speckled band Julia saw, while the whistle was Roylott's signal for its return.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1953,7 +1953,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1966,7 +1966,7 @@
       "recaps": {
         "ending": "Shift closes with Donald Keene in command of Silo 1 under another man's name. Woken for a third time to replace the dead head of the silo's psychiatric oversight, he is finally given access to everything: the Order, the archived legacy of the old world, the running files on all fifty silos, and the reasoning behind the entire scheme. It confirms what he had pieced together across two earlier shifts. The end of the world was engineered by Thurman's circle to forestall a technology they believed no one could contain; the silo populations were selected, drugged and lied to without their consent; and the plan only ever intended one silo to be brought out at the end of it. He also learns what became of his wife: she survived in one of the silos and lived a full life there, believing him dead. In the same span of years covered by his shifts, Silo 17 is destroyed and a teenage Jimmy Parker is sealed alone inside its server room by his father, becoming the man Wool calls Solo, while an uprising in Silo 18 is crushed and that silo's memory of itself is wiped clean again. Broken by what he now knows and by what he helped build, Donald kills Anna and takes Thurman's place at the head of Silo 1, leaving the shifts below him to believe nothing has changed. He holds the authority that decides whether the silos live or die, and he means to use it against the plan rather than for it.",
         "in_short": "Shift is the prequel to Wool, told in braided timelines. In the years before the silos were occupied, Donald Keene, a young congressman and trained architect, is commissioned by Senator Paul Thurman to design a deep underground facility in Georgia, presented as a shelter beside a national nuclear waste depot. The specifications are dictated to him in ways he does not understand, and the engineer assigned alongside him is Thurman's daughter Anna, his former lover. On the day the site is unveiled at a world exposition, an engineered catastrophe ends life above ground and the invited crowds are herded underground, where a drink handed out at the ceremony strips their memories. Donald wakes centuries later in Silo 1, the silo that secretly administers the other forty-nine, where men serve six-month shifts and sleep frozen between them. Across three shifts he reconstructs the plan he helped build: the apocalypse was deliberate, and the silos are a five-hundred-year experiment meant to yield one surviving population. He learns what became of his wife, watches an uprising crush Silo 18 and a catastrophe empty Silo 17, and ends the book having killed Anna and taken Thurman's place as the master of Silo 1.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2133,7 +2133,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2146,7 +2146,7 @@
       "recaps": {
         "ending": "After discovering that Judd has killed a doe outside the legal hunting season, Marty confronts him and asks to buy Shiloh. They agree that Marty will earn the dog by completing twenty hours of work for Judd. The arrangement is difficult: Judd gives Marty unpleasant jobs, mocks his effort, and at first claims that their bargain has no force. Marty continues working instead of using the poaching as a threat. His persistence gradually wins Judd's respect. When the twenty hours are complete, Judd gives Marty a dog collar and allows him to take Shiloh home. Marty has not solved every question about Judd's treatment of animals, but he has secured Shiloh's safety through work and a bargain rather than by continuing to hide the dog. Shiloh is openly accepted as part of the Preston family, and Marty ends the story joyful that the beagle is finally his.",
         "in_short": "Eleven-year-old Marty Preston finds a frightened beagle near his West Virginia home and learns that the dog belongs to Judd Travers, a hunter reputed to mistreat his animals. Marty returns the dog, but when it runs away again he hides it in a pen on the hill behind his house. Keeping Shiloh safe forces Marty to steal food, deceive his family, and struggle with whether a good purpose can excuse dishonest choices. The secret ends after another dog attacks Shiloh and Marty's family helps obtain medical care. Ordered to return the recovering beagle, Marty instead bargains with Judd after witnessing him shoot a doe out of season. Marty agrees to work twenty hours in exchange for Shiloh. Judd makes the work hard and threatens not to honor the deal, but Marty's persistence changes his mind. At the end Judd gives Marty a collar and releases his claim, allowing Shiloh to join the Preston family for good.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2335,7 +2335,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2348,7 +2348,7 @@
       "recaps": {
         "ending": "Kennit dies. He is brought down in the fighting that ends the Chalcedean threat, and the kingdom he built passes to Etta, who is carrying his child, with Wintrow beside her as adviser and the Vivacia, restored to herself, as their ship. Althea, who could have pressed her claim, lets Vivacia go: the ship belongs with Wintrow, and Althea's place is aboard Paragon with Brashen, whom she marries, and who is her captain in fact as well as in name. Paragon comes through his own history intact: the truth of what was done aboard him and what he did in return is finally spoken, Amber gives him carved eyes, and he sails whole for the first time in a generation. Tintaglia keeps her bargain. The Chalcedean fleet is broken and driven off, the sea serpents are brought up the Rain Wild River to the cocooning grounds, and they spin their cocoons under the dragon's guard, so that her kind will not end with her. Malta and Reyn, changed by long contact with dragon blood and Elderling stone, are married and take a leading part in the settlement that follows; Selden is changed too, and speaks for the dragon. Bingtown, the Rain Wilds, the Three Ships families and the Tattooed emerge from the siege as a single polity that has effectively bought its independence, with the Satrap restored on terms he had no power to refuse and Serilla's improvised regime finished. Amber's work is done, and she leaves.",
         "in_short": "Malta, swept out of the Rain Wilds with the Satrap of Jamaillia, keeps them both alive, reaches the Pirate Isles and turns herself into a negotiator for a Bingtown under siege. Reyn, believing her dead, brokers the bargain that saves the coast: Tintaglia, the last dragon, will drive off the Chalcedean fleet if the sea serpents are helped up the Rain Wild River to cocoon. Aboard Paragon, Althea and Brashen find the Vivacia; Althea is taken and raped by Kennit, and the ship herself is being overtaken by the ancient dragon memory sealed into her wizardwood. Paragon's own buried past comes out, and with it what tied a pirate king to a mad liveship. The siege of Bingtown ends in a general alliance of Traders, Rain Wilds, Three Ships and Tattooed. Kennit dies; Etta, carrying his heir, inherits his kingdom with Wintrow and the Vivacia beside her. Althea gives up her claim to the ship, marries Brashen and keeps Paragon, restored and given new eyes. Malta and Reyn, transformed into Elderlings, marry and help settle the peace, and the serpents cocoon under Tintaglia's guard.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2579,7 +2579,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2592,7 +2592,7 @@
       "recaps": {
         "ending": "Kennit gets what he has been manoeuvring for and takes the Vivacia. Kyle Haven is beaten and put off his own deck, and the ship, drawn to Kennit's certainty in a way she never was to Kyle's bullying, begins to belong to her captor. Wintrow, tattooed as his father's property and with nowhere to go, stays aboard and keeps Kennit alive by tending the ruined leg the serpent left him, which binds the pirate to him and him to the pirate. The Vivacia is out of the slave trade and into piracy, and the Vestrits have lost her. In Bingtown the news arrives as ruin: the family's ship, its livelihood and its heir are gone, Ronica's debts are called in, and the Trader families are quarrelling with the New Traders and the Satrap's grants while Chalcedean galleys move in the northern channel. Althea has earned a mate's ticket the hard way, sailing as a hand aboard another liveship, and has proof at last that she can do the work; she comes home to find there is no ship to claim and sets herself to getting Vivacia back. Brashen is ashore and out of prospects. Amber has bought the mad liveship Paragon outright, to Bingtown's scandal, and has her own reasons for wanting him afloat. Malta, courted by a veiled Rain Wilder, has opened a gift she was warned about and stepped into an entanglement she does not understand. Out at sea a tangle of serpents has found one who remembers, and has begun to move north.",
         "in_short": "In the merchant city of Bingtown, old Ephron Vestrit dies aboard his liveship Vivacia and she wakes into consciousness, as liveships do when three generations of a family have died on their decks. His younger daughter Althea, who has sailed with him for years, expects to inherit her; instead the will gives the ship to her sister Keffria and so to Keffria's husband Kyle Haven, who bars Althea from the deck and drags his son Wintrow out of a monastery to serve aboard because the ship needs a Vestrit. Kyle puts Vivacia into the slave trade. Althea sets out to earn a mate's ticket and prove her claim, sailing disguised aboard another liveship. In the Pirate Isles, Kennit works to make himself king by freeing slaves, and decides that what he needs is a liveship of his own. Ashore, the mad blinded liveship Paragon acquires an unlikely new owner in the newcomer Amber, Malta is drawn into a Rain Wild courtship, and sea serpents search for a memory they have lost. Kennit takes Vivacia, breaks Kyle, keeps Wintrow, and leaves the Vestrits ruined and Althea determined to win her ship back.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2801,7 +2801,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2814,7 +2814,7 @@
       "recaps": {
         "ending": "A violent storm tears the old Quoyle house from its moorings and carries it away, ending the family's attempt to preserve a structure burdened by its history. Agnis accepts the loss and continues the independent life she has begun in Newfoundland. At the Gammy Bird, Tert Card departs, and Quoyle has grown into a trusted reporter rather than the expendable worker he once believed himself to be. Jack Buggit is lost from his boat and presumed drowned; during the wake, however, the apparently dead man revives, returning to his family and community. Quoyle and Wavey move past the betrayals and deaths that shaped their earlier marriages and marry each other. Bunny and Sunshine gain a stable home with adults who attend to them, while Herry is included in the new family. Quoyle's ending reverses the pattern established by Petal without pretending the past did not happen: he can remember injury without treating it as the only possible form of attachment. Work, parenthood, friendship, and marriage now connect him to Killick-Claw, a place he first approached only as refuge.",
         "in_short": "After a life of ridicule and a disastrous marriage to the unfaithful Petal Bear, Quoyle is left with daughters Bunny and Sunshine when Petal dies in a car crash. His aunt Agnis Hamm takes them to their ancestral coast in Newfoundland, where they inhabit the old Quoyle house and begin again. Quoyle joins the eccentric staff of the Gammy Bird, writing car-accident reports and shipping news. His growing skill as a reporter, friendship with Billy Pretty and the Buggit family, and relationship with widowed Wavey Prowse gradually give him confidence and a community. The coast also exposes darker inheritances: the Quoyles' violent history, Agnis's childhood trauma, and the damage caused by loss and isolation. A storm finally sweeps away the old house. Jack Buggit is presumed drowned but revives at his wake. Tert Card leaves the paper, Quoyle becomes secure in his work, and he and Wavey make a family with Bunny, Sunshine, and Wavey's son Herry. Quoyle learns that his past need not dictate the shape of love that follows it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2978,7 +2978,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2991,7 +2991,7 @@
       "recaps": {
         "ending": "The impossible ballgame becomes a gathering of several unfinished lives. The young Archie Graham finally plays with great players, then gives up that renewed chance when Karin needs medical help; crossing out of the field, he becomes the elderly Doctor Graham and cannot return to youth, but accepts the choice. Mark is at last able to see the players and understand why the field must remain. J. D. Salinger is invited beyond the outfield and walks into the corn with the team, choosing the unknown continuation offered there. Ray's estranged twin Richard returns, and the final players include Ray's father, John Kinsella, restored as a young catcher. Ray introduces him to the family John never knew and asks him to play catch. The field thus fulfills a need deeper than the return of banned ballplayers: it gives Ray a peaceful reunion with his father and binds baseball memory to forgiveness. The threat to the farm is answered by the visitors the field will draw, while the closing game of catch completes Ray's personal journey.",
         "in_short": "Iowa farmer Ray Kinsella hears a voice telling him to build a baseball field in his corn, and he obeys despite the financial risk. Shoeless Joe Jackson and other dead players appear there, able to play again beyond the judgments that ended their careers. Further messages lead Ray to the reclusive writer J. D. Salinger and then to Archibald \"Moonlight\" Graham, whose only major-league game never included an at-bat. Ray meets Graham as an old doctor and later brings a young version of him home. As creditors close in, the field gathers banned players, Graham, Ray's estranged brother, and finally Ray's dead father. Young Graham abandons his baseball chance to save Ray's daughter and becomes the doctor again. Salinger follows the players into the corn, Mark finally sees them, and Ray plays catch with his restored father. The field survives as a place where lost possibilities and family bonds receive another chance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3192,7 +3192,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3203,7 +3203,7 @@
       "recaps": {
         "ending": "Shogun ends with Toranaga's hidden design laid bare. Sent to Osaka by Toranaga, Mariko forces a crisis over the noble hostages Ishido is holding, insisting on her right to leave the castle; when a ninja raid follows, she dies deliberately in an explosion, an act that disgraces Ishido, breaks his hold on the hostages, and frees the great families from his coalition - a decisive blow struck at the cost of her life. Blackthorne is left grieving, and then finds his ship, the Erasmus, burned. Only the reader learns that Toranaga himself ordered it destroyed, so that the Anjin will stay in Japan and remain dependent on him; Toranaga comforts Blackthorne and promises him a new ship. In the final passage, Toranaga's private reflections reveal that Mariko's sacrifice, the burning of the ship, and every apparent setback have all served a single purpose. With Ishido's alliance shattered, he is now free to go to war for supreme power and to make himself Shogun, sole ruler of Japan. He intends to keep Blackthorne close as a prized and useful man - and is privately certain the Englishman will never be permitted to leave. The great battle that will decide the realm still lies ahead, but its outcome is no longer in doubt.",
         "in_short": "In 1600 the English pilot John Blackthorne is shipwrecked in Japan, the first of his countrymen to reach it, and is drawn into the deadly power struggle that followed the Taiko's death. Brought before the great lord Toranaga, he reveals that the Portuguese Catholics entrenched in Japan are only one rival European power among many, knowledge that makes him both valuable and a target of the Jesuits. Caught between Toranaga and his enemy Ishido, who holds Osaka, Blackthorne throws in his lot with Toranaga, helps him escape Osaka, and is raised to samurai rank, given a fief, and set to training musketeers. He falls in love with his interpreter, the Christian noblewoman Mariko, whose brutal husband Buntaro complicates everything. Toranaga plays a long, deceptive game, even feigning surrender. The climax comes when Mariko goes to Osaka and forces a confrontation over Ishido's hostages, dying in a ninja attack in a way that breaks Ishido's grip. At the close, Blackthorne's ship is secretly burned on Toranaga's order to keep him in Japan, and Toranaga's thoughts reveal he has engineered everything to clear his road to becoming Shogun.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3379,7 +3379,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3392,7 +3392,7 @@
       "recaps": {
         "ending": "After the press exposes the mismatch between Becky's financial-advice career and her private debts, she loses professional credibility and her relationship with Luke appears broken. Back in Britain she stops searching for a quick escape. She sells much of the wardrobe she accumulated, uses the proceeds to confront what she owes, and recognizes how concealment allowed the crisis to grow. She also assembles evidence of the strong client relationships Luke has built, helping him see a future for his company despite the disloyalty surrounding the American effort. When Becky and Luke meet again, he acknowledges his own failure to balance ambition with trust and they reconcile. Becky emerges without her television role but with greater honesty, useful experience, and a possible future in fashion and personal shopping. They choose to continue their relationship on less illusory terms.",
         "in_short": "After becoming a popular television money adviser, Becky Bloomwood travels to New York with Luke Brandon as he tries to establish his public-relations firm in America. She hopes to build her own media career but is overwhelmed by the city's shops and hides another flood of spending. Luke's intense focus on business leaves them increasingly disconnected, while Alicia's manoeuvring and the complications of Luke's relationship with his distant mother add pressure. Becky's hidden debts are exposed by the press, destroying her credibility and damaging Luke's crucial negotiations. She returns to England humiliated and separated from him. Instead of inventing another rescue, Becky holds a sale of her clothes and begins paying what she owes. She also pieces together evidence of the professional disloyalty undermining Luke and helps him see the value of his established relationships. Luke and Becky reconcile after each accepts responsibility for their failures. Her television career is over, but her instinct for clothes suggests a more suitable path, and the couple can begin again with fewer secrets.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3524,7 +3524,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3537,7 +3537,7 @@
       "recaps": {
         "ending": "The story's revelation is that the entire investigation has been an elaborate therapeutic staging. Teddy Daniels does not exist as a marshal; he is Andrew Laeddis, a long-term patient at Ashecliffe who was once a U.S. Marshal. His wife, Dolores, suffered from severe mental illness and drowned their three children in a lake; returning to find them dead, Andrew shot and killed her. Unable to live with what happened, he shattered psychologically and constructed the persona of Teddy Daniels, a heroic investigator uncovering a conspiracy, casting the hated arsonist Andrew Laeddis as a separate villain to avoid recognizing himself. Dr. Cawley and Andrew's own doctor, who spent the case impersonating the partner Chuck, devised the immersive role-play in a final effort to lead him back to reality before the hospital resorts to a lobotomy. Confronted with the truth, Andrew appears to accept it, and for a moment is lucid. But in the closing scene he speaks to his doctor once more as Teddy, seemingly having relapsed into the delusion, and asks whether it is better to live as a monster or to die as a good man. He is then led away by the staff, the implication being that he has either genuinely regressed or chosen oblivion, and that a lobotomy awaits him.",
         "in_short": "In 1954, U.S. Marshal Teddy Daniels and his partner Chuck arrive at Ashecliffe Hospital for the criminally insane on Shutter Island to investigate how a patient vanished from a locked room. As a storm strands them, Teddy grows convinced the doctors are conducting sinister experiments, and he pursues his private obsession: finding Andrew Laeddis, the man he blames for the fire that killed his wife. The investigation is revealed to be an elaborate fiction. Teddy is himself the patient: he is Andrew Laeddis, a former marshal driven mad by tragedy. His wife Dolores, severely mentally ill, drowned their three children, and in his grief Andrew shot and killed her, then invented the Teddy Daniels identity and a web of conspiracy theories to escape the unbearable truth. Dr. Cawley and Andrew's psychiatrist, who has been posing as his partner Chuck, staged the whole role-play as a last attempt to break his delusion and spare him a lobotomy. Andrew briefly accepts reality, but by the end he appears to slip back into his false identity, and is led away to be lobotomized.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3633,7 +3633,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3646,7 +3646,7 @@
       "recaps": {
         "ending": "After a lifetime of seeking, Siddhartha reaches enlightenment not through any teaching but through his own long experience of the world and, above all, through listening to the river with Vasudeva, in whose voice he hears all of existence flowing together as one. Having endured the loss of his son, who fled back to the town, he lets his suffering dissolve into acceptance and love for the whole of life. Vasudeva, his work complete, walks into the forest and leaves Siddhartha as the ferryman and keeper of the crossing. In the final chapter his old friend Govinda, grown old and still restless in his search, comes to the river and does not at first recognize him. Siddhartha tells him that wisdom cannot be conveyed in words and that time is an illusion in which everything already exists at once, and he asks Govinda to kiss his forehead. Doing so, Govinda beholds a flowing vision of countless faces and forms merging into a single unity and a serene, all-embracing love, and he weeps, sensing that his friend has found what they both spent their lives pursuing.",
         "in_short": "Siddhartha, a Brahmin's son in ancient India, leaves home with his friend Govinda to seek enlightenment, first as a wandering ascetic and then in the presence of the Buddha, whom he admires but refuses to follow, convinced that wisdom cannot be taught. Turning instead to worldly experience, he crosses a river, learns love from the courtesan Kamala, and grows rich in trade, only to sicken of greed and pleasure and, in despair, nearly drown himself in that same river. Renewed, he stays to become a ferryman beside the wise Vasudeva, learning to listen to the river. Kamala, now a pilgrim, dies at the crossing and leaves Siddhartha their young son, whose bitterness and eventual flight teach him the pain of love and attachment. Through the river's voice Siddhartha finally attains the peace and unity he sought, and Vasudeva departs. Years later Govinda, still searching, meets him again, and Siddhartha shares a wordless vision of the oneness of all things.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3777,7 +3777,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3790,7 +3790,7 @@
       "recaps": {
         "ending": "After his son runs away, Siddhartha relives the pain he once caused his own father and finally understands that love cannot protect another person from the path he must experience. Listening to the river with Vasudeva, he hears its separate voices become a single whole and accepts that time, grief, joy, folly, and wisdom coexist rather than cancel one another. Vasudeva recognizes that Siddhartha has reached peace and leaves the ferry for the forest. Years later Govinda, still searching, visits the reputedly wise ferryman without initially recognizing his old friend. Siddhartha tells him that wisdom cannot be transferred as a teaching and that every being and object deserves love as part of the whole. At Siddhartha's request, Govinda kisses his forehead and experiences a vision of countless lives, deaths, and transformations united beyond time. He bows to Siddhartha, recognizing in his face the same serene completeness he once saw in Gotama.",
         "in_short": "Siddhartha leaves his Brahmin family with his friend Govinda to seek direct spiritual knowledge. Ascetic practice with the Samanas does not satisfy him, and although he reveres the Buddha Gotama, he refuses to become a disciple; Govinda stays behind. Siddhartha then enters worldly life, learning love from Kamala and commerce from Kamaswami. Wealth, gambling, and appetite eventually disgust him, and he abandons the town in despair. At a river he is renewed and joins the ferryman Vasudeva, who teaches chiefly by listening. Kamala later arrives with Siddhartha's unknown son and dies from a snakebite. The boy rejects his father and runs away, teaching Siddhartha through grief what abstract discipline could not. Listening deeply to the river, Siddhartha accepts the unity of all lives and times. Vasudeva departs, and the still-searching Govinda finally recognizes Siddhartha's wisdom through a visionary encounter rather than a doctrine.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3937,7 +3937,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3950,7 +3950,7 @@
       "recaps": {
         "ending": "Years after Vasudeva's departure, Siddhartha remains beside the river as a ferryman whose peace has become evident to others. Govinda, still a follower of Gotama and still searching, hears of the wise ferryman and visits without initially recognizing his old friend. Siddhartha explains that wisdom cannot be communicated as a doctrine and that every apparent opposite belongs to a single, timeless whole. His statements leave Govinda uncertain, so Siddhartha asks him to kiss his forehead. Govinda then experiences a vision in which Siddhartha's face becomes a flowing multitude of people, creatures, suffering, death, and renewal, all held together by unity and love. He recognizes in Siddhartha the same complete peace he once saw in Gotama. Govinda bows to his friend in gratitude and reverence. Siddhartha's search therefore closes without a new creed: his understanding rests in direct experience, compassionate acceptance, and the river's lesson that all existence is present at once.",
         "in_short": "Siddhartha, a gifted Brahmin's son, leaves home because ritual and instruction have not given him direct knowledge of the self. He practices severe asceticism with his friend Govinda, meets the Buddha Gotama, and then rejects discipleship to pursue his own path. Awakening to the physical world, he learns love from Kamala and business from Kamaswami, but years of wealth, pleasure, and gambling leave him disgusted and spiritually empty. At the edge of suicide he hears the sacred sound Om beside a river and begins again. Living with the ferryman Vasudeva, he learns to listen to the river's many voices. Kamala dies there and leaves him their rebellious son, whose eventual flight teaches Siddhartha the pain of attachment. In time he hears all grief and joy as one timeless unity; Vasudeva departs, his work complete. When the aging Govinda visits, a vision of countless lives in Siddhartha's face finally reveals the peace his friend found through experience rather than doctrine.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4072,7 +4072,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4084,7 +4084,7 @@
       },
       "recaps": {
         "in_short": "This volume gathers short stories and novellas set at many points across the Dresden Files, most previously published elsewhere. They range from an early case predating Harry's fame to lighter interludes and darker turns: a bodyguard job, a monster loose in a sorority, a day when everything goes wrong at once, a hidden supernatural war seen through his ally Thomas, and a confrontation that tests Harry's friend Michael and his family. Each piece stands on its own rather than forming a continuous plot. The collection closes with a longer novelette told from Karrin Murphy's point of view in the immediate aftermath of the events that ended the preceding novel, following how Harry's closest allies cope with his sudden absence and the dangerous vacuum it leaves in Chicago's supernatural underworld.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/siege-and-storm.json
+++ b/data/works-community/0/siege-and-storm.json
@@ -88,7 +88,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -101,7 +101,7 @@
       "recaps": {
         "ending": "The Darkling, alive and more dangerous than before, now commands a host of shadow creatures born of forbidden magic. After he forces Alina onto a sea hunt for a second amplifier, the privateer captain Sturmhond helps her and Mal escape, and Alina claims the power of the sea whip, adding a second amplifier to the stag's antlers. Sturmhond is revealed to be Prince Nikolai Lantsov, a younger son of Ravka's royal house working to save the country from collapse, and he returns Alina to the capital. There she becomes the reluctant symbol and leader of the Second Army and an object of religious devotion the Apparat cultivates, while Nikolai maneuvers to secure the crown, proposing an alliance and marriage with her for the good of the realm. The bond between Alina and Mal frays as power and duty pull her away from him. The book ends in catastrophe: the Darkling assaults the capital with his shadow soldiers and takes the city. Nikolai is grievously attacked and disappears, Alina's power falters at the worst moment, and she is led underground by the Apparat's devoted followers, weakened and cornered. The hope of stopping the Darkling now rests on finding a third amplifier, the firebird, and the balance has tipped sharply in the enemy's favor.",
         "in_short": "Hiding across the sea with Mal, Alina is captured by the Darkling, who has survived and now commands terrible shadow soldiers. He forces her onto a hunt for a legendary sea creature whose body holds a second amplifier. The privateer captain Sturmhond turns on the Darkling and helps Alina and Mal escape, and Alina claims the sea whip's power as her second amplifier, growing stronger. Sturmhond is revealed to be Prince Nikolai Lantsov of Ravka, and he brings them back to the capital. There Alina is made the figurehead of the Second Army and a saint to the common people, whose devotion the priest known as the Apparat encourages, while Nikolai schemes to save the failing kingdom and proposes binding himself to Alina to secure the throne. Mal grows ever more distant as Alina is consumed by power and politics. The Darkling attacks the capital with his shadow monsters and overwhelms it. Nikolai is gravely assailed and vanishes, and Alina, her strength faltering, is taken underground by the Apparat's followers, with the search now turned toward a third and final amplifier, the firebird.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -267,7 +267,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -280,7 +280,7 @@
       "recaps": {
         "ending": "The allied defenders hold Mithral Hall through the main drow assault, using the dwarves' command of the tunnels and support from the northern settlements to prevent Matron Baenre from turning superior numbers into a decisive breakthrough. The instability in magic passes, but it has already transformed the balance within Menzoberranzan: House Oblodra has been destroyed, and Baenre has led the city into a costly surface war. In the final fighting Matron Baenre is killed. Her death breaks the authority holding the invasion together, and the surviving drow withdraw into the Underdark rather than continue a campaign whose religious and political center has collapsed. Triel is positioned to inherit leadership of House Baenre, while Jarlaxle preserves enough of Bregan D'aerthe to survive the defeat. Bruenor remains king of an independent Mithral Hall, and the alliances forged for its defense leave the northern realms stronger. Drizzt has faced an army from his birthplace without losing the home he chose. He and Catti-brie remain together, still carrying Wulfgar's memory but no longer allowing grief alone to determine their future.",
         "in_short": "Drizzt and Catti-brie return from Menzoberranzan with warning that Matron Baenre is preparing to invade Mithral Hall. As Bruenor calls on Silverymoon, Citadel Adbar, the Harpells and nearby settlers, a crisis among the gods disrupts magic across the realms. In Menzoberranzan, House Oblodra's psionic abilities continue to function, allowing K'yorl Odran to challenge Baenre until the ruling house destroys her family and restores control. The drow army and its allied forces then march on Mithral Hall. Drizzt, Catti-brie, Bruenor, Regis, Guenhwyvar, Pwent and their allies fight through scouting actions and a full siege, exploiting the defenders' knowledge of the tunnels. The invasion fails, and Matron Baenre is killed in the final battle; without her authority the surviving drow retreat. Triel stands to lead House Baenre, while Bruenor keeps his kingdom. Drizzt and Catti-brie emerge together, their home preserved and the immediate threat from Menzoberranzan broken.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -450,7 +450,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -463,7 +463,7 @@
       "recaps": {
         "ending": "When the drained stone-pit yields Dunstan's skeleton and Silas's stolen money, Godfrey finally tells Nancy that Eppie is his daughter by his first wife. The couple ask Eppie to live with them and inherit their wealth, but she refuses to leave Silas, whom she knows as her father. Godfrey accepts that his earlier silence has cost him the right to claim her, though he and Nancy quietly help provide for her. Silas returns with Eppie to the site of Lantern Yard, hoping to learn whether his old name was cleared, but factories have replaced the chapel and neighborhood, leaving the mystery beyond recovery. His life in Raveloe has nevertheless restored his trust in people and in a providence he cannot fully explain. Eppie marries Aaron Winthrop, with the village celebrating at the cottage Silas has enlarged for them. She chooses to remain beside Silas, content in the home and relationships they have built together.",
         "in_short": "Silas Marner, a weaver falsely condemned for theft by his religious community, withdraws to the village of Raveloe and finds purpose only in hoarding his earnings. Dunstan Cass steals that gold, deepening Silas's isolation. Soon afterward, a toddler enters his cottage after her mother dies in the snow. Silas adopts the child, Eppie, and raising her draws him into village life, aided especially by Dolly Winthrop. Sixteen years later, Dunstan's remains and the stolen money are found in a drained pit. Godfrey Cass then admits that Eppie is his daughter from a secret first marriage. He and his wife Nancy offer Eppie wealth and a place as their child, but she chooses Silas, the father who raised her. Silas never learns why Lantern Yard betrayed him, because the old community has vanished. Eppie marries Aaron Winthrop and remains with Silas, whose love for her has replaced both his gold and his lost faith in human fellowship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -633,7 +633,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -646,7 +646,7 @@
       "recaps": {
         "ending": "The draining of the stone pit reveals Dunstan Cass's body beside Silas's stolen money, explaining both disappearances. Godfrey then tells Nancy that Eppie is his daughter. They offer to adopt her and give her a wealthy home, but Eppie refuses to leave Silas, whom she regards as her true father. Godfrey accepts that his years of silence have cost him any claim on her affection, while Nancy recognizes the strength of the family Silas and Eppie have made. Silas and Eppie visit Lantern Yard in search of an explanation for his old disgrace, only to find that the neighborhood and chapel have vanished beneath industrial development. He never learns how the theft was arranged, but he no longer needs the old community to restore him. Eppie marries Aaron Winthrop and chooses to remain beside Silas. Godfrey and Nancy quietly support the wedding and improvements to the cottage. Silas ends the novel surrounded by neighbors and certain that his life with Eppie is a blessing, even though the injustice that first exiled him remains formally unresolved.",
         "in_short": "Silas Marner, a weaver falsely condemned for theft by his religious community, withdraws to Raveloe and hoards the money earned at his loom. Dunstan Cass steals the hoard and disappears, deepening Silas's isolation. On a snowy night, Molly Farren dies near his cottage and her small daughter wanders inside. The child's secret father, Godfrey Cass, remains silent so that he can marry Nancy Lammeter, while Silas adopts the girl and names her Eppie. Raising her restores his ties to the village and gives him a human attachment stronger than his lost gold. Sixteen years later, Dunstan's body and the stolen money are found in a drained pit. Godfrey confesses to Nancy and offers Eppie wealth and social position, but she chooses Silas, the father who raised her. Silas cannot recover proof of his innocence because Lantern Yard has disappeared, yet he no longer depends on its judgment. Eppie marries Aaron Winthrop and stays with Silas in their enlarged cottage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -809,7 +809,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -822,7 +822,7 @@
       "recaps": {
         "ending": "When the drained stone-pit yields Dunstan's skeleton and Silas's stolen money, Godfrey finally tells Nancy that Eppie is his daughter by his first wife. The couple ask Eppie to live with them and inherit their wealth, but she refuses to leave Silas, whom she knows as her father. Godfrey accepts that his earlier silence has cost him the right to claim her, though he and Nancy quietly help provide for her. Silas returns with Eppie to the site of Lantern Yard, hoping to learn whether his old name was cleared, but factories have replaced the chapel and neighborhood, leaving the mystery beyond recovery. His life in Raveloe has nevertheless restored his trust in people and in a providence he cannot fully explain. Eppie marries Aaron Winthrop, with the village celebrating at the cottage Silas has enlarged for them. She chooses to remain beside Silas, content in the home and relationships they have built together.",
         "in_short": "Silas Marner, a weaver falsely condemned for theft by his religious community, withdraws to the village of Raveloe and finds purpose only in hoarding his earnings. Dunstan Cass steals that gold, deepening Silas's isolation. Soon afterward, a toddler enters his cottage after her mother dies in the snow. Silas adopts the child, Eppie, and raising her draws him into village life, aided especially by Dolly Winthrop. Sixteen years later, Dunstan's remains and the stolen money are found in a drained pit. Godfrey Cass then admits that Eppie is his daughter from a secret first marriage. He and his wife Nancy offer Eppie wealth and a place as their child, but she chooses Silas, the father who raised her. Silas never learns why Lantern Yard betrayed him, because the old community has vanished. Eppie marries Aaron Winthrop and remains with Silas, whose love for her has replaced both his gold and his lost faith in human fellowship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1203,7 +1203,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -1216,7 +1216,7 @@
       "recaps": {
         "ending": "Felix and Pit return to the continent through the ruined temple's blood gate. The Maw crosses with them and confronts an unidentified chained presence, leaving its fate and Felix's primordial connection unresolved. Felix's dependence on Ravenous Tithe and his advancing bloodline processing also remain dangerous. The Ten Hands captain is dead, many captives are free, and Dahlia escapes alone, but Korm's fate and the whereabouts of the corva farmer's spouse and children are unknown. In Harwatch, Evie, Harn, and their companions cremate Magda. The Inquisition seals the Hargate and controls Foglands access, while the guild's concealed primordial-essence experiments continue in a desert domain. The imprisoned unidentified envoy deliberately infects another prisoner with blood-red primordial rot, advancing an unexplained plan connected to his father.",
         "in_short": "Banished into the void with Pit and the weakened Maw, Felix Nevarre learns to control his mana, escapes the Ten Hands pirates, and finds temporary refuge in Echo's Reach. In Harwatch, Magda Aren's allies uncover the guild's secret exploitation of Foglands survivors and recover Magda's preserved body. Echo's Reach leaders blame and banish Felix, after which he learns that the Ten Hands engineered the attacks. The pirates destroy the settlement and enslave its people as mana sources. Felix pursues the raiders, frees many captives, destroys their ships, and kills their corrupted captain. He and Pit then reach a ruined temple and activate a blood gate with the pursuing whale maw's blood, returning to the continent. Magda is cremated, but the guild's experiments continue despite the Inquisition's arrival. An unidentified imprisoned envoy begins spreading primordial rot, while the Maw confronts a vast chained presence after the crossing.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1382,7 +1382,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1395,7 +1395,7 @@
       "recaps": {
         "ending": "Rodrigues is brought to Ferreira and learns that the groans he hears are not guards but Japanese Christians suspended in the pit. They have already formally apostatized; the officials will continue torturing them until Rodrigues abandons the faith publicly. Ferreira says that he too stepped on the fumie for the sake of others. Faced with suffering caused by his refusal, Rodrigues tramples the image of Christ, believing in that moment that Christ permits him to do so. The authorities register him as an apostate, give him the Japanese name Okada San'emon and a wife, and require him to help inspect imported objects for Christian content. He lives for decades under supervision and is buried according to Buddhist forms. Yet his public defeat does not settle his inward relationship with Christ. When Kichijiro later asks him to hear a confession, Rodrigues grants absolution, holding that even without the institutional priesthood this act does not sever him from the Christ whose apparent silence has troubled him throughout the mission.",
         "in_short": "Portuguese Jesuits Rodrigues and Garrpe secretly enter seventeenth-century Japan to aid persecuted Christians and learn why their mentor Ferreira reportedly apostatized. Hidden villagers receive them with desperate devotion, but official reprisals show that the priests' presence exposes believers to torture and death. After Rodrigues and Garrpe separate, the frightened Christian Kichijiro betrays Rodrigues. Magistrate Inoue avoids making the priest a martyr and instead forces him to witness suffering inflicted on Japanese converts. Garrpe dies trying to reach condemned Christians. Ferreira, now an apostate working for the authorities, tells Rodrigues that resistance only prolongs others' agony. Hearing believers tortured in the pit, Rodrigues steps on a fumie and is registered as an apostate. He spends the rest of his life under a Japanese identity, assisting official inspections, but his private faith remains unresolved rather than simply erased.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1596,7 +1596,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1609,7 +1609,7 @@
       "recaps": {
         "ending": "Sydney gets herself and Olive Sinclair out of the re-education facility, using magic she improvises from whatever the place will let her hold, and the escape converges with the rescue Adrian, Marcus, Eddie, Neil, Dimitri and Sonya have finally been able to mount once the location was known. Olive is pregnant, and the father is Neil Raymond - a child conceived between a restored Moroi and a dhampir, which by everything the Moroi believe about themselves should not be possible, and which is exactly the kind of fact the Alchemists were holding her to study. Sydney comes out of the facility physically wrecked and clear-headed, having spent months performing a conversion she never underwent. Adrian, who had been drinking, using spirit without his medication and had come close to giving up on her - including a moment with Nina Sinclair that he regrets and admits to - is reunited with her. Neither of them intends to be separated again or to leave the decision to anyone else, so they marry in Las Vegas, immediately and without asking permission from the Alchemists, the Moroi or their own families. Sydney is now a fugitive from her order rather than a target of it, Jill is still in hiding, Zoe is left with what she set in motion, and Olive's pregnancy is a secret several very powerful groups would want.",
         "in_short": "Sydney is held in an Alchemist re-education facility: underground, windowless, deliberately starved of food, sleep, daylight and information, and worked on until she renounces vampires and confesses to corruption. She refuses, is punished, and then changes tactics and performs the conversion her captors want, buying herself movement, privileges and time. Outside, Adrian falls apart - off his medication, drinking, unable to reach her through dreams - while Eddie, Neil, Marcus, Sonya and Dimitri hunt for a facility the Alchemists have hidden for generations, and Zoe lives with having reported her own sister. Inside, Sydney finds another prisoner: Olive Sinclair, a Moroi restored from Strigoi, held for study rather than reform - and pregnant, by the dhampir Neil Raymond, which should be impossible. Sydney improvises magic out of nothing and gets them both out as the rescue party closes in from outside. Reunited and refusing to be separated again by anyone's rules, she and Adrian marry in Las Vegas.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1861,7 +1861,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1872,7 +1872,7 @@
       "recaps": {
         "ending": "The book ends at the close of Sal's first month at Quest Academy. His underdog team wins the first-year combat tournament outright with a flawless record, narrowly outscoring the only other perfect team, captained by Nero's daughter, Erika Clifton. In the full semester ranking that follows, Divinity Khan is revealed as the new top-ranked first-year - a result her own foresight failed to predict - displacing Erika to second, with Sal third; every member of his close circle finishes safely clear of the students facing expulsion, though his estranged friend Kane keeps sliding since an early injury. Erika regards Sal and especially Divinity with open, unexplained hostility. At a private gathering for top rankers, Sal replicates a new \"analysis\" ability from an incoming lecturer, Beck, and chooses, as his prize, an unreadable fragment of a destroyed dungeon heart to study later. Divinity claims the evening's most coveted item partly to keep it from Erika. Hannah reunites with Sal openly in front of his friends. His standing is formalized: alias \"Myth,\" Mythcrafter ability rated Master, third in his year and a tournament champion, with scouting interest from rival guilds. Major threads carry into the next book: Erika's hostility and what drives it, the nature and origin of dungeon hearts and the fragment Sal took, the smarter demon suspected of having directed the defeated commander, and whether Sal reaches the elite Savior class.",
         "in_short": "Sal Argento, a guarded young man whose silver eyes let him appraise objects and copy other people's abilities, enrolls at Quest Academy, where heroes are trained to reclaim demon-held land. During skill registration he accidentally fuses several of his powers into a unique top-tier crafting ability the Academy calls \"Mythcrafter,\" and becomes the protege of the crafting lecturer Upgrade. Befriending the foresight-gifted Divinity, he is drawn into a secret disaster-prevention circle after glimpsing a vision of the city's destruction, and helps avert a coordinated demon-commander attack on the Academy. Building a fortune through appraisal and crafting, he leads a squad of overlooked underdogs to a perfect record in the first-year combat tournament. In the final rankings Divinity takes first place overall, Nero's daughter Erika Clifton second, and Sal third. The book ends with Sal having gained a second replicated ability, a mysterious dungeon-heart fragment to investigate, an open rivalry with Erika, and a public relationship with his friend Hannah - and, for the first time, a real sense of belonging.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2105,7 +2105,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2118,7 +2118,7 @@
       "recaps": {
         "ending": "The Silverthorn is brought back to Krondor, the priests use it, and Anita wakes. On the way south Baru meets Murad, the moredhel chieftain who destroyed his village, and kills him in single combat. Arutha reappears alive in his own city and the fiction of his death has served its purpose, though not without cost among those who mourned him. The immediate danger is over and the larger one is only now visible. The assassins, the poisoning and the gathering in the Northlands are all Murmandamus's work; he is not a raider but the head of an organised power, he wants Arutha dead specifically, and what he is ultimately after is not the Kingdom's throne but something buried beneath the eastern city of Sethanon. Neither Pug nor the Ishapians can yet say what that thing is, only that the records treat it as a matter of the world's survival. Murmandamus withdraws north to build his army rather than striking at once. Arutha, restored to Anita and to Krondor, begins preparing the Kingdom for an invasion whose real purpose he does not understand, and Pug turns to the question of who or what is directing the moredhel, having concluded that it is neither moredhel nor human. The story continues in A Darkness at Sethanon.",
         "in_short": "A year into the peace, Prince Arutha returns to Krondor to marry Princess Anita, and Squire Jimmy uncovers a guild of assassins, the Nighthawks, hunting the Prince on behalf of someone in the far north. At the wedding a poisoned bolt meant for Arutha strikes Anita instead, and she falls into a sleep no healer can break. The poison is Silverthorn, which grows only at the Black Lake of Moraelin deep in moredhel country, so Arutha lets it be given out that he has died and rides north in secret with Martin, Laurie, Jimmy, the mercenary Roald and a Hadati hillman named Baru. They research their enemy at the Ishapian abbey of Sarth, fight off an attack there, and take the monk Dominic with them. Meanwhile Pug founds an academy of magic at Stardock and begins to suspect that the intelligence behind the moredhel is neither moredhel nor human. The party reaches Moraelin, takes the Silverthorn, and fights its way home; Baru kills the chieftain who destroyed his village; Anita is healed. The enemy, Murmandamus, is revealed as the leader of a gathering northern army whose true objective lies beneath the city of Sethanon.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2253,7 +2253,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2266,7 +2266,7 @@
       "recaps": {
         "ending": "At the Green Chapel, the Green Knight feints twice and on his third swing gives Gawain only a shallow cut. He then reveals himself as Bertilak, Gawain's host. The first two withheld blows matched the two days when Gawain honestly gave Bertilak the kisses received from the lady; the cut answers Gawain's concealment of her green girdle on the third day. Bertilak explains that the old woman at the castle is Morgan le Fay, who devised the marvel to frighten Guinevere and test Arthur's court. Gawain is ashamed that fear led him to break the exchange agreement, though Bertilak considers the fault minor and forgives him. Gawain returns to Camelot wearing the girdle as a reminder of his failure. Arthur and the court welcome him, reject his harsh judgment of himself, and adopt green sashes in fellowship, turning his private badge of shame into a communal emblem.",
         "in_short": "During Arthur's Christmas feast, a supernatural Green Knight offers a beheading game: he will accept one blow now if the striker submits to a return blow in a year and a day. Gawain decapitates him, but the visitor picks up his head and rides away after reminding Gawain of the bargain. Nearly a year later Gawain journeys to the Green Chapel and shelters at Bertilak's castle. Bertilak proposes that each man exchange whatever he gains each day. While Bertilak hunts, his lady tests Gawain in bedchamber visits. Gawain returns her kisses to Bertilak but conceals a supposedly protective green girdle. At the chapel, the Green Knight reveals himself as Bertilak and gives Gawain a small cut for that dishonesty; the entire adventure was arranged by Morgan le Fay. Gawain returns ashamed, wearing the girdle as a reminder, but Arthur's court adopts green sashes in solidarity with him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2395,7 +2395,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2408,7 +2408,7 @@
       "recaps": {
         "ending": "At the Green Chapel, the Green Knight makes two feigned strokes, then gives Gawain a small cut with the third. He explains that he is Bertilak, transformed through Morgan le Fay's magic, and that the blows correspond to the three days of the exchange agreement. Gawain honestly returned the lady's kisses on the first two days, so the first two strokes do not touch him. On the third day he concealed the green girdle, hoping it would save his life, and the small wound marks that failure. Bertilak regards the fault as understandable and offers reconciliation, but Gawain condemns his own fear and dishonesty. He returns to Camelot wearing the girdle as a sign of his failing and tells the court the entire story. Arthur and the knights answer by adopting green sashes themselves, turning Gawain's private emblem of shame into a shared badge and welcoming him home.",
         "in_short": "During Arthur's New Year feast, a supernatural Green Knight challenges the court to exchange axe blows. Gawain beheads him, but the visitor calmly retrieves his head and orders Gawain to meet him in a year. Keeping his promise, Gawain journeys to a distant castle, where Lord Bertilak proposes another exchange: the lord's hunting gains for anything Gawain receives at home. Bertilak's wife tests Gawain for three mornings. He returns her kisses to his host but conceals a green girdle she claims can protect his life. At the Green Chapel, the Green Knight reveals himself as Bertilak. Two harmless strokes reward Gawain's honesty on the first two days; a third nicks him for hiding the girdle. Morgan le Fay devised the adventure through magic. Gawain returns ashamed of yielding to fear, but Arthur's court welcomes him and adopts the green sash as a common emblem.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2558,7 +2558,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2571,7 +2571,7 @@
       "recaps": {
         "ending": "Carrie's stage career continues upward until she has money, fashionable rooms, and public recognition, yet none of these gives her the complete happiness she once associated with them. Drouet attempts to renew their acquaintance, but she has outgrown his charm. Ames encourages her to aspire to serious artistic work, leaving that possibility open. Hurstwood moves in the opposite direction: after losing Carrie and failing to recover his livelihood, he drifts through shelters and begging until he uses gas to kill himself in a cheap lodging house. Carrie does not learn enough of his end for it to shape her success. The novel closes with her alone in her rocking chair, materially secure but still imagining a satisfaction beyond what she has attained.",
         "in_short": "Eighteen-year-old Carrie Meeber comes to Chicago and finds factory work too harsh to sustain her hopes. Salesman Charles Drouet supports her and treats her as his partner, then introduces her to the married bar manager George Hurstwood. Carrie and Hurstwood begin an affair. When his wife threatens him and his employers' money falls accidentally into his hands, Hurstwood deceives Carrie into fleeing with him. They settle in New York after he returns most of the money, but his business fails and his confidence collapses. Carrie begins earning money on the stage, leaves him, and rises from the chorus to celebrity. Hurstwood sinks into unemployment, dependence, homelessness, and finally suicide. Carrie gains the comfort and fame she wanted, but remains restless and lonely, still searching for a fulfillment that possessions and applause cannot provide.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2733,7 +2733,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2746,7 +2746,7 @@
       "recaps": {
         "ending": "The crew succeeds at the impossible: they break into and out of the Ice Court and get Kuwei Yul-Bo out of Fjerda alive, though the escape costs them dearly and forces terrible choices, including Nina taking the drug jurda parem to save the others and Matthias turning fully against his old countrymen to help them. Battered but triumphant, they return to Ketterdam expecting their enormous reward. Instead, their employer Jan Van Eck betrays them. He refuses to pay the promised fortune, reveals that he has captured Inej, and springs a trap meant to eliminate the crew and keep both the money and their prize. Kaz, who prides himself on anticipating everything, has been outmaneuvered, and the crew scatters with nothing to show for the deadliest job of their lives except their survival and one another. The book ends on the betrayal and on Kaz's cold resolve: he will recover Inej, reclaim what they are owed, and destroy Van Eck, carrying the conflict directly into the sequel.",
         "in_short": "In the criminal port city of Ketterdam, the ruthless young schemer Kaz Brekker is offered a vast fortune to break into the Ice Court, the impregnable heart of Fjerda, and free Kuwei Yul-Bo, whose late father invented jurda parem, a drug that turns Grisha into unstoppable, addicted weapons. Kaz gathers a crew of six: his spy Inej, the sharpshooter Jesper, the Grisha Nina, the Fjerdan witch-hunter Matthias, and the merchant's runaway son Wylan. They travel to Fjerda and infiltrate the Ice Court through a punishing plan that goes wrong at every turn, forcing improvisation, sacrifice, and shifting alliances, including Nina using parem herself in a desperate moment. Against enormous odds they extract Kuwei and escape the fortress. But when they return to Ketterdam to collect their payment, their employer Jan Van Eck betrays them: he refuses the money, springs a trap, and takes Inej captive. The crew is left with nothing, but Kaz, outplayed but not beaten, vows to get Inej back and make Van Eck pay, setting up the reckoning to come.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2888,7 +2888,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2901,7 +2901,7 @@
       "recaps": {
         "ending": "Alex prevents the detonation at the naval base, and Russian forces reach the site before the device can be used; the bomb never goes off and the president is not killed. Sarov, with his life's plan destroyed in front of him, makes Alex a last offer: come with him, be his son, and start again. Alex refuses. Rather than accept that refusal or be taken alive, Sarov puts his pistol to his own head and shoots himself in front of Alex, an image Alex cannot afterwards get rid of. Conrad, Sarov's security chief, does not survive the operation either. Alex is retrieved and brought home. Two CIA officers are dead, and both the Americans and MI6 treat the outcome as an intelligence success rather than as anything that happened to a fourteen-year-old. Nobody in either service seriously suggests leaving him alone in future, and Alex goes back to London knowing that being useful is now the most dangerous fact about him.",
         "in_short": "A summer job as a ball boy at Wimbledon turns into an MI6 errand when Alex uncovers a scheme to rig the tournament, and blows his cover badly enough that a Chinese criminal syndicate marks him. To get him out of London, MI6 lend him to the CIA, who need a child to complete a family cover: two agents pose as his parents on holiday near the island of Skeleton Key, off Cuba, where the retired Russian general Alexei Sarov has bought stolen nuclear material. The Americans are caught and killed, leaving Alex alone on the island. Sarov, who lost his own son in Afghanistan, takes Alex in and becomes fixed on the idea of making him a replacement. He is planning to detonate the bomb at a Russian naval base during a presidential visit, kill the president, and use the outrage to seize power and rebuild the Soviet Union. Alex is taken to Russia with him and stops the detonation. Confronted with failure and with Alex's refusal to become his son, Sarov shoots himself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3069,7 +3069,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3080,7 +3080,7 @@
       "recaps": {
         "ending": "The heist succeeds and the double-crosses resolve in layers. Nicodemus escapes with the Holy Grail - the thing he actually came for - but at ruinous cost: he sacrificed his daughter Deirdre at the Gate of Blood to reach it, his crew is dead or turned, his organization is gutted, and his defeat at the Carpenter house ends with his reputation - the thing a two-thousand-year-old schemer runs on - in ruins. Hannah Ascher, revealed as the host of Lasciel, dies in her fire-duel with Harry; the Genoskwa is dead; Goodman Grey stands revealed as Harry's own plant inside the crew, hired in advance for the price of one dollar. Murphy survives Nicodemus's trap, but Fidelacchius was broken when he goaded her into misusing it - until the assault on Michael's home, when Waldo Butters takes up the broken hilt and his faith ignites it into a blade of light: Butters is the new Knight of the Cross. Michael returns Uriel's borrowed Grace and goes back to his family at peace. The parasite in Harry's skull is delivered safely: not a killer but a child - Bonnie, a newborn spirit of intellect, daughter of Harry and the departed shadow of Lasciel - housed in a fresh skull in Harry's keeping. Harry walks away with a share of Hades' treasure, his life no longer under a deadline, and something better than gold: he goes to the Carpenters' door and properly meets his daughter Maggie, and decides to be her father. Mab, as always, has lost nothing: her debt is paid, and Nicodemus paid more.",
         "in_short": "Mab repays a debt to Nicodemus Archleone by loaning him Harry - as crew for a heist targeting the vault of Hades, lord of the underworld, to steal the Holy Grail. The crew: shapeshifter Goodman Grey, warlock Hannah Ascher and her partner Binder, the monstrous Genoskwa, thief Anna Valmont, Nicodemus's daughter Deirdre, and Murphy as Harry's eyes. Everyone plans to double-cross everyone; Harry, with Mab's tacit blessing, plans it best. Nicodemus goads Murphy into misusing Fidelacchius, breaking the sword and nearly killing her; Michael Carpenter leaves retirement to take her place, walking on Uriel's own borrowed Grace. The crew breaches the underworld through gates of Fire, Ice, and Blood - the last opened by Nicodemus sacrificing Deirdre. Ascher is unmasked as Lasciel's host and dies duelling Harry; Grey proves to be Harry's plant, hired for a dollar; Nicodemus flees with the Grail but is ruined at the Carpenter house, where Butters raises the broken sword, reignited by faith, and becomes the new Knight of the Cross. Harry's lethal head-parasite is born as Bonnie, a spirit-of-intellect daughter of Harry and Lash's shadow, and Harry finally meets Maggie and chooses to be her dad.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3223,7 +3223,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3236,7 +3236,7 @@
       "recaps": {
         "ending": "The neighbors of Hemlock Street put aside their dispute with Luther and Nora and rapidly create the celebration Blair expects. They decorate the Krank house, find food, gather guests, and help bring Blair and Enrique home through the holiday traffic. The party convinces the arriving couple that the family traditions are intact, even though the entire event was improvised after their call. Luther initially remains preoccupied with the expense and the lost cruise, but the situation of Walt and Bev Scheel changes his priorities. Because Bev has cancer and the Scheels badly need time together, Luther gives them the Caribbean trip that he and Nora can no longer take. His generosity is offered quietly and received with gratitude. The Kranks end Christmas at home, reconciled with the community they resisted. Their attempt to withdraw from the season fails, but it leads Luther to a less transactional understanding of what the holiday can ask of him.",
         "in_short": "With their daughter Blair serving in Peru, Luther Krank persuades his wife Nora to spend Christmas on a Caribbean cruise and to buy nothing for the holiday. His financial experiment angers friends, charities, coworkers, and especially the neighbors of Hemlock Street, whose coordinated display depends on the Kranks placing a giant Frosty on their roof. The couple withstands weeks of pressure and prepares to leave, but Blair calls on Christmas Eve: she is flying home with her new fiancé, Enrique, and has promised him the family's traditional party. Nora insists they recreate the celebration within hours. The same neighbors the Kranks rejected rally to decorate the house, assemble food, invite guests, and get the travelers home. Blair never learns how close the tradition came to disappearing. Luther then gives the unused cruise to Walt and Bev Scheel because Bev is being treated for cancer. The Kranks spend Christmas at home, restored to their community and changed by its generosity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3416,7 +3416,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3429,7 +3429,7 @@
       "recaps": {
         "ending": "Valkyrie gets the Sceptre back and uses it herself, killing Nefarian Serpine and ending the threat he posed to the Sanctuary, to her family and to the world Gordon died trying to warn people about. It also settles, at least partly, the debt owed for the murder of Skulduggery's wife and child and for Skulduggery's own death during the war. Skulduggery, badly damaged by his captivity, is put back together and returns to work. The Sanctuary survives the attack on it and the Elders remain in place, but the ease with which Serpine reached them has shaken everyone's confidence in the peace that followed the war. Valkyrie goes home to Haggard and to parents who know nothing about any of it, and she decides that she is not going back to an ordinary life: she stays on as Skulduggery's partner, keeps the name Valkyrie Cain, and continues her training as an Elemental. Gordon's house, his fortune and his research are hers. The Faceless Ones remain a distant threat rather than a defeated one, and Serpine was not the only one of Mevolent's people who survived the war.",
         "in_short": "When her uncle Gordon, a horror novelist, dies suddenly, twelve-year-old Stephanie Edgley inherits his house and estate and meets Skulduggery Pleasant, a skeleton detective who investigates Gordon's death and reveals that magic is real. Attacked at Gordon's house by a man demanding a mysterious key, Stephanie becomes Skulduggery's partner, takes the protective name Valkyrie Cain, and begins learning Elemental magic. The killer is Nefarian Serpine, once a lieutenant of the dark sorcerer Mevolent and the man who tortured and killed Skulduggery during the war. Serpine is hunting the Sceptre of the Ancients, a weapon that can destroy anything and that was once used to drive out the Faceless Ones, the dark gods who ruled before mankind. With help from Tanith Low, Ghastly Bespoke and the information broker China Sorrows, Valkyrie finds the Sceptre first, and it binds itself to her. Serpine takes it, captures Skulduggery and attacks the Sanctuary, but Valkyrie recovers the weapon and kills him with it. She goes home, tells her parents nothing, and stays on as Skulduggery's partner.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3735,7 +3735,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BGK5WQFJ",
@@ -3747,7 +3747,7 @@
       "recaps": {
         "ending": "Earth destroys the Legion transport after its alien pursuer devastates Mars and follows the ship toward Earth. McGill, Galina Turov, Winslade, and other survivors are revived. Drusus defeats Alexander Turov's attempt to remove him, remains consul, and pardons the current treason defendants, but the unknown origin of the purge and Dixon's unexplained restoration remain open. Rigel is still at war with Earth, while the alien vessel departs toward Rigel after accepting that the destroyed transport was responsible for attacking its allies. McGill then cuts into the forbidden bunker and discovers a single living brain among eight tanks. He steals gateway equipment, kills two guards during an unauthorized trip to Dust World, and moves the survivor to the Investigator's laboratory. Etta remains there to assist. Hegemony personnel are already looking for McGill when he returns home. Galina arrives disguised as Sophia, reveals herself after testing him, and resumes private contact with him. The survivor's identity, the bunker's purpose, and the wider political conspiracy are still unknown.",
         "in_short": "James McGill and Etta uncover a forbidden bunker on the family land just as Earth's Big Sky defense test is sabotaged, killing more than 90 million people and starting war with Rigel. Legion Varus strikes Rigel, captures Dark World's orbital factory, forces that world to surrender, and seizes Sky World's mine. Galina Turov evades a political purge by taking a flagship, but an immense alien vessel pursues the legion home, destroys Phobos and Mars's main colony, and boards the transport. Earth destroys the transport to end the pursuit, then Drusus retains the consulship and pardons the accused officers. McGill returns to the bunker, finds one living brain among eight tanks, and secretly moves her to Dust World, where Etta stays to help care for her. Hegemony agents continue searching for McGill, the war and purge remain unresolved, and Galina reunites with him in disguise.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3885,7 +3885,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3896,7 +3896,7 @@
       "recaps": {
         "ending": "Skysworn ends with the dreadgod known as the Bleeding Phoenix driven off rather than beaten, leaving the Blackflame Empire battered and much of its land in ruins. Lindon and Yerin, pressed into the Skysworn's service, fought alongside Eithan, Orthos, Emperor Naru Huan, and the empire's forces to endure the catastrophe and protect its people, since a dreadgod is beyond defeating outright. Yerin survives, but only after her bound blood-madra inheritance is torn away toward the Phoenix, gravely weakening her and driving home how far short of true power the companions still fall. In the chaos of the assault, an ancient hidden realm is opened, and Lindon is separated from the others and swept into it alone as the book closes. He ends the book cut off from Yerin and Eithan, plunged into an unknown and isolating danger, while the survivors are left to reckon with the devastation and the plain lesson that they must grow far stronger.",
         "in_short": "Lindon's forbidden Blackflame arts land him and Yerin in the service of the Skysworn, the Blackflame Empire's elite enforcers, just as a far greater catastrophe arrives: the Bleeding Phoenix, a dreadgod whose awakening draws hordes of dreadbeasts, turns toward the empire. The threat is doubly dangerous for Yerin, whose bound blood-madra inheritance resonates with the Phoenix's blood-related power. As the empire's cities are besieged, Lindon, Yerin, Eithan, Orthos, Emperor Naru Huan, and the empire's forces fight to endure and protect the people, since a dreadgod cannot simply be defeated. When the Phoenix descends, Yerin's bound blood presence is torn from her, gravely harming her and proving how badly outmatched they all are. The Phoenix is finally driven off, leaving the region devastated, and in the chaos an ancient hidden realm is opened and Lindon is swept into it alone, separated from his companions as the book ends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4115,7 +4115,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4128,7 +4128,7 @@
       "recaps": {
         "ending": "The Krell throw everything they have at Alta, including a lifebuster bomb meant to destroy the base and the caverns beneath it. The battle costs the DDF badly and kills several of Spensa's friends, Hurl among them. Flying M-Bot, Spensa deliberately uses her cytonic ability for the first time, teleports the ship, and gets above the debris field, where she finds the truth: the Krell fighters are unmanned drones controlled from an orbiting command ship crewed by living aliens. Humanity has not been hunted, it has been imprisoned and culled whenever it grew too numerous or too capable. Spensa destroys the command ship and the assault collapses. Ironsides gives up command and Cobb is made admiral of the DDF; Spensa's father is publicly cleared of cowardice, and Spensa is confirmed as a full pilot under the callsign Spin. M-Bot survives but is severely damaged and must be rebuilt. The DDF now knows the shape of its enemy for the first time, an alien civilization with vastly better technology that treats humans as a contained infestation, and it knows that Spensa can partly do what that civilization does. The ancient orbital platforms overhead, the origin of the fleet that stranded humanity here, and the identity of the people behind the drones are all left open, and Spensa's ability marks her as both the DDF's greatest asset and the thing its jailers will most want to stop.",
         "in_short": "The last of humanity lives in caverns on the planet Detritus, penned beneath a shell of orbiting debris and raided constantly by alien Krell fighters. Spensa Nightshade wants to be a pilot, but her father was shot down at the Battle of Alta and branded a coward, and Admiral Ironsides is determined to keep his daughter out of a cockpit. Forced into training by an old instructor's insistence on the rules, Spensa flies with Skyward Flight while secretly rebuilding a wrecked, far more advanced starfighter she finds in a cave, whose artificial intelligence calls itself M-Bot. Cadets die around her. She learns her father was not a coward: he was cytonic, able to hear the stars, and Ironsides shot him down out of fear of what that does to a pilot. When the Krell attack Alta with a weapon meant to end humanity on Detritus, Spensa uses the same ability herself, discovers that the Krell fighters are drones flown by aliens who have kept humanity imprisoned, and destroys their command ship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4275,7 +4275,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4288,7 +4288,7 @@
       "recaps": {
         "ending": "Alicia gives birth to Rufus, and Sam remains involved rather than repeating his father's pattern of distance. Parenthood is exhausting and constrains both teenagers, but their families provide imperfect support while Sam and Alicia learn practical care. Sam's imagined journeys into the future have shown several possible versions of their lives, including strain, separation, and new relationships; they are warnings and possibilities, not a fixed prediction. Sam continues his education and retains ambitions beyond immediate survival. He and Alicia are not presented with a simple permanent romantic solution, but they share responsibility for Rufus and gain a more mature understanding of one another. The closing perspective accepts that Sam cannot know the whole shape of his future. He can only make the next responsible choice and remain present for his son.",
         "in_short": "Sam Jones is a sixteen-year-old London skateboarder determined not to repeat the history of his mother, Annie, who had him at the same age. He begins a relationship with Alicia Burns, but after they drift apart she tells him she is pregnant. Panicked, Sam runs away briefly and is also propelled in a series of unexplained flashes into possible futures, where he sees himself and Alicia caring for their son, Rufus. The visions show that parenthood will be difficult and that their relationship may change, but they also make the baby real to him. Annie reveals that she too is pregnant, complicating the family without withdrawing her support. Alicia has Rufus, and Sam stays involved, continues school, and begins learning how to be a father. The future remains open rather than idealized, but Sam chooses responsibility over disappearance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4424,7 +4424,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4437,7 +4437,7 @@
       "recaps": {
         "ending": "Julia's cancer progresses rapidly, and Layken finally stops treating anger and denial as ways to protect her family. Guided by her mother's written advice, she helps make Julia's remaining time loving and deliberate. Julia dies with Layken and Kel prepared, as far as they can be, to continue without her. Will remains responsible for Caulder and becomes a stable part of the extended family around the two younger boys. Once Layken has completed school and the teacher-student barrier is no longer controlling their choices, she and Will openly choose the relationship they had repeatedly tried to suppress. Their reunion does not erase the deaths that shaped both households, but it reflects Julia's insistence that loss should not prevent them from living fully. Poetry remains the language through which the characters face grief, speak honestly, and turn private pain into connection.",
         "in_short": "After her father's death, eighteen-year-old Layken Cohen moves to Michigan with her mother Julia and younger brother Kel. She falls quickly for neighbor Will Cooper, a young man raising his brother Caulder, and he introduces her to performance poetry. Their happiness stops when Layken discovers that Will is her poetry teacher. They attempt to maintain a boundary despite their feelings, while Kel and Caulder become inseparable and Layken forms friendships with Eddie and Gavin. A greater crisis arrives when Julia reveals that she has terminal cancer. Layken initially responds with fury and a wish to flee, but Julia pushes her to accept responsibility without abandoning joy. Will and the neighbors help both families prepare for Julia's death. After Julia dies and Layken finishes school, the professional obstacle ends and she and Will commit to each other, joining two families already linked by friendship, grief, and mutual care.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4580,7 +4580,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4593,7 +4593,7 @@
       "recaps": {
         "ending": "The novel's threads converge on Billy Pilgrim's later years and the aftermath of Dresden. Billy's wife Valencia dies of carbon monoxide poisoning in a car while rushing to reach him after his plane crashes, leaving him the crash's sole survivor. Recovering in the hospital, he meets a historian researching the Dresden bombing. Billy goes public with his belief in the Tralfamadorians and their view of time, telling his story on the radio, and he claims already to know the moment of his own death: he will be shot years later by an assassin acting for the vengeful Paul Lazzaro. The book's wartime storyline ends just after the firebombing, with the prisoners digging corpses from the rubble. The kindly schoolteacher Edgar Derby is caught with a looted teapot and executed by firing squad. Then the war in Europe ends, the German guards vanish, and the surviving prisoners step out into a quiet, ruined springtime. The narrative closes on the sound of a bird's song, the only answer the book offers to the massacre.",
         "in_short": "The novel tells the story of Billy Pilgrim, an unremarkable American optometrist who survived the firebombing of Dresden as a prisoner of war and who believes he has become unstuck in time, living the events of his life out of sequence. The book opens with the author describing his own decades-long effort to write about the massacre he witnessed. It then follows Billy as he ricochets between his youth, his wartime capture during a German offensive, his abduction by aliens called Tralfamadorians who see all of time at once, his prosperous postwar life, and the destruction of Dresden, where he and other prisoners survived in a meat locker beneath a slaughterhouse. Along the way the vengeful Paul Lazzaro vows to have Billy killed, and the decent teacher Edgar Derby is executed for taking a teapot from the ruins. Through Billy's fatalistic, Tralfamadorian outlook, summed up by the phrase so it goes, the novel treats war, death, and free will as things simply to be endured.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4740,7 +4740,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4753,7 +4753,7 @@
       "recaps": {
         "ending": "The women of the other Dooling choose to return to their former world rather than abandon it permanently. Evie allows the passage to reopen, and the cocoons dissolve as women around the world wake. The decision restores families but does not erase the violence committed during Aurora or the inequalities that preceded it. At the prison, Clint's defense of Evie survives Frank Geary's armed assault, though people on both sides are killed and Dooling is left to reckon with the siege. Lila returns with a clearer understanding of what life without men offered and of the strains within her marriage. She and Clint are reunited with each other and Jared, but neither the supernatural interval nor their affection supplies an easy solution to their mistrust. Evie departs once the choice has been made, leaving humanity to decide whether it will learn from the brief division. The world resumes with women awake and no guarantee that relations between women and men will improve.",
         "in_short": "A supernatural epidemic called Aurora causes women who fall asleep to become wrapped in cocoons; disturbing one makes the sleeper violently defensive. In Dooling, West Virginia, prison psychiatrist Clint Norcross meets Evie Black, the only woman able to sleep and wake normally. Clint believes she is connected to the crisis and protects her, while his sheriff wife Lila fights exhaustion and animal-control officer Frank Geary gathers men who want Evie killed. Sleeping women awaken in a parallel version of Dooling without men, where they build a new community and learn that Evie will let them choose whether to remain or return. In the waking world, Clint and a small group defend Evie at the prison against Frank's armed assault. After deaths during the siege, the women vote to return, the cocoons open, and Aurora ends. Lila is reunited with Clint and Jared, though the crisis has not erased the family's strains. Evie disappears, leaving people to confront the violence and inequality Aurora exposed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4915,7 +4915,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4928,7 +4928,7 @@
       "recaps": {
         "ending": "After the prince inherits the throne, the existence of his wife and children is no longer concealed. When he leaves for war, his ogress mother orders the steward to kill and cook first Morning, then Day, and finally their mother. The steward hides all three and serves animals in their place. The queen discovers the deception and prepares a pit filled with dangerous creatures for the family and the servants who helped them. The king returns before the execution. Confronted by him, the ogress throws herself into the pit and dies. The princess, her husband, and their children survive and remain together.",
         "in_short": "A king and queen celebrate the birth of a daughter, but an overlooked fairy curses the princess to die from a spindle wound. A younger fairy changes the doom into a hundred-year sleep. Despite the king's ban on spindles, the princess finds an old woman spinning, pricks her hand, and falls asleep as the castle is enchanted around her. A prince reaches the castle when the century has passed, and the princess wakes. They marry and have two children, Morning and Day, but he hides them from his ogress mother. After he becomes king and leaves for war, the ogress orders the family killed and cooked. A compassionate steward conceals them and substitutes animals. When the deception is exposed, the ogress prepares to destroy everyone, but her son returns. She throws herself into her own deadly pit, leaving the royal family safe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5005,7 +5005,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5018,7 +5018,7 @@
       "recaps": {
         "ending": "The figure is complete, named Themis by Rose Franklin, and operated by Kara Resnik and Vincent Couture, the only pair the controls will answer to. It has been used, so neither its existence nor its destructive capability is a secret any longer, and every government on Earth now has an interest in who holds it. Rose is not the woman who began the book: the original died during the project, and the Rose who continues is physically identical to her, carries her memories, and cannot account for her own existence. The genetic findings stand, and they are the largest thing the project has established: the ability to operate the machine runs through a small number of human bloodlines, which means whoever left it buried on Earth left descendants here as well. Kara and Vincent are bound to the machine and to each other with no realistic way out of either. Ryan Mitchell remains near Kara; Alyssa Papantoniou remains on the project with the genetic work in her hands. The unnamed man who assembled the whole enterprise out of nothing has what he set out to get and turns to whatever comes next. The book closes on the implication it has been building toward from the first file: something that size was made to be noticed, it has now been switched on in front of the world, and there is no reason to assume the people who built it are not watching.",
         "in_short": "On her eleventh birthday, Rose Franklin falls through the ground in the woods outside Deadwood, South Dakota and lands in the palm of a giant metal hand buried in a lighted chamber. Seventeen years later she leads the team studying it, backed by an unnamed man of unexplained wealth and influence who conducts every interview in the record. The hand proves to be one piece of a two-hundred-foot figure made of an alloy Earth cannot produce, older than any civilization that could have built it. Because the buried pieces disturb electronics and magnetic readings, the rest of the body is located and dug up from sites around the world. Kara Resnik, an army helicopter pilot, and Vincent Couture, a Montreal linguist, turn out to be among the very few people the machine's controls will answer to, and they become its pilots and its couple. Rose is killed partway through the project and is replaced by a woman identical to her who cannot say where she came from. Genetic work shows the pilots carry sequences the rest of humanity does not. The completed machine, named Themis, is used, and the world learns what it is; switching it on also announces to whoever left it that their machine has been found.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5146,7 +5146,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5159,7 +5159,7 @@
       "recaps": {
         "ending": "After Katrina apparently rejects him, Ichabod rides home through the places featured in the evening's ghost stories. A large, silent rider follows him, and Ichabod becomes convinced that it is the Headless Horseman. He races for the bridge beside the churchyard, believing the apparition will vanish there, but the rider hurls its severed head at him. Ichabod is never seen in Sleepy Hollow again. Searchers find Gunpowder without his saddle and discover Ichabod's hat beside a shattered pumpkin. Brom Bones later marries Katrina and reacts knowingly whenever the pumpkin is mentioned, strongly suggesting that he staged the pursuit. A traveler eventually reports that Ichabod survived, left the region, studied law, entered politics, and became a judge. The people of Sleepy Hollow nevertheless preserve the supernatural version of his disappearance, and the abandoned schoolhouse acquires its own haunted reputation.",
         "in_short": "Ichabod Crane, an ambitious and deeply superstitious schoolmaster in the Hudson Valley settlement of Sleepy Hollow, courts Katrina Van Tassel, the wealthy farmer's daughter. His chief rival is the athletic prankster Brom Bones. After a party filled with local ghost stories, Katrina appears to reject Ichabod, who rides home alone and encounters a headless rider resembling the legendary Hessian spirit. The rider chases him to the churchyard bridge and strikes him with what seems to be a severed head. Ichabod disappears; only his borrowed horse, his hat, and a smashed pumpkin are found. Brom soon marries Katrina and appears amused by mention of the pumpkin, implying that he impersonated the ghost to frighten his rival away. A later report says Ichabod built a new life elsewhere, but Sleepy Hollow keeps the haunting explanation alive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5291,7 +5291,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5304,7 +5304,7 @@
       "recaps": {
         "ending": "Ram reaches the final stage of the quiz after explaining how the scattered experiences of his life supplied answers no formal education could have taught him. Prem Kumar attempts to misdirect him, but Ram distrusts the host and chooses the correct answer. He wins the billion-rupee prize. The full story also reveals Ram's determination to free Nita from the people controlling her, and the money makes that possible. Smita Shah is not merely a lawyer who happened upon his case; she is Gudiya, the girl Ram once protected from her violent father, and her intervention repays that act of courage. Ram's account persuades her that his victory was honest and helps him avoid being deprived of it. Ram and Nita are able to build a life together, and Salim reaches the film world he long dreamed about. The supposed miracle of Ram's victory is thus explained as the accumulated result of memory, endurance, loyalty, and chance.",
         "in_short": "After the penniless Ram Mohammad Thomas wins a billion rupees on a television quiz, the producers have him arrested because they cannot believe he knew the answers honestly. A lawyer, Smita Shah, hears his explanation. Each question connects to an episode from Ram's life: his upbringing by a priest, his brotherly friendship with film-obsessed Salim, escapes from adults who exploit children, service in households concealing crime or despair, a deadly train robbery, and his love for Nita in Agra. These experiences gave him the unlikely fragments of knowledge required by the show. At the last question, host Prem Kumar attempts to deceive him, but Ram answers correctly and secures the prize. He uses his freedom and winnings to rescue Nita. Smita is revealed as Gudiya, a girl Ram once saved from domestic abuse, and she has returned that help. Ram and Nita remain together, while Salim enters the film business.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5471,7 +5471,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5484,7 +5484,7 @@
       "recaps": {
         "ending": "Ram reaches the final stage of the quiz after explaining how the scattered experiences of his life supplied answers no formal education could have taught him. Prem Kumar attempts to misdirect him, but Ram distrusts the host and chooses the correct answer. He wins the billion-rupee prize. The full story also reveals Ram's determination to free Nita from the people controlling her, and the money makes that possible. Smita Shah is not merely a lawyer who happened upon his case; she is Gudiya, the girl Ram once protected from her violent father, and her intervention repays that act of courage. Ram's account persuades her that his victory was honest and helps him avoid being deprived of it. Ram and Nita are able to build a life together, and Salim reaches the film world he long dreamed about. The supposed miracle of Ram's victory is thus explained as the accumulated result of memory, endurance, loyalty, and chance.",
         "in_short": "After the penniless Ram Mohammad Thomas wins a billion rupees on a television quiz, the producers have him arrested because they cannot believe he knew the answers honestly. A lawyer, Smita Shah, hears his explanation. Each question connects to an episode from Ram's life: his upbringing by a priest, his brotherly friendship with film-obsessed Salim, escapes from adults who exploit children, service in households concealing crime or despair, a deadly train robbery, and his love for Nita in Agra. These experiences gave him the unlikely fragments of knowledge required by the show. At the last question, host Prem Kumar attempts to deceive him, but Ram answers correctly and secures the prize. He uses his freedom and winnings to rescue Nita. Smita is revealed as Gudiya, a girl Ram once saved from domestic abuse, and she has returned that help. Ram and Nita remain together, while Salim enters the film business.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/small-favor.json
+++ b/data/works-community/0/small-favor.json
@@ -118,7 +118,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -129,7 +129,7 @@
       "recaps": {
         "ending": "The Denarians' true target was never Marcone: the abduction was the opening move of a scheme to capture the Archive, and at the Accords parley they take Ivy after a devastating battle. Harry answers with an assault on the Denarians' island stronghold in Lake Michigan, alongside Michael, Sanya, Murphy, Kincaid and Luccio. Mab returns what she had secretly taken - Harry's blasting rod, veiled from his own memory along with his fire magic - and Harry burns the enemy's position down around them. Ivy and Marcone are recovered alive; a number of Denarians are killed and several of their coins captured; Nicodemus, half-strangled with his own noose, survives through his daughter Deirdre and escapes; Tessa escapes as well. In the battle Murphy takes up the holy sword Fidelacchius, which blazes for her, though she declines its calling. The victory's price is Michael: gunned down during the extraction, he survives only barely and is left too badly maimed to fight again - his sword, Amoracchius, passes into Harry's keeping alongside Fidelacchius, and Michael retires to his family with a serenity Harry cannot fathom. In a hospital corridor the archangel Uriel, wearing a janitor's clothes, confirms what has changed in Harry: the death of Lasciel's shadow left space that has filled with soulfire, Heaven's counterpart to hellfire, fueled by Harry's own soul. Mab's second favor is paid, one remains, Marcone stands as an Accords lord with his debts to Harry unresolved, and Ivy - saved by a wizard who refused to write her off as an office - has a friend for the first time.",
         "in_short": "Mab calls in the second of Harry's three favors: act as Winter's Emissary and protect John Marcone, newly a freeholding lord under the Accords and abducted from a panic room by the returned Knights of the Blackened Denarius. As Summer inexplicably sends its goat-legged gruff assassins after Harry and his own fire magic has somehow gone missing from his mind, Harry hunts Nicodemus through parleys and betrayals - and learns too late that Marcone was bait: the Denarians' real target is the Archive, the little girl Ivy, whom they seize at the Accords negotiation. Harry leads Michael, Sanya, Murphy, Kincaid and Luccio in an assault on the Denarians' island in Lake Michigan; Mab returns his blasting rod and the memory she had veiled, and the stronghold burns. Ivy and Marcone are saved, coins are captured, Nicodemus and Tessa escape - and Michael is shot down in the extraction, crippled out of his knighthood, his sword joining Fidelacchius in Harry's trust. Uriel reveals Harry's new silver fire is soulfire, one Winter favor remains, and Harry finishes the job having beaten the eldest gruff with a donut.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -258,7 +258,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -269,7 +269,7 @@
       "recaps": {
         "ending": "Small Gods ends with the tyranny of Omnia's Church broken and a new, gentler order begun. At the point of Brutha's public execution, the Great God Om finally reclaims his strength: carried up by an eagle and dropped onto Deacon Vorbis, he kills the man who had seized control of the Church, and as the crowd sees Brutha's courage, true belief floods back to Om. Brutha survives and becomes the new prophet. Instead of wielding the power he inherits as his predecessors did, he strikes a new bargain with his god and remakes Omnia, abolishing the Quisition and steering the nation toward tolerance, literacy, and a lasting peace, while stopping the war Vorbis had provoked. The story then jumps a hundred years forward to Brutha's own death as an old man. When Death comes for him and he must cross the desert that lies beyond life, Brutha finds the spirit of Vorbis still standing there, alone and terrified, unmoved since his death because he had never truly cared for anyone but himself. Brutha takes Vorbis's hand and walks with him across the desert, choosing kindness toward his old enemy as his final act.",
         "in_short": "In the theocratic nation of Omnia, the Great God Om finds his power gone: because true belief, not mere Church membership, feeds a god, and only the kind, perfectly remembering novice Brutha genuinely believes in him, Om has shrunk to a nearly helpless talking tortoise. Brutha, the only one who can hear him, is taken into the service of Deacon Vorbis, a cold master of the Church's torturing Quisition, and travels with him to the philosopher-city of Ephebe, where forbidden ideas, including that the world is a disc on a turtle, begin to shake Brutha's unquestioning faith. Vorbis engineers treachery and war; after a shipwreck Brutha carries the injured Vorbis across the desert out of sheer decency. In Omnia, Vorbis makes himself prophet and condemns Brutha to death, but Om intervenes, dropped by an eagle onto Vorbis to kill him as belief and his power return. Brutha becomes prophet, ends the Quisition, and turns Omnia toward tolerance and peace. A century later, dying, he helps even Vorbis's frightened soul cross the desert of death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -391,7 +391,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -404,7 +404,7 @@
       "recaps": {
         "ending": "On Christmas Eve, Bill returns to the convent rather than allowing his earlier encounter there to be absorbed into the town’s silence. He finds Sarah again in the coal shed, brings her out, and leads her through New Ross toward his own home. People can see them, so the act cannot be kept private or explained away. Bill knows that the convent’s reach may affect his coal business, his daughters’ schooling, his family’s reputation, and his marriage; Eileen has already made clear the danger of crossing powerful local interests. He nevertheless chooses the immediate fact of Sarah’s suffering over the safety produced by looking away. The novel closes before showing Eileen’s response or the institutional consequences. Its decisive outcome is Bill’s public commitment: remembering that Mrs. Wilson once protected his unmarried mother and thereby made his own life possible, he becomes the person who opens a door for someone else, despite having no assurance that the choice will end well for either of them.",
         "in_short": "In the weeks before Christmas 1985, New Ross coal merchant Bill Furlong reflects on the precarious good fortune of his life. Born to an unmarried servant, he was allowed to remain with his mother because her employer, Mrs. Wilson, chose kindness over convention. Now married to Eileen and raising five daughters, he depends on the same town whose respectable institutions conceal cruelty. Delivering fuel to a convent linked to a laundry, Bill encounters young women living under coercion. He later finds Sarah locked in a coal shed, cold and desperate to know about her baby. The Mother Superior smoothly contains the incident and sends Bill away under the weight of the convent’s local power. Eileen urges him not to endanger their family by interfering. On Christmas Eve he returns, frees Sarah from the shed, and walks her openly toward his home. The consequences remain unknown, but Bill has chosen to extend to her the intervention that once saved his mother and himself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -563,7 +563,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -576,7 +576,7 @@
       "recaps": {
         "ending": "At the arranged fencing match, Hamlet scores the first touches against Laertes but refuses the poisoned wine Claudius has prepared. Gertrude drinks from the cup without knowing the danger and collapses. Laertes then wounds Hamlet with the poisoned blade; in the struggle they exchange weapons, and Hamlet wounds Laertes with it. The dying Laertes admits the plot and identifies Claudius as its author. Hamlet stabs the king and forces him to drink the remaining poison, killing him. Hamlet and Laertes forgive one another before Laertes dies. With the poison overcoming him, Hamlet asks Horatio to live and give an accurate account of the events, then gives his support to Fortinbras as the next ruler and dies. Fortinbras arrives after returning from Poland, finds the Danish royal family destroyed, claims his right to the kingdom, and orders military honors for Hamlet. Horatio remains to explain how revenge, surveillance, accident, and planned murder brought the court to this end.",
         "in_short": "Prince Hamlet returns to Elsinore after his father's death and learns from the dead king's ghost that his uncle Claudius committed the murder before taking the crown and marrying Queen Gertrude. Hamlet adopts an erratic manner while testing the accusation, and a performance recreating the crime convinces him of Claudius's guilt. His delay and secrecy damage Ophelia and draw her father Polonius, her brother Laertes, and Hamlet's former friends into the conflict. Hamlet accidentally kills Polonius and is sent toward execution in England, but escapes. Ophelia loses her reason and drowns; Laertes returns seeking revenge and joins Claudius in a poisoned fencing plot. During the match Gertrude drinks poisoned wine, Laertes and Hamlet are both cut by the poisoned blade, and Laertes exposes the scheme. Hamlet kills Claudius before dying. Horatio survives to tell the story, while Fortinbras enters the ruined court and takes control of Denmark.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -782,7 +782,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -795,7 +795,7 @@
       "recaps": {
         "ending": "After the victory at Agincourt, the action moves toward settlement rather than another battle. Fluellen forces Pistol to eat a leek after Pistol mocked his Welsh customs; Pistol, now bereaved and disgraced, decides to return to England and live by deception. At the French court, Burgundy describes the damage war has done and urges peace. The French king accepts Henry as heir to France and agrees to the territorial and political terms advanced by England. Henry then courts Princess Katherine. Their limited command of each other's language makes the exchange awkward, but Katherine accepts the marriage arranged by the treaty, and the two kingdoms anticipate their union. The closing Chorus places the victory in a larger history: Henry will die young, leaving the infant Henry VI, under whose divided guardians England will lose the French territories. The play therefore ends with peace and a dynastic marriage while explicitly warning that Henry's gains will not endure.",
         "in_short": "Henry V accepts the church-supported case that he has a right to the French crown. Insulted by the Dauphin and strengthened by the exposure of a plot against him, he invades France, captures Harfleur, and marches his sick and depleted army toward Calais. On the eve of Agincourt he moves among his troops in disguise, hearing their doubts and considering the burdens of kingship. The French greatly outnumber the English, but Henry rallies his men and wins a decisive victory; prominent French nobles die, while English losses are comparatively small. The French king then agrees to peace terms recognizing Henry as his heir. Henry courts and is promised Katherine, the French princess, joining conquest to dynastic marriage. A final Chorus notes that Henry dies soon afterward and that England loses his French gains during the reign of his infant son, Henry VI.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -998,7 +998,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1011,7 +1011,7 @@
       "recaps": {
         "ending": "At Philippi, Cassius wrongly concludes that Titinius has been captured and has his servant Pindarus help him die with the sword used against Caesar. Titinius returns safely, finds Cassius dead, and kills himself. Brutus's forces continue fighting, but defeat becomes inevitable. Brutus asks several companions to help him die; they refuse until Strato agrees to hold a sword while Brutus runs onto it. Octavius and Antony find the body. Antony distinguishes Brutus from the other conspirators, judging that he acted from a sincere, though mistaken, concern for Rome rather than envy. Octavius orders an honorable burial and absorbs Brutus's surviving followers into the victorious side. Caesar's murder has therefore failed to preserve the republic: the conspirators are dead, their armies defeated, and power belongs to the triumvirs led by Caesar's heir and Antony.",
         "in_short": "As Julius Caesar returns to Rome in triumph, Cassius fears that he will become a monarch and recruits respected senator Brutus into a conspiracy. Brutus agrees because he believes Caesar's potential ambition threatens the republic. Despite omens and warnings, Caesar goes to the Senate, where the conspirators stab him. Brutus permits Caesar's ally Mark Antony to speak at the funeral. Antony uses Caesar's wounds and will to turn the crowd against the assassins, forcing Brutus and Cassius from Rome. Antony, Octavius, and Lepidus form a triumvirate and wage war on them. Brutus and Cassius quarrel but reconcile before meeting the opposing army at Philippi. After military reversals and mistaken reports, Cassius and his loyal officer Titinius kill themselves. Brutus, facing defeat, also dies by suicide. Antony honors Brutus's public motive, but the conspirators' attempt to save republican liberty ends with Caesar's heirs victorious.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1224,7 +1224,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1237,7 +1237,7 @@
       "recaps": {
         "ending": "Lear and Cordelia are captured after the French-backed army loses. Edmund secretly orders both killed. Goneril poisons Regan because they are rivals for Edmund, then kills herself when Albany exposes her conspiracy. Edgar defeats Edmund in a formal challenge and reveals his identity; the wounded Edmund admits his crimes and tries too late to stop the executions. Cordelia has already been hanged. Lear enters carrying her body and dies in grief. Gloucester has also died after learning that the disguised son who protected him was Edgar, while Cornwall died earlier from a wound received during Gloucester's blinding. Albany yields authority to Kent and Edgar, but Kent indicates that he will soon follow Lear in death. Edgar is left to bear responsibility for the damaged kingdom.",
         "in_short": "King Lear divides Britain between Goneril and Regan after disowning Cordelia for refusing to flatter him. Once empowered, the elder daughters strip away his followers and authority, driving him into a storm. Meanwhile Edmund frames Edgar, betrays their father Gloucester, and rises by serving Lear's daughters. Cornwall and Regan blind Gloucester, but disguised Edgar guides and protects him. Cordelia returns with French forces to rescue Lear, and the two reconcile. Their army loses; Edmund orders them executed while Goneril and Regan compete for him. Goneril poisons Regan and then kills herself. Edgar defeats Edmund and exposes his treachery, but the reversal comes too late: Cordelia is hanged, and Lear dies holding her body. Albany relinquishes power, Kent expects death, and Edgar is left to govern the ruined realm.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1433,7 +1433,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1446,7 +1446,7 @@
       "recaps": {
         "ending": "Malcolm's army advances on Dunsinane carrying branches cut from Birnam Wood, fulfilling one prophecy in a way Macbeth had not expected. Macbeth learns that Lady Macbeth has died but continues fighting because he trusts the promise that no man born of a woman can harm him. He kills Young Siward, then meets Macduff. Macduff reveals that he was delivered surgically before natural birth, removing Macbeth's final assurance. Macduff kills and beheads him. Malcolm is acclaimed king of Scotland, rewards his supporters with the new Scottish title of earl, recalls exiles, and promises to repair the damage of Macbeth's rule. Macduff has avenged his murdered family, but Duncan, Banquo, Lady Macduff, her children, and Lady Macbeth remain among the dead produced by Macbeth's pursuit of the crown.",
         "in_short": "After winning a battle for Scotland, Macbeth hears witches predict that he will become king and that Banquo's descendants will rule after him. Encouraged by Lady Macbeth, he murders King Duncan and takes the crown. Suspicion and fear drive him to arrange Banquo's death, though Banquo's son Fleance escapes. Macbeth returns to the witches and gains confidence from deceptive assurances, then has Macduff's wife and children killed when Macduff joins Duncan's son Malcolm in England. Malcolm leads an army against him. Lady Macbeth, tormented by guilt, sleepwalks and dies. Malcolm's soldiers disguise themselves with branches from Birnam Wood, fulfilling one prophecy; Macduff, not born by ordinary childbirth, fulfills another by killing Macbeth. Malcolm becomes king and begins restoring Scotland.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1620,7 +1620,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1633,7 +1633,7 @@
       "recaps": {
         "ending": "Romeo reaches the Capulet tomb before Friar Lawrence's explanation can reach him. Paris confronts him there and is killed in the fight. Believing Juliet truly dead, Romeo drinks poison beside her and dies. Juliet wakes soon afterward. Friar Lawrence tries to lead her away, but flees when the watch approaches; finding Romeo dead and no poison left, Juliet kills herself with his dagger. The watch gathers the friar, the families, and the prince. Friar Lawrence recounts the secret marriage, the intended escape, and the failed message, while Romeo's letter confirms his account. Lady Montague has also died from grief over Romeo's banishment. Prince Escalus condemns both houses for the feud that destroyed their children and acknowledges his own failure to stop it. The Montagues and Capulets finally reconcile, promising memorials to Romeo and Juliet. Their peace comes only after the deaths of the young couple, Mercutio, Tybalt, Paris, and Lady Montague.",
         "in_short": "In Verona, the Montague and Capulet families maintain a violent feud. Romeo Montague and Juliet Capulet meet at a masked feast, fall in love, and marry secretly with Friar Lawrence's help. Their attempt to create peace instead becomes trapped by public violence: Tybalt kills Romeo's friend Mercutio, Romeo kills Tybalt, and Prince Escalus banishes Romeo. The couple spend one night together before Romeo leaves for Mantua. When Juliet's parents demand that she marry Paris, the friar gives her a potion that will make her appear dead while a message summons Romeo to retrieve her from the tomb. The message fails to arrive. Told only that Juliet has died, Romeo buys poison, returns to Verona, kills Paris at the tomb, and dies beside Juliet. She wakes, finds him dead, and kills herself. Friar Lawrence explains the plan, and the bereaved Montagues and Capulets end their feud.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1803,7 +1803,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1816,7 +1816,7 @@
       "recaps": {
         "ending": "Sebastian's appearance resolves the apparent contradictions surrounding Cesario. Viola and Sebastian recognize each other and confirm that both twins survived the wreck. Olivia learns that she has married Sebastian, not Orsino's page, but accepts the match; Sebastian is glad to remain with her. Once Viola's identity is known, Orsino turns from his pursuit of Olivia and declares that he will marry Viola. Maria's letter is exposed as the cause of Malvolio's humiliation. Sir Toby has married Maria, while the injured Sir Andrew leaves to have his wounds treated. Malvolio, angry that he was confined and mocked, leaves promising retaliation. Antonio is no longer treated as a deluded stranger because Sebastian can explain his loyalty, although the play does not settle his future in detail. The households move toward the double marriage of Orsino with Viola and Olivia with Sebastian, and Feste closes the action after the other characters depart.",
         "in_short": "After a shipwreck separates Viola from her twin Sebastian, she disguises herself as a young man called Cesario and serves Orsino, ruler of Illyria. Viola falls for Orsino, who sends her to woo the mourning Olivia; Olivia instead falls for Cesario. Meanwhile, Olivia's uncle Sir Toby, her attendant Maria, and their companions forge a letter that persuades the self-important steward Malvolio that Olivia loves him. Sebastian, also alive, arrives with the devoted Antonio. Because Sebastian looks like the disguised Viola, strangers challenge, rescue, and court the wrong twin. Olivia secretly marries Sebastian while believing him to be Cesario. When both twins finally appear together, Viola's identity is revealed. Orsino accepts that Olivia is married and chooses Viola, while Sebastian welcomes his marriage to Olivia. Malvolio discovers the trick played on him and leaves in anger; Sir Toby has married Maria.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1989,7 +1989,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2002,7 +2002,7 @@
       "recaps": {
         "ending": "At the arranged fencing match, Hamlet scores the first touches against Laertes but refuses the poisoned wine Claudius has prepared. Gertrude drinks from the cup without knowing the danger and collapses. Laertes then wounds Hamlet with the poisoned blade; in the struggle they exchange weapons, and Hamlet wounds Laertes with it. The dying Laertes admits the plot and identifies Claudius as its author. Hamlet stabs the king and forces him to drink the remaining poison, killing him. Hamlet and Laertes forgive one another before Laertes dies. With the poison overcoming him, Hamlet asks Horatio to live and give an accurate account of the events, then gives his support to Fortinbras as the next ruler and dies. Fortinbras arrives after returning from Poland, finds the Danish royal family destroyed, claims his right to the kingdom, and orders military honors for Hamlet. Horatio remains to explain how revenge, surveillance, accident, and planned murder brought the court to this end.",
         "in_short": "Prince Hamlet returns to Elsinore after his father's death and learns from the dead king's ghost that his uncle Claudius committed the murder before taking the crown and marrying Queen Gertrude. Hamlet adopts an erratic manner while testing the accusation, and a performance recreating the crime convinces him of Claudius's guilt. His delay and secrecy damage Ophelia and draw her father Polonius, her brother Laertes, and Hamlet's former friends into the conflict. Hamlet accidentally kills Polonius and is sent toward execution in England, but escapes. Ophelia loses her reason and drowns; Laertes returns seeking revenge and joins Claudius in a poisoned fencing plot. During the match Gertrude drinks poisoned wine, Laertes and Hamlet are both cut by the poisoned blade, and Laertes exposes the scheme. Hamlet kills Claudius before dying. Horatio survives to tell the story, while Fortinbras enters the ruined court and takes control of Denmark.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2208,7 +2208,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2221,7 +2221,7 @@
       "recaps": {
         "ending": "After the victory at Agincourt, the action moves toward settlement rather than another battle. Fluellen forces Pistol to eat a leek after Pistol mocked his Welsh customs; Pistol, now bereaved and disgraced, decides to return to England and live by deception. At the French court, Burgundy describes the damage war has done and urges peace. The French king accepts Henry as heir to France and agrees to the territorial and political terms advanced by England. Henry then courts Princess Katherine. Their limited command of each other's language makes the exchange awkward, but Katherine accepts the marriage arranged by the treaty, and the two kingdoms anticipate their union. The closing Chorus places the victory in a larger history: Henry will die young, leaving the infant Henry VI, under whose divided guardians England will lose the French territories. The play therefore ends with peace and a dynastic marriage while explicitly warning that Henry's gains will not endure.",
         "in_short": "Henry V accepts the church-supported case that he has a right to the French crown. Insulted by the Dauphin and strengthened by the exposure of a plot against him, he invades France, captures Harfleur, and marches his sick and depleted army toward Calais. On the eve of Agincourt he moves among his troops in disguise, hearing their doubts and considering the burdens of kingship. The French greatly outnumber the English, but Henry rallies his men and wins a decisive victory; prominent French nobles die, while English losses are comparatively small. The French king then agrees to peace terms recognizing Henry as his heir. Henry courts and is promised Katherine, the French princess, joining conquest to dynastic marriage. A final Chorus notes that Henry dies soon afterward and that England loses his French gains during the reign of his infant son, Henry VI.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2424,7 +2424,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2437,7 +2437,7 @@
       "recaps": {
         "ending": "At Philippi, Cassius wrongly concludes that Titinius has been captured and has his servant Pindarus help him die with the sword used against Caesar. Titinius returns safely, finds Cassius dead, and kills himself. Brutus's forces continue fighting, but defeat becomes inevitable. Brutus asks several companions to help him die; they refuse until Strato agrees to hold a sword while Brutus runs onto it. Octavius and Antony find the body. Antony distinguishes Brutus from the other conspirators, judging that he acted from a sincere, though mistaken, concern for Rome rather than envy. Octavius orders an honorable burial and absorbs Brutus's surviving followers into the victorious side. Caesar's murder has therefore failed to preserve the republic: the conspirators are dead, their armies defeated, and power belongs to the triumvirs led by Caesar's heir and Antony.",
         "in_short": "As Julius Caesar returns to Rome in triumph, Cassius fears that he will become a monarch and recruits respected senator Brutus into a conspiracy. Brutus agrees because he believes Caesar's potential ambition threatens the republic. Despite omens and warnings, Caesar goes to the Senate, where the conspirators stab him. Brutus permits Caesar's ally Mark Antony to speak at the funeral. Antony uses Caesar's wounds and will to turn the crowd against the assassins, forcing Brutus and Cassius from Rome. Antony, Octavius, and Lepidus form a triumvirate and wage war on them. Brutus and Cassius quarrel but reconcile before meeting the opposing army at Philippi. After military reversals and mistaken reports, Cassius and his loyal officer Titinius kill themselves. Brutus, facing defeat, also dies by suicide. Antony honors Brutus's public motive, but the conspirators' attempt to save republican liberty ends with Caesar's heirs victorious.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2650,7 +2650,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2663,7 +2663,7 @@
       "recaps": {
         "ending": "Lear and Cordelia are captured after the French-backed army loses. Edmund secretly orders both killed. Goneril poisons Regan because they are rivals for Edmund, then kills herself when Albany exposes her conspiracy. Edgar defeats Edmund in a formal challenge and reveals his identity; the wounded Edmund admits his crimes and tries too late to stop the executions. Cordelia has already been hanged. Lear enters carrying her body and dies in grief. Gloucester has also died after learning that the disguised son who protected him was Edgar, while Cornwall died earlier from a wound received during Gloucester's blinding. Albany yields authority to Kent and Edgar, but Kent indicates that he will soon follow Lear in death. Edgar is left to bear responsibility for the damaged kingdom.",
         "in_short": "King Lear divides Britain between Goneril and Regan after disowning Cordelia for refusing to flatter him. Once empowered, the elder daughters strip away his followers and authority, driving him into a storm. Meanwhile Edmund frames Edgar, betrays their father Gloucester, and rises by serving Lear's daughters. Cornwall and Regan blind Gloucester, but disguised Edgar guides and protects him. Cordelia returns with French forces to rescue Lear, and the two reconcile. Their army loses; Edmund orders them executed while Goneril and Regan compete for him. Goneril poisons Regan and then kills herself. Edgar defeats Edmund and exposes his treachery, but the reversal comes too late: Cordelia is hanged, and Lear dies holding her body. Albany relinquishes power, Kent expects death, and Edgar is left to govern the ruined realm.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2829,7 +2829,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2842,7 +2842,7 @@
       "recaps": {
         "ending": "Malcolm's army advances on Dunsinane with soldiers carrying branches cut from Birnam Wood, fulfilling the apparition's warning in a form Macbeth had assumed impossible. Macbeth learns that Lady Macbeth has died but continues to rely on the assurance that no man born in the ordinary way can harm him. In the battle he kills Young Siward and refuses to surrender. Macduff confronts him and reveals that he was delivered by surgical birth rather than born naturally. Macbeth understands that the witches' assurances were dangerously incomplete, yet fights and is killed. Macduff enters with Macbeth's severed head and hails Malcolm as king. Malcolm rewards his supporters, calls home the exiles who fled Macbeth's rule, and announces his coronation at Scone. Lady Macbeth's death, Banquo's murder, the destruction of Macduff's family, and Scotland's losses cannot be reversed, but Duncan's line is restored through Malcolm and Macbeth's violent reign ends.",
         "in_short": "After Scottish general Macbeth helps defeat a rebellion, three witches predict that he will gain a new title and become king, while Banquo's descendants will rule. The first prediction comes true at once. Encouraged by Lady Macbeth, Macbeth murders King Duncan during a royal visit and takes the crown, while Duncan's sons flee. Fearful of Banquo's prophecy, Macbeth has Banquo killed, though Fleance escapes, and Banquo's ghost exposes Macbeth's distress at a banquet. Further apparitions give Macbeth confidence through deceptive assurances. He orders the slaughter of Macduff's wife and children after Macduff joins Malcolm in England. Lady Macbeth, burdened by guilt, sleepwalks and later dies. Malcolm's army uses branches from Birnam Wood as camouflage while advancing on Dunsinane, fulfilling a warning Macbeth dismissed. Macduff, who was delivered by surgical birth, kills Macbeth. Malcolm becomes king and begins restoring Scotland after Macbeth's rule.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3018,7 +3018,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3031,7 +3031,7 @@
       "recaps": {
         "ending": "Romeo reaches the Capulet tomb believing Juliet dead. He kills Paris when Paris confronts him there, then drinks poison beside Juliet's body. Juliet awakens after Friar Lawrence arrives, sees that Romeo is dead, and refuses to leave. When the friar flees at the sound of approaching guards, she kills herself with Romeo's dagger. The friar explains the secret marriage, the plan involving Juliet's sleeping potion, and the failed delivery of the message to Romeo. Evidence from Romeo's servant and letter confirms the account. Faced with the deaths caused by their hostility, Capulet and Montague reconcile and promise memorials to the young couple. Prince Escalus closes the inquiry by assigning shared responsibility: the families' feud, the lovers' desperate secrecy, and the adults' failures have turned an attempt at union into catastrophe.",
         "in_short": "In Verona, the Montagues and Capulets maintain a feud that repeatedly erupts into violence. Romeo Montague and Juliet Capulet meet at a Capulet feast, fall in love, and marry secretly with Friar Lawrence's help. Soon afterward Tybalt kills Romeo's friend Mercutio, and Romeo kills Tybalt, leading to Romeo's banishment. Juliet's parents then order her to marry Paris. The friar gives Juliet a potion that will make her appear dead so that she can escape and reunite with Romeo, but the explanatory message never reaches him. Believing Juliet truly dead, Romeo buys poison and dies beside her in the family tomb. Juliet wakes, finds him dead, and kills herself. Friar Lawrence reveals the full story, and the grieving Montague and Capulet families finally end their feud.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3204,7 +3204,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3217,7 +3217,7 @@
       "recaps": {
         "ending": "In the final gathering, Sebastian's appearance proves that he and Viola are separate people and resolves the many mistakes caused by their resemblance. The twins recognize each other and rejoice that both survived the shipwreck. Olivia accepts that she has married Sebastian rather than Cesario, while Orsino learns that Cesario is Viola and turns his affection toward her; Viola will resume her female clothing once it is recovered. Maria's forged letter is exposed as the cause of Malvolio's humiliation. Sir Toby has married Maria, but Malvolio leaves vowing retaliation against the household. Orsino orders that he be pursued and reconciled if possible. The play closes with two newly acknowledged couples, Olivia and Sebastian and Orsino and Viola, while Feste remains to sing about the persistence of ordinary hardship beyond the festivities.",
         "in_short": "After a shipwreck separates twins Viola and Sebastian, Viola disguises herself as a young man named Cesario and serves Duke Orsino, who sends her to court the mourning Countess Olivia. Viola falls for Orsino, while Olivia falls for Cesario. In Olivia's household, Maria, Sir Toby, Sir Andrew, Fabian, and Feste punish the pompous steward Malvolio with a forged letter that persuades him Olivia loves him. Sebastian, also alive, enters Illyria with the loyal Antonio. Because he looks like the disguised Viola, he is mistaken for Cesario, accepts Olivia's sudden proposal, and baffles people involved in Sir Andrew's challenge. The confusions converge when both twins appear together. Viola reveals her identity; Orsino recognizes his love for her, and Olivia remains happily married to Sebastian. The prank on Malvolio is confessed, and he departs angrily while the household celebrates the paired marriages.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3429,7 +3429,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3442,7 +3442,7 @@
       "recaps": {
         "ending": "Grigoriev, broken by Toby's team and questioned by Smiley in a Bern safe flat, gives up the whole arrangement: the girl in the clinic is Karla's daughter, mentally ill, smuggled out of Russia under a false identity and a false nationality, and maintained in Switzerland with money embezzled from Moscow Centre's operational funds. Kirov was ordered to build the legend, talked too much to Otto Leipzig, and was recalled and shot; Vladimir, Leipzig and very nearly Ostrakova were killed to bury the same secret. Smiley now has what no professional lever could give him: the private crime for which Karla's own service would destroy him. He sends word to Moscow through the channel Karla built, offering him the choice between exposure and coming across. Karla comes. On a bridge in Berlin, watched by Smiley, Toby and the reception party, he crosses into the West, a small man carrying almost nothing, and as he passes he drops the cigarette lighter Smiley once gave him. Smiley has beaten him by using the one human attachment Karla had, exactly as Karla would have done, and the victory gives him nothing. He turns away, and when Toby tells him he has won he can barely agree.",
         "in_short": "In Paris an ageing Russian emigree, Ostrakova, is approached by a Soviet official offering to release the daughter she left behind, and writes for help to General Vladimir, an old Estonian exile in London and a discarded Circus agent. Vladimir tries to reach his former case officer under Moscow rules and is shot dead on Hampstead Heath. Smiley, long retired, is sent to tidy the death away quietly, and instead follows the trail the old man left: a hidden negative, an emigre courier, a Hamburg confidence man named Otto Leipzig, and photographs and a tape recording of the Soviet official's indiscretions. Reassembling his old people, Connie Sachs, Toby Esterhase, Guillam and Mendel, and working outside the service, Smiley establishes that Karla, the head of Moscow Centre's special directorate, has been using Centre money and Centre officers to hide his mentally ill daughter in a Swiss clinic under a false identity. Everyone who learned of it has been killed. Smiley breaks the Soviet official who pays the clinic's bills, and uses the daughter to force Karla's defection. Karla crosses a Berlin bridge into the West, and Smiley takes no pleasure in it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3562,7 +3562,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3575,7 +3575,7 @@
       "recaps": {
         "ending": "The bomb is stopped: Alex prevents Royal Blue from triggering the landslide, no wave is generated, and the conference and the coastline are never hit. Major Winston Yu does not survive the operation, and the snakehead's network is broken open. The harder ending is Ash. Alex learns that his godfather was the traitor inside the operation years ago, the man Scorpia paid to betray John Rider and to make sure the Riders' plane came down; Alex's parents died because Ash sold them. Ash is fatally injured during the fighting, and dies having admitted it, leaving Alex with a truth that nobody else needs and no one to be angry at. Alex goes home to London knowing exactly how his mother and father died and who arranged it, having been used again by a service that is not even his own, and having been closer to being killed on an operating table than in any firefight. Scorpia, whose contract set the whole thing in motion, remains in business.",
         "in_short": "Fished out of the sea off Australia after his fall from orbit, Alex is recruited by the Australian Secret Intelligence Service to go into the snakeheads, the gangs that smuggle people across Southeast Asia. He is teamed with Ash, a former MI6 officer who turns out to be his godfather and who knew his parents. Posing as refugees, the two are moved along the smuggling route to a camp where the gang's other trade becomes clear: those who cannot pay are taken to an illegal clinic and stripped for organs, and Alex is nearly killed on the table. Captured, he is brought before Major Winston Yu, who runs the operation and has taken a contract from Scorpia called Royal Blue: a bomb sunk at an unstable point on the seabed to trigger an underwater landslide and a wave that would destroy an international aid conference and the coast around it. Alex stops the detonation and Yu is killed. He also learns that Ash was the traitor who betrayed his parents to Scorpia; Ash dies admitting it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3749,7 +3749,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3762,7 +3762,7 @@
       "recaps": {
         "ending": "Ishmael finds records from the lighthouse radio station showing that a freighter passed San Piedro during the fogbound night of Carl's death. Its wake, arriving during a local power failure, explains how Carl could have been knocked from his boat after climbing the mast to deal with his lantern. The evidence supports Kabuo's account of helping Carl with a dead battery and then leaving him alive. Ishmael initially sits alone with information that can save the husband of the woman he still loves, but Hatsue's appeal to his better nature ends his hesitation. He gives her the records, and she takes them to Sheriff Moran. The authorities confirm the accident and the charge against Kabuo is dismissed before the jury delivers a verdict. Kabuo returns to Hatsue and their children. Hatsue remains grateful to Ishmael but does not renew their youthful romance; her life is with Kabuo. By choosing truth over resentment, Ishmael begins to move beyond the grievance that has governed his postwar life and writes the full account of Carl's accidental death.",
         "in_short": "In 1954, Japanese American fisherman Kabuo Miyamoto stands trial on San Piedro Island for killing fellow fisherman Carl Heine. The prosecution links a head wound, blood and a disputed boat battery to an old conflict over strawberry land that Kabuo's family lost while incarcerated during World War II. The trial draws out the island's buried history: prejudice against its Japanese American residents, Kabuo's war service, and newspaper editor Ishmael Chambers's secret youthful love for Kabuo's wife, Hatsue. Kabuo eventually explains that he found Carl disabled at sea, helped him install a spare battery, discussed buying back the family acreage, and left him alive. Ishmael discovers lighthouse records proving that a freighter's wake could have knocked Carl from his mast during a power failure. After briefly withholding the evidence, Ishmael gives it to Hatsue. The accident is confirmed, Kabuo is freed, and Ishmael finally acts according to the fairness his father taught him rather than the bitterness he has carried since the war and Hatsue's rejection.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3914,7 +3914,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3927,7 +3927,7 @@
       "recaps": {
         "ending": "After publicly condemning Snow Flower, Lily learns that she misunderstood her friend's message: Snow Flower's sworn sisters had offered companionship during suffering, not replaced the laotong bond. By then Snow Flower is gravely ill. Lily goes to her, nurses her through her final days, and hears how loneliness, abuse, poverty, and the deaths of her children shaped the choices Lily judged so harshly. Snow Flower dies with their attachment restored but without giving Lily the absolution she wants. Lily assumes responsibility for Snow Flower's surviving children and later hears further testimony from the women who had supported her. In old age, socially honored but burdened by remorse, Lily writes the history of their relationship and addresses Snow Flower's spirit. The fan preserves their nüshu messages, including evidence of Lily's failures as well as their love, and Lily asks forgiveness for having valued pride and social rules above a faithful understanding of her friend.",
         "in_short": "In nineteenth-century Hunan, Lily's carefully bound feet bring her a prestigious marriage and a formal laotong match with Snow Flower. The girls communicate in women's nüshu writing, especially on a fan, and promise lifelong devotion. Lily rises into a wealthy household, while Snow Flower reveals that her family has fallen and that she must marry an abusive butcher. Marriage, childbirth, poverty, and the Taiping upheaval widen the difference between their lives. During a dangerous mountain refuge, Snow Flower suffers another devastating loss. Later she writes of sworn sisters who comfort her; Lily reads this as rejection, publicly denounces her, and breaks their bond. She discovers too late that Snow Flower never meant to replace her. Lily nurses Snow Flower as she dies, cares for her children, and spends the rest of her life regretting that pride and convention made her fail the person she loved most.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4103,7 +4103,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4116,7 +4116,7 @@
       "recaps": {
         "ending": "Ka arranges a bargain in which Kadife will bare her head during Sunay's televised play in exchange for Blue's release. Blue is freed, but security forces track him to a hiding place and kill him; evidence later convinces İpek that Ka revealed the location. Onstage, Kadife removes her headscarf and fires what she believes has become a harmless theatrical weapon, but the gun is loaded and Sunay dies. With the roads open, Ka prepares to leave Kars with İpek. After learning of his part in Blue's death, she refuses to join him. Ka returns alone to Frankfurt and spends four isolated years there before he is shot dead, apparently in revenge for Blue. His green notebook and the completed poems he called Snow cannot be found. Years later, Orhan retraces Ka's movements in Kars, interviews the survivors, and fails to recover the poems, leaving Ka's lost work and motives open to competing memories.",
         "in_short": "Ka, a poet exiled in Germany, travels through a snowstorm to Kars to report on an election and the suicides of young women pressured to remove their headscarves. He also hopes to reunite with İpek, a former acquaintance. Isolated by snow, the city becomes the site of a theatrical military coup led by actor Sunay Zaim, whose soldiers kill religious students during a live broadcast. Amid arrests and negotiations among secularists, Islamists, Kurdish activists, and state agents, Ka experiences a burst of poems that he arranges as a snowflake. He dreams that İpek will return to Germany with him but conceals information and mediates a bargain involving İpek's sister Kadife and the Islamist Blue. Blue is released and then killed after Ka reveals his location. Kadife unveils during a televised play and kills Sunay with a loaded gun. İpek learns of Ka's betrayal and stays in Kars. Ka returns alone to Frankfurt, where he is murdered four years later; his friend Orhan cannot recover the lost poems.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4305,7 +4305,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4318,7 +4318,7 @@
       "recaps": {
         "ending": "Vimes proves the case: local landowners, with money and a name behind them, have been shipping goblins abroad as slave labour for the tobacco plantations and running smuggled goods on the same boats, and a young goblin woman was murdered to keep it quiet. Stratford, the killer, makes a last attempt on Vimes and on his family, and is taken; the aristocrat who financed the trade is dealt with by Vetinari on terms that leave him with nothing. The captured goblins are freed, Sergeant Colon recovers once the goblin pot he was carrying is returned to its owners, and the young country constable Feeney Upshot finishes the case as a real policeman with a future in the Watch. The decisive stroke is not an arrest: at a concert in Ankh-Morpork's Opera House, in front of the city's wealthy and powerful, Tears of the Mushroom plays the harp, and an audience that had always been told goblins were vermin sits and listens to one make music. On the strength of that, and of the case Vimes has built, the law changes and goblins become people, with the rights that follow. Vimes goes home to the city and the job, having taken the only holiday of his life and turned it, as everyone including his wife expected, into police work.",
         "in_short": "Sam Vimes, Commander of the Ankh-Morpork City Watch and reluctant Duke of Ankh, is made to take a holiday at his wife's country estate, where he finds that a copper is still a copper. The district's goblins are treated as vermin, which under local law they are, and a young goblin woman has been murdered. The local chief constable, a young man named Feeney Upshot, arrests Vimes for it; Vimes turns him into a deputy instead, and together they uncover a trade run by the county's own gentry, shipping goblins abroad as slaves and smuggling goods on the return leg, with a professional killer named Stratford enforcing it. Vimes pursues the boats downriver through a flood, is nearly killed, and brings the evidence and the survivors back. The case ends not only in arrests but in a change of the law: at a concert in Ankh-Morpork a goblin girl plays the harp for the city's rich and powerful, and goblins are recognized as people. Vimes returns to the city with his family, his holiday having gone exactly as everyone expected.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/so-much-to-tell-you.json
+++ b/data/works-community/0/so-much-to-tell-you.json
@@ -58,7 +58,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -71,7 +71,7 @@
       "recaps": {
         "ending": "Marina's diary has become evidence that her silence does not mean an absence of thought or feeling. Friendship at school and the patience of adults who do not demand an immediate cure allow her to re-enter ordinary life, but her decisive unfinished relationship is with her father. She visits him in prison and confronts the person connected to both her childhood love and her disfigurement. At the close she speaks to him, breaking the silence she has maintained since the attack. The act does not erase her scars, excuse what he did, or settle her divided feelings about either parent. It marks instead Marina's recovery of her own voice: she can choose when and to whom she speaks. The diary ends with a beginning rather than a complete resolution, as she moves from being defined by injury and withdrawal toward participating in relationships on her own terms.",
         "in_short": "Fourteen-year-old Marina has stopped speaking after an acid attack during her parents' conflict left her facially scarred and her father in prison. Following a long hospitalization, she is sent to boarding school, where an English assignment requires her to keep a diary. On the page she describes everything she will not say: her anger at her mother, her confused love and fear toward her father, her discomfort under other people's gaze, and the social life of the girls around her. The diary shows that Marina's silence is not emptiness but a defense. As teachers and classmates continue to include her without forcing her, she forms connections and begins to imagine an identity beyond the attack. She eventually visits her father in prison. By speaking to him at the end, Marina breaks her long silence. Her family remains damaged and her future is unresolved, but the choice signals that her voice belongs to her again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -247,7 +247,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -260,7 +260,7 @@
       "recaps": {
         "ending": "The attack on Montolio's grove costs Drizzt the first home he has had on the surface. The orcs are broken and the drow hunting party is driven back underground, but Montolio is killed in the fighting. Drizzt buries the old ranger, keeps Hooter and the grove's animals in mind as he goes, and holds to the ranger's code and the goddess Mielikki that Montolio gave him rather than sliding back into the hunter he was in the Underdark. Kellindil and the elves of the region, who watched what Drizzt actually did rather than what he was, no longer count him an enemy. Because no settled place will have him and because staying anywhere populated invites the next hunt, Drizzt goes north to Icewind Dale, a frozen frontier at the edge of the maps where people are judged mainly on whether they are useful in a fight. The ten towns there greet him with the usual fear, but the dwarf king Bruenor Battlehammer takes his own measure of him, speaks for him, and offers him a place in the dwarven valley beneath Kelvin's Cairn; Bruenor's adopted human daughter Catti-brie befriends him outright. Drizzt's exile ends not with the world's acceptance but with a handful of people willing to take him as he is.",
         "in_short": "Drizzt Do'Urden climbs out of the Underdark into a surface world that blinds him, and spends his first years there learning to live under a sky and watching human farms from a distance because he knows his face will terrify anyone who sees it. When the barghest Ulgulu slaughters a farming family he has been quietly watching, the drow tracks nearby make Drizzt the obvious culprit, and the bounty hunter Roddy McGristle takes up a pursuit that outlasts every fact against it. Drizzt destroys the real killers, cannot clear his name, and retreats into the mountains for years. There he finds Montolio DeBrouchee, an old blind ranger who takes him in, teaches him the surface world, names what he already is, and introduces him to the goddess Mielikki. It is the first home he has had. When a drow hunting party led by his brother comes up after him and the local orcs are turned loose on the grove, the attack is beaten off but Montolio is killed. Drizzt travels north to Icewind Dale, where the dwarf king Bruenor Battlehammer speaks for him and offers him a home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -534,7 +534,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B010BZ654S",
@@ -546,7 +546,7 @@
       "recaps": {
         "ending": "Omega Force learns that the raids were a diversion meant to empty Eshquaria's home system before an assault on Shorret-3. With official channels unavailable or suspect, the crew attacks alone. Phoenix destroys one warship and damages another, but loses its shields, propulsion, and maneuvering before crashing near the settlement's tether anchor. Lucky breaks into the compound, and Kage stops the winch intended to bring the orbital ore platform down on six million people. Jason, Crusher, and Kage are seriously wounded while holding the control room. Colleren and Bostco reach them and summon medical aid. The crew has interrupted the attack, but the platform's final safety, the remaining enemy force, Phoenix's condition, and the immediate status of Doc and Twingo are not confirmed. Kross's appearance at The Complex and the presence of ConFed-linked assets leave the conspiracy's leadership and accountability unresolved, as do Dowarty's fate and Corran's political crisis.",
         "in_short": "After rescuing Corranian senator Hallis Vongaard and his family, Omega Force accepts a covert Eshquarian contract to investigate increasingly organized attacks on shipping. Posing as smugglers, the crew of Phoenix works through Mr. Black and Dowarty into a mercenary network, prevents an attack on a colonist fleet, and follows an injured Dowarty to The Complex. There Jason spots Mr. Kross, the official who manages Colleston's staff, amid a professional base, apparent ConFed transport, and supporting warships. Kage's copied records reveal that the raids are a diversion for an attempt to destroy Shorret-3 with its own orbital ore platform. Omega Force attacks without trusted support. Phoenix is crippled and crashes, but Lucky breaches the tether compound and Kage stops its winch. Colleren and Bostco arrive after Jason, Crusher, and Kage are seriously injured. The attack is interrupted, while the platform's safety, several crew members' conditions, Phoenix's future, and the conspiracy's leadership remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -672,7 +672,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -685,7 +685,7 @@
       "recaps": {
         "ending": "Dex finally ends his engagement and goes to Rachel, choosing their relationship rather than proceeding with the wedding. Before Rachel and Dex can decide how to tell Darcy, Darcy arrives and confesses that she has also been unfaithful: she has been sleeping with Marcus and is pregnant by him. The disclosure initially seems to release Rachel from her guilt, but Darcy discovers that Dex is in Rachel's apartment and realizes the affair has involved her fiancé and her oldest friend. The confrontation ends Rachel and Darcy's friendship, and the wedding is canceled. Rachel and Dex remain together, now without secrecy but aware of the hurt surrounding their beginning. Darcy's plan to build a future with Marcus does not hold. Later, visibly pregnant and preparing to leave for London, she encounters Rachel. Their exchange is restrained rather than reconciliatory. Rachel closes the story having made a choice for herself, while accepting that gaining Dex has cost her the friendship that defined much of her earlier life.",
         "in_short": "At her thirtieth birthday, cautious lawyer Rachel White sleeps with Dex Thaler, the fiancé of her lifelong best friend Darcy Rhone. Rachel has loved Dex since law school but introduced him to Darcy and habitually yielded to her more forceful friend. What seems like one betrayal becomes a continuing affair after Dex admits that he shares Rachel's feelings. Through a summer of group weekends, Rachel and Dex meet secretly while Darcy plans the wedding and Rachel uses dates with Dex's friend Marcus as cover. Confidants Ethan and Hillary push Rachel to stop accepting indefinite promises, and she demands that Dex choose. He eventually leaves Darcy and comes to Rachel. Darcy then reveals that she has been sleeping with Marcus and is pregnant, only to discover Dex in Rachel's apartment and understand their affair. The wedding and the women's friendship end. Rachel and Dex stay together; Darcy's relationship with Marcus fails, and she prepares to leave for London without reconciling with Rachel.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -801,7 +801,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -814,7 +814,7 @@
       "recaps": {
         "ending": "Claire's long search ends at the community led by the pale-eyed young man from the start of the series, where her son Gabe has grown into a teenager, ignorant that his mother is the frail, prematurely aged woman who has arrived among them. Her age is the price she paid the Trademaster to complete her journey. Gabe comes to understand who she is and discovers that he possesses a rare gift of his own, the ability to send his mind into another person. He seeks out the Trademaster and confronts him directly. Rather than fighting with force, Gabe uses his gift to make the Trademaster confront his own name and the hollow, joyless nature of what he is, and this recognition destroys him. With the villain undone, the bargain that stole Claire's youth is broken and she is made whole and young again. Mother and son are reunited, and the quartet closes on the linked communities at peace, the long harm of the controlled society and the Trademaster's cruelty finally answered.",
         "in_short": "Claire is a fourteen-year-old Birthmother in the rigidly controlled community of the series' opening, who bears a son through a difficult surgery and is quietly reassigned to other work. Unnumbed to feeling, she becomes fixated on the boy, Gabe, and when the infant is spirited out of the community to save his life, she is separated from him by a disaster at sea. Washed ashore with no memory in a remote cliffbound village, she slowly recovers, and once she learns she is a mother searching for her child, she trains for years to climb out and follow him. To complete her journey she strikes a bargain with the sinister Trademaster, trading away her youth, and arrives aged and weakened at the welcoming settlement where Gabe, now a young man, has grown up under the wise Leader. Gabe discovers his own gift for entering others' minds, confronts Trademaster, and destroys him by forcing him to face his own emptiness. With the villain undone, the bargain is broken, Claire is restored, and mother and son are reunited at last.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -993,7 +993,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1006,7 +1006,7 @@
       "recaps": {
         "ending": "Liir survives the fall that opened the novel, is nursed back to health at the Cloister of Saint Glinda, and finally acts on his own account. He goes to Princess Nastoya, whose spell-held human shape is failing, and helps release her so that she dies as the Elephant she was, among her own people. He puts the birds to work carrying news across a country whose government rules by controlling what people are allowed to know. The identity of that government's head is settled: the Emperor Apostle, who governs Oz as a living saint, is Shell, the dead Witch's brother, the man Liir dealt with in Southstairs. Nor is still not found, though the evidence is that she got out of the prison alive; Trism, separated from Liir after they burned the dragon stables, is likewise unaccounted for. Liir returns to the farm where he left Candle and finds that she has given birth alone and put the baby out of reach of anyone hunting the Witch's line. The child is a girl, and she is green. The book never states outright that Elphaba was Liir's mother, but the daughter settles the question as far as the rest of Oz will care: the line continues, the Emperor of Oz is the child's great-uncle, and everything owed to and against the Witch's name now attaches to an infant. Liir ends the book with a family at last, and hunted for it.",
         "in_short": "About fifteen and nobody's acknowledged son, Liir leaves Kiamo Ko after the Witch's death carrying her cloak and her broom, with one errand: to find Nor, the girl taken from that household by Emerald City soldiers. The search takes him to the Emerald City, down into the prison of Southstairs, where he meets the Witch's brother Shell, and at last into the Emperor's own forces, which carry him south to take part in the destruction of a Quadling village. Drifting afterwards, he investigates a wave of killings in which the dead are found with their faces scraped away, calls a great conference of birds to map them, and traces them to a secret stable of war dragons. With the dragonmaster Trism, who has come to hate his own work, he burns the stables, and is brought down out of the sky in flight. Broken and nameless, he is nursed back by a silent Quadling girl called Candle at a rural cloister. Recovered, he frees the dying Elephant princess Nastoya from the spell holding her in human shape, learns that the Emperor Apostle now ruling Oz is Shell, and comes home to find that Candle has borne and hidden his daughter, a girl with green skin.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1196,7 +1196,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1209,7 +1209,7 @@
       "recaps": {
         "ending": "Milkman learns that his grandfather Jake was the son of the legendary flying man Solomon and Solomon's wife Ryna. Family names and events have survived in a children's song, giving him an ancestry richer than the property and grievances inherited from his father. He returns north too late to reconcile with Hagar, who has died after her desperate attempt to transform herself for him. Milkman tells Pilate that the bones she has carried for years are those of her father, and they take them to Virginia for burial. At Solomon's Leap, Guitar shoots Pilate, having mistaken Milkman's actions and continued to pursue the supposed gold. As Pilate dies, Milkman openly names his love for her. He then leaps toward Guitar, no longer governed by fear of death; the novel leaves the outcome of their final encounter unresolved.",
         "in_short": "Milkman Dead grows up wealthy but spiritually unmoored, caught between his property-driven father Macon, his isolated mother Ruth, and his unconventional aunt Pilate. Seeking independence, he follows Macon's story of buried gold and steals a sack from Pilate with his friend Guitar, only to find human bones. Milkman then travels alone through Pennsylvania and Virginia. The failed treasure hunt becomes a search for family origins: by listening to local people and a children's song, he learns that his grandfather Jake descended from Solomon, an enslaved man said to have flown back to Africa. Meanwhile Hagar, whom Milkman discarded, dies after failing to remake herself for his love. Milkman returns transformed, helps Pilate bury Jake's bones, and watches Guitar fatally shoot her. Having accepted love, ancestry, and mortality, he leaps toward Guitar in an ambiguous final act.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1375,7 +1375,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1388,7 +1388,7 @@
       "recaps": {
         "ending": "Mrs Morel develops cancer and declines through prolonged pain. Paul and Annie, believing that recovery is impossible and unable to bear her suffering, give her an overdose of morphine, and she dies. Walter Morel survives her, diminished and largely outside the emotional center of the family. Paul is overwhelmed by grief because his mother's love had structured his choices and prevented him from giving himself fully to either Miriam or Clara. Clara has already returned to Baxter Dawes after Paul helped the estranged couple move toward reconciliation. Miriam offers Paul the possibility of marriage, but he refuses, knowing that he cannot offer the wholehearted bond she wants. Left alone, he briefly feels drawn toward death and reunion with his mother. Instead, seeing the lights of the town, he rejects that pull and walks toward the city. His future remains uncertain, but his final movement is toward continued life rather than self-destruction.",
         "in_short": "Gertrude Morel's disappointing marriage to the miner Walter Morel leads her to invest her deepest hopes in her sons. Her gifted eldest, William, escapes to London but dies young. Her second son Paul becomes an artist and forms an intense bond with her that shapes his adult relationships. He loves the spiritual, demanding Miriam Leivers but resists the total surrender she wants and his mother resents. He later begins a passionate affair with Clara Dawes, yet that relationship also fails to become a complete partnership. After conflict with Clara's estranged husband Baxter, Paul eventually helps the couple reconcile. Mrs Morel dies of cancer after Paul and his sister give her morphine to end her suffering. Grief leaves Paul almost without purpose. He refuses Miriam's final offer of marriage and feels the attraction of death, but ultimately turns toward the lights of the city and chooses to go on living.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1573,7 +1573,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1586,7 +1586,7 @@
       "recaps": {
         "ending": "Nathan returns in a paranoid rage and threatens both Sophie and Stingo. Warned by Larry that Nathan has obtained a gun, Stingo takes Sophie away from Brooklyn and plans a future with her in Virginia. During their flight Sophie finally tells him what happened when she arrived at Auschwitz: an SS doctor forced her to choose which of her two children would be killed immediately, and in panic she surrendered Eva while trying to save Jan. She and Stingo spend the night together, but her trauma and attachment to Nathan keep her from accepting the new life Stingo offers. She leaves Stingo while he sleeps and returns to Nathan at the Pink Palace. Stingo follows and finds Sophie and Nathan dead together after taking cyanide. He keeps vigil over them, then walks into Brooklyn at dawn. The older narrator presents the loss as the defining wound of his youth: he survives to become a writer, but cannot rescue Sophie from the burdens that she and Nathan carried toward their joint death.",
         "in_short": "In 1947, a young Southern writer who calls himself Stingo moves into a Brooklyn boarding house and befriends Sophie Zawistowska, a Polish Catholic survivor of Auschwitz, and her magnetic lover Nathan Landau. Their friendship alternates between joyful companionship and crises caused by Nathan's jealousy and delusions. As Sophie tells Stingo about occupied Poland and the camp, her versions of the past give way to harsher truths about her family, imprisonment, and failed attempt to save her son. Nathan's brother reveals that Nathan is seriously mentally ill and has misrepresented his scientific career. After Nathan threatens them, Stingo flees with Sophie and proposes a life in Virginia. Sophie finally reveals that on arrival at Auschwitz she was forced to choose which child would die and gave up her daughter Eva in a desperate effort to save her son Jan, who also disappeared in the camp. She spends a night with Stingo but returns to Nathan. Stingo finds the couple dead by cyanide, leaving him to carry their story into his later life as a writer.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1738,7 +1738,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1751,7 +1751,7 @@
       "recaps": {
         "ending": "During Sophie's garden party, Alberto announces that their world is a story controlled by Albert Knag and uses the surrounding chaos to escape with Sophie from the narrative he has written. They continue to exist outside its ordinary action, but as insubstantial figures whom Hilde and her father cannot see. Hilde, meanwhile, arranges a series of messages and delays during Albert's journey home so that he experiences a small version of the manipulation he imposed on Sophie and Alberto. Father and daughter reunite at Bjerkely and discuss the manuscript, philosophy, and humanity's place in the universe. Sophie and Alberto reach Bjerkely and listen as Albert explains the Big Bang and the shared material origin of everything. Sophie tries to make her presence known and manages to disturb a rowboat. Hilde notices the unexplained movement, leaving a faint possibility that the supposedly fictional pair can still affect her world even though direct communication remains beyond them.",
         "in_short": "Norwegian teenager Sophie Amundsen begins receiving anonymous lessons that guide her from ancient Greek thought through the major movements of Western philosophy. Her teacher, Alberto Knox, also helps her investigate postcards sent by UN major Albert Knag to his daughter Hilde but mysteriously routed through Sophie's life. The lessons increasingly demonstrate that Sophie's surroundings can be altered by an unseen author. Halfway through the book, Hilde receives a birthday manuscript entitled Sophie's World and reads the story Sophie has been living, revealing Sophie and Alberto as creations of Hilde's father. Alberto teaches Sophie to recognize their constructed reality while seeking a way beyond his control. They escape the manuscript during a chaotic garden party but become invisible, spiritlike presences in Hilde's world. Hilde answers her father's manipulation with an elaborate airport prank before welcoming him home. As father and daughter discuss the universe at Bjerkely, Sophie and Alberto arrive unseen; a mysteriously moved boat hints that their reality still touches Hilde's.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1954,7 +1954,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1967,7 +1967,7 @@
       "recaps": {
         "ending": "Death comes back. His attempt to forget fails, because forgetting is the one thing he cannot do, and he returns to find his granddaughter standing between the music and the boy it intends to use up. The Music With Rocks In has arranged Buddy's death to complete him as a legend, and Susan cannot hold it off alone. Death confronts the music directly, drives it out of the guitar and out of the world, and then does what he did once before for the sake of someone he cared about: he reaches back and puts the accident right, so that Imp y Celyn lives. The music leaves the Disc and goes looking for somewhere else, leaving only echoes behind, and the guitar is destroyed. Imp survives with his life ahead of him and goes home to Llamedos; Glod and Cliff come out of it intact and better off than they started; Dibbler, having sold everything a fashion could be printed on, moves on to his next enterprise. Death takes back the Duty and, as a kindness, removes Susan's memory of Buddy and of the whole affair, returning her to school and to an ordinary life. The kindness is imperfect: she is still who she is, she still cannot always be seen when she does not wish to be, and traces of what happened remain.",
         "in_short": "When Susan Sto Helit's parents are killed in a coach accident, Death, who is her grandfather, cannot bear it and abandons his duty to go away and try to forget. Susan, sixteen and rigorously sensible, is fetched from boarding school by Albert and the Death of Rats and made to take up the Duty in his place. At the same time a young harpist from Llamedos, Imp y Celyn, arrives in Ankh-Morpork, is refused a licence by the Guild of Musicians, and buys an ancient guitar from a shop that is not there the next day. The guitar carries the Music With Rocks In, a force older than the Disc that uses musicians and discards them. With the dwarf Glod and the troll Cliff, Imp becomes Buddy of the Band With Rocks In; the music sweeps the city, infects the wizards, and makes Cut-Me-Own-Throat Dibbler rich. Susan discovers that Buddy should already be dead and that the music is keeping him alive for its own ends, and repeatedly intervenes. At the climax Death returns, drives the music out of the world, and restores Imp's life, then takes Susan's memory of it and sends her back to school.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2106,7 +2106,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2117,7 +2117,7 @@
       "recaps": {
         "ending": "Soulsmith ends with Lindon and Yerin securely attached to Eithan Arelius and his family, having survived the contest over the Transcendent Ruins. Lindon emerges stronger, with new gains and a real trade in soulsmithing to complement his slowly growing Path, though he remains far weaker than the powers now around him. His rivalry with Jai Long, the masked Sandviper-allied spear artist, has hardened into a lasting enmity that is left unsettled, promising future conflict. In Eithan the pair have found a powerful, unpredictable patron who sees more in Lindon than anyone else and who intends to guide his growth for reasons of his own. As the book closes, Lindon and Yerin stand ready to move deeper into the powerful realm beyond the frontier under Eithan's wing, their sights set on challenges and strength far beyond anything the Desolate Wilds could offer.",
         "in_short": "Now in the wider world, Lindon and Yerin discover how far behind Sacred Valley truly was and search the rough frontier of the Desolate Wilds for strength and a place to belong. Lindon apprentices under the demanding old soulsmith Fisher Gesha, learning to craft constructs from the remnants of dead sacred artists and turning study into a real trade. The two are drawn into the orbit of Eithan Arelius, the eccentric, startlingly powerful head of the Arelius family, who sees rare potential in Lindon. They also make an enemy of Jai Long, a masked young spear artist driven by ambition and by concern for his ailing sister, Jai Chen. When the treasure-filled Transcendent Ruins open, the region's factions race to claim them, and Lindon joins the dangerous contest to gain the power he needs. The book ends with Lindon and Yerin coming through the struggle strengthened and firmly established under Eithan's patronage, their rivalry with Jai Long unresolved and their ambitions aimed higher.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2248,7 +2248,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2259,7 +2259,7 @@
       "recaps": {
         "ending": "Sourcery ends with the world pulled back from destruction at Rincewind's expense. The unchecked use of sourcery had worn the walls of reality thin enough for the Things from the Dungeon Dimensions to begin breaking through. Coin, the boy sourcerer, at last recognizes that the staff he carries holds the will of his dead father Ipslore and has been driving everything he has done; he frees himself by destroying it. To stop the invading creatures, Rincewind steps through into the Dungeon Dimensions to fight a holding action, armed with a half-brick in a sock, buying the time needed to seal the breach. Unseen University and the Disc are saved, and the flood of high magic recedes. Coin, whose power makes him too dangerous to remain among ordinary people, uses it one last time to create a separate world for himself and departs. Rincewind, however, is left behind, stranded in the Dungeon Dimensions beyond the edge of reality; he is alive but cut off from the world, and his return is left for a later book, while the Luggage sets off to look for him.",
         "in_short": "Rincewind, the Disc's most useless wizard, is swept up when sourcery returns to the world. The dying wizard Ipslore binds his vengeful will into a staff and gives it to his infant son Coin, a sourcerer whose raw magic outclasses ordinary wizardry. Grown, Coin takes over Unseen University and, driven by his father, incites the wizards to abandon restraint, raise war, and remake the world, which thins reality and invites the predatory Things from the Dungeon Dimensions. Rincewind, entrusted with the sentient Archchancellor's hat, flees with Cohen the Barbarian's warrior daughter Conina, the would-be hero Nijel, the wealthy Seriph Creosote, and the Luggage. As catastrophe nears, Coin realizes his staff has been controlling him and destroys it, breaking free of Ipslore. Rincewind holds off the invading creatures by walking into the Dungeon Dimensions himself. The world is saved, Coin leaves to build a private world of his own, and Rincewind is left trapped outside reality, his rescue still to come.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2434,7 +2434,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2447,7 +2447,7 @@
       "recaps": {
         "ending": "Ender ends his long wandering by making a home and a peace. On Lusitania he uncovers every hidden truth: the pequeninos killed Pipo and Libo not in cruelty but in a fatal misunderstanding, believing they were granting the humans the honored third life in which a pequenino male becomes a sentient tree. He learns that the deadly Descolada virus is inseparable from all life on the planet, and that Novinha's six children were all fathered by Libo, the man she loved but married another to protect. When Starways Congress, alarmed by illegal human contact with the natives, orders arrests and prepares to shut the colony down, Jane, the secret network intelligence bonded to Ender, severs the faster-than-light connections to save Lusitania, risking exposure and her own life. Miro is left crippled reaching the pequeninos across the colony's lethal fence. Ender meets the pequenino wives, the matriarchs who rule the tribe, and negotiates a treaty giving the natives standing and honest partnership. He lets the pequenino Human pass into the third life by consent, so that Human becomes a father-tree, and he plants the cocoon of the last hive queen in the Lusitanian forest, granting her destroyed people a chance at rebirth. The colony rises in rebellion against Congress to protect all three intelligent species, and Ender, no longer the guilt-haunted traveler, marries Novinha and stays, his old crime beginning at last to be answered by the lives he has helped preserve.",
         "in_short": "Three thousand years after he unknowingly destroyed an alien species as a child, Ender Wiggin travels the human worlds as a Speaker for the Dead, secretly carrying the last hive queen's cocoon and accompanied by Jane, a hidden intelligence born in the computer networks. A summons draws him to Lusitania, a Catholic colony where humans study the pequeninos, small forest aliens who have twice killed their human researchers in a way no one understands. Ender comes to speak the death of a violent man, Marcao, and is drawn into the secrets of the grieving Ribeira family and its guarded matriarch, Novinha. He discovers that the pequeninos kill by planting the dead as sentient trees, a transformation they wrongly believed they were granting the humans; that Novinha's children were all secretly fathered by the man she loved but refused to marry; and that a pervasive virus, the Descolada, underlies all native life. When Starways Congress moves to crush the colony, Jane sabotages interstellar communications to protect it, Ender negotiates a treaty with the pequeninos, plants a hive queen to revive her species, and settles on Lusitania, marrying Novinha, as the world rebels to shelter three kinds of intelligent life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2587,7 +2587,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2600,7 +2600,7 @@
       "recaps": {
         "ending": "The attack on Diego pushes Tally into open revolt against the organization that built her. She goes back to her own city after Dr. Cable, and her answer is not to kill her but to force the cure on her, taking away the mind that gave the orders. The cure spreads, the operations stop, and city after city is left with a population able to think clearly and no institution designed to cope with that. Zane is dead, killed by the damage the half-cure did to his brain. Maddy and the people of the New Smoke are absorbed into the new arrangements, and Shay takes her place inside the changed system. Tally refuses it. She keeps her Special body and her Special senses deliberately, and she and David walk out into the wild together as its self-appointed guardians, leaving behind a plain warning that they will be watching and that the freed cities will not be allowed to strip the world the way the Rusties did. The trilogy closes with the old order gone, the future undecided, and Tally standing outside both by choice.",
         "in_short": "Tally is now a Special, one of the Cutters that Shay leads for Dr. Cable, keeping her mind cold and clear through pain. When Zane, still a pretty and damaged by the half-cure he took, plans to escape the city with the Crims, Special Circumstances lets it happen so that he can be followed to the New Smoke. The plan collapses, and Tally ends up running with Zane to Diego, a city that has taken the cure and lets people look and think as they please. There Zane's injured brain fails and he dies, and Tally's own city attacks Diego outright, bombing a place that had forgotten what war was. Tally turns on her makers, hunts down Dr. Cable and forces the cure on her rather than killing her. The operations end, the cure spreads, and the cities wake up. Rather than join the new order, Tally and David keep their Special bodies and go into the wild as its self-appointed guardians, warning the freed world not to repeat what the Rusties did.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2955,7 +2955,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B06W5861HP",
@@ -2967,7 +2967,7 @@
       "recaps": {
         "ending": "The Flying Dutchman returns all seventy people to Earth after eliminating the Thuranin-Kristang survey mission. The surveyor, its destroyer escort, and both support tankers are destroyed, and Skippy replaces their recorder data with evidence of a Jeraptha attack. He shuts the ancient wormhole after the Dutchman passes through, but an old outbound trace of unknown origin shows that Earth cannot be considered completely isolated. Bishop remains in command and reports to General Huang with Chang, Simms, Desai, Adams, Giraud, Williams, Smythe, and the rest of the military and scientific crew ready for debrief. Skippy also remains with the humans. The Elder AI recovered on Newark is dead, and its communications node cannot reach the Collective. Their failure dates to the same ancient period as Newark's forced orbital displacement and the destruction of another Elder site. Skippy and the crew therefore postpone contact with the Collective while they investigate the unidentified power and the gaps in Skippy's history. The rebuilt and substantially altered Dutchman is operational, but it still depends on Skippy for critical capabilities.",
         "in_short": "Joe Bishop commands the Flying Dutchman on a search for an Elder communications node that might connect Skippy with the Collective. After several failed searches, an escape from Thuranin destroyers cripples the ship and forces all seventy humans into hiding on Newark while Skippy rebuilds it. The crew discovers that an unknown Elder-level power displaced Newark millions of years ago, destroying its native civilization. A Kristang scavenger camp holds a communications node and another Elder AI, so a multinational raid secures both, but the AI is dead and the node is unusable. The rebuilt Dutchman then learns that a Thuranin surveyor is headed for Earth. Bishop's crew destroys the surveyor, its destroyer escort, and both support tankers, altering their recorder drones to blame the Jeraptha. Everyone returns to Earth, but Skippy stays to investigate the ancient destruction, and Bishop warns UNEF that closing Earth's wormhole does not end the danger.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3141,7 +3141,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3154,7 +3154,7 @@
       "recaps": {
         "ending": "Dimitri is restored to life by a spirit-charmed stake and brought back to the Royal Court, where he is imprisoned while the Moroi argue about whether a former Strigoi can ever be trusted. He does not argue in his own defence. He remembers everything he did while he was Strigoi, including what he did to Rose, and he has decided he is owed nothing. When Rose finally reaches him he tells her plainly that whatever he felt for her is gone and will not come back, and refuses to see her again. Meanwhile Queen Tatiana forces through the law lowering the age of guardian service to sixteen, and Rose confronts her about it publicly and furiously in front of witnesses. Days later Tatiana is found dead in her rooms, killed with a silver stake. The evidence lines up against Rose: her public clash with the queen, a witness placing her nearby, and a murder weapon traced back to her. She is arrested at Court and charged with assassinating the queen, a capital crime, with her friends locked outside the process and no obvious way to prove where the stake came from.",
         "in_short": "Rose finishes her final trials and graduates from St. Vladimir's while living under Dimitri's written promise that he will come for her. Told that a Strigoi was once restored to life, she traces the story to Robert Doru, a spirit user who can only be reached through his half-brother Victor Dashkov, so Rose, Lissa, Christian, Eddie and Adrian break Victor out of a Moroi prison. Robert explains the method: a silver stake charmed with spirit, driven into a Strigoi's heart by a spirit user strong enough to hold the magic. Before they can plan anything, Dimitri and a group of Strigoi ambush them and take Rose and Lissa. In the confrontation that follows, Lissa uses the charmed stake on Dimitri, and he is restored to life as a dhampir who remembers everything he did. Back at Court he is imprisoned, refuses to defend himself, and tells Rose that his love for her is gone. Queen Tatiana passes a law sending novices into service at sixteen and Rose confronts her publicly over it. Shortly afterwards the queen is found murdered with a silver stake, the evidence points squarely at Rose, and Rose is arrested for the assassination.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3284,7 +3284,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3297,7 +3297,7 @@
       "recaps": {
         "ending": "Sumire vanishes from the Greek island after trying to become physically intimate with Miu and after learning about the experience that divided Miu's sense of self years earlier. The narrator searches the island but finds no physical trace, only Sumire's writings and a night of uncanny music and altered perception. He returns to Japan alone. His encounter with Carrot, a pupil who appears to have seen an inaccessible second version of himself on security footage, echoes the possibility that people can be divided between parallel states. The narrator ends his affair with Carrot's mother and accepts the depth of his solitude. Then Sumire calls him at night. Her voice says she has come back from wherever she disappeared to and asks him to collect her from a phone booth. The book ends before a reunion occurs, leaving her exact location and the reality of the call unresolved while changing absence into a sudden possibility of return.",
         "in_short": "An unnamed Tokyo teacher loves his closest friend Sumire, an aspiring novelist who instead falls passionately for the older businesswoman Miu. Sumire becomes Miu's assistant and travels with her to Europe, then vanishes from a small Greek island. Called there by Miu, the narrator learns that Miu was psychologically divided by a terrifying event years earlier and has since felt separated from part of herself. Sumire's writings suggest that she is searching for a passage between such divided worlds. The narrator finds no trace of her and returns to Japan, where a troubled pupil's strange experience reinforces the image of inaccessible double selves. After he accepts that Sumire may remain lost, she telephones unexpectedly, claiming to have returned and asking him to come for her. The novel stops before they meet, preserving uncertainty over whether her return is physical, imagined, or from another plane of reality.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3439,7 +3439,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3452,7 +3452,7 @@
       "recaps": {
         "ending": "Atticus reaches the ancient vampire Theophilus and kills him, breaking the leadership that coordinated the campaign against the Druids. The victory costs lives and does not make every surviving vampire an ally, but it ends Theophilus's direct control and leaves the vampire world to reorganize after the destruction. Granuaile survives her separate journey with Orlaith and succeeds in escaping the magical mark that allowed Loki to reach her, although Loki himself remains free and Ragnarok remains imminent. Owen commits to a future for Druidry by establishing a new grove and beginning the work of training candidates suited to the modern world. The three Druids complete their immediate goals on separate fronts, yet their successes only clear the way for the final crisis: the vampire ruler is gone and Loki's hold on Granuaile is broken, but the trickster's apocalyptic plan has advanced beyond a private feud.",
         "in_short": "Atticus, Granuaile, and Owen pursue separate goals. Atticus launches a campaign against the ancient vampire hierarchy led by Theophilus, relying on Oberon, Leif Helgarson, and uneasy alliances inside the vampire world. He survives the counterattacks, reaches Theophilus, and kills him, disrupting the organization that had repeatedly targeted the Druids. Granuaile travels with Orlaith in search of magic capable of removing Loki's mark, facing dangerous Slavic powers before she succeeds in escaping the trickster's direct hold. Owen, unwilling to let Druidry die with three survivors, adapts to modern life and starts assembling a new grove to train future Druids. Each narrator wins the immediate struggle: the vampire ruler falls, Granuaile is freed from the mark, and Owen gives the tradition a future. Loki nevertheless remains at large, and the movement toward Ragnarok becomes the unresolved threat binding the three stories together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3637,7 +3637,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3650,7 +3650,7 @@
       "recaps": {
         "ending": "The race for the Katana fleet ends with a costly partial victory for the New Republic. Han and Lando locate Garm Bel Iblis and bring his private force into the battle; afterward he agrees to reconcile with Mon Mothma and join the Republic. Ackbar is cleared as the Imperial effort to frame him unravels. Luke and Mara escape C'baoth's control on Jomark, though the dark Jedi remains with Thrawn and still intends to claim Leia's children. Leia's work on Honoghr persuades the Noghri clans to begin a secret turn against the Empire while maintaining the appearance of obedience. Karrde commits his intelligence network to opposing Thrawn. The Republic secures only a small fraction of the Katana dreadnaughts. Thrawn takes the great majority and reveals that he can crew them with rapidly produced clones, converting the legendary fleet into the foundation of a much larger Imperial offensive. The heroes have gained allies and exposed several deceptions, but the military balance shifts sharply toward Thrawn.",
         "in_short": "Thrawn hunts the lost Katana fleet while undermining the New Republic from within. Forged evidence removes Admiral Ackbar and strengthens Borsk Fey'lya, sending Han and Lando to investigate; their search uncovers Garm Bel Iblis, a Rebel founder leading a private war against the Empire. Leia returns to Honoghr and convinces the Noghri clans that the Empire has deliberately kept their world dependent, beginning their secret defection. Luke goes to Jomark for training under Joruus C'baoth but finds a would-be master obsessed with control. Mara helps free Luke after Thrawn seizes Karrde, and Karrde rallies smugglers to share intelligence. Both sides race to the Katana dreadnaughts. Bel Iblis joins the fight and later agrees to enter the New Republic, while Ackbar is exonerated. The Republic captures only a few ships; Thrawn claims most of the fleet and crews it with clones produced at the Emperor's Wayland complex, giving the Empire the strength for a major offensive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3849,7 +3849,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3862,7 +3862,7 @@
       "recaps": {
         "ending": "Thrawn attacks the shipyards at Sluis Van, using stolen mole miners to seize New Republic warships from within. Lando remotely overrides the machines and makes the threatened ships unusable, denying Thrawn the fleet he intended to capture, although the raid still inflicts serious losses. The Grand Admiral withdraws with his larger campaign intact and continues relying on C'baoth despite the dark Jedi's growing insistence on possessing Luke, Leia, and the twins. On Honoghr, Leia has learned that the Empire has prolonged the planet's devastation to keep the Noghri dependent, and Khabarakh secretly agrees to help her return. Luke escapes Myrkr with Mara after learning that she once served as the Emperor's Hand and has been driven by his dying command to kill him. Karrde survives Imperial retaliation and edges toward cooperation with the New Republic. The Republic wins the immediate battle, but Thrawn remains in command, the identity of his source inside the government is unknown, and the struggle for the Noghri and C'baoth is unresolved.",
         "in_short": "Five years after Endor, Grand Admiral Thrawn reunites Imperial forces and recruits the unstable Force-user Joruus C'baoth, offering him Luke, Leia, and Leia's unborn twins. Thrawn obtains creatures called ysalamiri that suppress the Force, raids Lando's Nkllon operation, and uses Noghri commandos against Leia. Smuggler chief Talon Karrde rescues Luke's disabled X-wing but holds him, while Karrde's lieutenant Mara Jade reveals a consuming wish to kill Luke. Forced to flee together across Myrkr, Luke and Mara survive Imperial pursuit; she eventually explains that she was the Emperor's secret agent and still hears his final command to kill Luke. Leia travels to devastated Honoghr and discovers that the Empire has kept the Noghri world poisoned to preserve their service. She begins a covert alliance with Khabarakh. Thrawn's attempt to steal warships at Sluis Van is thwarted when Lando disables the infiltrating machines, but the Grand Admiral escapes, C'baoth remains dangerous, and the New Republic still has a leak at its highest levels.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/star-wars-the-last-command-the-thrawn-trilogy-book-3.json
+++ b/data/works-community/0/star-wars-the-last-command-the-thrawn-trilogy-book-3.json
@@ -130,7 +130,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -143,7 +143,7 @@
       "recaps": {
         "ending": "The New Republic finds Mount Tantiss as Thrawn's forces close a trap at Bilbringi. Luke, Mara, Han, Leia, and their allies enter the Wayland complex to destroy the cloning center and rescue the twins from C'baoth. The dark Jedi confronts them with Luuke Skywalker, a clone grown from Luke's severed hand. Mara kills the clone, satisfying the literal target of the Emperor's command, and then kills C'baoth; the compulsion that has governed her life ends. The cloning complex is destroyed. At Bilbringi, Karrde's smugglers warn the Republic fleet and turn Thrawn's trap into a contested battle. Rukh then kills Thrawn in revenge for the Empire's poisoning of Honoghr. With the Grand Admiral dead, Pellaeon orders the Imperial fleet to retreat. The New Republic survives the campaign, the Noghri are free of Imperial service, and the Empire loses both its strategist and its supply of rapidly grown forces. Luke gives Mara his former lightsaber, marking her release from the Emperor and the beginning of a different path.",
         "in_short": "Thrawn attacks with the Katana fleet and clones from Mount Tantiss, using cloaked asteroids to blockade Coruscant while his hidden source continues leaking New Republic secrets. Han, Leia, Luke, Mara, and Karrde's smugglers trace the offensive to Wayland and expose the surveillance system inside the Imperial Palace. The Noghri quietly protect Leia's newborn twins and prepare to abandon the Empire. Thrawn sets a trap for the Republic at Bilbringi, but Karrde's network supplies warning. At Mount Tantiss, C'baoth takes the twins and confronts the rescue party with a clone made from Luke's severed hand. Mara kills this Luuke Skywalker, fulfilling the Emperor's command without killing Luke, and then defeats C'baoth as the cloning complex is destroyed. During the Bilbringi battle, Rukh kills Thrawn in revenge for the Empire's poisoning of Honoghr, and Pellaeon retreats. The Republic survives, the clone program ends, the Noghri are freed, and Luke gives Mara his old lightsaber as she begins a life no longer controlled by the Emperor.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -330,7 +330,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -343,7 +343,7 @@
       "recaps": {
         "ending": "Tristran returns to Wall with Yvaine but does not force Victoria to keep her bargain. Victoria admits that she is engaged to Robert Monday, and Tristran releases her from her promise on the condition that she marry the man she loves. He finally recognizes that he and Yvaine love one another. Una, freed from slavery, reveals that she is Tristran's mother and the daughter of the late Lord of Stormhold. Because all seven princes are dead and Yvaine carries the topaz, Tristran is the rightful heir. He and Yvaine are married and eventually rule Stormhold together. They travel widely before assuming the throne, and Tristran becomes a respected ruler. He ages and dies after a long reign, while Yvaine, as a star, does not age. She continues to rule alone and looks to the night sky, unable to return to it because her heart remains with Tristran.",
         "in_short": "Tristran Thorn leaves the village of Wall to retrieve a fallen star for Victoria Forester, only to discover that the star is a living woman named Yvaine. She is also hunted by the witch-queen, who wants her heart to restore her youth, and by the princes of Stormhold, who need the topaz that knocked her from the sky. During their journey Tristran grows capable and compassionate, and his uneasy bond with Yvaine becomes love. The witch's power is spent, the rival princes die, and Tristran returns to Wall without compelling Victoria to honor her bargain. His enslaved mother, Una, is revealed as Stormhold's princess, making him the realm's surviving heir. Tristran and Yvaine marry, travel, and eventually rule Stormhold. Tristran dies after a long life; the immortal Yvaine remains as queen, keeping watch beneath the stars.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -636,7 +636,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DLLJL1XH",
@@ -648,7 +648,7 @@
       "recaps": {
         "ending": "Goliath is destroyed after Jason's decoy fast-attack ship detonates four concealed antimatter warheads and the Dominion exploits the resulting breach. The Phoenix then disables the fleeing courier, allowing Crusher and Lucky to rescue the Starfall creator and house heir and capture the senior enemy operator. Military investigators take custody of that operator, while evidence of unauthorized human involvement heads toward Earth. Jason brings the creator to a retired alien scholar, whose account of a civilization ruined by dangerous technology persuades the scientist to reconsider the cost of his work. Omega Force remains together aboard the Phoenix, and Jason decides its work still matters. The larger threat remains active: the Synod retains Starfall data, intends to conquer the quadrant, and threatens Earth. Its human leader orders an attempt to abduct Admiral Webb, seize the Hialti-system evidence, and exchange the admiral for the captive operator. The archive's final containment is unstated, and three alleged completed Starfall weapons remain unverified and unlocated.",
         "in_short": "Omega Force rescues a wealthy-house researcher pursued over Starfall, an energy project whose altered design can mimic a stellar catastrophe. The investigation exposes secret weapon research, rival Dominion pursuit, and a human-linked organization using current Earth-derived ships and recruits. Jason's crew recovers the full technical package, learns that Starfall is meant to power Goliath, a jump-capable mobile fortress, and finds that the organization has abducted the project's creator and the house heir. Jason stages a false exchange, hides antimatter warheads aboard the offered ship, and draws a Dominion fleet into the confrontation. The blast cripples Goliath, and the Dominion destroys it. Omega Force rescues both detainees and captures a senior enemy operator. The creator accepts responsibility after studying an earlier technological catastrophe, and Jason recommits to Omega Force. Yet the Synod retains Starfall data, threatens Earth, and targets Admiral Webb and the evidence linking unauthorized human forces to Goliath.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -839,7 +839,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -852,7 +852,7 @@
       "recaps": {
         "ending": "Drizzt is freed from House Baenre before the planned sacrifice can be completed, and the rescue turns into a running fight through Menzoberranzan. Dantrag Baenre dies in combat with Drizzt, while Jarlaxle and Artemis Entreri follow their own interests rather than allowing the priestesses complete control of the escape. Catti-brie, Drizzt and Guenhwyvar reach the routes out of the city; Entreri also gets away from the drow who had kept him in the Underdark, leaving his rivalry with Drizzt unresolved. Drizzt and Catti-brie return to the surface together, each having rejected his attempt to protect her by disappearing alone. Their shared grief for Wulfgar remains, but it no longer requires them to deny the bond growing between them. Strategically, the mission does not stop the danger Drizzt feared: Matron Baenre survives the disruption and retains the Spider Queen's support for war. The companions now know that Menzoberranzan is preparing a major assault on Mithral Hall, and Drizzt's journey home becomes a race to warn Bruenor and organize a defense.",
         "in_short": "After Wulfgar's apparent death, Drizzt decides that remaining in Mithral Hall only draws drow danger toward his friends. He leaves alone for Menzoberranzan to discover and disrupt the city's plans, but Catti-brie follows with Guenhwyvar. Drizzt passes through Blingdenstone and reconnects with Belwar before entering a city dominated by Matron Baenre, whose rivals and mercenaries all pursue their own interests. Artemis Entreri is there as an unwilling guest of the drow, still obsessed with Drizzt, while Jarlaxle treats every faction as a possible bargain. Drizzt is captured for sacrifice, but Catti-brie and Guenhwyvar help break House Baenre's control. Dantrag Baenre is killed during the escape, and Entreri also wins his way out. Drizzt and Catti-brie return to the surface together, more honest about their attachment but still grieving Wulfgar. They have not prevented the coming war: Matron Baenre remains in power and Menzoberranzan is committed to a large invasion of Mithral Hall.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1064,7 +1064,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1077,7 +1077,7 @@
       "recaps": {
         "ending": "The collection closes with Something Old, Something New, set roughly two years after the events of Winter. Scarlet and Wolf marry at the Benoit farm in France, and the wedding brings the whole cast together for the first time since the revolution: Cress and Thorne arrive in the Rampion, Winter and Jacin come down from Luna, Iko is present in a body of her own, and Cinder and Kai attend as the leaders of two worlds still working out how to be neighbours. Luna is being rebuilt under an elected government rather than a crown, the plague is treatable, and the freed shells are being returned to lives of their own. The story is an epilogue rather than a plot: it settles where each couple has landed, gives Cinder and Kai's relationship its resolution, and lets the series end on the ordinary business of a farmhouse wedding rather than on a throne room.",
         "in_short": "Nine short stories set around the Lunar Chronicles. Michelle Benoit takes in a burned Lunar toddler and hides her on her farm; an eleven-year-old Cinder arrives in New Beijing as a new cyborg and gets an android friend; a twelve-year-old Ze'ev Kesley is taken for Levana's army and made into a wolf soldier; a thirteen-year-old Carswell Thorne runs a school scheme to impress a girl; a small Lunar shell called Crescent Moon is installed alone in an orbiting satellite; the princess Winter decides as a girl never to use her Lunar gift and scars her own face rather than be valued for it; a self-aware android in New Beijing loves a mechanic and gives up everything to become human, in a retelling of The Little Mermaid; and Prince Kai takes a broken android to a market mechanic, retelling the series' first meeting from his side. The collection closes two years after the end of the series with Scarlet and Wolf's wedding on the French farm, which reunites the entire cast.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1235,7 +1235,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1248,7 +1248,7 @@
       "recaps": {
         "ending": "After completing the classroom portion of Officer Candidates School, Rico serves as a probationary officer in combat and learns that command means accepting responsibility for other soldiers' lives. He returns to finish the course and receives his commission. The war continues, now focused on bringing the Arachnids to a decisive defeat rather than merely surviving their attacks. Rico reunites with his father, whose own loss and military service have carried him into the Mobile Infantry and the rank of sergeant. Rico then takes command of the platoon once known as Rasczak's Roughnecks. The novel closes as his unit prepares for another combat drop. He is no longer the unformed young man who enlisted because his friends did: he has chosen the Mobile Infantry as his profession and accepted both its fellowship and its obligations.",
         "in_short": "Juan Rico enlists in Federal Service with his friends Carl and Carmen, despite his father's opposition, and is assigned to the Mobile Infantry. Sergeant Zim's severe basic training teaches him that military skill is inseparable from discipline and personal responsibility. When war with the Arachnids destroys Buenos Aires, Rico loses his mother, sees his father enlist, and moves from peacetime recruit to combat soldier. Service in Rasczak's Roughnecks gives him a military family, but the death of Lieutenant Rasczak pushes him toward command. At Officer Candidates School, demanding study and a probationary combat assignment force him to understand the moral weight of giving orders. Rico earns a commission, reunites with his father as a fellow Mobile Infantryman, and ends the book leading the Roughnecks into another drop as humanity's war continues.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1442,7 +1442,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1455,7 +1455,7 @@
       "recaps": {
         "ending": "Winzik's department draws a delver to Starsight and makes no serious attempt to stop it, intending the destruction as a demonstration of the threat only he can manage. With evacuation impossible for most of the platform's millions, Spensa flies out to meet the delver and uses her cytonic ability to make contact rather than to fight. She finds that a delver is not a weapon but something vast and profoundly alone, which experiences the noise of living minds as pain, and she shows it what it is killing. The delver withdraws and Starsight survives. In the confusion Spensa frees a hoard of taynix from Superiority control and escapes with them, with Doomslug, and with M-Bot, whose ship is destroyed and whose mind continues in a far smaller body. She hyperjumps home to Detritus carrying the secret of faster-than-light travel, which means humanity can finally move ships between stars; the orbital platforms are brought online and Detritus has a shield over it for the first time. The cost is that Winzik got most of what he wanted: he has proved the delver threat, gained sweeping authority, and holds both a war fleet and a means of pointing delvers at his enemies. Alanik has woken on Detritus and the impersonation has to be answered for, Jorgen has begun showing cytonic ability of his own, and the friends Spensa made at Starsight are scattered and know she is human.",
         "in_short": "Humanity on Detritus now knows that its jailers are the Superiority, a galactic government that grades species by aggression and denies faster-than-light travel to those it judges unfit. When a cytonic alien pilot named Alanik crashes on Detritus and falls into a coma, Spensa takes her ship and her identity and infiltrates a Superiority fighter program on the space platform of Starsight, intending to steal the secret of interstellar travel. Disguised among alien cadets, she learns that the Superiority's hyperdrives are not machines but living creatures, taynix slugs of the same kind as her own Doomslug, and that the program's director, Winzik, does not want to defend anyone from the world-killing entities called delvers so much as to control one. When Winzik draws a delver to Starsight, Spensa flies out and makes contact with it, discovering it is a lonely intelligence rather than a weapon, and persuades it to leave. She escapes with a hoard of taynix, giving humanity hyperdrives at last, while Winzik gains the power he was after.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1665,7 +1665,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1678,7 +1678,7 @@
       "recaps": {
         "ending": "Kirsten and August survive their confrontation with the Prophet when one of his own young followers shoots him and then himself. Details the Prophet quoted from the Station Eleven comics allow Kirsten and Clark to recognize that he was Tyler Leander, Arthur and Elizabeth's son. The Traveling Symphony reaches the Severn City Airport, where Kirsten meets Clark and sees Arthur's history displayed in the Museum of Civilization. Clark shows her distant electric lights, proof that a settlement has restored power and that organized technology may be returning. The novel also reveals that Jeevan survived his long journey, became a healer, and formed a family in Virginia. Miranda died on a beach in Malaysia during the pandemic, but not before completing the comics that shaped both Kirsten and Tyler. Kirsten leaves the airport with the Symphony as it heads south toward the illuminated town, while Clark remains with the airport community. The scattered survivors continue building lives joined indirectly by Arthur, art, and objects carried from the lost world.",
         "in_short": "Actor Arthur Leander dies onstage in Toronto just before the Georgia Flu destroys modern civilization. Jeevan Chaudhary receives an early warning and shelters with his brother, while child actor Kirsten Raymonde survives by means she later barely remembers. Twenty years on, Kirsten performs Shakespeare with the Traveling Symphony around the Great Lakes. The troupe is pursued by a violent Prophet after finding one of its regular towns under his control. Interwoven pre-pandemic stories follow Arthur, his former wife Miranda, their friend Clark, and Arthur's second wife Elizabeth and son Tyler. Miranda's privately printed Station Eleven comics reach both Kirsten and Tyler and influence them in radically different ways. The Symphony's route leads to the Severn City Airport, where Clark has built a Museum of Civilization. The Prophet is revealed as Tyler and dies during a confrontation. Kirsten reaches the airport, sees distant electric lights suggesting renewal, and departs south with the Symphony. Jeevan, separately, survives to become a healer with a family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1913,7 +1913,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00GBC0GB4",
@@ -1925,7 +1925,7 @@
       "recaps": {
         "ending": "McGill's images and recovered bodies show that the Saurians repeatedly revived the same scarred jugger. Although the Nairbs initially award the battle to the Saurians on body count, their inquiry finds that the rival force used pirated revival technology. The violation disqualifies the Saurians, leaving Legion Varus in control of Steel World and its neighboring contracts. Graves has McGill killed by an orbital strike so he can be reconstructed aboard Corvus in a healthy, legitimate body. McGill is recommended for Weaponeer training and a silver Nova. Natasha is restored from the data he recovered, Carlos is alive, and all three return to Earth with the legion. Drusus overturns an internal order for McGill's permanent execution and accepts that he killed Thompson in self-defense. Varus suppresses both McGill's illicit earlier revival and the death of Inspector Xlur, but a later Galactic investigation could still make humanity collectively answer for the incident. The legion begins leave while negotiating its next contract.",
         "in_short": "Family debt drives James McGill from university into Legion Varus, where lethal training prepares him for a campaign on Cancri 9. A mine defense develops into a regulated contest against Saurian forces for control of Steel World. McGill kills Galactic inspector Xlur and is officially executed, but Graves secretly arranges his defective reconstruction. McGill and Carlos help seize a spaceport, and McGill later recovers stolen revival data that saves Graves, Natasha, and other soldiers from permanent loss. During the final siege, he proves that the Saurians repeatedly revive the same scarred jugger. The Nairbs first declare a Saurian victory by body count, then disqualify them for using pirated revival technology. Varus retains its contracts. McGill receives a healthy body, escapes a second permanent-execution order through Drusus's intervention, and returns to Earth with Carlos and Natasha. His survival after the Xlur affair remains a concealed danger for Earth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2086,7 +2086,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2099,7 +2099,7 @@
       "recaps": {
         "ending": "The Reckoners lure Steelheart into the steel caverns beneath Newcago after killing Nightwielder, whose power had covered the city in permanent night, and freeing Conflux, the Epic who supplied its electricity. The fight goes badly and Prof is forced to use his abilities openly, revealing to David that he is himself an Epic and that the Reckoners' equipment has always been his power channelled through devices; he uses it as rarely as possible because wielding an Epic's power drives its holder toward cruelty. Megan is killed and returns again. David finally works out Steelheart's weakness: he cannot be harmed by anyone who does not fear him, which is why David's father's bullet drew blood, since his father saw Epics as future protectors rather than threats. Losing his own fear at the critical moment, David kills him. Newcago is left without its ruler, the artificial night ends and daylight returns to the city for the first time in a decade. Megan leaves rather than stay with a team whose purpose is killing Epics, though she and David part on far better terms than they met. Prof binds David to secrecy about what he is, and the Reckoners stay in Newcago, now responsible for the city they have freed.",
         "in_short": "A decade after ordinary people began gaining superhuman powers and using them to take whatever they wanted, Chicago has become Newcago: a city turned to steel and held under permanent artificial night by the invulnerable Epic Steelheart. David Charleston, eighteen, watched Steelheart kill his father in a bank as a child and is the only living witness to Steelheart being wounded. He talks his way into the Reckoners, the one organisation that assassinates Epics, and persuades them to attempt Steelheart himself. The team provokes him into the open by inventing a rival Epic and dismantles his lieutenants, discovering along the way that David's teammate Megan is an Epic who returns from death, and that the Reckoners' leader, Prof, is an Epic whose powers have always been the source of the team's equipment. In the final confrontation David realises that Steelheart can only be harmed by someone who does not fear him, as his father did not, and kills him. The sun rises over Newcago, Megan leaves, and David stays on with the Reckoners.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2246,7 +2246,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2259,7 +2259,7 @@
       "recaps": {
         "ending": "By the final stage of the novel, Alice can no longer work, travel independently, follow her old memory tests, or consistently recognize the people around her. The computer file she once created to guide her toward suicide appears on her screen, but she cannot retain its instructions long enough to carry them out. John accepts a position in New York and prepares to leave; Alice remains in Cambridge, where Anna and Charlie now have twins and Lydia has returned from Los Angeles to help care for her. Although Alice has lost much of the language and autobiographical knowledge that once defined her, she still responds emotionally to her family. After Lydia performs a scene for her, Alice cannot explain its subject but identifies the feeling it conveyed as love. The closing exchange leaves her illness unchanged while showing that connection and emotion remain accessible after many other capacities have gone.",
         "in_short": "Harvard professor Alice Howland begins losing words and becoming disoriented at fifty. She is diagnosed with early-onset Alzheimer's disease caused by a hereditary mutation, forcing her husband John and their three adult children to confront both her decline and their own genetic risk. Alice leaves teaching, loses increasing amounts of independence, and creates a support group and public speech that let her speak for people living with dementia. Her relationship with her daughter Lydia improves as Alice becomes less able to impose old expectations. A plan Alice left herself for suicide fails because she can no longer follow it. John chooses a new job in New York, while Lydia returns to Cambridge and the family arranges Alice's care. At the end Alice cannot name many people or ideas, but after watching Lydia act she can still recognize and express love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2440,7 +2440,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2453,7 +2453,7 @@
       "recaps": {
         "ending": "Elena survives Winsloe's attempt to hunt her and rejoins Clay and the allies attacking the compound. Winsloe is killed, Matasumi's program is ended, and the surviving captives are freed as the facility is destroyed. Ruth Winterbourne dies during the rescue, leaving Paige to care for Savannah. Leah's cooperation with the compound and responsibility for Ruth's death are exposed, but Leah escapes and remains a danger. Elena returns to the Pack with direct knowledge that werewolves are only one part of a larger supernatural population. The rescuers cannot treat the compound as an isolated crime: its files and experiments prove that human discovery could lead to organized capture and exploitation. The werewolves, witches, vampires, and half-demons therefore leave with stronger reasons to share information, even though mutual trust remains limited.",
         "in_short": "When evidence of werewolves reaches other supernatural communities, Elena Michaels learns that witches, vampires, sorcerers, and half-demons have also been hiding among humans. Their attempt to discuss a common exposure threat is interrupted when Elena is abducted and taken to a secret research compound owned by billionaire Tyrone Winsloe and run by Dr. Matasumi. Supernatural captives, including young witch Savannah Levine and half-demon Leah O'Donnell, are imprisoned and experimented upon. Elena studies the facility, protects Savannah, and works toward escape while Clay, Jeremy, Paige Winterbourne, and the others search outside. Winsloe eventually turns Elena loose as prey, but she survives and the rescuers bring down the compound. Winsloe is killed and Matasumi's operation ends. Ruth Winterbourne dies, and Paige becomes Savannah's guardian. Leah is exposed as a collaborator responsible for Ruth's death but escapes. The survivors leave knowing that human discovery is a threat shared by every supernatural race.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2634,7 +2634,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2647,7 +2647,7 @@
       "recaps": {
         "ending": "The collection closes with a documentary-style debate over calliagnosia, a reversible condition that prevents people from perceiving facial beauty. Tamera Lyons, who has lived with it since childhood, temporarily disables it so that she can judge the campus controversy from both sides. She discovers that attractiveness is pleasurable but also that her reactions can be manipulated, especially when image-editing and targeted persuasion are used by people with commercial or political interests. Rather than treating either state as a neutral default, she chooses to restore her calliagnosia as an informed decision. The ending does not settle the wider referendum by simple argument; it leaves the competing speakers confronting how technology can both reduce one source of prejudice and become another means of controlling perception. Across the collection, this final choice echoes the earlier stories' concern with knowledge that permanently changes the knower, whether the knowledge concerns cosmology, mathematics, intelligence, time, biology, divine justice, or beauty.",
         "in_short": "Eight independent stories test what happens when a discovery changes the limits of human understanding. A Babylonian miner reaches the vault of heaven and learns the world's unexpected shape; a mathematician finds arithmetic inconsistent; and a medical patient develops superhuman intelligence only to meet a rival mind. A linguist learning an alien language begins to experience her future daughter's life alongside the present and knowingly accepts both its love and grief. Later pieces imagine ordinary humans trying to follow posthuman science, a Victorian science of names and constructed life confronting a fertility crisis, and a widower pursuing religious devotion in a universe where Heaven and Hell are visible. The closing documentary debates calliagnosia, a treatment that blocks the perception of beauty. After temporarily experiencing beauty and its power to bias and manipulate, Tamera Lyons makes an informed choice to resume the condition, while the social argument remains open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2790,7 +2790,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2801,7 +2801,7 @@
       "recaps": {
         "ending": "Victor Sells is dead, killed by his own storm-drawn power when Harry turned the ritual back on him, and the heart-ripping murders stop. Susan Rodriguez, who had secretly taken the Sight-granting drug to follow the story, survives the ordeal, and her relationship with Harry deepens even as the danger of his world becomes undeniable to her. Murphy, after briefly arresting Harry when she found him at the scene, accepts that he was working to stop the killer, and the partnership between Special Investigations and Chicago's wizard holds. The White Council lifts its immediate threat, though Warden Morgan remains convinced Harry is dangerous and keeps watching. Harry also leaves two lasting marks on his future: the vampire Bianca now hates him and will nurse the grudge, and the crime lord Gentleman Johnny Marcone has taken his measure and filed him away as a man worth watching. Broke and battered as ever, Harry returns to his small practice, his cat, and Bob the skull, a little more established as the city's reluctant supernatural defender.",
         "in_short": "Harry Dresden, the only wizard in Chicago's phone book, is hired from two directions at once: his police-consultant work brings him a double murder committed by heart-ripping black magic, and a worried wife hires him to find her missing husband, Victor. Because only forbidden magic could have killed that way, Warden Morgan of the White Council threatens Harry with execution if another such death occurs and treats him as the suspect. Investigating, Harry ties the murders to a new drug that grants the Sight and to the vampire Bianca, clashes with crime lord Johnny Marcone, and discovers that the missing husband, Victor Sells, has become a dark sorcerer killing at a distance with storm-powered rituals. Victor turns demons and conjurations on Harry. In a final confrontation at Victor's lake house during a storm, Harry, aided by the reporter Susan Rodriguez, destroys Victor and his ritual, clears himself with the Council, and keeps Murphy's uneasy trust.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3189,7 +3189,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07L1694R1",
@@ -3201,7 +3201,7 @@
       "recaps": {
         "ending": "McGill destroys the final Wur nexus and dies inside it. Sarah performs an accelerated revival, and he learns that the disconnected Wur attacked both Fort Beta and their Rigelian allies. Sateekas judges the human army inferior in direct combat, but Squanto refuses to make Rigel the province's new enforcer. Earth therefore retains the position, and McGill uses the promised truce to return Squanto alive. Rigel withdraws and transmits Florimel's engram, enabling her revival. She confirms that she surrendered the genuine Mogwa-killing formula to Rigel. Legion Varus evacuates Storm World, while Maurice Armel's legion remains behind to rebuild with the scuppers. Two months later, Claver-X brings Etta home. Central and the primary Claver line are hunting him, but McGill hides their contact and kills two pursuing clones. Galina Turov resumes her relationship with McGill while warning that the Core Worlds are investigating Xlur's permadeath. The formula's spread, Claver-X's role, Florimel's plan to seek her partner's revival, and McGill's exposure remain open.",
         "in_short": "James McGill pursues Etta and a book containing a Mogwa-killing formula, survives illegal revivals, and kills Chief Inspector Xlur while hiding the formula's loss. Legion Varus deploys to Storm World against the Wur, where McGill gains command of the native scuppers. Rigel intervenes, and Governor Sateekas makes Earth's provincial status depend on the conflict. Maurice Armel betrays the garrison and helps Claver Prime trade Florimel to Rigel. A renegade Claver-X then guides McGill toward the final Wur nexus. McGill destroys it and dies, but Sarah revives him. The leaderless Wur attack both armies, and Rigel withdraws. Sateekas keeps Earth as local enforcer only because Squanto refuses the appointment. Florimel returns by transmitted engram and admits giving Rigel the genuine formula. Varus leaves, Armel remains to rebuild, and Etta later comes home with Claver-X while the formula, Xlur investigation, and clone conflict remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3393,7 +3393,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3406,7 +3406,7 @@
       "recaps": {
         "ending": "Alex reaches London aboard an aircraft and drops through the glass roof of the Science Museum, landing on the Stormbreaker display seconds before the Prime Minister can press the button that would have activated every machine in the country and released the virus into Britain's schools. The launch is stopped and the plot exposed. Sayle escapes in the confusion and is cornered on a rooftop, where he draws a gun on Alex; before he can fire he is shot dead by Yassen Gregorovich from a helicopter, silencing him on his employers' behalf. Yassen leaves Alex alive, tells him to go home, and says they will meet again. Alex learns that it was Yassen who killed Ian Rider, and that the men who supplied Sayle with the virus were never Sayle's own. MI6 thank him, return him to school, and make no promise to leave him alone; Blunt and Mrs Jones have seen how useful a fourteen-year-old agent can be. Alex goes back to Brookland with a dead uncle, a debt he cannot collect, and the knowledge that the department now regards him as an asset rather than a schoolboy.",
         "in_short": "Fourteen-year-old Alex Rider is told that his uncle and guardian, Ian Rider, has died in a car crash, and discovers instead that the wrecked car is full of bullet holes and that his uncle was a career MI6 officer. The department blackmails Alex into finishing the assignment his uncle died on: infiltrating the Cornish plant of Herod Sayle, a computer magnate about to donate a Stormbreaker machine to every school in Britain. Posing as a competition winner, Alex uncovers a shipment of sealed vials, breaks into the mine beneath the plant, and finds that the computers are being loaded with a modified smallpox virus. Sayle intends to kill the nation's schoolchildren in revenge for being humiliated as a boy by the classmate who is now Prime Minister. Alex escapes, reaches London, and drops through the roof of the Science Museum in time to stop the launch. Sayle is shot dead by the Russian assassin Yassen Gregorovich, who spares Alex and reveals that he was also the man who killed Ian Rider.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3558,7 +3558,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3571,7 +3571,7 @@
       "recaps": {
         "ending": "The feared purge of the English department does not occur, and the list around which the faculty has organized its panic loses its power. Hank's public threat against the campus geese proves less consequential than the private crises it helped him avoid. His alarming urinary symptoms culminate in passing a kidney stone, giving a concrete answer to an anxiety he had converted into thoughts of mortality and decline. Lily returns, and their marriage survives the week's suspicions, distance, and Hank's resistance to speaking plainly. Hank also has to accept that his father's return and his mother's response belong to them, not to the grievance he has preserved since childhood. The college remains flawed and the department quarrelsome, but Hank ends the week with his family and job intact and with fewer excuses for treating detachment as wisdom.",
         "in_short": "William Henry Devereaux Jr., known as Hank, chairs the English department at an underfunded Pennsylvania college while avoiding nearly every form of authority the job requires. Rumored staff cuts turn his colleagues' rivalries into panic, and his mocking response escalates until he threatens on television to kill a campus goose each day unless the budget is restored. At home, his wife Lily considers a career move, their daughter's marriage is unstable, and news of Hank's famous, long-absent father returning reopens old resentment. Hank also fears that difficulty urinating signals serious illness. His jokes, flirtations, and evasions strain his marriage and friendships while doing little to settle the departmental crisis. The threatened mass dismissals do not happen, his medical terror proves to be a kidney stone, Lily returns, and his parents make their own choices. Hank finishes the chaotic week still at the same imperfect college, but less able to hide from adulthood behind irony.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3705,7 +3705,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3718,7 +3718,7 @@
       "recaps": {
         "ending": "Lanyon's narrative reveals that Hyde came to him under Jekyll's instructions, mixed a drug from materials retrieved from Jekyll's laboratory, and transformed into Jekyll before his eyes. The experience destroyed Lanyon's health. Jekyll's final statement explains that he created the drug to separate the conflicting sides of his nature and used the form of Hyde to act without the restraints attached to his own identity. Hyde gradually grew stronger, and the changes began occurring without the drug. After Hyde murdered Carew, Jekyll tried to stop transforming, but he could not maintain control. The original potion depended on an unidentified impurity in one chemical, and later supplies would not reproduce it. Trapped in the laboratory and nearly out of the effective mixture, Jekyll wrote his confession while he still could. By the time Utterson and Poole forced entry, Hyde had taken poison and died in Jekyll's clothes. Jekyll was gone, leaving the two identities' shared life ended with Hyde's body.",
         "in_short": "London lawyer Gabriel Utterson investigates the connection between his respectable friend Dr Henry Jekyll and the violent Edward Hyde, whom Jekyll's will names as heir. Hyde murders Sir Danvers Carew and disappears, while Jekyll briefly returns to society before shutting himself inside his laboratory. After Dr Lanyon dies from the shock of a secret encounter and Jekyll's butler fears foul play, Utterson and the servant break into the laboratory and find Hyde dead in Jekyll's clothes. Documents explain that Jekyll invented a potion that transformed him into Hyde, a separate body through which he indulged impulses he wished to conceal. The transformations eventually began without his consent, and the effective drug could not be recreated after its original ingredients ran out. Losing the struggle for control and facing exposure, Hyde kills himself; Jekyll's confession records the end of both identities.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3796,7 +3796,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3809,7 +3809,7 @@
       "recaps": {
         "ending": "Xan is killed in an accident during the military build-up around the settlement. Cara carries his body out to the dogs, and they repair him. What comes back is her brother in every way she can test and not a living boy in any way a doctor could recognize: he does not need to breathe, does not need to eat, and does not heal or fail the way people do. Their parents cannot accept him, and the new authorities on the planet regard him as a specimen and a security problem rather than a child. Cara chooses her brother. The two of them leave the settlement and their family for good and go out into the countryside with the dogs, beyond the reach of anyone who would take Xan apart to find out how he works, and Cara does not intend to remain what she is either. Nobody in the settlement understands what happened, and the world's new owners now know that the alien machines here will rebuild a dead human being. The novella ends there, on a planet that has just become the property of a fleet with no intention of leaving.",
         "in_short": "On a newly settled colony world with alien ruins and machines still running in the countryside, a girl named Cara looks after her small brother Xan and treats the local wildlife as her private responsibility. When a creature she has been feeding is killed, she carries it to the machines the settlement's children call dogs, and they repair it and send it back changed, no longer able to live among its own kind. Then a fleet arrives to claim the planet, the colony is absorbed into a military project it has no say in, and Xan is killed in the disruption. Cara takes her brother to the dogs. They repair him too: he comes back recognizably himself and no longer alive in any way that can be measured, and their parents cannot look at him. Rather than let him be taken, studied or explained, Cara leaves with him, and the two children disappear into the countryside with the machines, changed and beyond recall.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3947,7 +3947,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3960,7 +3960,7 @@
       "recaps": {
         "ending": "After Guy has built a successful public life with Anne, Bruno remains a dangerous reminder of the two murders binding them together. Gerard reconstructs their connection and keeps searching for proof. During a sailing trip, an intoxicated Bruno falls overboard; Guy tries to save him, but Bruno drowns. His death removes the threat of direct exposure without freeing Guy from his own guilt. Guy visits Owen Markman, Miriam's former lover, and confesses the exchange: Bruno killed Miriam, and Guy later killed Bruno's father. Owen responds with unexpected sympathy, but Gerard has followed Guy and hears enough to complete his case. The novel closes with Guy facing arrest, his effort to preserve an honorable identity finally undone by the confession he could no longer suppress.",
         "in_short": "Architect Guy Haines meets wealthy Charles Bruno on a train and is drawn into a conversation about the people obstructing their lives. Bruno proposes that they exchange murders, eliminating motive: he will kill Guy's estranged wife, Miriam, if Guy kills Bruno's hated father. Guy rejects the idea, but Bruno murders Miriam and then insists that Guy owes him his half of the bargain. Harassed and afraid that suspicion will destroy his career and marriage to Anne Faulkner, Guy eventually kills Mr. Anthony. The shared crimes do not produce freedom. Bruno becomes increasingly possessive and conspicuous, while detective Arthur Gerard traces the connection between the men. Bruno later drowns despite Guy's attempt to rescue him. Still unable to live with what he has done, Guy confesses to Miriam's former lover, unaware that Gerard is listening. He is exposed and faces arrest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4154,7 +4154,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4167,7 +4167,7 @@
       "recaps": {
         "ending": "Driven toward Garumn's Gorge with the gray dwarves behind them, the companions try to cross the bridge and get out of the mountain. Shimmergloom comes up out of the chasm to stop them. Bruenor soaks himself in oil, sets himself alight and leaps onto the shadow dragon's back, and the two of them fall together into the gorge; the fight and the collapse that follows give the others the seconds they need to get clear. Sydney is killed and Dendybar's expedition destroyed with her, and the wizard himself does not survive the failure. In the confusion Entreri takes Regis and starts south for Calimport, making no secret of his route, because what he wants now is for the dark elf to follow him. Drizzt, Wulfgar and Catti-brie escape the mountain with nothing: Mithril Hall is found and still held by its occupiers, Bruenor is gone into a chasm no one could survive, and the friend they came out of Icewind Dale with is in an assassin's hands. Having nothing they can do for Bruenor, they turn south to do the one thing left, and set out for Calimport to take Regis back.",
         "in_short": "Bruenor Battlehammer leads Drizzt, Wulfgar and Regis out of Icewind Dale to find Mithril Hall, the ancestral home of his clan, guided by nothing but childhood memories. Behind them, the assassin Artemis Entreri comes north for Regis and the stolen ruby pendant, taking Bruenor's daughter Catti-brie prisoner to follow the trail, and the Luskan wizard Dendybar sets his apprentice Sydney and a golem after the company to learn what Drizzt knows. The road takes the friends through hostile Luskan, the eccentric wizards of Longsaddle, a meeting outside Silverymoon with Lady Alustriel that finally gives Bruenor his bearings, and the troll-ridden Evermoors. They find Mithril Hall held by gray dwarves in the service of Shimmergloom, a shadow dragon. Cornered at Garumn's Gorge, Bruenor sets himself alight, leaps onto the dragon and falls with it into the chasm so the others can escape. Sydney dies and the wizard's expedition is destroyed. Entreri seizes Regis in the chaos and starts south for Calimport, and Drizzt, Wulfgar and Catti-brie follow him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4332,7 +4332,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4345,7 +4345,7 @@
       "recaps": {
         "ending": "Jim escapes Grimy Nick's violent control and returns to the London streets, still without family, money, or a secure place to sleep. He reaches a school for poor children associated with Thomas Barnardo. Although the available refuge cannot simply accommodate every homeless boy, Jim's presence and his account of life outside make the human cost of that limit impossible to ignore. Barnardo listens as Jim describes eviction, the loss of his mother and sisters, the workhouse, and the exploitation he has survived. Jim is finally treated as a child in need rather than a criminal or a source of labor. The closing historical note is hopeful: Jim's story strengthens Barnardo's determination to create a home whose door will remain open to destitute children. Jim's future is not restored to what it was, but his testimony helps begin a wider effort to protect children living as he has lived.",
         "in_short": "Jim Jarvis lives with his sick mother and two sisters in Victorian London until unpaid rent leaves them homeless. The family enters the workhouse, where they are separated, and Jim loses his mother and contact with his sisters. He befriends Tip but cannot accept the institution's hunger, labor, and punishments, so he escapes and survives on the streets. Brief kindness cannot give him lasting security, and Grimy Nick traps him into harsh work on a coal boat alongside another boy, Shrimps. Jim eventually escapes again and reaches a school serving poor children. There he meets Thomas Barnardo and explains what happens to children who have no family or bed and can still be turned away when shelters are full. Barnardo takes Jim seriously. The boy's experience helps inspire the promise that destitute children seeking refuge should not be refused for lack of money.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4471,7 +4471,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4484,7 +4484,7 @@
       "recaps": {
         "ending": "In Ames' Crossing, Stuart meets Harriet Ames, a young woman near his own size, and arranges an evening canoe trip. He carefully prepares a miniature canoe, food, and equipment, but unattended children find the boat before the date and ruin it. Stuart cannot adjust to the loss of the perfect outing he imagined, and his disappointment spoils the evening with Harriet. He nevertheless continues his search for Margalo. A local repairman tells him that northbound travel is worthwhile because something desired may always lie ahead. Stuart drives on toward the north, still without definite news of Margalo. The novel closes with the search unfinished but with Stuart committed to the journey.",
         "in_short": "Stuart Little is born into a human New York family but is only two inches tall and resembles a mouse. His scale turns household errands and city outings into adventures. He retrieves objects from narrow places, survives dangers involving the family cat Snowbell, and proves himself a skilled sailor by racing a model boat in Central Park. The Littles shelter an injured bird named Margalo, and Stuart grows devoted to her. After Margalo learns that Snowbell has helped place her in danger, she leaves without telling Stuart where she is going. Stuart sets out in a tiny automobile to find her. Along the way he briefly teaches a class and meets Harriet Ames, a young woman his size, but a carefully planned river date ends badly after children destroy his canoe. He resumes driving north, hopeful but uncertain, and the story ends before he finds Margalo.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4652,7 +4652,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4665,7 +4665,7 @@
       "recaps": {
         "ending": "After Dracula attacks Mina, the hunters use her involuntary psychic connection to track his retreat from England. They destroy or sanctify all but one of his boxes of native earth, follow his ship to Galatz, and divide into teams for the pursuit across Transylvania. Van Helsing takes Mina near Castle Dracula, wards her against the three vampire women, and destroys them while the other men close on the gypsies transporting Dracula's final box. Just before sunset, Jonathan and Quincey reach the cart. Jonathan cuts Dracula's throat and Quincey strikes his heart, causing the Count to disintegrate. Mina sees a look of peace on his face, and the sacred burn on her forehead vanishes, showing that the curse has ended. Quincey has suffered a fatal wound and dies beside his friends, comforted by Mina's recovery. An epilogue set seven years later shows Jonathan and Mina as parents of a boy named Quincey. Arthur and Seward have married, and the survivors return together to Transylvania, carrying their records as the principal evidence of their struggle.",
         "in_short": "Solicitor Jonathan Harker visits Count Dracula's Transylvanian castle and discovers that his client is a vampire preparing to move to England. Jonathan escapes, but Dracula reaches Whitby and preys on Lucy Westenra. Dr. Seward, Arthur Holmwood, Quincey Morris, and Professor Van Helsing repeatedly try to save Lucy; after she dies and returns as a vampire, they free her by destroying her undead body. Mina Harker assembles the group's records, helping them trace Dracula's London refuges, but Dracula attacks her and forces a blood bond that threatens to transform her. The hunters ruin his boxes of earth and pursue his last refuge back toward his castle, using Mina's psychic connection to follow him. Van Helsing destroys Dracula's three vampire women. Jonathan and Quincey intercept Dracula's box before sunset and kill him, breaking the curse on Mina. Quincey dies from a wound received in the fight. Seven years later, Jonathan and Mina have a son named for him, and the surviving friends remain united by the ordeal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4858,7 +4858,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4871,7 +4871,7 @@
       "recaps": {
         "ending": "After gaining both Wuthering Heights and Thrushcross Grange, Heathcliff loses interest in completing his revenge. Hareton increasingly resembles the people Heathcliff loved and hated, while Cathy and Hareton overcome their hostility: she teaches him to read, he responds with devotion, and they plan to marry. Heathcliff becomes preoccupied with Catherine's presence and withdraws from ordinary life, eating little and wandering the moors. Nelly finds him dead in Catherine's old room beside an open window. He is buried beside Catherine and Edgar, and local stories claim that Heathcliff and Catherine are seen together on the moors. Lockwood later returns to find the oppressive household transformed. Cathy and Hareton intend to marry on New Year's Day and move to Thrushcross Grange, leaving Joseph at the Heights. The younger pair's union reconciles the Earnshaw and Linton lines and ends the cycle of dispossession, while Lockwood closes at the three graves.",
         "in_short": "Tenant Lockwood asks housekeeper Nelly Dean to explain the hostile household of his landlord, Heathcliff. Nelly recounts how the orphan Heathcliff and Catherine Earnshaw grew up inseparable at Wuthering Heights, but Catherine married the genteel Edgar Linton. Heathcliff returned wealthy and pursued revenge: he ruined Catherine's brother Hindley, married and abused Edgar's sister Isabella, and remained consumed by Catherine until her death after giving birth to Cathy. Years later he controlled Hindley's son Hareton and his own sickly son Linton, then forced young Cathy to marry Linton so he could acquire Thrushcross Grange as well as the Heights. Edgar and Linton died, leaving Cathy trapped in Heathcliff's household. Cathy eventually befriended and educated Hareton, and they fell in love. Haunted by Catherine and no longer interested in revenge, Heathcliff died. Cathy and Hareton planned to marry and move to the Grange, restoring affection and inheritance to the younger generation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5088,7 +5088,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5101,7 +5101,7 @@
       "recaps": {
         "ending": "After Benoit kills the German soldier Bonnet, Lucile hides the fugitive in the Angellier house while German troops search Bussy. She asks Bruno for a permit and fuel to visit Paris, concealing her real purpose. Bruno, aware that she is withholding something but still attached to her, supplies the papers. Lucile then carries Benoit out of the village hidden in her car, committing herself to active resistance rather than to the private happiness she had briefly imagined with Bruno. Madame Angellier, once rigidly hostile to Lucile, helps protect the secret. Germany's war widens, and Bruno's regiment is ordered away toward the campaign in the Soviet Union. He and Lucile part without resolving their mutual love. The surviving manuscript ends with the occupation continuing, Benoit escaping toward Paris, and Bruno departing Bussy with the German army, leaving the villagers to face an uncertain next phase of the war.",
         "in_short": "As German forces invade France in 1940, Parisians of sharply different classes join the chaotic flight south. The Pericands lose their priest son Philippe and their elderly relative; the Michauds endure the road after their employer abandons them but are reunited with their wounded soldier son; other refugees expose their selfishness while trying to preserve comfort and possessions. After the armistice, German troops occupy Bussy. Lucile Angellier, trapped with a hostile mother-in-law while her husband is a prisoner, grows close to the cultivated officer Bruno von Falk, who is billeted in their house. Elsewhere, farmer Benoit Sabarie kills the German soldier harassing his wife, Madeleine. Lucile hides Benoit and uses travel papers obtained from Bruno to smuggle him toward Paris. When Bruno's regiment is sent east, he and Lucile separate, their affection overridden by the realities of occupation and her decision to aid a fugitive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5267,7 +5267,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5280,7 +5280,7 @@
       "recaps": {
         "ending": "Sula dies in 1940 after a final visit from Nel, realizing at the moment of death that she wants to tell her old friend what dying feels like. The Bottom initially treats her death as relief, but the unity created by opposition to her quickly dissolves. In 1941, Shadrack's annual procession attracts townspeople for the first time. Their frustrated march reaches the unfinished tunnel from which Black workers have long been excluded; the crowd attacks it, and the structure collapses, killing many, while Shadrack survives. Decades later, Nel visits Eva and then Sula's grave. She finally understands that the central loss in her life was not Jude but Sula. Her long-suppressed grief for their friendship breaks free.",
         "in_short": "In the Black hill community called the Bottom, Nel Wright and Sula Peace become inseparable girls despite their very different homes. They share freedom, danger, and the secret of Chicken Little's accidental drowning. Nel later marries Jude, while Sula leaves for a decade and returns determined to live without conventional obligations. When Sula sleeps with Jude, he abandons Nel and the friendship breaks. The community makes Sula a symbol of evil, paradoxically becoming kinder and more united in opposition to her. Sula's only deep adult attachment, to Ajax, ends when he senses her wish for permanence. She dies after a final estranged conversation with Nel. The Bottom's unity then fails, and many residents die when an angry procession destroys an unfinished tunnel. In 1965, Nel recognizes that she has mourned Sula, not Jude, throughout her adult life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5416,7 +5416,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5429,7 +5429,7 @@
       "recaps": {
         "ending": "Pregnant and convinced that Lucius Harney will return to his socially suitable fiancée, Annabel Balch, Charity turns away from a dangerous attempted abortion and climbs the Mountain in search of her origins. She finds her mother dying amid extreme poverty and remains with her until death. Mr. Royall follows Charity, sees that the mother is buried, and leads his exhausted ward back toward North Dormer. In Nettleton he again offers marriage, this time as practical shelter rather than a demand, and Charity accepts. They marry quietly before returning home. Royall behaves with unexpected tenderness and does not press his marital rights, while Charity resolves to protect the child she is carrying and build a life from the limited security available to her. Harney does not return to claim her; Charity sends him a farewell and closes the summer by re-entering Royall's house as his wife, carrying another man's child.",
         "in_short": "Charity Royall, brought as a child from an impoverished mountain settlement and raised by a widowed lawyer in North Dormer, longs to escape village life. She falls in love with Lucius Harney, a visiting architect from a wealthier world. Their secret relationship deepens after Mr. Royall publicly humiliates her, but Charity learns that Harney is engaged to Annabel Balch and he leaves without securing a future with her. Discovering that she is pregnant, Charity rejects a dangerous abortion and climbs the Mountain to find her birth mother, arriving as the woman is dying in destitution. Royall follows, arranges the burial, and brings Charity away. Faced with abandonment and determined to protect her child, Charity accepts his renewed offer of marriage. She returns to North Dormer as Mrs. Royall, while Harney remains absent and the hopes attached to their summer romance give way to a constrained but survivable future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5595,7 +5595,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -5606,7 +5606,7 @@
       "recaps": {
         "ending": "The killer proves to be Aurora, the Summer Lady herself: she murdered the Summer Knight, Ronald Reuel, and arranged for the stolen power to pass into the changeling Lily, meaning to sacrifice her at the Courts' battle and unmake the balance between Summer and Winter - a fanatic's plan to end the Courts' eternal war by destroying the cycle itself. In the battle on the Stone Table at midsummer, Harry, aided by Murphy, the Alphas, and the changelings Meryl and Fix, breaks Aurora's plan; Aurora dies at the hands of Toot-toot and his swarm of tiny faeries wielding cold iron, and Meryl gives her life in the fight. The Summer Knight's mantle passes to Fix, and Lily becomes the new Summer Lady. Mab's name is cleared, discharging the first of Harry's three tasks - two remain, and Mab makes clear she is not finished with him. The White Council, having seen the case through, declines to trade Harry to the Red Court; he remains a wizard in bad odor but under the Council's protection, with Ebenezar McCoy's support publicly declared. Murphy now knows everything, Elaine survives and departs still bound to her own path, and the vampire war goes on.",
         "in_short": "Months after Bianca's ball, Harry is a guilt-wrecked recluse hunting a cure for Susan's half-vampire curse while the White Council debates surrendering him to the Red Court to end the war he started. Mab, Queen of the Winter Court, buys his debt from his faerie godmother and offers freedom for three tasks, the first: prove she did not murder the Summer Knight, whose stolen power has unbalanced Faerie and pushed the Courts toward a war that could wreck the mortal world. Harry finally tells Murphy the whole truth and gains her open-eyed partnership, and finds his first love Elaine alive and working for Summer. The killer is Aurora, the Summer Lady, who means to sacrifice the changeling Lily on the Stone Table to destroy the Courts' balance forever. In the midsummer battle Harry's side prevails: Aurora is killed by Toot-toot's iron-armed faerie swarm, Meryl dies, Fix becomes Summer Knight, Lily becomes Summer Lady, Mab is cleared, and the Council keeps Harry - still at war, still owing Mab two tasks.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5743,7 +5743,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5756,7 +5756,7 @@
       "recaps": {
         "ending": "Rachel finds enough evidence of Julia's witchcraft to understand that the apparent accidents, illnesses, and changes in affection were parts of a deliberate effort to displace her. Julia's hold over the family weakens once Rachel can identify the methods being used instead of reacting only with fear and jealousy. In the final confrontation, Julia tries to remove Rachel permanently and secure the life she has been taking over, but the violence she has set in motion turns against her. Julia dies, while Rachel and the rest of the Bryant family survive. The immediate supernatural threat is over, and Rachel is vindicated, but the summer cannot be reduced to an ordinary rivalry: her family has to absorb that their sympathy was exploited and that Rachel faced danger while they dismissed her. Rachel emerges with a harder trust in her own perception and an awareness that evil can present itself through vulnerability and charm rather than open menace.",
         "in_short": "When orphaned cousin Julia joins the Bryant household for the summer, Rachel Bryant feels an unease no one else shares. Julia soon changes from an awkward newcomer into the focus of family and social attention, drawing away Rachel's boyfriend Mike as Rachel suffers bizarre illnesses, accidents, and losses. Because Rachel has obvious reasons to be jealous, her warnings sound cruel and self-serving. She investigates instead and, with guidance from Professor Jarvis, connects Julia to witchcraft and to objects used to direct harm. Julia has been deliberately weakening Rachel's relationships and position in the family so she can take over her life. Once Rachel understands the pattern, she resists Julia's influence and confronts her. Julia's final attempt to eliminate Rachel fails and rebounds into Julia's own death. Rachel survives, her family finally recognizes the danger, and the summer ends with her instincts vindicated but her former sense of safety permanently changed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5901,7 +5901,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5914,7 +5914,7 @@
       "recaps": {
         "ending": "A violent storm drives Jimbo and the smaller monkeys from the river bottoms to the Lee farm, where they willingly take shelter. Jay Berry recognizes that they are frightened and exhausted, and he is finally able to secure the whole troop without hurting them. Their circus caretakers recover them, and Jay Berry receives the reward he had dreamed of spending on a pony and a rifle. He instead gives up that plan so the money can pay for an operation on Daisy's disabled leg. The operation succeeds, allowing Daisy to walk and run normally. Jay Berry's generosity is answered when the grateful circus people arrange for him to receive the pony and rifle he wanted after all. The summer closes with both children's wishes fulfilled, while Jay Berry has learned that the reward matters less than what he can do for his sister.",
         "in_short": "On his family's farm in the Cherokee Nation, fourteen-year-old Jay Berry Lee discovers monkeys that escaped from a circus train. Capturing the small animals carries a modest reward, while their clever leader, Jimbo, is worth enough for Jay Berry to buy the pony and rifle he longs for. With help from his grandfather and his hound, Rowdy, Jay Berry tries traps, bait, and other schemes, but Jimbo anticipates them and the monkeys repeatedly leave the boy defeated. After the animals get into sour mash, Jay Berry cares for them rather than taking advantage of them. A later storm sends the troop to the Lee barn for safety, and he delivers them unharmed. Jay Berry earns the reward but chooses to spend it on surgery for his twin sister Daisy's disabled leg. She recovers, and the circus's gratitude brings Jay Berry the pony and rifle as gifts, giving the family a joyful ending.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6042,7 +6042,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6055,7 +6055,7 @@
       "recaps": {
         "ending": "The slug program works. Enough taynix are found, coaxed out and sorted by what they can actually do that the DDF can hyperjump ships rather than merely defend a fixed position, and when a Superiority force arrives to close Detritus down, that mobility is what carries the engagement. Humanity ends the story no longer trapped at the bottom of its own gravity well, with hyperdrives of its own and a fleet that can appear where it is not expected. FM's argument about who is entitled to know things is only partly won: she has forced open a little of what the National Assembly was holding back, and Jorgen has taken on more responsibility than his rank warrants, but the question of who actually governs Detritus is left unsettled and will get worse. FM and Rodge, who spent the whole crisis working together, admit what has been obvious to everyone else. Alanik, no longer stranded now that hyperjumping is possible, leaves for ReDawn to warn her own people and to try to stop them signing themselves over to the Superiority, and the humans have their first real prospect of an ally against Winzik. Spensa is still gone, still unreachable, and the war is now something the DDF will have to fight beyond its own sky.",
         "in_short": "With Spensa away and Detritus newly shielded, the Defiant Defense Force has hyperdrives for the first time, in the form of taynix, the teleporting slugs Spensa brought back from Starsight. There are nowhere near enough of them. FM and the engineer Rodge take on the work of finding more in the caverns of Detritus, learning to coax and care for them, and discovering that different varieties do quite different things. The program pulls FM into a fight she did not expect, over how much the National Assembly is entitled to keep from the people it governs and who really commands the DDF. When a Superiority force moves against Detritus, the new ability to jump ships in and out of a battle proves decisive, and humanity ends the book mobile rather than besieged. FM and Rodge come together, and Alanik, able to travel again, departs for her own world to try to keep it out of the Superiority's hands.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -6175,7 +6175,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -6188,7 +6188,7 @@
       "recaps": {
         "ending": "Haymitch wins the fiftieth Hunger Games. After losing his ally Maysilee Donner to a swarm of Capitol-made mutant birds, he ends up as one of the final tributes and triumphs at the arena's boundary when a weapon hurled at him bounces off the arena's force field and kills his last opponent. But by turning the Capitol's own hidden machinery against a tribute and revealing its flaw on live television, he humiliates President Snow. Snow's retaliation is merciless: rather than punish Haymitch directly, he destroys everything Haymitch loves, and Haymitch's mother, his younger brother, and his sweetheart Lenore Dove are all killed. He comes home to District 12 a victor in name only, guilt-ridden and utterly alone, with no family and no future. The bright, quick-witted boy is gone, replaced by the grieving, sardonic drunk who will spend the coming decades watching District 12's children die in the Games, until, many years later, two of them finally give him a reason to fight again.",
         "in_short": "Set a generation before Katniss, this prequel follows a sixteen-year-old Haymitch Abernathy of District 12, who is reaped into the fiftieth Hunger Games, the Second Quarter Quell, which demands double the usual tributes. Torn from his mother, younger brother, and his sweetheart Lenore Dove, Haymitch is thrown into an enormous, brutal arena against dozens of competitors. He forms an alliance with fellow District 12 tribute Maysilee Donner, and the two survive together until Maysilee is killed by a flock of vicious mutant birds. Reaching the arena's edge, Haymitch wins the Games when his last opponent's thrown weapon rebounds off the arena's force field and strikes her dead, a victory that exposes the Capitol's engineering and humiliates it. President Snow makes him pay: in revenge for the embarrassment, Snow has Haymitch's mother, his brother, and Lenore Dove killed. Haymitch returns home a victor with nothing left to live for, and the loss hardens into the bitter, hard-drinking man who will one day mentor the tributes of District 12.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6299,7 +6299,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6312,7 +6312,7 @@
       "recaps": {
         "ending": "Sunshine accepts that Bo's pressure will continue until she and Constantine act. Using the magical bond formed during their escape, she joins Constantine in an assault on Bo's stronghold. Her affinity with sunlight and her inherited magic let her carry its destructive force into the vampires' dark territory. Bo and his gathered followers are destroyed, while Constantine survives despite being caught within power that should be fatal to his kind. Sunshine returns to the human world exhausted and changed, with no simple way to restore the ordinary life she had before the kidnapping. Constantine remains separate from her rather than becoming a conventional partner, but their connection endures. Jesse and Special Other Forces still know that her account is incomplete, and the full nature of her abilities remains unsettled. She goes back to Charlie's Coffeehouse and to baking, choosing her familiar life while recognizing that vampires, government scrutiny, her father's magical legacy, and her bond with Constantine can no longer be excluded from it.",
         "in_short": "Rae \"Sunshine\" Seddon, a baker in a world scarred by wars with supernatural beings, is kidnapped by vampires and chained near another captive, the vampire Constantine. Their captors serve Bo, Constantine's enemy, and expect one prisoner to destroy the other. Instead Sunshine draws on inherited sunlight magic to help them escape. Back at Charlie's Coffeehouse, she hides the truth from her family, boyfriend Mel, and Special Other Forces, but her bond with Constantine and Bo's attacks make a return to normal impossible. As memories of her magical family sharpen, Sunshine learns to control powers expressed through sunlight, wards, and transformation. She and Constantine eventually enter Bo's stronghold together. Sunshine releases sunlight within it, destroying Bo and his followers while Constantine survives through their unusual connection. She returns to her work and loved ones, but with her supernatural abilities exposed and her relationship with Constantine unresolved rather than ended.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6462,7 +6462,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6475,7 +6475,7 @@
       "recaps": {
         "ending": "After a year of changes, the Hatcher household has expanded to include baby Tootsie and Fudge's talkative myna bird, Uncle Feather. Peter has made a real friend in Alex and adapted to Princeton, while Fudge has started school and adjusted, unevenly, to no longer being the youngest child. A late scare involving Uncle Feather is resolved, and Tootsie's growing ability to speak becomes another sign that the family is moving into a new stage. The Hatchers decide that their Princeton year will remain temporary and prepare to return to New York. Peter leaves with more mixed feelings than he expected: he is glad to regain his old city life and friendship with Jimmy, but the place he originally resisted has also become a home he will miss.",
         "in_short": "Twelve-year-old Peter Hatcher is dismayed when his parents announce both a new baby and a year-long move from New York to Princeton, where his father plans to write a book. Fudge, now five, greets the upheaval with his usual enthusiasm, starts kindergarten, becomes fascinated with money, and acquires a talkative myna bird named Uncle Feather. Peter slowly settles into Princeton and befriends Alex Santo. The baby, Tamara Roxanne, is born and nicknamed Tootsie, making Fudge confront the loss of his position as the youngest Hatcher. Visits, school problems, pet trouble, and the demands of three children keep the household unsettled, but Peter gradually develops a life of his own in Princeton. By the end of the family's planned year, Tootsie is beginning to talk, the major crises have passed, and the Hatchers decide to return to New York, leaving Peter unexpectedly sorry to say goodbye to the friends and routines he found in New Jersey.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/supremacy-of-the-density-god.json
+++ b/data/works-community/0/supremacy-of-the-density-god.json
@@ -361,7 +361,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -374,7 +374,7 @@
       "recaps": {
         "ending": "A mountain strike destroys most of the defended city, but Olive, Mayalyn, Markhiss, and the allied peoples establish a surviving line. The emperors and rankers separate the Graymin king from its horde, stopping its production of new beasts. A Church artifact detonates against the king, leaving it maimed but alive and moving north. Jiran prevents a second mountain launch, only to be trapped by Graymin and captured by the temple agent Three. A bone restraint remains embedded in him, yet his Remalon body lets him resist its mana drain. Jiran and Three accept a mutual non-harm agreement in exchange for ten unspecified tasks. Jiran then absorbs his stored Challenger density and loses consciousness during the transformation. An unseen scarlet rift pulls both men into an unknown red-energy realm. Jiran's destination, the collar, the contract, and the Challenger trial remain unresolved. Niya, Mayalyn, Olive, Cameron, Lulu, Markhiss, and the coalition remain behind amid a shattered defense. Elsewhere, a Remalon leader begins searching for a Tier 4 anomaly whose description strongly points to Jiran, but she expects the trial to kill the fugitive.",
         "in_short": "Jiran rescues the Timberlings from exploitation, uncovers their shared spiritual origin, and equips them to defend themselves. Preparing for an unprecedented Graymin assault, he allies with former enemies, secures long-term service from most of their warriors, and brings multiple peoples through his portals to reinforce Olive's defense of Melathon. He supplies mana, weapons, formations, healing, and elemental instruction while the Graymin king drives and replenishes an enormous horde. Church and shadow factions obstruct Imperial reinforcements and seek control of Jiran's gateways. Markhiss defects to Jiran and exposes their plan. A mountain devastates the city, though its defenders survive and the king is maimed by a Church artifact. After stopping a second mountain strike, Jiran is captured by the temple agent Three. They make a mutual non-harm agreement that leaves Jiran owing ten tasks. Jiran absorbs his Challenger density, falls unconscious, and vanishes with Three through a scarlet rift. The Remalon leadership has also begun searching for an apparent Tier 4 anomaly matching him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -582,7 +582,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -595,7 +595,7 @@
       "recaps": {
         "ending": "In Paris, the adolescent narrator organizes his days around seeing Gilberte in the Champs-Élysées. Their games grow into a fragile friendship, and he is admitted to the Swann household, but his desire for constant reassurance makes every delay or cool response painful. Gilberte gradually withdraws, and his attempts to recover her attention only deepen his dependence until he forces himself to stop visiting. The book then shifts to the adult narrator walking in the Bois de Boulogne. Remembering the elegance once embodied there by Mme Swann, he finds that the people, clothes, carriages, and social meanings he associated with the place have disappeared. The landscape cannot restore the past because the observer and the world have both changed. The volume closes not with a recovered scene but with recognition that memory preserves an arrangement of time that the physical setting no longer contains.",
         "in_short": "An adult narrator's reflections on sleep and memory lead back to childhood visits to Combray, where family rituals, his longing for his mother, the church, gardens, servants, neighbors, and two country walks form the first geography of his imagination. A madeleine dipped in tea unexpectedly restores this world with an intensity deliberate recollection could not achieve. The narrative then turns to family friend Charles Swann's earlier obsession with Odette de Crécy. Music and repeated meetings transform mild interest into love, while exclusion from the Verdurin salon and uncertainty about Odette feed destructive jealousy. Swann eventually recognizes that his love has largely vanished, though he later marries Odette. In Paris, the young narrator falls for their daughter Gilberte and suffers through an unequal childhood attachment. Returning as an adult to the Bois de Boulogne, he sees that the fashionable world he remembers is gone and concludes that places alone cannot recover lost time.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -808,7 +808,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -823,7 +823,7 @@
       "recaps": {
         "ending": "Earth has eliminated the active Macro ground force, but the wider conflict remains unresolved. Star Force rebuilds on Andros Island, expands its ships and factories, and develops a large standing force of Nano-enhanced Marines. Crow remains the organization's nominal leader and fleet commander, while Kyle Riggs retains a senior combat role over its ground forces. Kwon survives in Riggs's command element, and Riggs resumes his relationship with Sandra as they consider marriage. Wilson is missing and presumed dead after destroying a Macro factory, while Radovich and his force are lost in an ambush. A much larger Macro fleet then arrives near Venus. Unable to win a direct battle, Riggs negotiates a one-year reprieve by agreeing that Earth will provide a shipload of Star Force ground troops for service in an unknown external war, followed by a replacement army. The Macros withdraw, but the arrangement is coerced tribute rather than peace. Riggs commits to accompany the first contingent himself. The identity and aims of the Nanos' biological creators, the larger Macro war, and the political background to Pierre's murder remain open.",
         "in_short": "After an alien ship kills his children and selects him through lethal tests, professor and former reserve officer Kyle Riggs becomes commander of Alamo. He helps Jack Crow organize Star Force, fights off Macro vessels, and learns that the invaders are machine forces seeking Earth's resources. Nano enhancement lets Riggs leave his ship, retake Versailles after Pierre's murder, and build weapons, factories, and altered Marines with government support. His new ground force suffers devastating losses but destroys the Macro factories in South America, ending the active invasion. Riggs returns to Sandra and helps expand Star Force under a divided command with Crow. When an overwhelming Macro armada arrives, Riggs avoids Earth's immediate destruction by accepting a one-year truce in exchange for sending a full cargo of human troops to fight in an unknown war. He resolves to lead the first contingent himself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -970,7 +970,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -983,7 +983,7 @@
       "recaps": {
         "ending": "The covert subsidy becomes public, leaving Serena exposed as an intelligence officer and Tom publicly reduced to the role of an unwitting government client. Serena expects that the deception has destroyed both his career and their relationship. Tom's final letter changes the meaning of the account: after learning enough to investigate her, he obtained the materials needed to reconstruct her history and wrote the narrative the reader has just finished, adopting Serena's voice and arranging events with a novelist's freedom. He does not simply answer betrayal with exposure. Instead, the manuscript becomes part of a proposal that asks Serena to choose whether their intimacy can survive the lies on which it began. The book closes before giving her direct reply, but Tom has taken authorship of the story away from the intelligence service and returned the next decision to Serena. Their professional lives are damaged and the Sweet Tooth operation is compromised; their personal future rests on how she answers him.",
         "in_short": "In early-1970s Britain, devoted reader Serena Frome joins MI5 after Cambridge and is assigned to Sweet Tooth, a secret scheme that quietly funds writers thought likely to oppose communism. Posing as a representative of a private foundation, she recruits the young author Tom Haley. Professional interest becomes love, but she withholds the real source of his stipend while he develops a successful novel. The concealment grows harder as Tom's reputation rises and Serena's colleague Max Greatorex presses his own interest in her. When the operation is exposed, Tom learns that his career and relationship were founded on a deception, and Serena assumes she has lost him. His closing letter reveals that he has reconstructed her life from documents and written the first-person narrative the reader has just completed. He turns that manuscript into both an answer to her secrecy and a conditional proposal of marriage, leaving Serena to decide whether they can make a shared life from a story begun under false pretences.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1126,7 +1126,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1137,7 +1137,7 @@
       "recaps": {
         "ending": "The book ends with Aethelstan king and Uhtred's debt to him paid in full. In the battle for Lundene, Uhtred faces Aethelhelm's monstrous champion Waormund - the man who had captured and brutalized him and taken Serpent-Breath - and kills him in single combat, reclaiming his sword. Aethelstan's victory is total: Lundene is his, the rival heir Aelfweard is dead, and Aethelhelm the Younger's faction is destroyed with him, ending the family feud that began when his father died in Bebbanburg's fall. Aethelstan, whom half of Wessex called a bastard, emerges as king of Wessex, Mercia, and East Anglia - the greatest ruler in Britain, and no longer the boy who needed Uhtred's protection. Queen Eadgifu and her children are safe under Uhtred's wing. Uhtred himself, battered by captivity and battle, turns home to Bebbanburg with his oath discharged. One kingdom remains outside the new king's reach: Northumbria, where Uhtred's son-in-law Sigtryggr reigns and where Bebbanburg stands - and an ambitious young king who means to rule all the English will not look away from it forever.",
         "in_short": "A murdered fisherman from Bebbanburg's waters is the first move in a plot against Uhtred: with King Edward dying, Ealdorman Aethelhelm the Younger means to crown his nephew Aelfweard and has sent his champion Waormund to deal with Aethelstan's great northern ally. Bound by an oath to Aethelstan, Uhtred sails south with a handful of men, rescues Edward's queen Eadgifu and her children from Aethelhelm's grasp - gaining, in her Italian attendant Benedetta, a brave companion - and makes for Lundene. Edward dies, the succession splits the kingdoms, and Waormund betrays Lundene to Aethelhelm's army, trapping Uhtred in the fallen city. Captured after giving himself up to save his people, Uhtred survives Waormund's brutality, wins free, and rejoins Aethelstan's cause as Aelfweard's claim collapses and the pretender is killed. In the final battle for Lundene, Uhtred kills Waormund in single combat, reclaims Serpent-Breath, and sees Aethelhelm's faction destroyed. Aethelstan is crowned king of Wessex, Mercia, and East Anglia; only Northumbria remains outside his rule.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1277,7 +1277,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1288,7 +1288,7 @@
       "recaps": {
         "ending": "The book ends in slaughter at Beamfleot. The ransom of Aethelflaed collapses when Haesten betrays his allies and tries to carry her off for a larger prize, and in the chaos Sigefrid retakes her. Uhtred and Erik's planned escape - Erik and Aethelflaed have fallen genuinely in love, and Uhtred has chosen to help them flee rather than see her ransom beggar Wessex and Mercia - turns into a battle in the Norse camp. Erik is killed by his own brother's hand in the fighting; Uhtred's men break the camp, and Uhtred has the wounded Sigefrid killed, ordering Osferth to strike the blow. Haesten escapes to scheme another day. Aethelflaed, freed but bereaved, must be returned to her father and to her loveless marriage with Aethelred, carrying a grief she can never openly name. Lundene stands secured for Alfred with Uhtred as its military governor, the Thurgilson brothers are dead, and the great Norse threat on the Temes is broken - but Aethelred's jealousy has been planted, Haesten lives, and Uhtred, still oath-bound to a king he does not love, has learned how much Wessex's dream of England will cost the people he cares for.",
         "in_short": "Alfred sends Uhtred to retake Lundene, seized by the Norse brothers Sigefrid and Erik Thurgilson with the ever-treacherous jarl Haesten alongside. Uhtred storms the old Roman city in an amphibious assault, drives the brothers out, and becomes Lundene's military governor, while Alfred's young daughter Aethelflaed is married to Uhtred's vain Mercian cousin Aethelred to bind Mercia to Wessex. On a river campaign, Aethelred's blundering lets Aethelflaed be captured and held at the Norse camp of Beamfleot for a kingdom-breaking ransom. There Erik and Aethelflaed fall in love, and Uhtred secretly agrees to help them escape rather than see the ransom paid. Haesten's betrayal wrecks everything: the escape becomes a battle in which Sigefrid kills his own brother Erik, Uhtred's men storm the camp, Sigefrid is killed at Uhtred's order, and Haesten slips away. Aethelflaed returns, grieving, to her father and her cold marriage; Lundene is Alfred's; and Uhtred remains bound to Wessex's dream of England.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1629,7 +1629,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1644,7 +1644,7 @@
       "recaps": {
         "ending": "Derek completes the first clear of the Undying Dungeon, destroys its lich, and stops the extreme overflow behind the forest crisis. The victory raises him to level 76 after his class becomes the legendary Legend of the Void, while every participant receives two valuable storage rings. He stages Wallace Gracefall's body as the victim of an acidic dungeon creature. Bronson accepts the physical explanation, but judges Derek to be exceptionally dangerous and intends to report to House Gracefall.\n\nRayna remains chief of the surviving village, supported by Leon, Sana, Richard, Delilah, Malorie, Brandi, and the resettled refugees. They must hide the storage rings, Derek's abilities, and Brandi's broad All Smith class. Derek hopes to create a safer future for Brandi and Malorie, while Rayna may join him if the village is secured or lost to outside control. Derek bonds Silvi, giving her a legendary void-companion class and tying her survival to his soul. Thomas chooses advancement over safety and leaves his grandparents under Derek's protection. After two weeks on the road, Derek, Thomas, Silvi, and Bronson arrive in Torith.",
         "in_short": "After a rescue portal collapses, veteran fighter Derek Hunt is stranded beyond his home system and escapes into a world governed by the Great System. He escorts the lost Thomas home, helps survivors of a monster-destroyed village, and discovers that an overflowing level-100 Undying Dungeon is poisoning the forest. His retained strength and new Champion of the Void class let him train Thomas, Rayna, Malorie, and Brandi while concealing how powerful he truly is. When Wallace Gracefall's party attacks the village, Derek kills all six attackers and builds a false account placing their deaths inside the dungeon. Derek's group clears the Undying Dungeon, ending its overflow and earning conspicuous storage rings. He advances to the legendary Legend of the Void, bonds the returned Silvi as a void-rabbit companion, and persuades investigator Bronson that Wallace died to a dungeon monster. Derek, Thomas, Silvi, and Bronson finally reach Torith, while House Gracefall's scrutiny and the village's secrets remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/system-clash.json
+++ b/data/works-community/0/system-clash.json
@@ -565,7 +565,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -578,7 +578,7 @@
       "recaps": {
         "ending": "Derek attacks the assembled champions at Virindal after Jace convinces them he remains hostile. Trisha's nullification strips away Derek's spatial and void abilities, and Darvin combines council power into a sustained beam. Jace arrives at the planned moment, allowing Derek to release the energy stored by Void's Embrace and kill Darvin. Silvi forces Kuthos to surrender, Marrick removes Bria and the unconscious Trisha, and the insect commander is captured while trying to escape underground. Amelia yields only after Derek defeats her and demonstrates that she cannot survive in the void. Her surrender ends the invasion and completes the favor requested by the defending system. Derek remains in Davin Resh with Silvi, Jace, and the surviving alliance. He is already level 251 and qualified to ascend, cannot meaningfully grow in the local system, and will be forced to leave within six months. Alana remains alive but unreachable in another system. Derek's relationship with the Universal System, Jace's future, Marrick's advancement, and the possibility of taking allies through ascension all remain unresolved.",
         "in_short": "After Alana ascends beyond his reach, Derek prepares to follow her but agrees to delay his own ascension when he learns that the Universal System is approaching Davin Resh. He reaches level 251, gains the title Ascending Monarch, and organizes four kingdoms against a three-month invasion. Jace, Derek's former best friend from Earth, enters independently, conquers Virindal, and later reconciles with Derek. The two use Jace's apparent hostility to lure the invading champions together. Trisha temporarily suppresses Derek's void and spatial powers, but Jace's timed rescue lets Derek turn Void's Embrace against the council ritual and kill Darvin. Derek's allies remove the remaining champions, and Amelia's surrender ends the invasion. The defending system records its requested favor complete, while Derek remains with Silvi and his surviving allies under a six-month deadline for forced ascension.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -775,7 +775,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -788,7 +788,7 @@
       "recaps": {
         "ending": "The second group of colonists makes an informed choice. Shown plainly what a Barish-Estranza labor contract does to the people who sign it, and what Preservation is actually offering instead, they refuse the combine and take the alternative. Barish-Estranza's position on the planet collapses and Supervisor Leonide leaves without the workforce the combine came for, and the colony's future moves toward resettlement on the colonists' own terms rather than salvage. The more important resolution is the SecUnit's. The gap it has been redacting out of its own account is finally closed: what it could not talk about was the earlier crisis, when the alien contamination took control of it, and the failures it has spent the whole book denying are the aftereffects of that rather than a hardware fault. It says so, out loud, to ART and to the humans who have been waiting for it to, and having named the thing it can begin dealing with it instead of hiding it. Three carries on learning how to be a person with choices, ART and its crew stay with the SecUnit, and the SecUnit remains what it has been since the beginning: free, difficult, and watching serials while it works. Nothing about the trauma is finished; it is simply no longer secret.",
         "in_short": "Still on the abandoned colony world after the crisis with the alien remnant technology, the SecUnit is malfunctioning in a way it refuses to describe, redacting parts of its own account and losing reliability at bad moments. When the group discovers a second, isolated settlement of colonists that Barish-Estranza is racing to sign to labor contracts, a team - the SecUnit, Three, ART's crew, the Preservation contingent and Dr. Bharadwaj with her documentary - sets out to reach them first. The second settlement is wary, its old installation is dangerous and not free of contamination, and the combine is willing to misrepresent anything to get signatures. Under pressure the SecUnit freezes, and is finally forced to admit that its fault is not technical: it is the aftermath of having been taken over during the earlier crisis. Naming it is what lets it work again. In the end the colonists are persuaded not by force but by evidence, Bharadwaj's footage among it, of what indenture actually means. They refuse the corporate contracts and choose Preservation's offer, and Barish-Estranza's operation on the planet is finished.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1251,7 +1251,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -1264,7 +1264,7 @@
       "recaps": {
         "ending": "Silvi kills Starfury Leonarus by opening Void Travel inside it and using Dragonfire, ending the raid dungeon. The victory costs seven lives. Ray Fergus dies when the boss redirects Derek's attack through a spatial rift, and four raiders die when the boss's star attack penetrates Time Prison. The survivors recover at a new Adventurer's Guild outpost, where Elena and Jasper are assigned to give the official account. Dave intercepts Derek and Silvi after the exit and identifies Origin System attention as the cause of their anomalous evolution and blocked rewards. Derek can no longer gain direct stats or skill upgrades from the Great System and must seek suitable essence instead. Dave provides new space abilities, gives Silvi recipes, authorizes a one-time release for Bones and Ogre, and reserves an unspecified future favor. Savannah has survived its assault, and Alana, Edgar, and Blitz have pushed the invaders close to Cydaria's border, but the war is still active. Derek and Silvi leave the outpost for Savannah, while Bones and Ogre remain oath-bound prospective allies whose practical release and employment are still pending.",
         "in_short": "Derek and Silvi emerge from linked evolutions with stronger void powers, a shared oath, and advancement that the ordinary system increasingly refuses to grant. While Cydaria faces an invasion, Derek survives a lethal solo trial and takes command of the raid after Silvi rescues Edward and Edgar leaves for the war. Alana, Natalie, and Marcus repel the assault on Savannah. Derek recruits Bones and Ogre before leading the remaining raiders against Starfury Leonarus. Silvi kills the boss from within, but seven raiders die during the dungeon. Dave then explains that Origin System attention caused the interference and that Derek now needs higher-quality essence to progress. He grants new abilities in exchange for a future favor. The raid returns to a new outpost, while Derek and Silvi depart for Savannah and the war remains unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1456,7 +1456,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1469,7 +1469,7 @@
       "recaps": {
         "ending": "A devastating typhoon strikes Hong Kong. Dirk and May-may take shelter in their house, but the building collapses and kills them. The disaster ends Dirk's attempt to control the future personally just as he has secured the Noble House against its immediate financial danger and laid plans intended to reach far beyond his lifetime. Culum survives and inherits leadership of Struan and Company, becoming the new Tai-Pan. His bond with Tess joins the younger members of the rival families even though Tyler Brock's hatred of the Noble House remains. Dirk's secret arrangements also survive him: obligations involving Jin-qua, Gordon Chen, and the divided coins can make claims upon later generations. Hong Kong itself endures the storm. The settlement Dirk championed is battered and uncertain, but it remains the base from which the Noble House and its enemies will continue their struggle.",
         "in_short": "In 1841, trader Dirk Struan is determined to turn the newly acquired island of Hong Kong into Britain's permanent gateway to China and preserve Struan and Company as the Noble House. His rival Tyler Brock tries to exploit the firm's financial crisis, while Dirk obtains a lifesaving loan from the Chinese merchant Jin-qua in return for binding future favors. Dirk also prepares his reluctant son Culum to succeed him, manages a hidden family life with his Chinese mistress May-may, and works through political, commercial, and personal threats. Culum falls in love with Brock's daughter Tess, linking the rival houses despite their fathers' hostility. Dirk defeats immediate attempts to destroy his company and removes the threat posed by Brock's brutal son Gorth, but cannot master the forces surrounding the new colony. A typhoon devastates Hong Kong and kills both Dirk and May-may when their house collapses. Culum survives to become the next Tai-Pan, inheriting the Noble House along with Dirk's concealed obligations and unfinished feud.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1652,7 +1652,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1665,7 +1665,7 @@
       "recaps": {
         "ending": "Sydney Carton uses his resemblance to Charles Darnay to enter the prison, drug Darnay, exchange clothes with him, and have him carried out under Carton's identity. Darnay escapes Paris in a carriage with Lucie, their child, Doctor Manette, and Jarvis Lorry. Madame Defarge goes to their lodging intending to denounce or kill the remaining family, but Miss Pross delays her; during their struggle Madame Defarge's pistol fires and kills her, while Miss Pross is permanently deafened. Carton remains in Darnay's place and comforts a frightened young seamstress as they approach the guillotine. He dies knowing that Lucie's family will survive, remember him lovingly, and give his name to a child. His voluntary sacrifice fulfills his promise to Lucie and transforms a life he considered wasted into the means of the family's rescue.",
         "in_short": "After eighteen years in the Bastille, Doctor Manette is restored to life with the help of his daughter Lucie and banker Jarvis Lorry. In London, Lucie marries French émigré Charles Darnay, while the gifted but self-destructive Sydney Carton privately promises he would sacrifice anything for her. Darnay is secretly an Evrémonde, heir to an aristocratic family whose cruelty has helped fuel revolution. When he returns to revolutionary France to aid a former servant, he is imprisoned. Doctor Manette's former-prisoner status first saves him, but a letter he wrote in the Bastille condemns the Evrémondes and sends Darnay back to death. Madame Defarge, whose family suffered through Evrémonde violence, seeks the destruction of Darnay's entire household. Carton exploits his resemblance to Darnay, takes his place in prison, and sends Darnay out to escape with Lucie, their child, Doctor Manette, and Lorry. Miss Pross kills Madame Defarge accidentally while defending the family's flight. Carton goes calmly to the guillotine, giving his life so the family can live.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1807,7 +1807,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1820,7 +1820,7 @@
       "recaps": {
         "ending": "Fudge swallows Peter's turtle, Dribble, and is rushed to the hospital. Doctors remove the turtle, but Dribble does not survive. Relatives and neighbors shower Fudge with attention and presents after his return, leaving Peter feeling that even the loss of his own pet has once again become an event centered on his brother. His parents finally acknowledge Peter's grief and how often his needs have been eclipsed. They bring home a puppy chosen especially for him. Peter names the dog Turtle, gaining a pet that is unmistakably his and too large for Fudge to swallow.",
         "in_short": "Fourth grader Peter Hatcher feels perpetually overshadowed by his unruly toddler brother, Fudge. After Peter wins a turtle named Dribble, family life becomes a succession of Fudge-created emergencies: he disrupts an important client visit, refuses food, injures himself while imitating a bird, throws a chaotic birthday party, ruins Peter's school project, and becomes an accidental television-commercial star. Adults frequently find Fudge adorable while Peter absorbs the embarrassment and inconvenience. The conflict peaks when Fudge swallows Dribble. Fudge survives after hospital treatment, but the turtle dies, and the attention surrounding the patient makes Peter feel more invisible than ever. His parents finally recognize the scale of his loss and give him a puppy of his own. Peter names the dog Turtle.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1967,7 +1967,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1980,7 +1980,7 @@
       "recaps": {
         "ending": "Fudge swallows Dribble, forcing the family to rush him to the hospital. Doctors remove the turtle, and Fudge recovers, but Dribble does not survive. Peter is distressed that the crisis again seems to center everyone's concern on Fudge, even though Peter has lost his pet. His parents finally acknowledge Peter's loss and the strain he has endured. His father brings home a puppy for him, and Peter names the dog Turtle. The gift does not undo what happened to Dribble, but it gives Peter a pet Fudge cannot swallow and closes the story with Peter receiving some long-delayed consideration of his own.",
         "in_short": "Nine-year-old Peter Hatcher struggles to live with his disruptive toddler brother, Farley Drexel, known as Fudge. While their parents repeatedly expect Peter to be patient, Fudge derails a visit from Father's business clients, turns meals and shopping trips into contests, causes chaos at his birthday party, injures himself while pretending to fly, ruins Peter's school project, and complicates an advertising shoot. Peter's most valued possession is Dribble, the pet turtle he won at his friend Jimmy's party. Fudge's fascination with the turtle culminates in his swallowing Dribble. Fudge survives after hospital treatment, but the turtle dies. Peter feels overlooked even in his own loss until his parents recognize what he has endured and give him a puppy, which he names Turtle.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2106,7 +2106,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2119,7 +2119,7 @@
       "recaps": {
         "ending": "After witnessing Ostap's execution in Warsaw, Taras returns to the Cossacks and leads a merciless campaign through Poland. He refuses a negotiated peace and continues raiding with his own regiment. Polish forces eventually trap him near the Dniester. Captured after turning back for his dropped pipe, he is chained to a tree and burned. Even while the fire rises, he calls directions to his escaping comrades, who reach boats and flee downriver. Taras dies certain that the Cossack cause and the strength of the Russian land will outlast his enemies. Ostap is dead, Andriy died by Taras's own hand after joining the Polish side, and Taras's final band survives without him; the family story closes in destruction rather than reconciliation.",
         "in_short": "Cossack colonel Taras Bulba takes his newly educated sons, Ostap and Andriy, from their mother's home to the Zaporozhian Sich. A Polish campaign gives both sons their first experience of war. During the siege of Dubno, Andriy enters the starving city to help a Polish noblewoman he loves and abandons the Cossacks for her people. Taras confronts and kills him in battle. Ostap fights steadfastly but is captured and taken to Warsaw, where Taras secretly watches his public execution and answers his son's final call. Taras then leads a destructive revenge campaign across Poland. Surrounded near the Dniester, he is captured and burned alive while directing his comrades' escape. All three central men die, each expressing a different loyalty: Andriy to romantic love, Ostap to his comrades, and Taras to the Cossack brotherhood and its faith.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2449,7 +2449,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -2462,7 +2462,7 @@
       "recaps": {
         "ending": "Ruwen rescues Big D, destroys Nameless inside his mind, and learns that the Infernal Lord has likely joined forces with the Dark Priest and two corrupted angels. When both crossing rings on the last city's world explode, Ruwen uses Hamma's unexplained resonance with Clouds Embracing the Sun to extend his soul vault around the whole city and move its population to Grave. The artifact breaks into four pieces, Hamma remains in pain, and Ruwen's soul regeneration falls to one percent of its former rate. Ruwen then leads an assault into the Infernal Realm, but the Infernal Lord has emptied the central sanctuary and escaped. Echo remains there to mourn her mother and parts from Ruwen as an ally. Big D returns safely to Midpoint, Fractal remains sealed in a crystal cocoon, and Eiru's reconstruction continues. The locations of the Infernal Lord, the Dark Priest, and the corrupted angels remain unknown. Penn's soul vault may have been taken, safe soul restoration through godstone is still unproved, and the Harbinger and Outerverse threats remain urgent.",
         "in_short": "After the Pact collapses, Ruwen investigates godstone, a temporal rift, and the system changes caused by his divine advancement. The rift yields affinity technology, while Tarot reveals that Ruwen is the ninth Harbinger after Penn and the Infernal Lord. Ruwen rescues Lylan, reforms and rebuilds Eiru, gains realm-travel artifacts, splits and delays the local segment of a realm zipper, becomes a Conductor of the Eighth Harmony, and reaches Grandmaster Alchemist. Penn's research links souls, chakras, Harmony, divine golems, and dangerous experiments. The Infernal Lord then abducts Big D as bait and helps Nameless attack Ruwen through Rami's mental bond. Ruwen saves Big D and destroys Nameless, but a linked crossing-ring blast threatens an entire city. With Hamma channeling a powerful artifact, Ruwen stores the city in his soul vault and relocates it to Grave. He attacks the Infernal Realm, only to find the Infernal Lord gone. Echo remains behind as an ally, while Ruwen returns to reconstruction and prepares to hunt the missing enemy alliance and strengthen his companions.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2669,7 +2669,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2682,7 +2682,7 @@
       "recaps": {
         "ending": "Tartuffe returns with an officer, expecting Orgon to be arrested for possessing politically dangerous papers. The officer instead takes Tartuffe into custody. The king has investigated the case, recognized Tartuffe as an offender with a history of false identities, and understood that Orgon was deceived rather than disloyal. The royal decision cancels Tartuffe's claim to the house and pardons Orgon's earlier indiscretion. Orgon's family is therefore spared eviction and prosecution. Even after being rescued, Orgon is ready to vent his anger on Tartuffe until Cleante urges him to accept justice without vindictiveness. With the household restored, Orgon turns at last to the promise he nearly broke: Mariane and Valere are free to marry.",
         "in_short": "Orgon brings the apparently devout Tartuffe into his home and becomes so infatuated with him that he disregards his family, breaks his daughter's engagement to Valere, and plans to give Tartuffe both Mariane and his estate. Tartuffe privately propositions Orgon's wife, Elmire. When Damis reports this, Orgon believes Tartuffe and disinherits his son. Elmire then makes Orgon hide and witness a second attempt at seduction. Convinced too late, Orgon orders Tartuffe out, only to learn that he has already transferred the house to him and entrusted him with compromising papers. Tartuffe tries to evict the family and have Orgon arrested. A royal officer instead arrests Tartuffe as a known criminal, restores Orgon's property, and pardons him. The family is saved, and Mariane may finally marry Valere.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2942,7 +2942,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0D38CR7BR",
@@ -2954,7 +2954,7 @@
       "recaps": {
         "ending": "Operation Olympic succeeds in its hidden purpose but leaves Task Force Hammer badly damaged. Frey's Star Force extracts the Collector called Biscuit from the reserve armory while the declared assault absorbs the enemy response. An atomic-compression blast cripples the ground force. David Chica and Jesse Coulter survive the blast, but their eventual fate is not established; Perkins's condition after the attack is also unknown. When the diverted regional fleet returns, it destroys two assault carriers and fatally damages the Flying Dutchman. Derek Bonsu abandons the ship, but Nagatha remains because her core cannot be removed. Valkyrie catches Team Razor's damaged dropship cabin and secures Biscuit. Rindhalu reinforcements shield the ship long enough for an emergency jump, but malware planted by the Outsider redirects the escape and ejects Skippy's pod. Skippy transfers his momentum to Valkyrie, saving Bishop, Reed, Bilby, Frey, and the Collector, then falls into the system star. The Outsider is still free, its intergalactic gateway project is unresolved, and it now knows what kind of artifact may threaten it. Bishop and Reed remain committed to the war, with recovering Skippy as their immediate objective.",
         "in_short": "After a hostile Outsider escapes and seizes Elder weapons, Joe Bishop and Skippy pursue it while defending Earth and Jaguar. Valkyrie survives a nanobot ambush, and Bishop and Skippy alter the wormhole network so the Maxolhx and Rindhalu cannot activate Elder weapons carried through it. Evidence of a stolen Rindhalu array reveals a long-prepared invasion gateway. Fragmented Elder programming points to a Collector that may locate a Spinner defense, so Bishop mounts Operation Olympic against a fortified Maxolhx world. The main assault suffers devastating losses while Frey's covert teams recover the Collector, Biscuit. The Flying Dutchman is fatally damaged, with Nagatha left aboard. Valkyrie escapes with Biscuit, but Outsider malware ejects Skippy during the jump. He saves the ship by transferring its momentum and falls into the system star. The Outsider and its gateway remain active, and Bishop and Reed turn immediately toward recovering Skippy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3433,7 +3433,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BSS6X5KF",
@@ -3445,7 +3445,7 @@
       "recaps": {
         "ending": "Liscor survives, but its walls and eastern gate are badly damaged. Magnolia Reinhart's threat forces the human army to withdraw, postponing rather than resolving the wider conflict. Rhys dies at Erin's inn after Garen frees him briefly from Az'kerash's control, and Ralk kills Garen as he fights toward the city. Pyrite, the Goblin spellcaster, Yellow Splatters, and one hundred other Painted Antinium also fall. Head Scratcher remains critically wounded, Bird is still recovering, and Erin closes the inn while grieving. Rags unites the surviving Flooded Waters, Redfang, Cave Goblins, and remnants of Rhys's army as Great Chieftain of the Mountain. Laken Godart takes several hundred Goblin prisoners north under his protection. Pawn establishes that the Antinium dead will be remembered as heroes and refuses to have Yellow Splatters resurrected. Ilvriss secretly learns that Az'kerash survived. Calruz remains imprisoned and warns Ceria of a female presence deeper in the dungeon, while the Horns commit to growing stronger together. The hidden mountain legacy still requires Garen's key and a second unknown key.",
         "in_short": "After rescuing Ceria and Mrsha from Liscor's dungeon, Erin helps the survivors recover while Rags and other Goblin factions are driven south by a human army. Rhys, a Goblin Lord controlled by Az'kerash, tries to force Rags to help seize Liscor, but she refuses and survives his attempt to kill her. As human trebuchets break the city's defenses, Erin's allied Goblins return and fight Rhys's army to protect Liscor. Garen frees Rhys briefly from magical control, but both brothers die, along with Pyrite, the Goblin spellcaster, Yellow Splatters, and many Goblin and Antinium fighters. Magnolia Reinhart coerces the human commander into withdrawing before he attacks the damaged city. Rags gathers the Goblin survivors under her rule as Great Chieftain of the Mountain, while Erin closes her inn in grief beside the critically wounded Head Scratcher. Az'kerash remains active, Mrsha's emerging magic needs training, and Calruz warns that a female presence still waits below the dungeon.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3698,7 +3698,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00NVOJYYU",
@@ -3710,7 +3710,7 @@
       "recaps": {
         "ending": "McGill, Natasha, Carlos, and Kivi escape permanent execution after Turov takes the Galactic Key, pardons the group, and presents their unauthorized destruction of the cephalopod ship as her own secret operation. Graves helps preserve that account while retaining a record that could place responsibility back on McGill. Legion Varus and Legion Germanica return to Earth early because their losses and limited revival capacity have left them badly depleted. McGill reaches Earth as a candidate for veteran, with Harris expected to oppose him during the trials. McGill and Natasha resume their relationship. Anne was killed during the escape from revival custody, and her later status is not established. The corrected Tau projectors have freed thousands from the imposed conditioning, but the orbital habitat's ultimate fate is unresolved. The destroyed cephalopod ship sent a data packet toward the galactic rim, leaving Earth exposed to a larger hostile power while the regional battle fleet remains absent.",
         "in_short": "Legion Varus rejects absorption into Earth's hegemony and is sent to Tau Ceti, where Claver's gunrunning and altered holographic projectors have helped turn local unrest into mass violence. After framing McGill for attacks on Turov and Drusus, Claver uses a Galactic Key to seize Minotaur and fire a devastating broadside that leaves the orbital habitat falling. McGill kills Claver, revives Turov, and helps recover the ship. Natasha creates a program that reverses the Tau conditioning, but Turov offers the habitat to Glide's cephalopods. McGill, Natasha, and Carlos secretly destroy the cephalopod ship. Turov revives the condemned mutineers, trades pardons for the Key, and claims the attack as her operation. The depleted legions return to Earth, McGill becomes a veteran candidate, and he reconciles with Natasha. A transmission from the destroyed ship leaves a wider cephalopod conflict unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/temper-an-apocalyptic-litrpg-series.json
+++ b/data/works-community/0/temper-an-apocalyptic-litrpg-series.json
@@ -241,7 +241,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B088ML5RVN",
@@ -253,7 +253,7 @@
       "recaps": {
         "ending": "Drew's forces break the coordinated Naga assault and confront the mind-worm conspiracy beneath Nats Park. Dak kills the submerged hive leader, which causes the infected Gonzalez to become its monstrous successor. Drew, Daryl, and Luke kill Gonzalez, and Drew claims the stadium node before collapsing from his wounds. Nats Park becomes a shielded habitat where Katie, Sarah, Daryl, JP, Hoffacker, Gunn, Luke, Dak, and the surviving civilians and Marines can regroup. Drew remains unconscious but stable, sustained by stored vitality. The local worm leadership is gone, though the existence of other infected hosts is uncertain. The supporting nodes are being developed for food, materials, and combat training ahead of an expected world boss. Snyder's condition after being shot is unknown, and Robbi's former faction has not reestablished contact. Drew's emerging connection to Retribution remains unresolved. The final threat is immediate: a fae seed ship descends west of the newly visible habitat.",
         "in_short": "Drew Michalik brings more than two hundred rescued survivors to Nats Park, where food shortages and a hidden mental influence threaten the community. His team traces the danger to mind worms beneath the stadium, loses Robbi during the first descent, and learns that Luke is a seraph assigned to guide Drew as a developing Red Mage. Drew then claims a network of nearby nodes, prepares Dak to reach the submerged hive leader, and rescues stranded Marines. After Dak kills the hive leader, a coordinated Naga attack exposes Gonzalez as an infected collaborator and successor to the hive. Drew, Daryl, and Luke defeat him, allowing Drew to turn Nats Park into a shielded habitat. Drew ends the battle unconscious but healing, while his allies hold the base and prepare for a future world boss. A fae seed ship arrives immediately afterward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -508,7 +508,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0CK52KV5S",
@@ -520,7 +520,7 @@
       "recaps": {
         "ending": "Novusheim survives all twenty-five waves and becomes a town when Joe uses the strengthened Ritual of Slaughter to kill the Frozen Cyclops. The damaged town hall is repaired and returned to its original site, and the settlement receives a 100-hour period in which monsters cannot approach its walls unless provoked. Grandmaster Snow gives the human population formal representation through Joe, while Major Cleavage holds the Master of Sarcasm pending a still-unresolved judgment. Jaxon, Havoc, Jake, Bauen, Socar, Heartpiercer McShootypants, Smitty, and the principal dwarven leaders survive. Joe secretly keeps the artifact-grade core taken from the Cyclops, and a policy change grants him half the experience and aspects from indirect monster kills. Jake still controls the Pyramid carrying Joe's mythic core, with his debt increasing for as long as he safeguards it. Daniela's allegiance and situation remain uncertain. The refugees have secured a viable base, but political divisions, unfinished infrastructure, and the need to build a city capable of supporting an escape route keep their larger struggle open.",
         "in_short": "Joe and the refugees arrive in a freezing giant world and race to turn an exposed camp into a lasting settlement. After the first guild hall falls, Joe builds shelter, water systems, businesses, ritual towers, mana batteries, and stronger walls while political suspicion limits his authority. A twenty-five-wave upgrade trial brings ice monsters, devastating bosses, heavy losses, and a factional split. Joe accepts responsibility for those who remain and becomes the settlement's defense coordinator. During the final crisis, the Master of Sarcasm frames and attacks him, but Major Cleavage intervenes and Jaxon helps preserve the town hall from the Frozen Cyclops's charged strike. Joe strengthens the Ritual of Slaughter and uses it to kill the boss, allowing the defenders to complete the trial. Novusheim becomes a town, Joe gains formal standing as the humans' representative and better rewards for indirect kills, and he privately takes the boss's artifact-grade core. The survivors gain a brief defensive respite but remain trapped and must continue building toward an eventual escape.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -692,7 +692,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -705,7 +705,7 @@
       "recaps": {
         "ending": "Jasmine goes into labor at Marcos's home. Marcos calls Cecilia, who returns and helps deliver a healthy boy. The birth gives the estranged couple the child they have been unable to replace since Leo's death, and their old intimacy rapidly reforms around the newborn. Once the baby is safe, Marcos kills Jasmine with a blow to the head. Cecilia is shocked and suggests that they could have kept her, but Marcos dismisses that possibility by classifying Jasmine as domesticated livestock. His action reveals the limit of the sympathy he appeared to show her: he protected, named, and impregnated her, yet still treated her life as expendable when she had served his purpose. Marcos and Cecilia keep the boy and treat Jasmine's corpse as something to be disposed of. The ending leaves the couple reunited through an act that reproduces the society's fundamental violence inside their home.",
         "in_short": "After a crisis makes animals officially unsafe to eat, governments legalize the breeding and slaughter of people as meat. Marcos Tejo manages a processing plant while grieving his infant son, living apart from his wife Cecilia, and caring for his father. He despises the industry's euphemisms but remains essential to its operation. A supplier gives him a captive woman as premium livestock. Marcos hides her, names her Jasmine, has sex with her, and eventually makes her pregnant, while continuing to tour slaughterhouses, breeding centers, hunting grounds, and laboratories built on the same dehumanization. His father dies, and Marcos's isolation deepens. When Jasmine gives birth, Cecilia returns to help and the couple claim the boy as the replacement for the child they lost. Marcos then kills Jasmine and treats her body as meat. His final act shows that his private tenderness never amounted to recognizing her as free or equal; he has used the system he professed to hate to rebuild his family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -855,7 +855,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -868,7 +868,7 @@
       "recaps": {
         "ending": "At Cyber Research Systems, General Brewster is mortally wounded by the T-X after Skynet has been activated. He directs John and Kate to Crystal Peak, which they believe may house Skynet's central hardware. The damaged T-850 gets them to the site and destroys both itself and the pursuing T-X before the pair enter the bunker. Inside, John and Kate discover that Crystal Peak is a hardened command shelter, not a computer center: Skynet has spread through networks and has no single core they can destroy. The system launches nuclear weapons, provoking worldwide retaliation and beginning the catastrophe John hoped had been prevented. Calls arrive over the shelter's radio from surviving civil and military stations. John accepts that the promised future has begun and, with Kate beside him, answers the calls and starts coordinating the survivors. They have not stopped Judgment Day; they have survived it and taken the first step toward leading the human resistance.",
         "in_short": "John Connor has lived off the grid since he and his mother delayed the rise of the military intelligence Skynet. A new machine, the T-X, arrives from the future to kill John and the people who will become his commanders. Another Terminator, a T-850, rescues John and veterinarian Kate Brewster, explaining that Judgment Day was postponed rather than prevented and that Kate is central to John's future. Kate's father, General Robert Brewster, activates Skynet to fight a computer virus, unaware that the virus is Skynet's route to control. The T-X attacks the military facility as Skynet begins its takeover. Brewster sends John and Kate to Crystal Peak, supposedly their best hope of stopping it. The T-850 sacrifices itself to destroy the T-X, but Crystal Peak proves to be a fallout shelter rather than Skynet's core. Nuclear missiles launch around the world. Safe inside, John and Kate answer calls from scattered survivors and begin the leadership roles the future assigned them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1072,7 +1072,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1085,7 +1085,7 @@
       "recaps": {
         "ending": "Angel returns from Brazil changed by hardship and ready to forgive Tess, but finds that his change has come too late: poverty and her family's homelessness have driven her back to Alec, who has installed her at Sandbourne. Tess tells Angel that Alec persuaded her he would never return. After Angel leaves in despair, she blames Alec for destroying her chance of reconciliation and kills him. She catches up with Angel, and the two spend several hidden days together before traveling toward Stonehenge. There Tess rests on an altar stone, knowing that the police are near, and is arrested at dawn. Before they part she asks Angel to care for and marry her younger sister Liza-Lu after Tess is gone. Angel and Liza-Lu later watch the prison signal announcing Tess's execution, then leave together. Tess's death closes her struggle; the surviving pair carry out the personal bond she asked them to form.",
         "in_short": "After her father learns that their poor family descends from the ancient d'Urbervilles, Tess Durbeyfield is sent to seek help from wealthy people who have adopted that name. Alec d'Urberville pursues and sexually exploits her, and Tess returns home to bear a child who soon dies. Seeking a new start at Talbothays dairy, she falls in love with Angel Clare and agrees to marry him. On their wedding night each confesses a past sexual experience, but Angel cannot extend to Tess the forgiveness she gives him. He leaves for Brazil while she endures poverty and harsh farm work. Alec reappears, first as a preacher and then as her persistent pursuer. After Tess's father dies and her family loses its home, Alec's material support draws her back to him. Angel returns repentant, but Tess believes their future has been destroyed. She kills Alec, flees with Angel, and is arrested at Stonehenge. Tess is executed, while Angel leaves with her younger sister Liza-Lu in accordance with Tess's last request.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1262,7 +1262,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1275,7 +1275,7 @@
       "recaps": {
         "ending": "Angel comes home from Brazil prepared to accept Tess's past, but his return follows the death of her father and her family's loss of their home. He finds Tess at Sandbourne, where Alec is supporting her and her relatives. Tess explains that Alec convinced her Angel would never return. Angel leaves, and Tess kills Alec for destroying the future she might have recovered. She catches up with Angel, confesses, and spends a brief period in hiding with him. They travel as far as Stonehenge, where Tess rests on an altar stone and allows the pursuing police to arrest her at dawn. She asks Angel to look after and eventually marry her younger sister Liza-Lu. Angel and Liza-Lu later see the prison signal announcing that Tess has been executed. They walk away together, fulfilling the relationship Tess asked them to form after her death.",
         "in_short": "Tess Durbeyfield's poor family sends her to seek help from wealthy people who use their ancestral name. Alec d'Urberville pursues and sexually exploits her; she returns home, bears a son, and loses the baby. At Talbothays dairy she loves and marries Angel Clare, but his idealized view of her collapses when she tells him her history. Angel leaves for Brazil while Tess struggles through harsh farm work. Alec returns, abandons a temporary religious conversion, and pressures her to accept his support. After Tess's father dies and the family becomes homeless, she gives in for their sake. Angel returns repentant, but Tess believes Alec has destroyed their reunion and kills him. She flees with Angel, is captured at Stonehenge, and is executed. Angel leaves with Tess's younger sister Liza-Lu, as Tess asked him to do.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1466,7 +1466,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1479,7 +1479,7 @@
       "recaps": {
         "ending": "Angel returns from Brazil ready to acknowledge that he judged Tess cruelly, but finds her living with Alec in Sandbourne after Alec has supported her displaced family. Tess tells Angel that his return is too late. She then kills Alec and escapes with Angel, and the two spend a few hidden days together in an empty house before moving on. At Stonehenge, Tess rests on an altar-like stone and accepts that the authorities will find her. She is arrested while Angel watches. Tess asks Angel to care for and marry her younger sister Liza-Lu after her death. Tess is subsequently executed at Wintoncester. Angel and Liza-Lu see the prison signal announcing that the sentence has been carried out, then leave together. Alec is dead, Tess's brief reunion with Angel has ended, and Angel is left to fulfil the responsibility she entrusted to him.",
         "in_short": "Tess Durbeyfield, the eldest child of a poor rural family, is sent to seek help from wealthy people using the d'Urberville name after her father learns of their ancient ancestry. Alec d'Urberville pursues and sexually exploits her; she returns home, gives birth to a child who soon dies, and later begins again as a dairymaid. At Talbothays she and Angel Clare fall in love and marry, but Angel cannot forgive the past she confesses, despite admitting his own sexual lapse, and abandons her for Brazil. Poverty and responsibility for her family drive Tess into harsh farm work. Alec returns, pressures her relentlessly, and eventually supports her destitute household. When Angel comes back repentant, Tess is living with Alec. She kills Alec and flees with Angel, enjoying only a brief reunion before she is arrested at Stonehenge. Tess is executed, and Angel leaves with her younger sister Liza-Lu, whom Tess asked him to protect.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1626,7 +1626,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1639,7 +1639,7 @@
       "recaps": {
         "ending": "After Cathy and Bryon bring M&M home from a terrifying drug experience, Bryon realizes that Mark has been selling pills. He finds Mark's supply and, unable to dismiss the harm as another harmless hustle, calls the police. Mark is arrested, convicted, and sent to prison. When Bryon visits, Mark no longer treats him as a brother and says that he hates him. Bryon's relationship with Cathy also fades; he cannot recover the intensity of feeling he once had for her or for Mark. Looking back, he understands that he made the choice he believed was right, yet he is left isolated and emotionally numb. The novel closes without repairing the friendship: Bryon has crossed into a more responsible view of consequences, but the cost is the bond that had defined his childhood.",
         "in_short": "Sixteen-year-old Bryon Douglas and his adopted brother Mark have grown up treating fights, hustles, and theft as ordinary adventures. Bryon begins to change after dating Cathy Carlson, taking a job, and seeing the damage caused by the boys' reckless life. Their friend Charlie dies while saving them from men they cheated, and Cathy's vulnerable younger brother M&M runs away to a communal house, where drug use leaves him psychologically shattered. Bryon discovers that Mark has been selling drugs and calls the police, choosing the victims of Mark's trade over their lifelong loyalty. Mark is imprisoned and comes to hate him. Cathy and Bryon drift apart as well, leaving Bryon older and more responsible but cut off from the relationships that once gave his life certainty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1805,7 +1805,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1818,7 +1818,7 @@
       "recaps": {
         "ending": "Inspector Aronsson finally catches up with Allan's group and hears an account in which the pursuing criminals died through accidents and their own aggression. With bodies missing and the supposed kidnapping victim plainly acting by choice, he accepts a version that gives the police little reason to continue. The surviving leader of Never Again abandons his pursuit and is absorbed into the unlikely company. Allan, Julius, Benny, Gunilla, and their companions use the suitcase's fortune to leave Sweden, arranging travel that can also accommodate Sonya the elephant. They settle into luxury in Bali, where Allan is reunited with Amanda from his earlier adventures. The escape that began as a short walk away from a birthday party has given him a new circle of friends rather than a return to institutional life. Even at one hundred, however, Allan is not entirely finished with international affairs: remarks about his knowledge of nuclear weapons attract fresh official interest, suggesting that another historical detour may begin just as this journey closes.",
         "in_short": "On his hundredth birthday, Allan Karlsson climbs out of his nursing-home window and accidentally steals a gangster's suitcase filled with cash. He joins petty criminal Julius, broadly educated Benny, farmer Gunilla, and her elephant Sonya while members of the Never Again gang pursue them and die in a succession of accidents. Inspector Aronsson follows a trail that looks like kidnapping and murder but eventually accepts that Allan left voluntarily and that the evidence cannot sustain the case. Alternating chapters reveal Allan's earlier life as an explosives expert whose political indifference carried him through the Spanish Civil War, the Manhattan Project, China, Stalin's Soviet Union, North Korea, Indonesia, and Cold War espionage. His technical talent and willingness to share a meal repeatedly win the favor of powerful people. The surviving fugitives and a reformed pursuer finally take the money to Bali, where Allan reunites with an old friend and approaches his next improbable involvement in world affairs.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1994,7 +1994,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2007,7 +2007,7 @@
       "recaps": {
         "ending": "Pongo and Missis lead all ninety-seven rescued puppies back toward London. To pass unseen beneath Cruella's attention, the spotted dogs roll in soot and resemble black dogs until melting snow begins washing the disguise away. Cruella pursues them, but the Badduns' van and her car are wrecked, ending the immediate chase. The exhausted dogs reach the Dearly home at Christmas, where the humans recognize Pongo and Missis despite the soot and willingly adopt every puppy. The rescue therefore creates a household of one hundred Dalmatians: ninety-seven puppies, Pongo, Missis, and Perdita. Mr Dearly uses his resources to buy Hell Hall after Cruella is forced to sell it, planning a country home with room for the dogs. The White Cat is given a safe place there. Perdita is also reunited with her lost mate, Prince, who joins the family and brings the Dalmatian total to the promised one hundred and one. Cruella survives but loses her furs and her power over the animals she intended to kill.",
         "in_short": "Pongo and Missis live with the Dearlys in London and have fifteen puppies, aided by a lost Dalmatian named Perdita. Fur-obsessed Cruella de Vil tries to buy the litter and, when refused, has the puppies stolen. Pongo and Missis use the Twilight Barking, a canine message network, to trace them to Hell Hall in Suffolk. There they learn that Cruella has collected ninety-seven Dalmatian puppies and plans to have them killed for their skins. Helped by country dogs and a courageous cat, the parents free every puppy and lead them toward London. Farms along the route provide shelter and food, while soot temporarily disguises the spotted dogs from Cruella. Her pursuit ends in a road accident, and the whole company reaches the Dearlys at Christmas. The Dearlys adopt all ninety-seven puppies and buy Hell Hall as a country home. Perdita later finds her lost mate Prince, whose arrival brings the extended family to one hundred and one Dalmatians.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2147,7 +2147,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2160,7 +2160,7 @@
       "recaps": {
         "ending": "Hannay traces Scudder's phrase about thirty-nine steps to a staircase descending from a house on the Kent coast. The three apparently ordinary residents of the house are the Black Stone agents, waiting for the tide so that a yacht can carry them and the stolen defence information to Germany. Hannay is briefly uncertain because their behavior and cultivated English identities seem convincing, but a small habitual gesture reveals the leader he previously met in Scotland. With officials watching the coast and sea, Hannay confronts the group and prevents their escape; all three spies are arrested. The naval secrets are recovered before they can reach Germany. Europe nevertheless moves toward the wider conflict Scudder predicted, and Hannay receives an army commission. The book closes shortly before Britain enters the First World War, with the immediate espionage plot defeated but the international crisis no longer avoidable.",
         "in_short": "Richard Hannay, recently returned to Britain, shelters American agent Franklin Scudder, who has uncovered a German plot to steal naval intelligence and worsen the crisis in Europe. When Scudder is murdered in Hannay's flat, Hannay becomes both the police suspect and the spies' next target. He escapes to Scotland, deciphers Scudder's notebook, crosses the countryside through disguises and improvised identities, and survives capture by the German network called the Black Stone. Reaching official Sir Walter Bullivant, Hannay gives his warning, but an enemy disguised as a senior naval officer still obtains secret plans. Hannay realizes Scudder's cryptic reference to thirty-nine steps identifies a house on the Kent coast. He finds the Black Stone's leaders there, exposes them before they can depart by yacht, and secures their arrest and the recovery of the plans. The larger European war still begins, and Hannay enters military service.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2347,7 +2347,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2360,7 +2360,7 @@
       "recaps": {
         "ending": "Poirot explains that there was never a maniac working through the alphabet. The murders were a screen for one killing, on the principle that the safest place to hide a leaf is a forest. Franklin Clarke killed his brother Sir Carmichael for the fortune he expected to inherit, having realised that once Lady Clarke died his brother would marry Thora Grey and disinherit him. To conceal that single motive he invented a lunatic, wrote the challenges to Poirot, and manufactured a series in which his brother's death would be simply the third item. He found his scapegoat in Alexander Bonaparte Cust, an ill, suggestible ex-soldier subject to blackouts, engaged him by letter for a fictitious stocking firm, supplied him with the goods and with railway guides, and sent him to each town on the appointed day, so that Cust would half believe in his own guilt when the police came. The fourth murder, at Doncaster, was deliberately made to break the alphabetical pattern, so that the series would collapse into apparent madness at the moment Cust was caught. Poirot secures his proof and Franklin Clarke is arrested. Cust is cleared and released, his health attended to, and finds himself briefly famous and, for the first time, of interest to other people. Megan Barnard and Donald Fraser are left with a future to work out between them, and Hastings and Poirot part with Poirot cheerfully unrepentant about the theatricality of his methods.",
         "in_short": "Poirot receives a typed letter signed A.B.C. daring him to prevent a crime at Andover on a stated date. An old shopkeeper named Alice Ascher is found battered behind her counter with an ABC railway guide open beside her. A second letter names Bexhill, where a young waitress, Betty Barnard, is strangled on the beach; a third names Churston, where Sir Carmichael Clarke is killed on his evening walk. The country panics over an alphabet maniac, while an ailing travelling salesman, Alexander Bonaparte Cust, moves from town to town selling stockings and suffering blackouts. Poirot gathers the victims' relatives into an unofficial working party and studies the dead rather than hunting the killer. A fourth murder at Doncaster breaks the pattern, and Cust is arrested with a bloodstained knife, half convinced he is guilty. Poirot proves he cannot be, and shows that the series was camouflage for a single murder: Sir Carmichael's brother Franklin Clarke killed him for the inheritance and built a fictitious madman around it, using Cust as the scapegoat. Clarke is arrested and Cust set free.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2533,7 +2533,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2546,7 +2546,7 @@
       "recaps": {
         "ending": "After Mary dies in a fire at her Montana home, Junior grieves the third alcohol-related death among his family and friends within a few months. He returns to Reardan and is met with sympathy from classmates he once assumed would never truly see him. As the school year ends, he recognizes that he belongs to many overlapping groups rather than having to choose one absolute identity, though he also knows that leaving the reservation school has separated him from people he loves. Rowdy eventually comes to Junior's house. He is still hurt, but he tells Junior that Native people were once nomadic and predicts that Junior is meant to travel beyond the reservation. The two play basketball one-on-one without keeping score. Their friendship is not restored to its old simplicity, yet the game establishes a real reconciliation. Junior closes his freshman year carrying grief, wider possibilities, and renewed connection to Rowdy at the same time.",
         "in_short": "Fourteen-year-old Junior Spirit leaves the underfunded school on the Spokane reservation for the mostly white high school in Reardan, hoping for a future his community's poverty has made difficult to imagine. The decision ruptures his friendship with Rowdy and makes him feel disloyal at home, while racism and his hidden poverty isolate him at Reardan. Junior gradually earns respect, befriends Gordy, dates Penelope, and joins the basketball team. His new school defeats Wellpinit, but victory makes him ashamed when he sees the unequal lives behind the score. Meanwhile his grandmother, his father's friend Eugene, and his sister Mary all die in incidents connected to alcohol, forcing Junior through repeated grief. By year's end he understands himself as belonging to many communities. Rowdy returns, calls Junior a nomad who will travel beyond the reservation, and plays basketball with him without keeping score, beginning their reconciliation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2695,7 +2695,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2708,7 +2708,7 @@
       "recaps": {
         "ending": "On a business trip to Paris, Macon discovers that Muriel has booked the same journey, though he refuses to treat the coincidence as a reunion. A recurrence of his back trouble leaves him confined to his hotel, and Sarah comes to help him. Her competence briefly restores the familiar shape of their marriage, while Muriel is kept at a distance. Macon nevertheless recognizes that returning to Sarah has not undone the habits of withdrawal that divided them. He tells Sarah that he is leaving and accepts that choosing a less controlled life may bring pain as well as connection. On his way through Paris he sees Muriel walking with her luggage, stops the taxi, and joins her. Rose, meanwhile, has moved beyond the closed Leary household and is building a marriage with Julian, leaving the siblings to manage without her. Macon's final choice does not erase Ethan's death or guarantee an easy future; it marks his decision to engage with Muriel and Alexander rather than continue using familiarity as protection from change.",
         "in_short": "Travel-guide writer Macon Leary responds to the murder of his twelve-year-old son, Ethan, by retreating further into routine. His wife, Sarah, separates from him, and after an accident Macon moves back in with his eccentric siblings. Muriel Pritchett, a dog trainer and single mother, persists in befriending him while working with Ethan's unruly corgi, Edward. Macon begins a relationship with her and becomes involved with her son, Alexander, discovering a disorderly form of family life that both attracts and frightens him. When Sarah asks to try again, Macon leaves Muriel and resumes his marriage, but the old emotional distance remains. During a trip to Paris, Muriel follows and Sarah arrives after Macon hurts his back. Forced to choose, Macon tells Sarah he cannot remain with her merely because their shared life is familiar. He leaves the hotel and stops his taxi when he sees Muriel, choosing an uncertain future with her and Alexander.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2913,7 +2913,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2926,7 +2926,7 @@
       "recaps": {
         "ending": "The final completed narrative section follows Lancelot through a sequence of adventures in which he escapes Morgan le Fay and the other queens holding him, repays the young woman who freed him by fighting for her father, and resumes his wandering. He exchanges armor with Kay, defeats knights who mistake him for an easier opponent, overcomes the brutal Tarquin, and releases Tarquin's prisoners. Further traps test his judgment as well as his strength before he returns to Arthur's fellowship with his reputation enlarged. This is not the intended conclusion of Arthur's reign: Steinbeck stopped adapting Malory long before the betrayal, collapse of the Round Table, and deaths announced by the traditional legend. The published narrative therefore ends in the expansive middle of the cycle, with Lancelot celebrated, Arthur's court still standing, Morgan still a danger, and the tensions around Guinevere unresolved. Editorial material following the story records the unfinished project's development rather than completing its plot.",
         "in_short": "Merlin arranges Arthur's secret birth to Uther and Igraine, his fostering by Sir Ector, and his recognition when he draws the sword from the stone. Arthur secures his kingdom and establishes a Round Table fellowship, but its ideals are repeatedly compromised. Balin's anger leads to the Dolorous Stroke and an unwitting fatal duel with his brother Balan. At Arthur's wedding to Guinevere, the first quests expose both courage and failures of mercy. Nimue learns Merlin's magic and confines him, depriving Arthur of his chief counselor. Morgan le Fay then attempts to kill Arthur through Accolon and the stolen Excalibur, but Arthur survives and Morgan escapes. Gawain, Ewain, and Marhalt undertake adventures that test loyalty and relations between knights and women. The last section celebrates Lancelot's rescues, battles, and growing renown. Because Steinbeck left the adaptation unfinished, the book stops during Lancelot's early adventures rather than reaching the fall of Camelot.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3041,7 +3041,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3054,7 +3054,7 @@
       "recaps": {
         "ending": "Holmes proves that Arthur was trying to recover the coronet rather than steal it. Arthur had seen Mary pass the treasure to Sir George Burnwell and followed Burnwell outside, where the two men struggled. The coronet broke during the fight, and Arthur returned with the portion he had recovered. He accepted arrest rather than expose Mary, whom he loved. Holmes tracks Burnwell down and compels him to surrender the three missing beryls in exchange for payment. Mary has fled with Burnwell, leaving a note behind, and Holder recognizes that his suspicion wronged his son. The gems can be restored to the coronet, but the damage to the family cannot be so neatly repaired.",
         "in_short": "Banker Alexander Holder accepts the beryl coronet as security for a loan from an exalted client and takes it home for safekeeping. During the night he finds his indebted son Arthur holding the bent coronet, with three stones missing, and has him arrested. Holmes studies the house, the snow outside, and the strength needed to break the gold setting. He discovers that Holder's niece Mary had given the coronet to Sir George Burnwell. Arthur witnessed the exchange, fought Burnwell, and recovered part of the treasure, but kept silent to protect Mary. Holmes obtains the missing beryls from Burnwell. Mary flees with him, while Holder learns that the son he condemned was acting out of loyalty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3168,7 +3168,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3181,7 +3181,7 @@
       "recaps": {
         "ending": "Holmes identifies Colonel Valentine Walter as the person who stole the plans to pay his debts. Cadogan West saw the theft, followed Walter to Hugo Oberstein's railway-side house, and confronted the spy. Oberstein killed West, kept the most valuable pages, and placed the body on the roof of a stopped train; it fell beside the line later in the journey. Confronted through a coded newspaper exchange, Walter confesses and agrees to help the authorities lure Oberstein back within reach of British justice. The missing papers are recovered, West's name is cleared, and the government rewards Holmes for preventing the defense secret from remaining in foreign hands.",
         "in_short": "Mycroft asks Holmes to investigate the death of government clerk Arthur Cadogan West, whose body is found beside an Underground line with most of the stolen Bruce-Partington submarine plans in his pocket. Holmes notices that West could not have reached the place in the ordinary way and concludes that his body fell from the roof of a train. A nearby house belongs to foreign agent Hugo Oberstein. There Holmes finds evidence that West was killed after following the real thief, Colonel Valentine Walter, who had taken the plans to sell them and escape his debts. Oberstein retained the crucial pages and used the railway to dispose of West's body. Holmes exploits Oberstein's coded newspaper correspondence, obtains Walter's confession and cooperation, recovers the papers, and clears West of treason.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3268,7 +3268,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3281,7 +3281,7 @@
       "recaps": {
         "ending": "Holmes deciphers the dancing figures as a substitution cipher used by Abe Slaney, an American criminal who knew Elsie before her marriage. By the time Holmes and Watson reach Norfolk, Hilton Cubitt has been shot dead and Elsie is gravely wounded by a self-inflicted gunshot. Evidence at the window shows that Cubitt exchanged fire with an outside visitor. Holmes writes a message in the same cipher ordering Slaney to come and has it delivered to the farm where he is staying. Believing that Elsie sent it, Slaney arrives and is arrested. He explains that Elsie's father led a Chicago gang and created the code. Elsie fled that life; Slaney followed and tried to force her to return to him. During their final meeting Cubitt appeared, and the two men fired at each other. Cubitt died, while Slaney escaped and Elsie attempted suicide. Slaney's death sentence is reduced because Cubitt fired first. Elsie survives and remains in Norfolk, devoting herself to the management of her husband's estate and care for those in need.",
         "in_short": "Norfolk landowner Hilton Cubitt asks Sherlock Holmes to explain drawings of dancing stick figures that terrify his American wife Elsie. She had required him to promise never to question her about her past, so he seeks help without breaking her confidence. As more messages appear, Holmes identifies the figures as a substitution cipher and gradually reads them as communications from Abe Slaney. An urgent message brings Holmes and Watson to the Cubitt home too late: Hilton is dead and Elsie is critically wounded. The police suspect murder followed by attempted suicide, but Holmes shows that a third person fired through a window. Using the solved cipher, he summons Slaney and has him arrested. Slaney reveals that he knew Elsie through her father's Chicago criminal gang and pursued her after she escaped to England. Hilton interrupted their final meeting, and the men exchanged shots; Elsie then shot herself in despair. Slaney is convicted, while Elsie recovers and continues her husband's charitable responsibilities in Norfolk.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3377,7 +3377,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3390,7 +3390,7 @@
       "recaps": {
         "ending": "Holmes determines that burning a rare African poison called devil's-foot root produced the terror and madness in both rooms. Mortimer Tregennis had thrown the substance into the fire while visiting his siblings, killing Brenda and destroying his brothers' sanity in a dispute over family property. Leon Sterndale, who had secretly loved Brenda for years, learned the truth and forced Mortimer to experience the same death by burning the poison beneath his lamp. Sterndale admits what he did and explains that his existing marriage had prevented him from openly joining Brenda. Holmes, judging that formal proceedings would add little justice, allows him to leave. Holmes and Watson survive their own hazardous test of the poison, and the case closes without an arrest.",
         "in_short": "While Holmes is recovering in Cornwall, Mortimer Tregennis reports that his sister Brenda died and his brothers George and Owen went insane during a night at their home. All three showed signs of overwhelming terror. Mortimer is soon found dead in a similar locked room. Holmes connects both incidents to fumes created by burning a rare African poison, a theory he and Watson nearly die testing. Explorer Leon Sterndale then confesses that he killed Mortimer in retaliation. Mortimer had poisoned his siblings during a quarrel over property, murdering Brenda, whom Sterndale loved, and leaving the brothers insane. Sterndale made Mortimer suffer the same fate. Accepting his account and motive, Holmes lets him go.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3498,7 +3498,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3511,7 +3511,7 @@
       "recaps": {
         "ending": "Holmes identifies Lady Hilda as the person who removed the state letter from her husband's dispatch box. Eduardo Lucas had obtained an indiscreet letter she wrote before her marriage and threatened to expose it unless she brought him the diplomatic paper. While she was delivering it, Lucas's jealous wife arrived and killed him; hidden nearby, Lady Hilda saw Lucas place the paper beneath a loose section of floor. She later returned and shifted the bloodstained carpet to retrieve it, producing the mismatch that attracted Lestrade's attention. Holmes compels her to surrender the paper but protects her marriage and reputation. Following his instructions, she replaces it in the dispatch box before Trelawney Hope and Lord Bellinger return. Holmes then invites Hope to search again. The letter is found, and the prime minister concludes that it was never stolen. Holmes leaves both officials unaware of Lady Hilda's theft, the blackmail, and his intervention.",
         "in_short": "Prime Minister Lord Bellinger and European secretary Trelawney Hope ask Sherlock Holmes to recover a stolen letter whose publication could cause an international crisis. The disappearance coincides with the murder of suspected agent Eduardo Lucas. A bloodstained carpet at Lucas's house has been shifted, revealing a hiding place beneath the floor. Holmes traces the second visitor to Hope's wife, Lady Hilda. Lucas had blackmailed her over a compromising letter from before her marriage and forced her to steal the state paper. Lucas's jealous wife killed him while Lady Hilda was concealed in the room, allowing her to see where he hid the document and recover it later. Holmes persuades Lady Hilda to give him the paper and has her replace it in her husband's dispatch box. When Hope searches again, he finds it. Holmes preserves Lady Hilda's secret and lets the government believe the dangerous document had never left its keeper's possession.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3675,7 +3675,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3688,7 +3688,7 @@
       "recaps": {
         "ending": "Inside the Dogfish, Pinocchio discovers Geppetto alive but weakened after two years of confinement. The puppet waits until the creature sleeps with its mouth open, then carries his father toward freedom. The Tuna, inspired by their escape, helps them reach shore when Pinocchio's strength fails. Pinocchio thereafter supports Geppetto through steady work, study, and practical care. He also gives away money he had saved when he learns that the Blue Fairy is ill, choosing her need over his planned new clothes. This sustained change, rather than a single promise, earns his reward. He awakens as a real boy in a clean home, with Geppetto restored to health and the Fairy's gift providing security. Looking at the lifeless wooden puppet he once inhabited, he recognizes the distance between his former recklessness and the responsible son he has become.",
         "in_short": "Geppetto carves a talking piece of wood into Pinocchio, a puppet whose impatience repeatedly turns good intentions into danger. He abandons school for a marionette show, is cheated out of gold by the Fox and Cat, ignores the Blue Fairy's guidance, and cycles through punishment and rescue. Even after trying school, he follows Candlewick to the Land of Toys, where endless play transforms both boys into donkeys. Pinocchio is sold, injured, and nearly killed for his hide before becoming a puppet again and being swallowed by the giant Dogfish. Inside he finds Geppetto, who was lost at sea while searching for him. Pinocchio carries his father out, receives help from the Tuna, and brings him safely ashore. By working, studying, caring for Geppetto, and sacrificing his savings to help the Fairy, Pinocchio finally demonstrates lasting responsibility. The Fairy transforms him into a real boy and restores the household's health and comfort.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3786,7 +3786,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3798,7 +3798,7 @@
       },
       "recaps": {
         "in_short": "Watson presents twelve independent investigations from his association with Sherlock Holmes. The volume opens with Holmes meeting Irene Adler in \"A Scandal in Bohemia\" and proceeds through problems involving missing people, strange inheritances, threatened households, disputed identities, and objects whose importance is not immediately apparent. Holmes moves between private drawing rooms, London streets, country estates, and Scotland Yard inquiries, using observation and inference while Watson supplies the narrative record and a humane view of clients in distress. Inspector Lestrade and Mrs Hudson recur around the Baker Street partnership, but each adventure brings its own client and mystery. The stories establish the durable pattern of a visitor at 221B Baker Street, an investigation that challenges the first account of events, and an explanation assembled from details others have overlooked, without forming a single continuous plot.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3885,7 +3885,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3898,7 +3898,7 @@
       "recaps": {
         "ending": "Holmes identifies John Turner as the man who killed Charles McCarthy. In Australia, Turner had led a band of robbers, and McCarthy later recognized him in England and used that knowledge to extort land and money. When McCarthy tried to force a marriage between James and Alice, Turner struck him with a stone beside Boscombe Pool. The victim's final reference to a rat was an unfinished attempt to say Ballarat, pointing back to Australia. Turner gives Holmes a written confession. Because Turner is gravely ill, Holmes does not immediately expose him; instead, he keeps the confession available in case James is convicted. Holmes's analysis of the physical evidence is enough to undermine the prosecution, and James is acquitted. Turner dies several months later, while James and Alice are free to build a life together without knowing every detail of their fathers' history.",
         "in_short": "James McCarthy is arrested after his father, Charles, is found dying beside Boscombe Pool. Witnesses saw James follow him, and James admits to a quarrel, but Alice Turner asks Holmes to prove her childhood friend innocent. At the scene Holmes finds signs that a third man was present. He learns that Charles had known Alice's wealthy father, John Turner, in Australia and had long held unexplained power over him. Turner confesses that he once led a criminal gang and that Charles had recognized and blackmailed him. When Charles demanded that James marry Alice, Turner killed him with a stone. Holmes retains Turner's confession but uses the physical evidence to clear James, sparing the terminally ill Turner a public trial. James is acquitted, Turner dies soon afterward, and James and Alice are left free of the coercion that caused the crime.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-aeneid.json
+++ b/data/works-community/0/the-aeneid.json
@@ -158,7 +158,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -171,7 +171,7 @@
       "recaps": {
         "ending": "Aeneas and Turnus agree to settle the war by single combat, but Juno's agent Juturna helps provoke the armies into breaking the truce. Aeneas is wounded, healed with Venus's aid, and returns to battle. When he threatens the Latin city, Queen Amata mistakenly believes Turnus dead and takes her own life. Turnus finally dismisses Juturna and faces Aeneas. The Trojan defeats and wounds him. Turnus concedes and asks that his body be returned to his father; Aeneas hesitates and is close to sparing him. He then notices that Turnus is wearing the sword belt taken from Pallas, the young Arcadian entrusted to Aeneas and killed earlier by Turnus. Anger and his obligation to avenge Pallas overcome mercy, and Aeneas kills Turnus. The poem stops at that death. The marriage to Lavinia, the union of Trojans and Latins, and the eventual rise of Rome remain foretold rather than narrated, while Aeneas's final act leaves the cost and moral character of the destined victory unresolved.",
         "in_short": "After Troy falls, Aeneas leads survivors toward Italy, where prophecy promises that their descendants will found Rome. Juno opposes them, driving the fleet to Carthage. Queen Dido shelters Aeneas and falls in love with him, but he obeys the gods and departs; she kills herself and curses his people. In Italy, Aeneas visits the underworld, where Anchises reveals Rome's future. King Latinus welcomes the Trojans and intends Aeneas to marry Lavinia, but Juno inflames Queen Amata and Lavinia's suitor Turnus, starting a war. Aeneas gains Arcadian and Etruscan allies. Turnus kills Evander's son Pallas, and Aeneas answers with a devastating counterattack. After further losses, including Camilla, the conflict narrows to a duel. Aeneas defeats Turnus and considers mercy, but sees Pallas's captured belt on him and kills him. The poem ends before the foretold political union, with Rome's future secured through a victory marked by grief and vengeance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -381,7 +381,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -394,7 +394,7 @@
       "recaps": {
         "ending": "After Camilla's death weakens the Italian forces, both sides attempt to settle the war through a duel between Aeneas and Turnus. Juno's agent Juturna helps break the truce, and Aeneas is wounded before returning to battle. He attacks Latinus's city, where Amata, mistakenly believing Turnus dead, takes her own life. Turnus finally meets Aeneas in single combat and is defeated. He asks to be spared and returned to his father, and Aeneas initially hesitates. Then Aeneas sees that Turnus is wearing the sword belt taken from Pallas after killing him. Recalling his duty to the dead youth and to Evander, Aeneas kills Turnus. The poem stops at that act, with the military obstacle to the Trojan settlement removed but without narrating Aeneas's marriage, the later union of the peoples, or the founding generations that prophecy has promised.",
         "in_short": "After Troy's destruction, Aeneas leads refugees west toward an Italian homeland promised by fate. Juno drives them to Carthage, where Queen Dido shelters them and falls in love with Aeneas; when he obeys the gods and leaves, she dies by suicide. In Italy, Aeneas consults the dead and learns that his descendants will become the Roman people. King Latinus welcomes him and offers a marriage alliance with Lavinia, but Juno incites opposition led by Turnus, Lavinia's local suitor. Aeneas gains Arcadian and Etruscan allies, while the war kills young Pallas, the enemy champions Mezentius and Camilla, and many Trojans and Italians. Attempts at peace fail. Aeneas defeats Turnus in a final duel and considers mercy, but the sight of Pallas's captured belt makes him avenge the youth by killing Turnus. The poem ends there, at the violent removal of the last barrier to the Trojans' future in Italy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -675,7 +675,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audiosilo-meta:work:the-affair",
@@ -687,7 +687,7 @@
       "recaps": {
         "ending": "Frances Neagley's search establishes that Alice Bouton never existed, confirming Reacher's suspicion that the Marine Corps case against Elizabeth Deveraux was fabricated. Duncan Munro helps keep Deveraux away while arranging for Reed Riley to leave Senator Carlton Riley's event last. Reacher intercepts father and son, forces the senator to acknowledge that the Fort Kelham operation served Reed's interests, and concludes that Reed murdered Rosemary McClatchy, Shawna Lindsay, and Janice May Chapman. Reacher kills both Rileys and makes their deaths appear to result from a train collision. The public case closes under a false Army account that assigns the murders to a dead member of a local white-supremacist militia. Deveraux and Munro know that the official resolution is untrue, Frazer is dead, and the Tennessee Free Citizens have been dispersed. Reacher and Deveraux's relationship has no stated final resolution. Reacher remains in the Army for the moment but is exposed to career repercussions for defying the effort to protect Senator Riley.",
         "in_short": "In 1997, Army military police major Jack Reacher investigates murders near Fort Kelham while Sheriff Elizabeth Deveraux pursues the same case from the civilian side. A secret perimeter manned by the Tennessee Free Citizens leads Reacher to Colonel John James Frazer, who monitored Reacher's calls and arranged the militia deployment. Frazer dies after attacking Reacher. Evidence then points toward Captain Reed Riley, son of Senator Carlton Riley, but a Marine Corps file attempts to blame Deveraux. Frances Neagley proves that a central figure in that file never existed. Reacher concludes that Reed killed Rosemary McClatchy, Shawna Lindsay, and Janice May Chapman, and that the senator's influence drove the protection effort. Reacher kills Reed and Carlton Riley, stages their deaths as a train collision, and supports a false official account blaming a dead militia member. Deveraux is privately cleared, while Reacher faces likely consequences within the Army.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -873,7 +873,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -886,7 +886,7 @@
       "recaps": {
         "ending": "After Ellen leaves for Europe, Newland remains with May and gives up the life he had imagined with Ellen. Decades pass. May proves a devoted wife and mother and dies after their children are grown. Their son Dallas reveals that May understood Newland's feelings: before her death she told Dallas that she could trust his father because Newland had once surrendered what he most wanted when she asked him to. In Paris, Dallas arranges a visit with Ellen and expects Newland to accompany him. Newland waits outside her building but decides not to go up. He tells himself that the remembered relationship is more real to him than any meeting could now be, then walks back to his hotel. Ellen and Newland therefore never resume their connection; the final choice preserves both his idealized memory and the pattern of renunciation that governed his marriage.",
         "in_short": "In 1870s New York, lawyer Newland Archer becomes engaged to the impeccably conventional May Welland just as her cousin Ellen Olenska returns from Europe after leaving her husband. Newland is drawn to Ellen's candor and helps prevent a divorce that their families fear would cause scandal. He marries May but increasingly recognizes his love for Ellen and the narrowness of the society he once defended. Years of restrained encounters culminate in a plan for Newland and Ellen to be together. May then tells Ellen that she is pregnant, and Ellen returns to Europe; Newland stays with his wife, learning only later that May had not yet been certain of the pregnancy. After May's death and a long marriage, the older Newland travels to Paris with his son, who knows the family history. Offered a chance to see Ellen, Newland remains outside her home and leaves without meeting her, choosing memory over a belated reunion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1087,7 +1087,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1100,7 +1100,7 @@
       "recaps": {
         "ending": "At the farewell dinner for Ellen, Newland realizes that the guests have silently closed ranks around May and are treating Ellen's departure as the proper end to a suspected scandal. Afterward he resolves to tell May the truth and seek a life with Ellen. May first tells him she is pregnant, then reveals that she had already given Ellen the news before she was certain. Ellen leaves for Europe, and Newland remains with May. Decades pass: May dies after a marriage in which Newland fulfills his responsibilities, raises their children, and never resumes his relationship with Ellen. In Paris, his son Dallas discloses that May knew Newland had once given up the person he loved when Ellen left. Dallas arranges a visit to Ellen, who now lives independently. Newland waits below her apartment while Dallas goes in, then chooses not to join him. He returns to his hotel preserving his memory of Ellen instead of testing it against a meeting in their changed lives.",
         "in_short": "Newland Archer, a young lawyer in 1870s New York, is engaged to the admired May Welland when her cousin Ellen Olenska returns after leaving her husband. Newland helps Ellen withstand their circle's hostility and discourages a divorce that would expose her to scandal, but he falls in love with her while continuing toward marriage. He and May wed, and the conventions he once accepted begin to feel confining. When Ellen later returns to care for their grandmother, she and Newland acknowledge their love but refuse a secret affair that would betray May. May and their social circle quietly arrange Ellen's departure. May announces that she is pregnant, having already used the possibility to convince Ellen to leave. Newland stays, raises a family, and honors his marriage. After May's death, he travels to Paris with their son and has the chance to see Ellen again, but remains outside her home, choosing the remembered possibility over a belated reunion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1268,7 +1268,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1281,7 +1281,7 @@
       "recaps": {
         "ending": "The Vanishers are destroyed in a running fight along a railway line. Wax cannot kill Miles Hundredlives with bullets, so he wears him down instead until the gold that heals him is spent, and Miles is taken alive. The captives are recovered, and the purpose behind the abductions comes out: the women were selected for the Allomantic and Feruchemical traits in their bloodlines, gathered for a breeding program rather than for ransom. Miles refuses to name his employers and goes to a firing squad unrepentant; his last words are that they are already in Elendel and will come for him. Wax then finds proof that his uncle Edwarn Ladrian faked his own death and is one of them, part of a secretive, wealthy organization called the Set whose planning is measured in generations and whose stockpiling of aluminum, the one metal Allomancy cannot touch, was never about profit. House Ladrian's immediate financial crisis eases and Wax's engagement to Steris Harms stands, arranged and unromantic but not unkind. Marasi Colms takes a post with the city constabulary instead of returning to her studies, having proved herself in the field and discovered her own Allomancy along the way. Wayne stays in Elendel. Wax gives up the pretence that he can be only a house lord and takes on both roles at once, and he is left knowing that Harmony, the god who remade the world three centuries ago, has been paying attention to him and is prepared to say so directly.",
         "in_short": "Three centuries after Harmony remade a dying world, Waxillium Ladrian is a lawman from the frontier Roughs called home to Elendel to run a bankrupt noble house. He intends to give the work up, but a gang called the Vanishers is stripping railway cars and abducting noblewomen, and after they attack a dinner party he is pulled back in. With his old partner Wayne and a criminology student named Marasi Colms, Wax traces the robberies to stolen aluminum, the one metal Allomancy cannot affect, and to Miles Dagouter, once the Roughs' most celebrated lawman, who heals from any wound almost instantly and who believes Elendel's law deserves to be robbed. The kidnappings turn out to be a breeding program: the women are being taken for the Allomantic and Feruchemical bloodlines they carry. Wax breaks the operation on a moving train, outlasting Miles rather than out-shooting him, and frees the captives. Miles is executed, warning that his employers are already in the city. Wax discovers that his supposedly dead uncle Edwarn is one of them, working for an organization called the Set, and chooses to remain both a lord and a lawman.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1461,7 +1461,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1474,7 +1474,7 @@
       "recaps": {
         "ending": "The rat-catchers are exposed as the real plague: they had been stealing and hoarding the town's food, faking infestations, and breeding rats for illegal fights, and they are arrested. The Rat King, which had been made from their captives and had been forcing rats, cats, and people to obey it, is destroyed when Maurice attacks it directly, an act that costs him one of his nine lives. Meeting Death immediately afterwards, Maurice bargains and gives up a second life to bring back Dangerous Beans, who had been fatally hurt in the confrontation. Hamnpork does not survive; Darktan leads the Clan afterwards. With Keith speaking for the humans and Dangerous Beans and Darktan for the rats, the town and the Clan negotiate a formal agreement instead of a trick: no more poison and traps, an agreed share of food and space, rats working in the town's tunnels and drains, and Keith installed as the town's paid piper so that the arrangement has an official face. Malicia writes the whole affair up as a story. Maurice, given his share of the money and a great deal of goodwill, finds it all far too respectable, and is last seen a long way off, sizing up another likely-looking boy and beginning to explain a business proposition.",
         "in_short": "Maurice, a talking cat, runs a confidence trick with a clan of talking rats and a boy piper: the rats stage an infestation, the boy pipes them away, and the grateful town pays. All of them woke into thought after eating magical rubbish from Unseen University, and the rats have begun to want something better than a swindle. In the mountain town of Bad Blintz the trick collapses, because the town is starving and there are no rats in it at all. The Clan is caught in traps and cages; Keith and the mayor's daughter Malicia discover that the town's celebrated rat-catchers have been stealing the food themselves, faking the plague, and running rat fights in a cellar. Below them the rat-catchers have made something worse: a rat king of eight rats knotted together that can seize other minds and means to rule. The Clan, led by Darktan after Hamnpork is lost, fights back; Maurice destroys the rat king at the cost of two of his lives, one of which he trades to save Dangerous Beans. The rat-catchers are arrested, and the town and the rats settle on a treaty and a paid piper instead of a trick.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1644,7 +1644,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1657,7 +1657,7 @@
       "recaps": {
         "ending": "The war ends through sacrifice: Lord Asriel and Mrs. Coulter together drag the Regent Metatron into a bottomless abyss, dying to destroy him, while the ancient Authority, freed from his crystal litter by Will and Lyra, simply dissolves into the air. Reunited with the daemons they left at the shore of the dead, Will and Lyra reach the world of the mulefa and Mary Malone. There, as Mary tells of losing her faith and choosing love, the two children fall in love themselves. That love fulfills the prophecy: the Dust that had been draining out of all the worlds stops flowing away and begins to settle again, and their daemons take their final adult shapes, Pantalaimon a pine marten and Will's daemon a cat. The angel Balthamos kills Father Gomez before he can murder Lyra. But they learn a hard truth: every window the knife has cut leaks Dust and spawns Spectres, so all must be closed except the one through which the dead escape. Because a person can only truly live in their own world, Will and Lyra must return to their separate worlds and can never meet again. They part in grief, vowing to sit each year on the same day on a bench in the Botanic Garden of their own Oxford. Lyra, her instinctive gift for reading the alethiometer gone, resolves to grow up, study, and help build the Republic of Heaven where she belongs.",
         "in_short": "Mrs. Coulter hides the drugged Lyra in a cave to keep her from a Church that wants her killed, believing prophecy names her a second Eve. Will, bearing the subtle knife and helped by rebel angels and tiny Gallivespian spies, has the blade repaired by Iorek Byrnison and rescues her. Together they journey into the land of the dead to free the ghost of Lyra's dead friend Roger; leaving their daemons behind, they release all the ghosts to dissolve into the universe. Mary Malone, among the wheeled mulefa, builds a spyglass that reveals Dust draining from every world. In the great war, Will and Lyra free the ancient Authority, who crumbles away, while Lord Asriel and Mrs. Coulter sacrifice themselves to destroy the Regent Metatron. Reunited with their daemons, the two children fall in love, which halts the loss of Dust and settles their daemons into adult forms; an assassin priest is killed before he can harm Lyra. But because open windows drain Dust and breed Spectres, all must be closed, and Will and Lyra, unable to live in each other's worlds, part forever, promising to remember each other each year.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1840,7 +1840,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1853,7 +1853,7 @@
       "recaps": {
         "ending": "Newman possesses written evidence that the Marquise de Bellegarde and Urbain concealed the circumstances of the old marquis's death, and he initially intends to use it to punish them for forcing Claire to abandon him. He confronts the family and makes clear that he could disgrace their name, but their rigid composure denies him the satisfaction he expected. Claire has entered a Carmelite convent, placing herself permanently beyond his reach. After time away in America, Newman returns to Paris and learns that her withdrawal is final. He visits the convent church but can gain no access to her. Recognizing that public revenge will neither restore Claire nor accord with the person he wishes to be, he burns the incriminating paper in Mrs. Tristram's fireplace. The Bellegardes keep their social standing, while Newman gives up both his marriage and his means of retaliation. He leaves with his moral independence intact but with his faith in straightforward justice chastened by the family's closed world.",
         "in_short": "Christopher Newman, a self-made American millionaire, comes to Paris hoping to acquire culture and find a wife. He falls in love with Claire de Cintré, a widowed aristocrat whose younger brother Valentin becomes his friend. Claire accepts Newman, and her proud mother and elder brother temporarily permit the engagement because of his wealth. They later reverse themselves and compel Claire to renounce him. Valentin is mortally wounded in a duel and, before dying, directs Newman to Mrs. Bread, an old servant who knows a damaging Bellegarde secret: Claire's mother and elder brother concealed their part in the old marquis's death. Newman obtains proof and threatens to expose them, but Claire enters a Carmelite convent and cannot be recovered. After returning from America, he abandons revenge and burns the evidence. He remains honorable, but his confidence that openness and money can master entrenched European privilege has been permanently altered.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1995,7 +1995,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2008,7 +2008,7 @@
       "recaps": {
         "ending": "After twenty-eight days in the house, the disturbances culminate in a night of violent sounds, apparent movement, and terror affecting the whole family. George and Kathy gather Daniel, Christopher, Missy, and Harry and drive away, abandoning most of their possessions. They briefly return for essential belongings but do not resume living at 112 Ocean Avenue. The Lutzes relocate and say that the phenomena stop once they are away from the property. Father Mancuso remains convinced that something hostile was present, although distance relieves the attacks and illness associated with his involvement. Later investigators, including people experienced with alleged hauntings, visit the empty house and report disturbing impressions and an unsettling photograph, but their findings do not provide a settled explanation. The account closes with the family maintaining that flight was necessary and that their twenty-eight-day residence ended only when they left the house behind.",
         "in_short": "George and Kathy Lutz buy a waterfront house in Amityville where Ronald DeFeo Jr. murdered six members of his family the previous year. They move in with Kathy's three children and soon report a growing pattern of unexplained events: a priest hears an order to leave, rooms remain unnaturally cold, flies gather in winter, foul substances appear, doors and windows move or break, and George wakes repeatedly around the hour of the killings. Five-year-old Missy talks to an unseen pig-like friend named Jodie, while George becomes increasingly angry and obsessed with keeping the fire burning. Apparent levitation, physical marks, and visions erode the family's ability to dismiss the incidents. On their twenty-eighth night, an overwhelming eruption of noises and movement drives them out. They abandon the house and most belongings, later saying the phenomena cease. Subsequent paranormal investigators report troubling experiences but no conclusive explanation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2153,7 +2153,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2166,7 +2166,7 @@
       "recaps": {
         "ending": "After years of legal pressure, the allegation against Denny collapses when Annika tells the truth and withdraws her accusation. The criminal threat ends, and Denny defeats Maxwell and Trish's attempt to take permanent custody of Zoe. He and his daughter can live together again without court supervision. Luca Pantoni renews the professional opportunity that Denny had been unable to accept during the case, offering him work and a future in racing in Italy. Enzo, now old and failing, has remained with Denny through the entire fight. Denny gives him a final experience connected to the track before Enzo dies peacefully, ready for the human life he has always believed will follow. Denny and Zoe move to Italy, where his driving career succeeds. Years later, Denny meets a young boy named Enzo who is intensely drawn to racing and asks for an autograph. The encounter leaves the novel's reincarnation belief unproved but strongly implies that the dog has returned in human form and may one day race against Denny.",
         "in_short": "Enzo, an observant dog who expects to be reincarnated as a human, narrates the life of race-car driver Denny Swift. Denny marries Eve and they have Zoe, but Eve develops a fatal brain tumor. After her death, her wealthy parents seek custody of Zoe, arguing that Denny's racing makes him unfit. A false sexual-assault allegation from teenage Annika adds criminal danger and drains Denny's finances. Enzo, injured by a car and growing old, interprets their ordeal through racing: control comes from preparation, attention, and refusing to surrender in bad conditions. Denny rejects settlements that would cost him his daughter. Annika eventually recants, the charge collapses, and Denny regains Zoe. Italian racing executive Luca Pantoni offers him a career in Italy. Enzo dies after sharing a final track experience with Denny, confident that he is ready to become human. Years later in Italy, Denny meets a racing-obsessed boy named Enzo, suggesting his friend has returned.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2294,7 +2294,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2307,7 +2307,7 @@
       "recaps": {
         "ending": "The struggle between President Prentiss's regime, the Ask, and Mistress Coyle's resistance, the Answer, escalates into open, brutal conflict, with both sides willing to do terrible things and Todd increasingly implicated in the regime's cruelty. In the chaos Mayor Prentiss coldly kills his own son Davy, severing the fragile bond that had formed between Davy and Todd and showing just how far the man will go. The regime's long enslavement and abuse of the native Spackle finally ignites their revolt, and the book closes as an enormous Spackle army advances on the city, promising all-out war. At the same moment the first scout ship of the settler convoy, thousands of colonists still en route, touches down, drawing Viola's people directly into the conflict. Todd and Viola, battered and morally scarred by what they have done to survive and to protect each other, are left facing a new and far larger war on three sides, with the outcome entirely unresolved.",
         "in_short": "Todd and Viola reach the city of Haven only for it to fall at once to Mayor Prentiss, now calling himself President, who separates the two and holds each as leverage over the other. Todd is set to grim labor branding and corralling the planet's native Spackle alongside the Mayor's cruel son Davy, while Viola recovers among the city's healers and is drawn into a rising resistance, the Answer, led by the fierce Mistress Coyle. As Prentiss's regime, the Ask, tightens its grip, the Answer strikes back with bombings, and the city slides into a spiral of attack and reprisal that compromises everyone caught in it, Todd most of all. Both sides commit terrible acts in the name of their cause. The enslavement of the Spackle finally provokes them to rise, and the book ends as a vast Spackle army sweeps toward the city and the first scout ship of the long-awaited settler convoy arrives, leaving Todd and Viola facing a three-sided war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2593,7 +2593,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2606,7 +2606,7 @@
       "recaps": {
         "ending": "The coalition wins at Emeros after losing about 40 percent of its force. Ryun and Selia become the Eternal Hunters, Nayra helps them kill the last generals, and the Lord of Death raises the fallen into an army that reverses the ground battle. Twilight Melody's gravity specialist kills the enemy city leader in a black-hole attack, while the Exalted Empire destroys the citadel's warden leader. The Herald of the Machine demands that the exhausted sects withdraw, but Ryun and Nayra demonstrate enough remaining strength to prevent an immediate second war. Anrosh stays at Consequence to govern Twilight Melody. Nayra returns Vanessa to life and escorts the dead, while Selia temporarily enters the afterlife to understand her path and bond with Ryun. Zach and Naha remain allied Wardens after freeing Helsa, though Zach's altered arm, lost weeks, and promised instruction from a dragon soul remain unresolved. Ryun still owes the Dealmaker a favor. The eighth iteration will arrive in seven days, Kael intends to open every dome, and the altered flow of time has drawn the attention of distant powers.",
         "in_short": "Ryun returns after the Empire's fall, strengthens Twilight Melody, reconciles void and stillness as Oblivion, and prepares the sects for war. Zach removes his destabilizing cultivation path, reverses Dragon's Peak's destruction by establishing the first Way of Time, and joins Naha in freeing Helsa's enslaved population. Kael is remade by an ancient shade and marks Zach's arm. The coalition's attack on Emeros becomes a prepared encirclement, but Ryun and Selia unite as the Eternal Hunters, the Lord of Death raises an undead army, Nayra helps kill the last generals, and a gravity specialist destroys the enemy leader. The Exalted Empire kills the citadel's warden leader but avoids fighting the depleted sects. Selia enters the afterlife temporarily, Vanessa returns to life, and Anrosh remains at Twilight Melody. With the eighth iteration seven days away, Kael orders every dome opened and distant powers notice a change in time.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2799,7 +2799,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2812,7 +2812,7 @@
       "recaps": {
         "ending": "After Juliana catches the narrator near the cabinet where he believes the Aspern papers are kept, she collapses and dies soon afterward. Miss Tita first recoils from his intrusion, then lets him understand that he might receive the papers if he married her. Horrified by the personal price, he leaves Venice. Away from the palace, he persuades himself that marriage may be tolerable for the sake of the documents and returns to accept. Miss Tita, newly self-possessed, tells him it is too late: she has burned all of Aspern's papers, one by one, so that no one can ever obtain them. The narrator loses both the archive and any imagined moral justification for his deception. He retains Aspern's small portrait and sends Miss Tita money while allowing her to believe that the portrait supplied it. Looking at the image afterward only intensifies his sense of irrecoverable loss.",
         "in_short": "An unnamed editor obsessed with the dead poet Jeffrey Aspern learns that Aspern's aged former intimate Juliana Bordereau may still possess his letters. Using a false name, he rents rooms in the Venetian palace where Juliana lives with her isolated niece, Miss Tita. He cultivates the garden and Miss Tita's trust while concealing his purpose. Juliana remains suspicious and offers to sell him a portrait of Aspern for an extravagant price. When he searches for the papers at night, she surprises him and soon dies. Miss Tita implies that marriage to her would bring him the documents, but he flees from the prospect. He returns after deciding the sacrifice is worthwhile, only to learn that she has burned every paper. His attempt to turn private lives into literary property leaves him with only Aspern's portrait and the knowledge that the archive is permanently lost.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2921,7 +2921,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2934,7 +2934,7 @@
       "recaps": {
         "ending": "After Juliana catches the narrator searching her private furniture, she denounces him and collapses; she dies soon afterward. Tita tells him that she could give the Aspern papers only to someone who belonged to the family, making marriage the implied price. Repelled and embarrassed, he leaves Venice, but during his absence he begins to imagine marrying her and returns prepared to do so. Tita has understood his first reaction. She tells him that the papers no longer exist: she burned them one by one. The narrator therefore loses the documents he compromised himself to obtain. He does receive the small portrait of Aspern that Juliana had offered for sale. He later sends Tita money while saying that he sold the portrait, though he privately values it too highly to part with it. The surviving image above his desk becomes a reminder both of Aspern and of the archive destroyed through the narrator's intrusion and hesitation.",
         "in_short": "An American editor goes to Venice seeking letters and papers left by the poet Jeffrey Aspern with Juliana Bordereau, an aged former intimate of Aspern's. Concealing his identity, he rents rooms in the palace Juliana shares with her niece Tita and cultivates its neglected garden while trying to win Tita's confidence. Juliana remains guarded but reveals that she knows the commercial value of Aspern's memory. When she becomes gravely ill, the editor searches her rooms for the papers; she catches and condemns him, then dies. Tita implies that marriage to her would make the documents his, but his recoil humiliates her. After reconsidering, he returns willing to marry, only to learn that she has burned every paper. He keeps a small portrait of Aspern and sends Tita money for it, left with the image but without the private record he pursued.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3102,7 +3102,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3115,7 +3115,7 @@
       "recaps": {
         "ending": "The collection ends with everything Celaena has been building for destroyed in a matter of days. She and Sam are days away from buying their freedom and leaving Adarlan when Sam goes alone after Rourke Farran, and Farran takes him and kills him slowly. Celaena finds the body. She goes after Farran to settle it and is captured instead, beaten, handed to the king's guard, and sentenced without trial to the salt mines of Endovier, a place nobody survives for long. Farran is killed in revenge for Sam by Arobynn's bodyguard Wesley, who pays for that with his own life, and the word that reaches Celaena afterward is the one thing worse than the sentence: Arobynn Hamel arranged her capture himself, to bring his investment to heel. She goes into Endovier at seventeen years old with no name, no allies, and no reason left to trust anybody, which is exactly where the first book of the series finds her.",
         "in_short": "Five linked novellas covering the last year of Celaena Sardothien's life as Adarlan's most feared assassin, before Endovier. Sent to Skull's Bay with her rival Sam Cortland, she discovers that her master Arobynn Hamel has gone into the slave trade, frees two hundred captives, burns the Pirate Lord's fleet, and is beaten nearly to death for it. Exiled to the Red Desert to train with the Silent Assassins, she stops in a coastal town and quietly changes the life of a would-be healer named Yrene Towers, then survives a betrayal by her closest friend at the desert fortress. Back in Rifthold she and Sam become lovers, take a job against a slave trader, and decide to buy their way out of the guild and leave Adarlan altogether. Arobynn hands them a last contract on the crime lord who rules the capital. Sam goes after the crime lord's second alone and is tortured to death; Celaena, hunting the man responsible, is captured, betrayed, and sentenced to the salt mines of Endovier.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3257,7 +3257,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3270,7 +3270,7 @@
       "recaps": {
         "ending": "Morris never fully recovers from the strains placed on his health. After clearing snow outside the grocery he becomes gravely ill and dies, leaving Ida and Helen with the failing shop and little security. Frank, who has confessed his part in the robbery and been rejected by Helen, returns to shoulder the work Morris had carried. He pays the household's expenses, tries to repair what he stole, and secretly supports Helen's return to college. His persistence does not erase the robbery, theft, deception, or sexual violence for which he is responsible, and Helen does not simply accept him. Over time, however, he takes on Morris's obligations and embraces the ethical demands he had admired in him. After Passover, Frank formally converts to Judaism. The ending leaves him running the grocery and accepting sacrifice rather than escaping it, with any future reconciliation dependent on sustained change rather than a single declaration.",
         "in_short": "Morris Bober, an impoverished Brooklyn grocer, is injured when two masked men rob his store. Frank Alpine, one of the robbers, conceals his guilt and becomes Morris's assistant, drawn to the older man's moral endurance. Frank improves the shop and falls for Morris's daughter Helen, but he also steals from the till and lies about himself. After Morris catches him stealing, Frank is dismissed. He later saves Helen from Ward Minogue and then sexually assaults her himself, destroying her trust. Frank confesses his role in the robbery and is rejected. When Morris falls ill and dies, Frank returns to support Ida and Helen, runs the grocery, repays what he took, and helps finance Helen's education. He ultimately converts to Judaism, accepting the burdens and ethical discipline represented by Morris. His transformation remains shadowed by the harm he caused, and the novel ends with responsibility rather than easy absolution.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3419,7 +3419,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3432,7 +3432,7 @@
       "recaps": {
         "ending": "The Baudelaires succeed in exposing Coach Genghis as Count Olaf in disguise, defeating his scheme to have them expelled and taken into his care. But Olaf turns the confusion to his advantage: rather than escape alone, he and his troupe seize the Quagmire triplets, Duncan and Isadora, and flee with them, intending to steal the Quagmire sapphires. As their friends are carried off, the Baudelaires are unable to stop it, and Duncan and Isadora manage to shout out a cryptic clue, the letters V.F.D., something they had discovered while researching Olaf. Vice Principal Nero and Mr. Poe prove useless, and Olaf once again escapes justice, now with two captives. The Baudelaires are removed from the school to be placed elsewhere, but for the first time they leave with a purpose beyond mere survival: to rescue the kidnapped Quagmires and to uncover the meaning of the mysterious V.F.D. that has begun to shadow their lives.",
         "in_short": "The Baudelaires are sent to Prufrock Preparatory School, run by the vain, cruel Vice Principal Nero, who forces them to live in a wretched Orphans Shack. Bullied by the horrible student Carmelita Spats, they find real friends in the Quagmire triplets, Duncan and Isadora, orphans with their own fortune who lost their parents and their brother Quigley in a fire. A new gym teacher, Coach Genghis, arrives in a turban and running shoes, and the Baudelaires recognize him as Count Olaf. Genghis forces them into exhausting nightly running exercises meant to ruin their grades so Nero will expel them into his custody. With the Quagmires' help, the children keep up and plot to unmask him. They expose Coach Genghis as Count Olaf, but in the chaos Olaf and his troupe abduct Duncan and Isadora and escape, and as they are dragged away the Quagmires shout the mysterious letters V.F.D. The Baudelaires are moved on, determined to rescue their friends and learn what V.F.D. means.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3556,7 +3556,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3569,7 +3569,7 @@
       "recaps": {
         "ending": "After witnessing a lynching, the narrator abandons his plan to develop Black folk music into concert compositions and decides to pass as white. He settles in New York, enters business, and accumulates money while keeping his ancestry private. He falls in love with a white widow and tells her the truth before they marry. Though initially shaken, she chooses him; they have two children, and she later dies. The narrator devotes himself to providing security for the children and maintains the identity that white society assigns him. Materially, the decision succeeds, but his closing judgment is uneasy. Watching prominent Black Americans commit themselves to collective advancement, he feels that safety has cost him participation in a cause larger than himself. He ends with the sense that he traded a valuable birthright for comfort and has become an observer of the history he might have helped make.",
         "in_short": "An unnamed light-skinned man recounts learning at school that he is considered Black, despite having been raised in Connecticut by his Black mother with financial help from his absent white father. After his mother's death, theft prevents him from entering college, and work in Jacksonville introduces him to varied Black communities. In New York he becomes a celebrated ragtime pianist and travels in Europe as a wealthy white man's personal musician. He leaves that security intending to use Black folk music as the basis for serious composition, but in the South he witnesses a lynching. Horrified by the murder and by the vulnerability imposed on Black life, he decides to pass as white. He succeeds in business, reveals his ancestry to the white woman he loves, marries her, and raises their children after her death. His safe, prosperous life remains shadowed by regret that he surrendered a public Black identity and a possible role in racial progress.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3700,7 +3700,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3713,7 +3713,7 @@
       "recaps": {
         "ending": "After witnessing a lynching, the narrator abandons his plan to develop Black folk music into concert compositions and decides to pass as white. He settles in New York, enters business, and accumulates money while keeping his ancestry private. He falls in love with a white widow and tells her the truth before they marry. Though initially shaken, she chooses him; they have two children, and she later dies. The narrator devotes himself to providing security for the children and maintains the identity that white society assigns him. Materially, the decision succeeds, but his closing judgment is uneasy. Watching prominent Black Americans commit themselves to collective advancement, he feels that safety has cost him participation in a cause larger than himself. He ends with the sense that he traded a valuable birthright for comfort and has become an observer of the history he might have helped make.",
         "in_short": "An unnamed light-skinned man recounts learning at school that he is considered Black, despite having been raised in Connecticut by his Black mother with financial help from his absent white father. After his mother's death, theft prevents him from entering college, and work in Jacksonville introduces him to varied Black communities. In New York he becomes a celebrated ragtime pianist and travels in Europe as a wealthy white man's personal musician. He leaves that security intending to use Black folk music as the basis for serious composition, but in the South he witnesses a lynching. Horrified by the murder and by the vulnerability imposed on Black life, he decides to pass as white. He succeeds in business, reveals his ancestry to the white woman he loves, marries her, and raises their children after her death. His safe, prosperous life remains shadowed by regret that he surrendered a public Black identity and a possible role in racial progress.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3900,7 +3900,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3913,7 +3913,7 @@
       "recaps": {
         "ending": "Jimmy Aaron returns to the Samson quarters as a civil-rights organizer and calls on the residents to join a protest in Bayonne. Years of racial terror and economic dependence make most people reluctant, but Jane recognizes the familiar demand to turn nominal freedom into action. Jimmy is killed before he can lead the march. His death initially seems likely to deepen the community's fear, just as earlier murders silenced Ned and other challengers. Instead, Jane assumes the public role that Jimmy can no longer fill. She joins the march and walks toward the courthouse with the others, confronting the segregationist order embodied by the authorities there. Her movement forward completes the life story without suggesting that the struggle itself is finished. The child who once headed north after emancipation now leads another passage toward freedom almost a century later. Ned, Joe, Tee Bob, Mary Agnes, and Jimmy are gone from her immediate life, but their losses have become part of the memory and resolve she carries into collective action.",
         "in_short": "Born enslaved as Ticey, Jane takes a new name from a Union soldier and begins a long search for freedom after the Civil War. She protects Ned after white attackers destroy their traveling group, works on plantations, builds a life with horse breaker Joe Pittman, and survives his death. Ned grows into a teacher and organizer, then is murdered for challenging white power. On the Samson plantation, Jane witnesses the racial order destroy Tee Bob Samson's hope of a life with the Black Creole teacher Mary Agnes. Decades later, Jimmy Aaron emerges from the quarters as a civil-rights leader. When he is killed before a planned protest, Jane refuses to let another murder end the movement. Now more than a hundred years old, she walks at the front of a march toward the Bayonne courthouse. Her remembered life connects emancipation to the unfinished struggle against segregation and turns individual survival into public witness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4080,7 +4080,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4093,7 +4093,7 @@
       "recaps": {
         "ending": "After finally admitting their love, Edna and Robert are interrupted when Adele summons Edna to attend her labor. Adele's suffering and her plea that Edna think of her children force the consequences of Edna's choices into view. Doctor Mandelet senses her distress and offers help, but Edna returns home to find that Robert has left. His note says that he loves her and has gone because of that love; he cannot imagine a life with her outside the conventional terms of marriage. Edna travels alone to Grand Isle. Remembering her children, Leonce, Robert, and the claims each would continue to make upon her, she walks naked into the sea and swims beyond her strength. The final images move through sensations and memories from her childhood as she drowns. Robert has fled the freedom she imagined with him, while Edna's attempt to secure complete possession of her own life ends in death rather than a sustainable place in her society.",
         "in_short": "During a summer at Grand Isle, Edna Pontellier grows emotionally close to Robert Lebrun and begins questioning the duties that define her as a wife and mother. Learning to swim becomes part of a wider sense of independence. After Robert abruptly leaves for Mexico, Edna returns to New Orleans transformed: she neglects social obligations, pursues painting, has an affair with Alcee Arobin, and moves from her husband's house into a small home of her own. Robert returns and admits that he loves her, but his hope that Leonce might release her so they can marry reveals that he still understands freedom conventionally. Called away to Adele Ratignolle's difficult labor, Edna comes home to find Robert gone. She returns alone to Grand Isle and swims into the sea until she can no longer return, choosing death when neither marriage, romance, motherhood, nor her limited independence offers the wholly self-directed life she seeks.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4215,7 +4215,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4228,7 +4228,7 @@
       "recaps": {
         "ending": "Violet, forced into Count Olaf's marriage scheme to save the kidnapped Sunny, outwits him during the live performance of his play by signing the wedding document with her left hand. Because she is right-handed and did not sign in her own hand as the law requires, Justice Strauss declares that the marriage is not legally binding, so Olaf gains no control over the Baudelaire fortune. Enraged, Olaf and his troupe flee before they can be arrested, and he warns the children that he will find them again and get their money one day. Sunny is freed unharmed. Mr. Poe removes the three orphans from Olaf's care, promising to place them with another relative, but Olaf has escaped justice entirely and remains at large, so the children's troubles are far from over as the series begins.",
         "in_short": "The three Baudelaire children, inventive Violet, bookish Klaus, and biting baby Sunny, lose their parents in a fire that destroys their home. The banker Mr. Poe places them with a distant relative, Count Olaf, a cruel actor who forces them to do chores in his filthy house and cares only about their inheritance. Olaf devises a scheme to seize the fortune by staging a play in which Violet, without realizing it, will be legally married to him before a real judge, their kind neighbor Justice Strauss. To force Violet to cooperate, Olaf kidnaps Sunny and dangles her in a cage from his tower. During the performance Violet signs the marriage document with her left hand rather than her right, and afterward reveals the trick, so Justice Strauss rules the marriage invalid. Olaf's plan collapses and he escapes into the night, vowing to return, and the children are taken away from him to be placed elsewhere.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4338,7 +4338,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4351,7 +4351,7 @@
       "recaps": {
         "ending": "The Valory Arch is opened, and what that produces is not the outcome anyone described to Evangeline in advance. The people she trusted in the North turn out to have been working toward much older ends than the ones they admitted to her, and Jacks' reason for needing the arch is not the one she was allowed to assume. Then Evangeline is removed from her own story. Her memories are taken and replaced with a fabricated account of her life, one in which Prince Apollo is her husband and the man she loves, and Jacks is the monster who tried to destroy her. She has no way to tell that any of it is invented, and no reason to doubt it: the false version is complete and internally consistent. The book ends with Evangeline living inside a story written for her by someone else, unable to recognize the people who could tell her who she actually is, and with Jacks left on the wrong side of a lie he cannot argue her out of. Everything that was unresolved - Luc and Marisol still stone in Valenda, Apollo's condition, what the arch released - carries forward with her memory of none of it.",
         "in_short": "Evangeline Fox begins the book stranded in the Magnificent North, living with what her first bargained kiss did to Prince Apollo, who is no longer the ruler who courted her and is now genuinely dangerous. She strikes a new deal with Jacks, the Fate who put her in this position: she will help him with the sealed Valory Arch if he helps her undo the harm. Opening the arch means collecting particular things out of the North's stories, so Evangeline spends the book traveling among cursed houses, vampires and old families, discovering that each legend is truer and worse than the version she was raised on, and that her own mother's connection to the North was never innocent. Her friends prove to have far longer histories than they claimed, Jacks becomes harder to keep at a distance despite a kiss that kills, and Apollo pursues her throughout. The arch is finally opened - and then Evangeline's memories are taken and replaced with a false life in which Apollo is her husband and Jacks her enemy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-ballad-of-songbirds-and-snakes.json
+++ b/data/works-community/0/the-ballad-of-songbirds-and-snakes.json
@@ -105,7 +105,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -118,7 +118,7 @@
       "recaps": {
         "ending": "Coriolanus gets Lucy Gray through the tenth Hunger Games alive, partly by secretly handling Dr. Gaul's venomous snakes so they will not strike her, but his rule-breaking is discovered and he is stripped of the scholarship he needed. To avoid disgrace and punishment he enlists as a Peacekeeper and is posted to District 12, where he reunites with Lucy Gray and the Covey. His conscience-stricken friend Sejanus Plinth conspires with local rebels; Coriolanus reports him to Dr. Gaul, and Sejanus is hanged. Terrified that his own crimes, including killings he committed, will surface, Coriolanus plans to run away north with Lucy Gray, but at a lakeside cabin they uncover the hidden guns and he realizes the evidence ties him to murder. He turns on her in the woods; she disappears among the mockingjays and he fires blindly, never finding her body. Returning to the Capitol, he is welcomed by Dr. Gaul as a promising protege, discovers that Dean Highbottom devised the Hunger Games from his dead father's idea, and coldly secures his own rise. The boy who began desperate and charming ends the book hardened into the ruthless future President Snow.",
         "in_short": "Decades before Katniss, eighteen-year-old Coriolanus Snow is a proud but secretly impoverished Capitol student staking his future on the tenth Hunger Games, where Academy students now mentor the tributes. Assigned the District 12 girl, Lucy Gray Baird, a charismatic singer with the traveling Covey, he schemes to keep her alive and popular, inventing sponsorship and betting to draw the Capitol's attention, and falls for her along the way. He bends and breaks the rules to help her win, even tampering with the Gamemakers' venomous snakes, and she survives the arena. But his cheating is exposed; stripped of his prize, he enlists as a Peacekeeper and is sent to District 12, where he reunites with Lucy Gray. When his friend Sejanus becomes entangled with rebels, Coriolanus informs on him and Sejanus is executed. Fleeing north with Lucy Gray, Coriolanus finds evidence of his own crimes and turns on her; she vanishes into the woods, and he returns to the Capitol to be rewarded by Dr. Gaul, stepping onto the path that will make him President Snow.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -303,7 +303,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -316,7 +316,7 @@
       "recaps": {
         "ending": "Wax puts on the Bands of Mourning and, with Feruchemical reserves on a scale nothing living has held since the Lord Ruler, breaks the Set's operation at the temple, brings down their transport and gets his people out. The victory is partial. Edwarn Ladrian escapes, and Telsin leaves with him: Wax's sister is not the prisoner he came to rescue, and has not been for a long time. Allik Neromnian survives and becomes the Basin's first real contact with the Malwish, whose medallion technology, capable of granting Feruchemical attributes to people not born to the art, is a change to the world that nobody has begun to absorb. The burial chamber Marasi found is the tomb of the figure the Malwish call the Sovereign, and the evidence in it identifies him as Kelsier, the Survivor of Era 1, who outlived his own death and founded a nation on the southern continent. Back in Elendel, Wax and Steris marry. Wax puts his earring back in and speaks to Harmony again, and Harmony finally tells him what he has been withholding: the Set serves another god, called Trell, one of several powers that exist beyond this world, and Harmony is bound in ways he has never admitted. Wax keeps the Bands. The Basin ends the book knowing it is neither alone on its own planet nor alone in the universe, and the Set is still moving.",
         "in_short": "Months after the death of Elendel's governor, the kandra bring Waxillium Ladrian a case: one of their own has come back from the far south damaged and short a spike, carrying an image of a bracer that may be the Bands of Mourning, the metalminds said to have made the Lord Ruler unstoppable. Wax, Wayne, Marasi, Steris and the kandra MeLaan travel to New Seran, where the Set is already established, and their attempt to work the city ends in a fight and a flight. Following the Set out of the mountains they find a hidden airship and Allik Neromnian, a survivor of the Malwish, an advanced nation on the southern continent nobody in the Basin knew existed, whose medallions let ordinary people use Feruchemy. They fly to a buried temple, where the Set captures them and Wax faces his uncle Edwarn. Marasi finds a tomb at its heart belonging to the Malwish founder, whose identity ties the southern continent back to Kelsier, the Survivor. Wax claims the Bands and wrecks the Set's operation, but Edwarn escapes with Telsin, who proves to be with the Set willingly. Wax marries Steris, takes Harmony back, and learns that the Set serves a rival god called Trell.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -476,7 +476,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -489,7 +489,7 @@
       "recaps": {
         "ending": "The Temujai invasion is broken. Halt's plan holds: the Skandian line gives ground where it is meant to, the Temujai cavalry is drawn into ground it cannot use, and the Araluen archers, commanded by Will after Halt is wounded, break the charge that was supposed to end the battle. The eastern army withdraws, and Skandia survives as an independent country because two escaped Araluen slaves and a banished Ranger chose to warn it. In the aftermath Evanlyn's identity comes out. Ragnak's Vallasvow would bind him to kill her, but he does not survive the battle, and the Skandian leadership that follows, with Erak's weight behind it, sets the oath aside rather than begin a war it has just finished paying for. What is agreed instead is a treaty: peace between Skandia and Araluen, the freeing of the Araluen slaves, including the men who fought as Halt's archers, and an alliance between two countries that have spent a generation raiding one another. Halt's banishment, engineered so that he could leave, is lifted by King Duncan, who has his daughter and his Ranger back. The Araluens sail home. Will has come through addiction, slavery and a battle, and returns to finish an apprenticeship that now looks very different.",
         "in_short": "Halt and Horace finally reach the mountain cabin where Evanlyn has nursed Will through warmweed withdrawal, but Temujai scouts, eastern horse warriors probing Skandia, seize Evanlyn first, and the three Araluens have to track the raiders and take her back. What they learn doing it is that a Temujai army is about to invade Skandia. Escaped slaves and enemies though they are, they carry the warning to Hallasholm, where Erak's backing and Halt's usefulness buy them a hearing from the Oberjarl Ragnak, while Evanlyn's royal identity stays hidden because of Ragnak's blood oath against her family. Skandians despise the bow, so Halt and Will train the Araluen slaves into an archery corps in exchange for their freedom, and Halt plans a battle around ground the Temujai cavalry cannot use. In the fighting Halt is wounded and Will commands the archers; the invasion is broken and Ragnak is killed. Evanlyn's identity emerges, the oath dies with him, and Skandia and Araluen make peace, free the slaves and send the Araluens home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -676,7 +676,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -689,7 +689,7 @@
       "recaps": {
         "ending": "Luke's Titan army invades Camp Half-Blood through the Labyrinth, and in the battle the inventor Daedalus, having helped the defenders, chooses to end his long life; his death collapses the maze and permanently cuts off the enemy's shortcut into the camp, though the fighting costs demigod lives. The lost wild god Pan has died deep in the maze after entrusting his work to Grover and the others, marking the end of an age for satyrs and nature spirits. Percy returns home for his birthday, where his mother, Sally, is now happily involved with a kind mortal teacher, Paul Blofis. The gravest turn is the enemy's: the Titan lord Kronos completes his return by fully taking over the body of Luke, who has given himself to his master, so the coming war will be led by Kronos in a demigod's form. Nico di Angelo, reconciled somewhat with Percy, reveals a dangerous plan for how Percy might stand against Kronos when the final conflict comes. The great prophecy about a child of the eldest gods now points squarely toward Percy as his sixteenth birthday nears.",
         "in_short": "Percy learns that Daedalus's Labyrinth has an entrance inside Camp Half-Blood, so Luke's army could invade from within. Annabeth leads a quest, with Percy, Grover, and Tyson, into the maze to reach the inventor Daedalus before the enemy can obtain the means to control it. In the shifting maze they meet gods and monsters, cross paths with Nico, a son of Hades shadowed by a manipulative ghost, and seek Hephaestus, who sends Percy into a volcano. Blown clear, Percy washes up on Calypso's island before choosing to leave and is found to have been presumed dead. The mortal Rachel Elizabeth Dare, who sees through the Mist, guides them to Daedalus, who has been living at camp as the instructor Quintus. Grover finds the dying wild god Pan, who passes on his work. When Luke's army invades through the maze, Daedalus dies to collapse it, and the camp holds. Kronos completes his return by taking over Luke's body, and Nico shares a plan for the war ahead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -850,7 +850,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -863,7 +863,7 @@
       "recaps": {
         "ending": "In Oklahoma, Taylor learns that no official record can establish who Turtle's parents were or authorize the informal transfer that placed the child in her care. Estevan and Esperanza agree to pose as Turtle's biological parents and sign papers consenting to Taylor's adoption of her. The performance is emotionally difficult for Esperanza because Turtle recalls Ismene, the daughter taken from her in Guatemala, but it also lets her enact a safe farewell she was denied. Taylor then delivers the couple to a new sanctuary and returns toward Tucson with Turtle as her legal daughter. On the telephone, Lou Ann describes her growing confidence and her decision to continue the independent life she has made rather than simply follow Angel. Turtle, emerging from the silence created by abuse and renewed after the park attack, talks about the people and places that now make up her world. Her fascination with the wisteria vines links them to rhizobia, organisms that allow roots to thrive through cooperation. Taylor understands her own life similarly: she and Turtle survive through a network of friends who have become family.",
         "in_short": "Taylor Greer leaves Kentucky determined to avoid motherhood, but in Oklahoma a woman abruptly gives her an abused Cherokee toddler. Taylor names the girl Turtle and reaches Tucson, where they build a home with another young mother, Lou Ann Ruiz, and her baby. Tire-shop owner Mattie gives Taylor work and quietly shelters Guatemalan refugees, including Estevan and Esperanza, whose daughter was taken by the regime they fled. When Turtle is attacked in a park, authorities discover that Taylor has no legal custody and may lose her. Taylor drives Turtle and the threatened refugees to Oklahoma. With Estevan and Esperanza posing as Turtle's birth parents, she secures adoption papers and takes the couple to a new sanctuary. Taylor returns to Tucson as Turtle's legal mother, while Lou Ann chooses confidence and independence over dependence on her absent husband. The beanlike pods Turtle sees on wisteria suggest the novel's central pattern: lives damaged by isolation can grow through mutual support.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1091,7 +1091,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1104,7 +1104,7 @@
       "recaps": {
         "ending": "The Bear is loose, the dead are walking, and Vasya rides home from the winter-king's house to find that Lesnaya Zemlya has decided she is the cause of all of it. Anna Ivanovna dies in the chaos. Konstantin learns that the voice he has obeyed and preached for was the Bear's and not God's, and has nothing left to say. In the forest clearing where the thing was first bound, Vasya faces it, and her father follows her there; because the Bear can only be chained again by a life freely surrendered, Pyotr Vladimirovich gives up his own and dies in the snow. Morozko binds his brother, and the winter finally breaks. The household survives, but Pyotr is dead, Dunya is dead, and the village wants the witch's daughter gone. Vasya refuses both of the futures her world allows her, a husband or a convent, and there is no third one. Alyosha stays to hold their father's lands. Olga is a princess in Moscow, and Sasha is a monk who does not yet know what has happened at home. Konstantin leaves for Moscow with his reputation intact and his faith in ruins. Vasya rides north and away on Solovey, wearing Morozko's blue jewel, intending to travel as far as the road goes, and carrying his warning that the world outside is no kinder than the one she is leaving.",
         "in_short": "In a lord's household in the forests north of medieval Moscow, Marina Ivanovna dies bearing a daughter she wanted deliberately, believing the child would inherit the strange sight of her own mother. Vasilisa grows up seeing the household spirits of Rus' and feeding them as her people always have. Her father remarries a devout, terrified girl from Moscow who sees the same creatures and calls them demons, and a proud young priest, Konstantin Nikonovich, is sent north and preaches the old observances away. As the offerings stop the spirits weaken, and so does the binding on a one-eyed devil called the Bear, who feeds on fear and raises the dead. Refusing marriage and the convent both, Vasya is driven out into the snow and taken in by Morozko, the frost-demon and death-god of the winter tales, who has been quietly arming her for years without saying so. She rides home on a stallion called Solovey to face the Bear, and her father dies giving up his life freely so that the Bear can be bound again. Named a witch by her own village, Vasya leaves home to see the world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1282,7 +1282,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1295,7 +1295,7 @@
       "recaps": {
         "ending": "After the war, Anthony and Gloria live in worsening poverty while their challenge to Adam Patch's will proceeds slowly. Gloria's attempt to enter films ends in rejection, and Anthony's drinking, humiliation, and fixation on the lawsuit deepen. Dorothy Raycroft's reappearance further destabilizes him. By the day the court finally awards the inheritance to Anthony, he has suffered a severe mental and physical collapse and can no longer enjoy the victory coherently. Wealth arrives only after the habits formed in expecting it have destroyed the couple's resilience and much of their relationship. On an ocean liner, Gloria tends to the diminished Anthony while other passengers see only a rich, successful pair. Anthony insists that he has triumphed because he never surrendered, unable to recognize that the fortune has confirmed rather than repaired his ruin.",
         "in_short": "Anthony Patch, an idle heir, marries the beautiful Gloria Gilbert, and together they postpone purpose while waiting for Anthony's rich grandfather to die. Their intense courtship gives way to expensive parties, boredom, jealousy, and dependence on money they do not yet possess. When the reform-minded Adam Patch unexpectedly witnesses a drunken gathering at their country house, he disinherits Anthony. The couple contests his will, but years of legal delay and the First World War accelerate their decline. Anthony drinks heavily and has an affair while in the army; Gloria grows bitter and later fails in an attempt to enter films. Debt, separation, and mutual resentment consume them. They eventually win the inheritance lawsuit, but Anthony has already collapsed mentally and physically. The pair become rich at last, publicly enviable and privately ruined.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1462,7 +1462,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1475,7 +1475,7 @@
       "recaps": {
         "ending": "Under Dr. Nolan's humane care at the private hospital, Esther slowly climbs out of her breakdown through insulin treatment and a course of properly administered electroshock that finally lifts the crushing weight of her depression. She begins to reclaim a sense of control over her own life, most pointedly by being fitted for a diaphragm and then losing her virginity to a man named Irwin, an encounter that leaves her hemorrhaging badly and needing medical help. Her fellow patient Joan Gilling, a woman from her past who had also known Buddy Willard, appears to be improving but then hangs herself, and Esther attends her funeral. As the novel closes, Esther, much recovered and released from many of her old illusions, waits to be interviewed by the hospital board before returning to college. She steps toward the door uncertain of the future and conscious that the bell jar of madness might one day close over her again, but for now free of it and ready to go on. Buddy visits and their romance is plainly over.",
         "in_short": "Esther Greenwood, a brilliant college student, spends a summer as a guest editor at a New York fashion magazine but feels numb and disconnected amid its glamour, disillusioned with the expectations placed on young women and with her conventional suitor Buddy Willard. Returning home to Massachusetts, she learns she has been rejected from a writing course and sinks into a severe depression, unable to sleep, read, or write. An incompetent psychiatrist subjects her to a traumatic electroshock treatment, and her despair deepens until she attempts suicide by swallowing sleeping pills and hiding in a crawlspace. Found alive after several days, she is hospitalized and eventually transferred, through the help of a wealthy benefactor, to a private hospital under the care of the compassionate Dr. Nolan. There, with insulin therapy and properly managed electroshock, she gradually recovers. A fellow patient and acquaintance, Joan Gilling, hangs herself, and Esther, having taken new steps toward independence, prepares to leave the hospital and resume her life, cautiously hopeful but aware that the suffocating bell jar of her illness could descend again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1648,7 +1648,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1661,7 +1661,7 @@
       "recaps": {
         "ending": "The resistance and Joseph's expedition combine for the assault on Castle Floret. Southsward's prisoners are freed and the occupying horde is defeated. Mariel settles her struggle with Silvamord, while Urgan Nagru is killed in the final fighting. Finnbarr Galedeep also dies in the battle, paying for victory with the life he had risked throughout the voyage. Gael is restored as Squirrelking with Serena and Truffen safe, and Southsward can begin recovering from the Foxwolf's rule. Joseph is reunited with Mariel, the danger foretold in his dream having brought him across sea and country to her. The surviving Redwall travellers prepare to return north, while Mariel and Dandin remain free to choose further roads rather than being bound permanently to either a court or the Abbey. The story closes with Castle Floret restored, but with Finnbarr and the other fallen remembered as the price of its liberation.",
         "in_short": "Joseph the Bellmaker receives a warning from Martin the Warrior that his wandering daughter Mariel is in danger. Far south, the fox Urgan Nagru and his mate Silvamord have conquered Castle Floret, imprisoned Queen Serena and young Truffen, and driven Squirrelking Gael from power. Mariel, Dandin, and Bowly Pintips help Gael and join Southsward's resistance. Joseph leaves Redwall with Rufe Brush and Durry Quill, later joining the sea-otter captain Finnbarr Galedeep for a hazardous voyage south. After separations, sea dangers, and battles with the occupiers, the travellers unite with Gael, Rab Streambattle's otters, and other Southsward allies. They attack Castle Floret, release the captives, and overthrow the Foxwolf's horde. Silvamord and Urgan Nagru are killed, but Finnbarr also falls in the final battle. Gael is restored with his family, Joseph is reunited with Mariel, and Southsward regains its freedom.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1842,7 +1842,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1855,7 +1855,7 @@
       "recaps": {
         "ending": "The performance is rough and unlike any previous church pageant, but the Herdmans treat the Nativity as immediate and real. Gladys announces the birth with fierce urgency, the boys playing the Wise Men bring their own ham instead of the standard prop gifts, and Imogene appears protective of the baby rather than posed and polished. Beth sees Imogene crying while holding the doll. The audience, prepared for embarrassment or disaster, responds to an unexpectedly moving portrayal of poor travelers, frightened shepherds, and outsiders bringing what they have. No fire occurs, and Mrs. Bradley's improvised production succeeds on its own terms. Beth concludes that the Herdmans, precisely because they had never heard the story before, have shown the congregation aspects of Christmas that its experienced participants had stopped noticing.",
         "in_short": "When the injured regular director cannot run the church Christmas pageant, Beth Bradley's mother takes charge. The six Herdman children—widely feared for stealing, fighting, and causing trouble—come to Sunday school after hearing that snacks are available, then seize every leading role despite knowing nothing about the Nativity. Their blunt outrage at Herod and concern for the holy family disrupt rehearsals and alarm the congregation. Everyone expects the performance to be the worst ever. Instead, the Herdmans play the story with an awkward seriousness the familiar cast had lost: the Wise Men offer a ham of their own, Gladys announces the birth with force, and Imogene weeps as Mary. The pageant's imperfections make the events seem real to the audience, and Beth recognizes it as the best pageant the church has had.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1981,7 +1981,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1994,7 +1994,7 @@
       "recaps": {
         "ending": "Amanda returns to her family after accepting that the life she and Dawson once imagined cannot simply replace the responsibilities of the present. Dawson, meanwhile, follows a conviction that he has one final chance to make amends for the accidental death that has burdened him since youth. He intervenes when Ted and Abee threaten Alan Bonner, saving the son of the man he killed, but Dawson is fatally shot. After Jared is gravely injured in an accident and needs an immediate heart transplant, Amanda learns that the donor heart that saves her son came from Dawson. His last act of rescue and the donation bind his life to hers in a way neither anticipated: Amanda remains with her family, Jared survives, and Dawson's heart continues to sustain the child of the woman he loved.",
         "in_short": "Dawson Cole and Amanda Collier, former teenage lovers separated by family pressure and tragedy, return to Oriental, North Carolina, after their old friend Tuck dies. Tuck's instructions force them to revisit their shared past, and their love briefly revives, but Amanda is married with children and ultimately goes home. Dawson then tries to redeem the accidental killing that sent him to prison by protecting the dead man's son from his violent relatives. He succeeds but is shot and killed. At nearly the same time, Amanda's son Jared suffers injuries that require a heart transplant. Dawson becomes the donor, saving Jared and leaving Amanda with a final, literal connection between the man she loved and the family she chose.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2194,7 +2194,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2207,7 +2207,7 @@
       "recaps": {
         "ending": "After surviving Canino and discovering that Mona Mars was hidden rather than traveling with Regan, Marlowe returns to the Sternwoods determined to resolve the remaining mystery. Carmen asks him to teach her to shoot at the family's abandoned oil field, then fires at him with a pistol he has secretly loaded with blanks. Her collapse after the attempt confirms the pattern he suspected. Marlowe confronts Vivian, who admits that Carmen killed Rusty Regan after he rejected her advances. Vivian turned to Eddie Mars for help; Mars concealed Regan's body in an oil sump and then used the secret to control her and profit from her gambling. Marlowe agrees to keep the truth from General Sternwood if Carmen is placed in secure psychiatric care and taken away. The official mysteries therefore remain unresolved, Mars remains at large, and the general is spared knowledge of Regan's fate. Marlowe leaves thinking of Regan dead beneath the oil field and of Mona Mars, whose loyalty was exploited by her husband.",
         "in_short": "Los Angeles private detective Philip Marlowe is hired by dying millionaire General Sternwood to stop Arthur Geiger from blackmailing the family over Carmen Sternwood. Geiger is murdered, compromising photographs of Carmen disappear, and the investigation exposes a chain of blackmailers and criminals. Marlowe clears away the immediate Geiger case but continues looking into the disappearance of Rusty Regan, husband of Carmen's elder sister Vivian. Gangster Eddie Mars appears connected to Regan's supposed flight with Mars's wife Mona. After Mars's gunman kills an informant and captures Marlowe, Mona helps the detective escape and Marlowe kills the gunman. He eventually discovers that Mona never fled with Regan: Carmen killed Regan after he rejected her, Vivian had Mars hide the body, and Mars has blackmailed Vivian ever since. Marlowe promises silence if Carmen is institutionalized, protecting the ailing general from the truth while leaving Mars unpunished.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2383,7 +2383,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2396,7 +2396,7 @@
       "recaps": {
         "ending": "After the Yorkist victory at Shoreby, Richard of Gloucester knights Dick and gives him men to pursue Sir Daniel, who has fled with Joanna. Dick's inexperience costs him most of that force, but he continues with a few loyal companions and finds Joanna in the forest. Sir Daniel escapes the immediate pursuit and later approaches Dick in disguise, asking for safe passage. Dick recognizes his former guardian but allows him to go rather than kill him. Ellis Duckworth, unwilling to abandon his vengeance, shoots Sir Daniel with a black arrow. Dick and Joanna are then free to marry. Dick also uses his standing with Gloucester to obtain mercy for Captain Arblaster, whose ship was lost during the earlier rescue attempt. Lawless eventually leaves fighting for religious life. Dick and Joanna withdraw from the shifting civil war and make a peaceful home together, while the wider conflict between Lancaster and York continues beyond their private resolution.",
         "in_short": "During the Wars of the Roses, young Richard Shelton serves his guardian, the changeable knight Sir Daniel Brackley. A fellowship of outlaws known as the Black Arrow accuses Sir Daniel of murder, including responsibility for the death of Dick's father. While carrying messages, Dick helps a supposed boy called John Matcham escape and later discovers that Matcham is Joanna Sedley, an heiress Sir Daniel controls and intends to marry for profit. When Sir Daniel turns against him, Dick joins Ellis Duckworth and the Black Arrow, learns the truth about his father, and repeatedly tries to rescue Joanna. Their struggle passes through ambushes, disguises, a failed sea attack, and the battle for Shoreby. The Yorkist Richard of Gloucester knights Dick after the victory, but Dick's pursuit of Sir Daniel nearly ends in disaster. Dick finally recovers Joanna and spares his defeated guardian, only for Duckworth to kill Sir Daniel with a black arrow. Dick and Joanna marry and leave the civil war behind.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2532,7 +2532,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2545,7 +2545,7 @@
       "recaps": {
         "ending": "Anneke Jespersen was not a random casualty of the 1992 riots. Her reporting had preserved evidence of a wartime killing involving American servicemen, and men connected by that military past tracked her to Los Angeles and murdered her to keep the record buried. The handgun used in the alley later passed through other crimes, allowing Bosch to follow its history back toward the group, while Anneke's photographs and overseas work supply the motive that the original riot-era file lacked. Thomas Trent's connection to the case was a false direction, and the damage caused by Bosch's early pressure on him fuels Nancy Mendenhall's investigation of the detective. Bosch ultimately travels beyond Los Angeles to confront the surviving men tied to Anneke's evidence. They imprison him and intend to prevent him from returning with the truth, but he escapes, survives the confrontation, and recovers proof linking the old war crime to her execution. Anneke's family finally receives an answer and her death is separated from the anonymous disorder in which the killers hid it. Bosch returns to Maddie having closed one of the cases that first taught him how easily a victim could be lost when the system was overwhelmed. His DROP clock continues to run, but he remains in Open-Unsolved.",
         "in_short": "During the 1992 Los Angeles riots, Bosch briefly examines the execution-style murder of Danish photojournalist Anneke Jespersen before scarce police resources force the case aside. Twenty years later, now in Open-Unsolved and counting down to retirement, he takes it back. A ballistics trail follows the murder weapon through later crimes, while Anneke's family and photographic work reveal that she had documented lethal wrongdoing by American servicemen overseas. An early lead involving Thomas Trent ends disastrously and brings internal investigator Nancy Mendenhall into Bosch's path. Bosch eventually traces Anneke's death to men bound by their military past: they killed her in Los Angeles to suppress evidence of a wartime crime and used the riot as cover. Captured during his pursuit of them outside the city, Bosch escapes and recovers the proof needed to close the murder. Anneke is no longer an anonymous riot victim, and her family learns why she died. Bosch returns to Maddie and the Open-Unsolved Unit with his retirement countdown still running.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2716,7 +2716,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2729,7 +2729,7 @@
       "recaps": {
         "ending": "Bucky's private investigation connects Elizabeth Short to the Sprague household and uncovers the concealed relationship between Ramona Sprague and Georgie Tilden, Madeleine's biological father. Ramona confesses that jealousy and terror over Georgie's fixation on Elizabeth drove the killing, after which Elizabeth's body was mutilated and staged. Bucky kills Ramona and arranges the scene as a suicide, choosing a private resolution that cannot become an honest public case. The official Black Dahlia murder therefore remains unsolved. Madeleine, whose resemblance to Elizabeth helped draw Bucky into the family, is confined to an institution. Bucky also learns the extent of Lee's corruption and the violence behind his disappearance, ending the heroic image he once held of his partner. He reunites with Kay and turns toward a life with her away from the obsessions that consumed Lee and nearly consumed him, but he carries the knowledge that neither the department nor his own actions delivered lawful justice for Elizabeth.",
         "in_short": "LAPD officers and former boxers Bucky Bleichert and Lee Blanchard become partners after a promotional bout, and Bucky joins Lee's close but secretive life with Kay Lake. When aspiring actress Elizabeth Short is found murdered and mutilated, both detectives are pulled into the sensational Black Dahlia investigation. Lee becomes dangerously obsessed, while Bucky follows Elizabeth's movements and begins an affair with Madeleine Sprague, a wealthy young woman who resembles the victim and admits knowing her. Lee disappears amid a confrontation tied to gangster Bobby DeWitt; Bucky discovers that his partner was corrupt and dies pursuing old vengeance. Continuing alone, Bucky traces the Dahlia murder into the Sprague family's hidden history. Ramona Sprague confesses to killing Elizabeth in a jealous crisis involving Georgie Tilden, Madeleine's biological father, who helped turn the body into its grotesque final form. Bucky kills Ramona and disguises her death as suicide, leaving the crime officially open. Madeleine is institutionalized, and Bucky reunites with Kay, chastened by the obsessions and compromises the case exposed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2881,7 +2881,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2894,7 +2894,7 @@
       "recaps": {
         "ending": "Bosch and Wish enter the storm-drain system as the burglary plan reaches its end. FBI agent John Rourke is exposed as the insider who directed the operation and eliminated people who could connect him to it, including Billy Meadows. Rourke tries to kill Bosch underground but dies during the confrontation. Wish then admits that she knowingly took part in the scheme: the targeted vault held valuables tied to men she blamed for her brother's death in Vietnam, and her alliance with Bosch did not erase her role in the crimes. She surrenders and is imprisoned. Bosch solves Meadows's murder and survives both the tunnel and Internal Affairs scrutiny, but the relationship he had begun with Wish ends with her confession. The case leaves him facing the cost of pursuing truth when the people closest to the investigation have concealed the most important facts.",
         "in_short": "A body in a drainage pipe draws LAPD detective Harry Bosch back to his service as a Vietnam tunnel soldier when he identifies the dead man as former comrade Billy Meadows. Signs that the apparent overdose was staged connect the death to a sophisticated bank-vault burglary carried out through Los Angeles tunnels. Bosch works uneasily with FBI agent Eleanor Wish while Internal Affairs watches him and more witnesses are placed in danger. The inquiry moves from veterans of the tunnel units to the people who knew confidential details of the robbery investigation. Bosch ultimately enters the underground route and breaks up a second operation. He learns that trusted participants on the investigative side helped plan the crimes and silence Meadows. One dies in the confrontation; another confesses and goes to prison. The murder is solved, but Bosch's growing personal attachment to Wish is destroyed by the truth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3046,7 +3046,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3059,7 +3059,7 @@
       "recaps": {
         "ending": "At the Mexican drug compound, Bosch discovers that the dead man in the motel was Humberto Zorrillo, not Cal Moore. Moore and Zorrillo were half brothers, and Moore used the shotgun damage and falsified identifying evidence to exchange their identities. After killing Zorrillo, he intended to leave his police life behind and take control of the black-ice operation under his brother's name. Bosch confronts Moore at the compound; Moore is killed as the operation collapses, and the drug facility is destroyed. The result explains the misleading suicide, the message about discovering who he was, and the Los Angeles murders linked to the trade. Bosch returns with the truth rather than the official version his superiors preferred. Sylvia has to absorb that her husband planned the deception and became the man Bosch pursued. Her connection with Bosch survives the revelation and becomes the beginning of a relationship, while Bosch's unauthorized methods leave his conflict with the department unresolved.",
         "in_short": "When narcotics detective Cal Moore is found dead in a motel, the LAPD accepts an apparent suicide, but Harry Bosch notices problems with the identification and with Moore's final message. He links the death to black ice, a dangerous street drug moving into Los Angeles from Mexico, and to another homicide that his division has allowed to stagnate. Interviews with Moore's estranged widow Sylvia and a search through his childhood reveal that the detective had been investigating both the supply network and his own family history. Bosch follows the trail across the border to a fortified drug operation controlled by a trafficker called the Pope. There he learns that the motel death was an elaborate identity exchange involving two half brothers. The architect of the deception dies when Bosch confronts him, the production site is destroyed, and Bosch returns with a solution the department had tried to avoid. He and Sylvia begin a relationship after the truth about her husband is established.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3261,7 +3261,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3274,7 +3274,7 @@
       "recaps": {
         "ending": "Garriston cannot be held. Gavin gets the city's people out by sea and leaves Corvan Danavis, his old general, in charge of the refugees, while the rebellion takes the ruined city. Rask Garadul is dead, killed by Kip with the jewelled dagger his mother left him, and one of the dagger's seven stones has filled with stolen colour, which nobody can yet explain. Command of the rebellion passes to the Color Prince, who intends to break the Chromeria outright. Aliviana Danavis, disgusted by how the Chromeria treats Tyrea and by the Freeing, the ritual killing of drafters who reach the end of their power, goes over to him willingly. Karris is recovered alive and knows now that Kip is a Guile. Beneath the Chromeria, the prisoner breaks out of his blue cell and finds only another cell beyond it, and at the same time Gavin loses blue for good. The last thing the book gives the reader is the truth behind all of it: the man the world calls Gavin Guile is Dazen. He won the war, took his dead-seeming brother's name, face and office, and has kept the real Gavin alive in a private prison ever since. Kip is the son of a man who does not exist, and Gavin's five great purposes and shrinking span of colours are the debts of a sixteen-year-old lie.",
         "in_short": "In the Seven Satrapies, drafters turn light into luxin, a physical substance, and pay for it with their lives; the Prism alone can draft every colour, and the Chromeria governs magic in his name. Sixteen years after Gavin Guile won a civil war against his brother Dazen, a fifteen-year-old boy named Kip watches his Tyrean town destroyed by a would-be king, receives a jewelled dagger and the claim that Gavin is his father from his dying mother, and is swept up by the Prism himself. At the Chromeria Kip meets a family that regards him as a liability, while Gavin conceals two things: that his colours are failing one by one, and that he keeps a prisoner in a cell beneath the tower. When the rebellion marches, Gavin raises a luxin wall around the city of Garriston in a week and still loses it. Kip kills the rebel king with the dagger, which drinks the man's magic; Liv Danavis defects to the rebels' new leader, the Color Prince; and the reader learns that the Prism is actually Dazen, wearing his brother's name, and that the prisoner below is the real Gavin Guile.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3454,7 +3454,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3467,7 +3467,7 @@
       "recaps": {
         "ending": "Rosa brings her remaining bulb and her account of the theft to William of Orange, giving him the means to test Boxtel's claim to the black tulip. At the Haarlem celebration, the prince establishes that the flower was cultivated by Rosa from one of Cornelius van Baerle's bulbs and that Boxtel stole it. Boxtel's long campaign of envy collapses; overcome when van Baerle is vindicated, he dies. William also recognizes that van Baerle was an innocent keeper of the de Witt correspondence rather than a political conspirator. He pardons and releases him, confirms his right to the horticultural prize, and permits him to marry Rosa. The black tulip is named Rosa Baerlaensis in her honor. Van Baerle leaves prison with Rosa, his reputation and fortune restored, while the flower created through their shared patience becomes the public proof of both his achievement and her courage.",
         "in_short": "During the Dutch political violence of 1672, the brothers John and Cornelius de Witt are killed by a mob. Cornelius van Baerle, the elder Cornelius's apolitical godson, is absorbed in the Haarlem prize for the first black tulip. His jealous neighbor Isaac Boxtel denounces him after seeing political letters entrusted to him by de Witt. Van Baerle is condemned but receives a last-minute pardon from William of Orange, changing death to lifelong imprisonment. He preserves three precious bulbs and, with the help of his jailer's daughter Rosa, continues the experiment from his cell. Rosa learns to read, grows the surviving bulb, and falls in love with him. Boxtel follows under a false name, steals the flowering black tulip, and claims the prize. Rosa appeals to William with the remaining evidence. The prince exposes the theft, frees and rewards van Baerle, and approves his marriage to Rosa. The tulip is named for her, while Boxtel dies upon seeing his scheme defeated.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3630,7 +3630,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3641,7 +3641,7 @@
       "recaps": {
         "ending": "The Blade Itself ends by launching three separate journeys rather than resolving anything. Bayaz has assembled his company - Logen, Ferro, Jezal, the apprentice Malacus Quai and the Navigator Brother Longfoot - and led them out of Adua on a quest west to the edge of the World for the Seed, an ancient weapon he claims can defeat the Gurkish; the travellers are bound to him more by circumstance than by trust. Glokta has been made Superior of Dagoska by Arch Lector Sult and dispatched to the Union's crumbling southern city, tasked with holding it against an imminent Gurkish siege and with discovering what became of the predecessor who disappeared. Major Collem West has joined the Union army heading north to fight King Bethod under the incompetent Crown Prince Ladisla, leaving his sister Ardee in Glokta's keeping. Jezal, newly famous as Contest champion, leaves Ardee behind with real regret. War with the North is certain and war with the South is looming, Bayaz's true nature and intentions remain hidden, and none of the men he has set in motion can see where he means to take them. Everything is arranged; nothing is yet decided.",
         "in_short": "Three men in the declining Union - the Northman Logen Ninefingers, the self-loathing crippled Inquisitor Glokta, and the vain young officer Jezal dan Luthar - are drawn into the orbit of Bayaz, First of the Magi, an old wizard most people took for a legend. While Glokta tortures confessions out of corrupt merchants and is steered by the Arch Lector toward ever more dangerous secrets, and Jezal trains for and wins the great fencing Contest, Bayaz forces his way onto the Union's ruling council and reveals a purpose: a journey to the edge of the World to recover an ancient weapon, the Seed, to save the Union from the Gurkish Empire. By the end he has bound Logen, Jezal, the vengeful escaped slave Ferro Maljinn and others to that quest, and they set out. Glokta is sent south to hold the doomed fortress-city of Dagoska, and Major West marches north with the Union's army to war against King Bethod. Little is resolved; every road is only beginning.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3845,7 +3845,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3858,7 +3858,7 @@
       "recaps": {
         "ending": "Gavin marries Karris in defiance of his father's plans for a more profitable match, then sails to meet the rebellion. In the fighting around Ru he destroys the bane, the great floating body of luxin the rebellion had been growing so that an old god could be born back into the world. It costs him everything: when it is over his drafting is gone, and the Prism who could split light into seven colours cannot make one. Half-drowned and unrecognised, he is fished out of the water by the pirate cannoneer Gunner, who keeps him. The Seven Satrapies are left believing their Prism is dead, with a war they are losing, an Andross Guile free to fill the vacancy, and a Chromeria whose next Prism will have to come from somewhere. Karris is a Guile by marriage and a widow by every report she is given. Kip survives, blooded and increasingly unwilling to be managed, and now knows what the jewelled dagger is and roughly what his grandfather wants it for. Liv has gone further into the rebellion than she can walk back from. Below the Chromeria, the real Gavin Guile breaks out of another cell, and another of his brother's colours goes with it.",
         "in_short": "Garriston is lost and the Chromeria blames its Prism. While the Color Prince's army marches north out of Tyrea, Kip fights his way through Blackguard training, makes a squad out of the other misfits, and is played against his grandfather Andross across a card table that is never really about cards. The jewelled dagger Kip carries turns out to be an artifact old enough to predate the Chromeria: a knife that can strip a drafter of their magic. Gavin, secretly the brother who stole the Prism's name, loses colours faster than he can conceal, holds the Spectrum together with bluff, and buries his own mother at the ritual that kills drafters at the end of their span. He marries Karris against his father's wishes and sails to fight the rebellion at Ru, where he destroys the vast floating bane of luxin that would have birthed an old god. The victory takes his drafting entirely, and he is pulled from the sea by the pirate Gunner. The satrapies are told their Prism is dead; below the Chromeria, the real Gavin Guile breaks through another wall of his prison.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4092,7 +4092,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4105,7 +4105,7 @@
       "recaps": {
         "ending": "Karris learns what her marriage actually was: the man she married is Dazen Guile, who took his dead brother's name, face and office after the False Prism's War and has been lying to her, and to everyone, for sixteen years. Gavin himself comes to the end of his descent through the cells he built, blind and without magic, and is out of that prison alive by the close of the book, no longer Prism and no longer anyone the satrapies think exists. Andross Guile holds the Chromeria as promachos, with Zymun installed as Prism-elect and Karris as a White with the title but not the power. Teia is further inside the Order of the Broken Eye than anyone can retrieve her from, still hunting its hidden head. Kip finishes the book as a war leader with a real army, a liberated city and a name in the Blood Forest, and with a marriage to Tisis that has become an actual partnership. On the other side, the White King's forces are still growing their banes, and Aliviana Danavis has taken a seed crystal and become something that is not a drafter any more, an old god of superviolet reborn under the name Ferrilux. The last defensible ground in the north is Kip's, the Jaspers are Andross's, and the gods are coming back.",
         "in_short": "Blind, powerless and given up for dead, Gavin is imprisoned in the deepest of the cells he built beneath the Chromeria and works his way down through them, forced back through everything the war cost. Above him, Andross Guile has himself made promachos and rules the Seven Satrapies outright, with the murderous Zymun as Prism-elect and Karris holding the White's title without its authority. Teia lives as an assassin of the Order of the Broken Eye, killing to hold a cover nobody can confirm, hunting the Order's hidden master. Kip and Tisis, exiled to the Blood Forest, raise an irregular army out of foresters, ghosts and refugees, break the siege of the city of Dunbheo, and turn a marriage of convenience into a real one. The White King's armies keep taking ground and his banes keep growing, and Aliviana Danavis takes a seed crystal and ascends as Ferrilux, an old god returned. By the end Karris has learned that her husband is Dazen, not Gavin, and Gavin is out of the cells alive with nothing left of what he was.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4278,7 +4278,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4291,7 +4291,7 @@
       "recaps": {
         "ending": "The two efforts succeed together. Reyna, Nico, and Coach Hedge deliver the Athena Parthenos to Camp Half-Blood just as the Roman legion is about to attack, and the statue's arrival reconciles the Greek and Roman demigods, ending the threat of war between them. In Athens, Gaea awakens and the giants rise, but the reunited camps and the gods, whose warring Greek and Roman natures are finally settled, join the seven in battle. Jason and Piper seize Gaea and lift her into the sky, severing her from the earth that is the source of her strength, and Leo strikes the helpless goddess with a blast of fire, unmaking her and ending the war. Leo, who had secretly obtained a physician's cure, appears to die in the blast, but the cure revives him, and he flies away on the restored bronze dragon Festus to rescue the immortal Calypso from her hidden island as he had sworn. The prophecy of the seven is fulfilled: Gaea is defeated, the giants are scattered, and the Greek and Roman camps stand united in peace. Percy and Annabeth, having survived Tartarus, look toward an ordinary future together. Nico, having let go of a long-held secret grief, chooses to stay at Camp Half-Blood and make a place among friends. In a closing surprise, Leo returns alive, Calypso at his side, reuniting with the crew who had mourned him.",
         "in_short": "In the final book, the seven demigods race to reach Athens and stop Gaea from waking, while Reyna, Nico, and Coach Hedge carry the Athena Parthenos statue across the world to reconcile the Greek and Roman camps before they go to war. Both journeys are hounded by giants and by the ancient hunter Orion. Leo secretly builds a device meant to defeat Gaea and quietly prepares to sacrifice himself, having obtained a means that might, or might not, bring him back. In Athens the giants gather and Gaea begins to rise from the earth. The gods, whose split Greek and Roman personalities have paralyzed them, are freed to help once the two camps are reconciled. In the climactic battle Jason and Piper lift Gaea off the ground into the air, cutting her off from the earth that gives her power, and Leo blasts her with fire, undoing her. Leo appears to die in the explosion but is revived by a physician's cure and flies off on the bronze dragon Festus to keep his promise to Calypso. Gaea is defeated, the camps are at peace, and the surviving heroes return home, with Leo turning up alive at the very end.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4408,7 +4408,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4421,7 +4421,7 @@
       "recaps": {
         "ending": "After a railway accident fails to produce the fatal attack she expects, Valancy learns that she never had the terminal heart condition described in Doctor Trent's letter: the message was sent to her by mistake, while her own symptoms were not deadly. She is horrified that Barney married her on a false premise and prepares to release him. At the same time she discovers that Barney Snaith is Bernard Redfern, the estranged son of a wealthy manufacturer, and that he is also John Foster, the nature writer whose books she has loved. Believing the disparity between them makes her look calculating, she returns to her mother's house. Barney follows and explains that neither her health nor his fortune changes his love for her. They reconcile, while the Stirling family abruptly revises its opinion of the man it despised. Valancy leaves Deerwood with Barney by choice, now able to imagine travel and a shared future beyond the island home that gave her the first happiness of her independent life.",
         "in_short": "Valancy Stirling has allowed her family to govern her nearly twenty-nine years of life when a doctor tells her that she has a fatal heart condition and little time left. Convinced that respectability can no longer protect her, she speaks honestly, leaves home, and nurses the dying Cissy Gay despite the Stirling clan's outrage. After Cissy's death, Valancy proposes a temporary marriage to the socially suspect Barney Snaith. He accepts, and their simple life on his secluded island becomes the happiness Valancy had only imagined in her private Blue Castle. When Valancy survives a severe shock without the predicted consequences, she discovers that the doctor's terminal diagnosis reached her by mistake. She also learns that Barney is both Bernard Redfern, heir to a fortune, and John Foster, her favorite nature writer. Fearing that their marriage is invalid in spirit and that she appears to have pursued his money, she leaves him. Barney follows, declares that he loves her, and brings her back to a marriage now founded on mutual knowledge and a freely chosen future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4537,7 +4537,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4550,7 +4550,7 @@
       "recaps": {
         "ending": "After beating Johnnie in the fight, the Swede leaves the hotel alone and enters a saloon. His earlier fear has become aggressive confidence. He tries to force the other patrons, including a quiet gambler, to drink with him and seizes the gambler when he refuses. The gambler kills him with a knife and is later sentenced to prison. Months afterward, the Easterner tells the cowboy that Johnnie really did cheat during the card game. He argues that the killing cannot be blamed on the gambler alone: his own silence, Johnnie's cheating, the cowboy's encouragement of the fight, and Scully's actions all helped move the Swede toward his death. The cowboy resists that broad division of guilt, but the story closes on the Easterner's insistence that responsibility extends beyond the person who struck the fatal blow.",
         "in_short": "At a conspicuously blue hotel in a small Nebraska town, an unnamed Swedish traveler becomes convinced that his host and fellow guests plan to kill him. Hotel keeper Patrick Scully tries to calm him with whiskey, but the drink turns his fear into defiance. During a card game the Swede accuses Scully's son Johnnie of cheating. The dispute becomes a fight, which the Swede wins before leaving for a saloon. There he provokes a gambler who finally kills him and later goes to prison. Months afterward, the Easterner admits that he saw Johnnie cheat. He tells the cowboy that everyone who fed the quarrel or withheld the truth bears part of the responsibility for the Swede's death, shifting the story's focus from the fatal act to the chain of choices that made it possible.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4709,7 +4709,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4722,7 +4722,7 @@
       "recaps": {
         "ending": "Pecola becomes pregnant after Cholly rapes her. Claudia and Frieda alone hope the baby will live, planting marigold seeds and giving up money as a private bargain for its survival, but the baby is born prematurely and dies. Soaphead Church tells Pecola that her wish for blue eyes has been granted after arranging the death of a dog as a false sign. Unable to bear what has happened, Pecola retreats into a divided inner life and talks with an imagined companion who confirms her new eyes and protects her from doubt. The community treats her as an object of contempt or pity and avoids recognizing its own part in her destruction. Cholly dies in a workhouse, Pauline remains with her employers, and Pecola wanders at the town's edge. Claudia concludes that the failure belonged not to Pecola or the marigolds but to the world that could not nurture either.",
         "in_short": "In Lorain, Ohio, young Claudia MacTeer looks back on the year her friend Pecola Breedlove's life collapsed. Pecola has absorbed a culture that treats whiteness and blue eyes as the measure of beauty, while poverty, family violence, school cruelty, and color prejudice teach her to despise herself. The histories of her parents show how Cholly's humiliation and Pauline's isolation damaged them, but their pain is passed to their children. Cholly rapes Pecola, and she becomes pregnant. Claudia and Frieda hope to save the baby, but it dies. A fraudulent spiritual adviser tells Pecola she has received the blue eyes she prayed for, and trauma drives her into an imagined conversation in which the wish seems true. The community casts her out rather than face its complicity. Claudia recognizes that Pecola was made to carry the ugliness others refused to see in themselves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4837,7 +4837,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4850,7 +4850,7 @@
       "recaps": {
         "ending": "The book has no single plot to resolve. It closes at the end of its second part, after the war, with the Blythes older, the family circle reduced by Walter's death, and the last of the linking scenes at Ingleside given over to reading his verses and to the family's talk around them. The stories of the second part end as they began, in the private affairs of Glen St. Mary and Four Winds neighbours, several of them on a note of irony or plain bitterness rather than the reconciliations the earlier books preferred. The Blythes themselves are left as the district sees them: prosperous, respected, endlessly quoted, and privately carrying a loss the Glen mentions but does not feel. Taken as a whole the collection is Montgomery's closing word on the world of Avonlea and the Glen, published complete only long after her death, and it leaves that world intact but noticeably darker than she had drawn it before.",
         "in_short": "The last Anne book is not a novel but a collection: two parts of short stories set in and around Glen St. Mary and Four Winds, interleaved with poems attributed to Anne and Walter Blythe and with brief scenes of the Blythe family at Ingleside talking over those poems and their neighbours. The first part is set before the First World War and the second after it. The Blythes themselves stay mostly at the edges; the stories belong to the people of the district, who quote the doctor and his wife, measure themselves against Ingleside, and conduct their own courtships, feuds, deceptions, and reconciliations. The tone is markedly harder than in the earlier books, with more irony and more unhappiness allowed to stand. Walter's death in the war is the shadow across the second part, and his verses are read aloud in the family scenes. Montgomery sent the manuscript to her publisher at the very end of her life; a shortened version appeared decades later, and the complete text only in 2009.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4996,7 +4996,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5009,7 +5009,7 @@
       "recaps": {
         "ending": "At Ray Brower's body, Ace Merrill's older gang orders Gordie, Chris, Teddy and Vern to leave. Gordie uses the pistol brought on the trip to force Ace to back down, but the encounter strips away the younger boys' fantasy of becoming heroes. They decide that no one should profit from Ray's death and later place an anonymous call so the authorities can recover him. The four return to Castle Rock exhausted and changed. Ace's gang retaliates by beating them, and the friends gradually drift apart as school and family expectations separate them. Adult Gordie explains that Vern and Teddy both die young. Chris refuses the future Castle Rock assumes for him, succeeds academically and becomes a lawyer, but is later stabbed to death while trying to stop a public argument. Gordie becomes a professional writer and preserves the journey as a memory of the friends he had before adulthood divided them.",
         "in_short": "In 1960 Castle Rock, Maine, twelve-year-old Gordie Lachance and his friends Chris Chambers, Teddy Duchamp and Vern Tessio learn that the body of missing boy Ray Brower lies beside a distant railroad track. Hoping to become heroes, they tell their parents they are camping and set out on foot. The journey exposes their fears and troubled homes: Gordie grieves his brother and feels unwanted, Chris fears being trapped by his family's reputation, Teddy idealizes an abusive father, and Vern struggles to keep up. After dangers including a train trestle, a hostile dump caretaker and a leech-filled marsh, they reach Ray. Ace Merrill's older gang arrives to claim the discovery, but Gordie drives them off with a pistol. The boys then reject fame and anonymously report the body. They return home and eventually separate. As an adult writer, Gordie records that Vern and Teddy died young and that Chris became a lawyer before being killed while intervening in a fight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5185,7 +5185,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5198,7 +5198,7 @@
       "recaps": {
         "ending": "Miss Marple proves that the body in the Bantrys' library was Pamela Reeves, disguised to resemble Ruby Keene, while the burned body in George Bartlett's car was Ruby. Josie Turner and Mark Gaskell arranged the substitution to produce a false timeline and protect their alibis. Conway Jefferson intended to adopt Ruby and leave her a large settlement, reducing the inheritance expected by Mark and Josie. Josie killed both girls and Mark helped execute the plan. Miss Marple uses a false claim about overlooked evidence to provoke Josie into trying to silence Jefferson, allowing the police to catch her. Mark is also arrested. The Bantrys are cleared of scandal, and Jefferson is left to rebuild his family life without the conspirators who exploited him.",
         "in_short": "A young blonde woman is found dead in the Bantrys' library, although nobody in the household knows her. She is identified as hotel dancer Ruby Keene, whose growing closeness to wealthy Conway Jefferson threatened the expectations of his dependent family. A second missing girl, Pamela Reeves, is apparently found burned in a car, but Miss Marple notices that the two deaths have been arranged around a swapped identity. The library body is Pamela disguised as Ruby; the burned victim is the real Ruby. Josie Turner murdered both young women, and Mark Gaskell helped her construct the alibis and false chronology, because Jefferson planned to adopt Ruby and give her money they expected to inherit. Miss Marple lays a trap, Josie and Mark are arrested, and the Bantrys are publicly cleared.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5378,7 +5378,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5391,7 +5391,7 @@
       "recaps": {
         "ending": "Sherman and his lawyer obtain a recording in which Maria acknowledges that she was driving during the collision, exposing the central lie on which her self-protection and Sherman's prosecution depend. The truth does not restore the old order. Legal disputes over the recording, the weakness of Roland Auburn's testimony, and Judge Kovitsky's resistance to a politically scripted prosecution disrupt the case, but public pressure ensures that Sherman remains exposed to renewed criminal and civil proceedings. Henry Lamb dies from his injuries. Maria avoids taking responsibility, while Peter Fallow's sensational coverage brings him professional rewards. Sherman's bond-trading career, marriage, fortune, home, and social identity collapse under legal costs and notoriety. By the epilogue, he has spent a year moving through the courts and has become hardened by the struggle. The institutions that used the case—press, church, prosecution, finance, and high society—largely preserve themselves, while neither Henry's death nor the factual question of who drove produces simple justice.",
         "in_short": "Bond trader Sherman McCoy and his lover Maria Ruskin take a wrong turn into the Bronx, where Maria, driving Sherman's Mercedes, hits Black teenager Henry Lamb and flees. Sherman hides the event to protect his marriage and status. Tabloid reporter Peter Fallow, Reverend Reginald Bacon, and the Bronx district attorney turn Lamb's injuries into a public cause and a politically valuable prosecution. Investigators trace the car to Sherman; Maria denies driving, while witness Roland Auburn gives a useful but unreliable account. Sherman is arrested, abandoned by his social and professional circle, and forced to depend on defense lawyer Thomas Killian. A recording eventually captures Maria admitting the truth, weakening the case without undoing the damage. Henry dies. Fallow profits from the story, Maria evades accountability, and Sherman loses his career, family life, wealth, and protected identity. The case continues beyond the apparent courtroom victory, leaving him trapped in criminal and civil litigation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-book-thief.json
+++ b/data/works-community/0/the-book-thief.json
@@ -67,7 +67,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -80,7 +80,7 @@
       "recaps": {
         "ending": "The war closes in on Himmel Street with devastating finality. After the Hubermanns are forced to send Max away for the household's safety, and after Liesel glimpses him again among a column of prisoners driven through the town, the street is destroyed in a nighttime bombing raid that catches everyone asleep. Liesel alone survives, because she had been down in the basement writing the story of her own life, and she emerges to find her foster father Hans, her foster mother Rosa, and her beloved friend Rudy among the dead, along with nearly all their neighbors. Death, the narrator, gathers the souls and keeps the book Liesel dropped in the rubble. Liesel is taken in and grows up, and Max survives the concentration camps; the two are reunited after the war. She goes on to live a long life far from Germany, marrying and raising a family, and dies as an old woman many years later. Death, who has carried her story all this time, finally comes for her and returns the book she wrote, reflecting on how a single human life, amid so much horror, could contain such love and such words.",
         "in_short": "Narrated by Death, the story follows Liesel Meminger, a German girl sent in 1939 to foster parents on Himmel Street in a small town near Munich after her brother dies and her mother disappears. Her kind foster father, Hans Hubermann, teaches her to read, and books become her comfort as Nazi Germany goes to war. She befriends the loyal neighbor boy Rudy Steiner and steals books wherever she can, even snatching one from a Nazi book burning. When the Hubermanns hide a young Jewish man, Max Vandenburg, in their basement, Liesel forms a deep friendship with him, and the household lives in constant danger. Through air raids, hunger, and the cruelties of the regime, Liesel keeps reading and begins to write her own story. In the end, a bombing destroys Himmel Street and kills nearly everyone Liesel loves while she survives by chance in the basement. Max lives through the camps, and years later they are reunited; Liesel goes on to a long life, her book eventually kept by Death itself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -185,7 +185,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -198,7 +198,7 @@
       "recaps": {
         "ending": "Violet Gamart's campaign succeeds through political influence rather than through the merits of the competing plans for Old House. Legislation tailored to the situation allows the local authority to acquire a building left unused for a specified period, placing Florence's shop and home beyond her defense. Mr. Brundish makes the rare decision to leave his seclusion and confront Mrs. Gamart on Florence's behalf, but he collapses and dies before his support can change the outcome. With her strongest independent ally gone and Milo North's apparent friendship exposed as useless, Florence loses Old House and closes the business. She leaves Hardborough with little money and no public acknowledgment that the shop had served the town. Her final response is not triumph over her opponents but shame and grief that the community where she spent years of her life proved unwilling to sustain a bookshop. Mrs. Gamart's vision of local culture prevails by excluding the person who actually created it.",
         "in_short": "In 1959, widow Florence Green opens a bookshop in Old House, a damp and reputedly haunted building in the Suffolk town of Hardborough. The business slowly finds customers, and schoolgirl Christine Gipping becomes Florence's capable assistant. Florence's decision brings her into conflict with Violet Gamart, the town's dominant social figure, who wants the building reserved for an arts centre. Florence earns the support of reclusive Mr. Brundish, notably after seeking his judgment on whether to stock Lolita, but most townspeople accommodate whichever side holds more power. Milo North appears friendly while remaining aligned with the Gamarts. Mrs. Gamart uses family and political influence to secure a law enabling the authorities to take Old House. Brundish dies after setting out to defend Florence, leaving her without an ally strong enough to resist. Forced to close, Florence departs Hardborough ashamed that the town where she lived for years did not want her bookshop.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -361,7 +361,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -374,7 +374,7 @@
       "recaps": {
         "ending": "Verena's first major Boston appearance is due to begin before a large audience at the Music Hall. Olive has built the occasion into the public beginning of their shared reforming mission, while Basil has come determined to prevent it. Backstage, Basil presses Verena to leave with him immediately. Torn between her promise to Olive and her attachment to Basil, Verena finally submits to his demand. Basil leads her out through the waiting crowd as she hides her face and weeps. Olive is devastated by both personal abandonment and the collapse of the public career she had planned, but when the impatient audience must be addressed she goes onto the stage herself. Verena departs with Basil toward marriage, yet her tears make clear that the choice is not a simple liberation. Basil has won the contest for her future, but the closing note anticipates further sorrow rather than assuring domestic contentment; Olive, forced into the exposure she dreaded, is left to speak without the woman whose gift had sustained her hopes.",
         "in_short": "After the Civil War, conservative Mississippi lawyer Basil Ransom visits his wealthy Boston cousin Olive Chancellor, a committed advocate of women's rights. At a reform gathering they hear Verena Tarrant, a beautiful young speaker with an extraordinary instinct for moving audiences. Olive draws Verena into an intense friendship and prepares her for a public career, while Basil is fascinated despite rejecting her ideas. Verena promises herself to Olive's cause, but Basil later courts her in secret and argues that public reform has made her the instrument of other people's ambitions. A prosperous admirer, Henry Burrage, offers another route through marriage, but Verena refuses him. At Cape Cod, as Miss Birdseye dies believing Verena will serve the movement, Verena admits her love for Basil yet delays leaving Olive. On the night of Verena's great Boston debut, Basil takes her away before she can speak. Olive faces the audience herself, and Verena leaves in tears, bound for marriage but not guaranteed happiness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -487,7 +487,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -500,7 +500,7 @@
       "recaps": {
         "ending": "Kokua discovers that Keawe bought the bottle for one American cent, leaving no smaller American coin with which to resell it. She takes him to Tahiti, where the currency permits a sequence of lower prices. Without telling Keawe, she pays an intermediary to buy the bottle for four centimes and then buys it for three, knowingly taking his danger upon herself. Keawe learns what she has done and arranges a mirror sacrifice: a boatswain buys the bottle from Kokua for two centimes, after which Keawe intends to buy it for one. The boatswain refuses to complete the second sale. He accepts the supernatural risk, believes he is already beyond salvation, and values the bottle's power. Keawe and Kokua are therefore both freed from ownership. Reconciled after each has proved willing to sacrifice everything for the other, they return to Hawaii and live together in the house the bottle originally obtained for Keawe.",
         "in_short": "Keawe buys a wish-granting bottle whose owner will be damned if he dies before selling it for less than he paid. He wishes for a splendid house in Hawaii, receives it through an inheritance following family deaths, and passes the bottle to his friend Lopaka. Later, after falling in love with Kokua, Keawe discovers signs of leprosy. He tracks the bottle down and buys it for one cent, uses it to cure himself, and marries Kokua, but believes he can never resell it because American currency has no lower price. Kokua secretly takes him to Tahiti, where smaller denominations let her acquire the bottle through an intermediary. Keawe then arranges for a boatswain to buy it from her, planning to take it back himself. The boatswain chooses to keep it. Keawe and Kokua are both free, and their willingness to sacrifice themselves for one another restores their happiness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -596,7 +596,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -609,7 +609,7 @@
       "recaps": {
         "ending": "After Dennis is exposed at school and expelled, he loses both his ordinary place in class and his place on the football team. Lisa, Darvesh, and the other players refuse to accept that punishment as the last word. Their solidarity helps Dennis return for the decisive match, with dresses becoming a shared team statement rather than evidence that he should be isolated. Dennis's skill helps the team win, and the public support around him makes the headmaster's rigid response impossible to sustain. Mr Hawtrey's own concealed interest in women's clothing further undercuts his claim to moral authority. At home, Dennis's father begins to move beyond the shame, silence, and narrow ideas about masculinity that followed Mum's departure. He recognizes his son's courage and allows affection back into their relationship. Dennis is restored to school and football without having to renounce his interest in fashion. The story closes with his friendships and family bonds strengthened, and with difference treated as something a community can make room for rather than punish.",
         "in_short": "Twelve-year-old Dennis is a gifted footballer who misses the mother who left his family and secretly loves fashion. His father discourages emotion, so Dennis hides that interest until an older pupil, Lisa, sees his magazine and befriends him. She lends him a dress, and together they invent Denise, supposedly a French exchange student. Dennis enjoys attending school in the disguise, but when he is recognized, the headmaster expels him and bars him from football. The punishment leaves the school team without its best player before an important match. Lisa, Dennis's friend Darvesh, and the other boys rally around him, using dresses themselves to turn the thing used to shame Dennis into a sign of support. Dennis returns and helps win the match. The headmaster's hypocrisy is exposed, Dennis is accepted back, and his father begins showing love and pride instead of enforcing silence. Dennis keeps both football and fashion as parts of his life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -751,7 +751,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -764,7 +764,7 @@
       "recaps": {
         "ending": "Although Seibert cancels the murder program, Mengele continues on his own and reaches the Wheelock home before Liebermann can stop him. Henry Wheelock is killed, and Mengele confronts and wounds Liebermann. When Bobby Wheelock returns, Liebermann provokes the family's dogs into attacking Mengele. Bobby delays calling for help and coldly photographs the mauling, allowing Mengele to die. Liebermann survives and obtains the list identifying the boys created by the project. David Bennett argues that all of them must be killed before any can become another Hitler. Liebermann refuses to condemn children for a possible future shaped by both heredity and circumstance, and destroys the list so it cannot become a death list. Bobby develops his photographs and imagines the recognition they might bring him, leaving an unsettling final suggestion that Mengele's experiment may have recreated some dangerous tendencies without determining what any individual boy will become.",
         "in_short": "Young Barry Kohler overhears Josef Mengele assigning Nazi fugitives to murder ninety-four sixty-five-year-old men, but he is killed after alerting Nazi hunter Yakov Liebermann. Liebermann traces several deaths and discovers that the victims are civil servants with much younger wives and adopted thirteen-year-old sons who look identical. A scientist helps him understand that Mengele produced genetic copies of Adolf Hitler and placed them in families designed to reproduce Hitler's childhood, including the death of an authoritarian father at the same age. Mengele's organization cancels the exposed operation, but he continues alone. At the Wheelock home he kills the father and wounds Liebermann; the boy Bobby's dogs then maul Mengele as Bobby photographs the scene. Liebermann destroys the list of cloned boys rather than let militants kill children for what they might become. Bobby's hunger for fame leaves the experiment's outcome morally and psychologically unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -934,7 +934,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -947,7 +947,7 @@
       "recaps": {
         "ending": "Lady Ashton isolates Lucy, intercepts Edgar's letters, and drives her toward marriage with Bucklaw. Lucy finally signs the contract, but Edgar appears and demands that she confirm her rejection of him; he leaves after she cannot resist her family. On the wedding night Lucy stabs Bucklaw and is found delirious, hiding in the room. Bucklaw survives but refuses to explain what occurred, while Lucy dies soon afterward. Lady Ashton displays no public remorse and has the broken engagement erased from Lucy's memorial. Colonel Ashton challenges Edgar, who rides to meet him on the seashore. Crossing dangerous sands below the old Ravenswood estate, Edgar and his horse vanish into quicksand, leaving only a black feather visible. His death ends the male Ravenswood line and fulfills the fatal pattern long associated with the feud and with the lovers' bond.",
         "in_short": "Edgar Ravenswood, impoverished heir of a dispossessed Scottish house, rescues Lucy Ashton and her father, Sir William, whose family now owns the Ravenswood estate. Despite the feud, Edgar and Lucy fall in love and pledge themselves at the Mermaid's Fountain. Political advantage temporarily encourages Sir William to accept the match, but Lady Ashton returns determined to destroy it. While Edgar is abroad, she intercepts correspondence, isolates and pressures Lucy, and arranges her marriage to Bucklaw. Edgar returns as Lucy signs the contract but cannot free her from her family's control. On her wedding night Lucy stabs Bucklaw, loses her reason, and dies; Bucklaw survives. Challenged by Lucy's brother, Edgar rides across the sands to their meeting and is swallowed by quicksand, ending the Ravenswood line and completing the tragedy anticipated by family legend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1115,7 +1115,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1128,7 +1128,7 @@
       "recaps": {
         "ending": "Brother Juniper spends six years assembling his immense study of the five people killed on the bridge, hoping their virtues and failings will demonstrate a just design. Church authorities instead judge the work heretical. The book is burned publicly, and Juniper is burned with it; a secret copy later disappears. Human consequences outlast his failed proof. Doña Clara comes from Spain and recognizes too late the depth of her mother's love. Camila, scarred and withdrawn after smallpox and grieving Uncle Pio and Jaime, eventually seeks the Abbess. The women encounter one another through Madre María del Pilar's work among people who are ill, orphaned, or forgotten. The Abbess has also lost Pepita and Esteban, the young people in whom she had placed her hopes. She understands that individual lives and even memories vanish, but love forms the enduring connection between the living and the dead. The novel closes on that bond rather than on Juniper's attempt to calculate providence.",
         "in_short": "In 1714, a celebrated rope bridge in Peru collapses and kills five travelers. Brother Juniper, who sees the disaster, investigates their lives in hopes of proving that divine justice selected them. The victims are the lonely Marquesa de Montemayor and her young companion Pepita; Esteban, a twin shattered by his brother Manuel's death; Uncle Pio, the mentor of actress Camila Perichole; and Camila's young son Jaime. Each has approached a turning point involving love, grief, or responsibility. The Marquesa has begun to move beyond possessive devotion to her distant daughter, Esteban has agreed to leave Peru with Captain Alvarado, and Uncle Pio hopes to educate Jaime. Juniper's exhaustive study is condemned as heresy, and he is burned along with it. Afterward, the survivors—including the Marquesa's daughter and the grieving Camila—are drawn toward the Abbess whose work had touched several victims. The book finally locates meaning not in a provable scheme behind the accident but in the love connecting people across loss and death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1234,7 +1234,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1247,7 +1247,7 @@
       "recaps": {
         "ending": "Francesca remains with Richard and their children rather than leaving Iowa with Robert. She watches Robert's truck in the rain when she has one final chance to follow him, but she stays and keeps their four days together private. Neither of them replaces the relationship. After Richard's death, Francesca tries to contact Robert and eventually learns that he has died. His belongings come to her, including his cameras and evidence that he remembered her throughout the years apart; his ashes have been scattered at Roseman Bridge. Francesca preserves the story for Michael and Carolyn and asks to be cremated and scattered there as well. Her children honor that request. Learning the truth changes the way they view both their mother and their own troubled relationships, and they leave with a greater willingness to make honest choices in their lives.",
         "in_short": "After Francesca Johnson's death, her adult children discover her account of four days in 1965 when the family was away and traveling photographer Robert Kincaid stopped at her Iowa farm for directions to a covered bridge. Francesca guides him there, and companionship quickly becomes a profound love affair. Robert asks her to leave with him, offering the wider, unsettled life she once imagined, but she decides that abandoning her husband and children would destroy too many lives. They part and never meet again, though neither forgets the other. Years later Francesca learns that Robert has died and had his ashes scattered at Roseman Bridge. She leaves their story to her children and asks that her own ashes be placed there. Michael and Carolyn fulfill her wish, newly aware of their mother's hidden emotional life and prompted to reconsider their own choices.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1443,7 +1443,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1456,7 +1456,7 @@
       "recaps": {
         "ending": "Oscar returns alone to the Dominican Republic despite his family's efforts to keep him safe. He resumes his relationship with Ybón and accepts that the Captain's power makes the choice deadly. The Captain's men take Oscar to the cane fields, where he speaks of love and the future before they kill him. Some time later, a final letter arrives describing the intimacy Oscar and Ybón shared and presenting it as the discovery he had sought throughout his life. Lola eventually marries and has a daughter, Isis. Yunior's continued infidelity destroys his relationship with Lola, but he preserves Oscar's writings, studies the family's past, and imagines showing the archive to Isis when she is older. The possible family curse is not conclusively broken; what remains is a record assembled from incomplete testimony, history, and Oscar's own words.",
         "in_short": "Oscar de León is a Dominican American science-fiction writer whose longing for love collides with isolation, depression, and a family history shaped by dictatorship. His sister Lola resists their formidable mother, Beli, while Yunior—Lola's unfaithful boyfriend and Oscar's roommate—narrates much of their story. In the Dominican Republic, Trujillo destroyed Beli's Cabral family; as a young woman she was nearly killed after an affair with a man tied to the dictator, then fled to New Jersey. Oscar survives a college suicide attempt and later teaches school. Visiting Santo Domingo, he falls in love with Ybón, whose police-captain boyfriend has him brutally beaten. Oscar returns anyway, reunites with Ybón, and is murdered in the cane fields. His last letter says their relationship was finally consummated. Lola builds a family of her own, while Yunior loses her, keeps Oscar's manuscripts, and tries to preserve the history for Lola's daughter Isis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1669,7 +1669,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1682,7 +1682,7 @@
       "recaps": {
         "ending": "Gavin gets back to the Jaspers under his own power and is beaten there by his father. Andross has him blinded and put in the deepest of the coloured cells beneath the Chromeria: the prison Gavin built himself, for the brother he stole a name from. No one outside that room knows he is alive. The Order of the Broken Eye is exposed as a live organisation with people inside the Chromeria's own walls, and Teia is left inside it, cut off from anyone who can vouch for her and carrying an invisibility cloak she is not supposed to have. Orea Pullawr dies and Karris is raised to the White, an office she never wanted, at the youngest age anyone can remember, with Andross Guile installed opposite her and Zymun confirmed as Prism-elect. Kip cannot stay: his grandfather has made the Jaspers lethal for him, so he leaves with his squad, marrying Tisis Malargos on the way out because the marriage buys them an army's worth of allies in Ruthgar and the Blood Forest. The rebellion, unopposed, holds most of two satrapies. The Seven Satrapies end the book with a boy king for a Prism, a young widow for a White, an old man holding the real power, and their actual Prism blind in a hole under their feet.",
         "in_short": "The Prism is presumed dead at Ru, and the Chromeria fills the hole with whoever is nearest: Andross Guile takes control of the succession and produces Zymun, a charming psychopath who turns out to be the son Karris bore and lost before the war. The dying White sends Teia into the Order of the Broken Eye, the assassins' society the Chromeria claims to have wiped out, where she is trained by the killer Murder Sharp and given a cloak that makes her invisible. Kip fights his grandfather across a card table and a city, survives repeated attempts on his life, and is pushed into an alliance-marriage with Tisis Malargos. Gavin, an oar slave with no magic, works his way off Gunner's ship and back to the Jaspers, where his father takes him, blinds him, and locks him in the deepest of the cells he once built for his brother. Orea Pullawr dies and Karris is made the White. Kip and his squad flee the Jaspers for the Blood Forest, and the rebellion keeps everything it has taken.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2045,7 +2045,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2058,7 +2058,7 @@
       "recaps": {
         "ending": "Jane Eyre ends with Jane independently marrying the injured Rochester after Bertha's death. Wuthering Heights ends with Heathcliff dead and the younger Catherine and Hareton planning a marriage that reunites the families and estates. The final novel, The Tenant of Wildfell Hall, closes after Helen returns to nurse her abusive husband, Arthur Huntingdon, through his last illness. His death frees her legally, and an inheritance makes her independently wealthy. Gilbert repairs his friendship with Frederick Lawrence, learns that Helen still loves him, and overcomes his doubts about their difference in fortune. Helen and Gilbert marry and live at Staningley with her son. Frederick marries Esther Hargrave, while the reformed Hattersley has made a happier home with Milicent. The collection therefore ends with Helen secure in a marriage entered freely after escaping coercion and protecting her child.",
         "in_short": "The collection brings together three stories of constrained lives and chosen bonds. Jane Eyre survives an abusive childhood, becomes Rochester's governess, leaves when his existing marriage is exposed, gains family and an inheritance, then returns after Bertha's death to marry Rochester as an equal. In Wuthering Heights, Heathcliff's thwarted bond with Catherine Earnshaw becomes a campaign of revenge against the Earnshaw and Linton families. He gains both estates, but the younger Catherine and Hareton overcome his abuse, fall in love, and plan to marry after his death. In The Tenant of Wildfell Hall, Gilbert Markham learns that the supposed widow Helen Graham is hiding from Arthur Huntingdon, whose drinking, cruelty, and infidelity endangered her and their son. Helen later nurses Huntingdon through his fatal illness. Once free and financially secure, she accepts Gilbert, and they form a new household with her child.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2332,7 +2332,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2345,7 +2345,7 @@
       "recaps": {
         "ending": "Grayson stops hiding: he tells Savannah and Gigi who he is and what he knows about their father, and instead of losing them he ends the book with two sisters, their mother's household secured, and the scheme that was stripping the Grayson estate broken. The twins are now part of the Hawthorne orbit rather than a secret Grayson keeps from it, and Savannah's own long silence about their father is finally out in the open. In London, Jameson wins his way into the Devil's Mercy and wins its game, taking his father's measure in the process and refusing to be the instrument Ian intended; Ian ends the book without the leverage he came for, and Rohan's standing inside the club is transformed by what happens. Jameson and Avery leave London with a much better sense of what the Hawthorne name is worth outside Texas. The brothers come home to a family larger than the one they started the book with, and Avery's plan to turn the fortune into a game that ordinary people can enter moves closer to its first running.",
         "in_short": "The fourth book splits between two brothers on separate errands. Grayson goes to Phoenix to quietly look after the family his biological father left behind, a wife and twin daughters who have no idea the man is dead or that Grayson is related to them, and finds their money gone and their affairs being picked over. Savannah keeps her composure and her secrets; Gigi starts investigating her father's disappearance and pulls the whole thing open. Jameson, meanwhile, is approached by Ian Johnstone-Jameson, the English father he has never met, who needs him to win a favor from the Devil's Mercy, a private London club where the stakes are debts and favors rather than money. Jameson has to win his way in through trials set by Rohan, the club's factotum, with Avery beside him and his father's account of what he needs shifting every time it is told. Both brothers end up choosing honesty over the plan they arrived with: Grayson tells the twins the truth and claims them as family, and Jameson wins the club's game and refuses to be used by his father.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2510,7 +2510,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2523,7 +2523,7 @@
       "recaps": {
         "ending": "Fyodor Pavlovich is murdered and robbed, and Dmitri, who had quarreled violently with his father and cannot fully account for that night, is charged with the crime. At his trial, despite the passionate defense mounted on his behalf, the circumstantial case overwhelms him and he is convicted of killing his father and sentenced to penal servitude in Siberia. The real murderer is the servant Smerdyakov, who killed Fyodor after concluding, from Ivan's teaching that in a world without God all things are permitted, that he was licensed to act; he reveals this to Ivan in a series of confrontations and then hangs himself, leaving no confession the court will accept. Ivan, crushed by guilt and haunted by a hallucination of the devil, breaks down into a feverish madness. Katerina Ivanovna and Grushenka are left to their divided loves, and a scheme is set in motion to help Dmitri flee his sentence. The novel closes not on the courtroom but on the funeral of the boy Ilyusha, where Alyosha urges the assembled schoolboys to hold on to their good memories and their love for one another, offering a note of faith and renewal against the family's ruin.",
         "in_short": "The dissolute landowner Fyodor Pavlovich Karamazov and his three very different sons - the passionate Dmitri, the intellectual Ivan, and the gentle novice Alyosha - are drawn into bitter conflict over money and over the young woman Grushenka, whom both Fyodor and Dmitri pursue. When Fyodor is found murdered and robbed, suspicion falls on Dmitri, who had publicly threatened his father and was near the house that night, though he insists he is innocent. He is arrested, tried, and convicted of parricide on powerful circumstantial evidence. In truth the killer is the servant Smerdyakov, who acted after absorbing Ivan's argument that without God everything is permitted; Smerdyakov confesses privately to Ivan and then hangs himself, while Ivan, tormented by his share of guilt, collapses into brain fever and delirium. Dmitri is sentenced to hard labor in Siberia, with a plan afoot to help him escape. Alongside the family tragedy runs the story of Alyosha and a group of schoolboys around the dying child Ilyusha, ending on Alyosha's message of love, memory, and hope.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2731,7 +2731,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2744,7 +2744,7 @@
       "recaps": {
         "ending": "The jury convicts Dmitri of murdering Fyodor, despite the defense's argument that the case rests on inference and despite Dmitri's continued denial. He is sentenced to penal servitude in Siberia. Ivan lies dangerously ill after revealing that Smerdyakov confessed to the murder and then killed himself; Katerina cares for Ivan while also helping plan Dmitri's escape. Dmitri and Katerina acknowledge their enduring love and forgive each other, but accept that they will not build a life together. Grushenka remains committed to Dmitri, and he imagines escaping with her to America before perhaps returning secretly to Russia. In the novel's final movement, Ilyusha dies. After the funeral, Alyosha gathers Kolya and the other boys near the stone associated with their friendship. He asks them to preserve the memory of Ilyusha and of the kindness that united them, arguing that one good memory can guide a person through later corruption. The boys affirm their bond and leave together for the memorial meal.",
         "in_short": "Fyodor Karamazov's household is divided by money, desire, and resentment. His eldest son Dmitri quarrels with him over an inheritance and over Grushenka, while intellectual Ivan wrestles with innocent suffering and devout Alyosha follows the teachings of Elder Zosima. Fyodor is murdered after Dmitri has publicly threatened him. Evidence points to Dmitri, who had desperately sought money and struck the servant Grigory while approaching the house, but the actual killer is Smerdyakov, Fyodor's servant and probable son. Smerdyakov claims Ivan's ideas and departure gave him moral permission, then kills himself. Ivan breaks down before he can save Dmitri with the confession. At trial, Katerina produces a damaging letter and Dmitri is convicted, though plans are made for his escape with Grushenka. The novel closes after the death of the schoolboy Ilyusha, when Alyosha urges his young friends to keep their shared memory of love and loyalty as protection against future moral failure.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2955,7 +2955,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2968,7 +2968,7 @@
       "recaps": {
         "ending": "The jury convicts Dmitri of murdering and robbing his father despite his denial and Ivan's attempt to identify Smerdyakov as the killer. Dmitri is sentenced to twenty years of hard labor in Siberia. Ivan remains dangerously ill after his breakdown; Katerina cares for him, burdened by the testimony she gave against Dmitri. Alyosha and others consider a plan for Dmitri to escape during transfer and eventually live abroad with Grushenka, though the escape has not occurred when the story ends. Dmitri and Katerina acknowledge their lasting love but accept that their lives now lie with Grushenka and Ivan respectively. After Ilyusha dies, Alyosha gathers the schoolboys at the stone where Ilyusha wished to be buried. He asks them to preserve the memory of kindness and fellowship as protection against future wrongdoing. Their response closes the novel on shared remembrance rather than on resolution of the Karamazov family's legal and spiritual conflicts.",
         "in_short": "Fyodor Karamazov's three acknowledged sons return to a family divided by money, desire, and belief. Dmitri disputes an inheritance and rivals his father for Grushenka; Ivan wrestles with innocent suffering and moral freedom; Alyosha follows Elder Zosima's teaching of active love. Fyodor is murdered after Dmitri has openly threatened him. The evidence points to Dmitri, but Smerdyakov privately tells Ivan that he committed the crime, encouraged by Ivan's ideas and departure. Smerdyakov then kills himself, and Ivan collapses while trying to expose him at Dmitri's trial. Katerina's conflicted testimony helps secure Dmitri's conviction and a twenty-year Siberian sentence. Friends discuss an escape with Grushenka, but it remains only a plan. The novel ends after young Ilyusha's funeral, where Alyosha urges the gathered schoolboys to keep one good shared memory throughout their lives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3205,7 +3205,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3218,7 +3218,7 @@
       "recaps": {
         "ending": "Dmitri is convicted of murdering Fyodor Pavlovich and sentenced to twenty years of hard labor, although Smerdyakov privately confessed the murder to Ivan before killing himself. Ivan suffers a severe mental and physical collapse after trying to reveal that confession in court. Katerina and Ivan had already developed a plan to bribe guards and help Dmitri escape during transport; Alyosha supports the plan, and Dmitri imagines leaving for America with Grushenka, though exile from Russia troubles him. Dmitri and Katerina meet in the hospital and acknowledge the love and harm that still connect them. Grushenka arrives, and full reconciliation remains difficult. The final chapter turns to Ilyusha's funeral. After the burial, Alyosha gathers Kolya and the other boys by a stone where they once met. He asks them to preserve the memory of Ilyusha and of their present compassion, arguing that one good memory can guide a person later. The boys answer with affection for Alyosha and for their dead friend. The murder judgment remains uncorrected and the escape remains only a plan, but the novel closes on a deliberately sustained community of memory and responsibility.",
         "in_short": "Fyodor Pavlovich Karamazov's neglected sons return to a family divided by money, desire, faith, and resentment. Dmitri quarrels with his father over an inheritance and over Grushenka, while remaining engaged to Katerina. Ivan challenges religious explanations for innocent suffering; Alyosha follows the compassionate teaching of the dying elder Zosima. After Fyodor is murdered and robbed, Dmitri is arrested because his threats, desperate search for money, and violent movements make him appear guilty. The actual murderer is the servant Smerdyakov, who tells Ivan that Ivan's ideas and departure gave him permission and opportunity. Smerdyakov kills himself, Ivan collapses, and Katerina's damaging evidence helps convict Dmitri despite conflicting testimony. Plans are made for Dmitri to escape with Grushenka, but they remain unfulfilled when the novel ends. After the death of the schoolboy Ilyusha, Alyosha brings his friends together and asks them to keep one another and their shared kindness in memory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3432,7 +3432,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3445,7 +3445,7 @@
       "recaps": {
         "ending": "At Dmitri's trial, the prosecution builds a persuasive circumstantial case from his threats, his sudden possession of money, Grigory's testimony, and the absence of another accepted suspect. Ivan attempts to accuse Smerdyakov and produce the stolen cash, but his feverish collapse and lack of a living witness make the intervention seem unreliable. Katerina, torn between protecting Dmitri and answering his love for Grushenka, submits Dmitri's earlier letter describing a possible plan to kill his father. The jury convicts him, and he is sentenced to penal servitude in Siberia. Ivan and Katerina arrange a possible escape, while Dmitri considers accepting suffering yet hopes to flee with Grushenka. Ivan remains seriously ill. The novel closes after Ilyusha's funeral. Alyosha gathers the boy's friends by the stone where Ilyusha once wanted to be buried and asks them to preserve their memory of love and fellowship. Their promise does not settle the Karamazov family's future, but it answers the trial's despair with a commitment to mutual responsibility and remembered goodness.",
         "in_short": "Fyodor Karamazov's three acknowledged sons return to a household divided by money, desire, and belief. Dmitri fights his father over an inheritance and over Grushenka; Ivan challenges religious explanations for innocent suffering; Alyosha follows Elder Zosima's teaching of active love. After Fyodor is murdered, Dmitri is arrested because his threats, desperate search for money, and flight make him appear guilty. The actual killer is the servant Smerdyakov, who says Ivan's ideas and departure gave him moral permission. He returns the stolen money to Ivan and then kills himself. Ivan breaks down before he can make the truth credible. Katerina's damaging letter helps convict Dmitri, who is sentenced to Siberia while friends plan his escape with Grushenka. Alongside the family tragedy, Alyosha befriends the dying schoolboy Ilyusha and his companions. After Ilyusha's funeral, Alyosha urges the boys to remember their shared kindness, ending the novel with fellowship rather than a resolved future for the brothers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3690,7 +3690,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3703,7 +3703,7 @@
       "recaps": {
         "ending": "At Dmitri's trial, Ivan produces the stolen money and accuses Smerdyakov, but his feverish collapse makes the testimony appear unreliable. Katerina, torn between Dmitri and Ivan, submits a letter in which Dmitri once threatened to kill his father for the money; the jury convicts him, and he receives twenty years of hard labor in Siberia. Ivan becomes gravely ill. Katerina and Alyosha plan to help Dmitri escape while he is transferred, and Grushenka intends to go with him; Dmitri imagines exile in America followed by a return to Russia under another identity. He and Katerina acknowledge their lasting love but accept that they will not be together. Meanwhile Ilyusha dies. After the funeral, Alyosha gathers Kolya and the other boys at the stone where Ilyusha wished to be buried. He asks them to preserve the memory of their friendship and of having acted kindly together. Their answering affection closes the novel with a communal promise that love and remembered goodness can resist cruelty, guilt, and despair.",
         "in_short": "Fyodor Karamazov's household is divided by money, desire, and ideas. His eldest son Dmitri fights him over an inheritance and over Grushenka; Ivan challenges religious faith and discusses moral freedom with the servant Smerdyakov; Alyosha follows the compassionate teaching of Elder Zosima. Fyodor is murdered and robbed. Dmitri, who had threatened him and arrives with unexplained money after striking the servant Grigory, is arrested, but Smerdyakov later tells Ivan that he committed the murder under the influence of Ivan's arguments. Smerdyakov kills himself, Ivan breaks down, and Dmitri is convicted despite his innocence of the murder. Plans form for Dmitri and Grushenka to escape his Siberian sentence. Alongside the family tragedy, Alyosha reconciles a group of boys with the dying Ilyusha. After Ilyusha's funeral, he urges them to remember their friendship and the good they shared, ending the novel with hope grounded in active love and communal memory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3836,7 +3836,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3849,7 +3849,7 @@
       "recaps": {
         "ending": "Orders remove the Japanese families from their homes and send them to undisclosed confinement sites. They sell or entrust possessions, close businesses, leave crops behind, and gather with only what they are permitted to carry. The women, their husbands, and their American-born children disappear together from towns where many had lived for decades. The final chapter transfers the collective voice to the white people left behind. At first they notice empty houses, untended gardens, lost workers, and missing classmates. They speculate about where the families went and whether the removal was justified, while opportunists occupy property or acquire belongings. With no Japanese neighbors present to contradict rumor, suspicion persists for a time. Gradually ordinary routines cover the absence. Signs vanish, new tenants arrive, and even people who once knew the families stop mentioning them. The book ends not at a camp but inside this public forgetting, making disappearance from communal memory part of the removal itself.",
         "in_short": "A collective voice follows Japanese picture brides who sail to the United States in the early twentieth century. The men awaiting them are often older and poorer than their photographs suggested, and the women enter difficult marriages and exhausting work in fields, homes, and small businesses. They learn English unevenly, endure racism and exploitation, bear children, and watch those American-born children distance themselves from Japanese language and custom. After Japan attacks Pearl Harbor, suspicion turns against the entire community. Men are questioned or arrested, bank accounts are frozen, restrictions multiply, and families destroy objects they fear could be treated as evidence of disloyalty. Removal orders finally force them to leave homes, farms, schools, and businesses for confinement. The closing perspective belongs to the white neighbors who remain: they notice the vacancies, speculate, take over property, and then slowly cease to speak about the missing Japanese families. The community's physical disappearance becomes an act of collective forgetting.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3982,7 +3982,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3995,7 +3995,7 @@
       "recaps": {
         "ending": "Wistan kills Querig after defeating Sir Gawain, ending the enchantment that has suppressed the country's memories. He expects the Saxons to remember Arthur's massacre and predicts that their descendants will take revenge on the Britons. Axl and Beatrice remember that their son died and that Axl once left Beatrice after her infidelity, although they later reconciled. At the shore, Beatrice is weak and ready to cross to the island. The boatman agrees to take her first but refuses to carry Axl in the same trip, promising to return for him. Axl understands that the separation is probably permanent. He reassures Beatrice, watches her depart with the boatman, and walks away alone as rain falls. The national peace and the couple's private peace have both depended partly on forgetting; with memory restored, neither can remain untouched.",
         "in_short": "In post-Arthurian Britain, Axl and Beatrice are an elderly couple living beneath a mist of collective forgetfulness. They leave their village to find the son they dimly remember and travel with Wistan, a Saxon warrior, and Edwin, a boy marked by a strange wound. Sir Gawain, Arthur's surviving knight, also crosses their path. The travelers learn that the dragon Querig's breath sustains the mist: Merlin's enchantment concealed a massacre of Saxons ordered after Arthur's peace was broken. Axl once served Arthur and helped advance that settlement, while Gawain protects the dragon to preserve it. Wistan defeats Gawain and kills Querig, allowing memory to return but making renewed war likely. Axl and Beatrice recall their son's death and old damage within their marriage. At the coast, a boatman takes the dying Beatrice toward an island but leaves Axl behind, separating the couple at the end of their journey.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4162,7 +4162,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4175,7 +4175,7 @@
       "recaps": {
         "ending": "Morgarath's flanking plan collapses. The bridge his slaves built is burned, and the Wargal column that crosses the gorge is met and destroyed rather than falling on the Araluen army's rear. With his trap gone and his army now facing the King's, Morgarath demands that the matter be settled by single combat. Horace, still a Battleschool apprentice, answers the challenge and kills him. Deprived of the mind that drove them, the surviving Wargals stop fighting. The war that has hung over Araluen since the first book is over in an afternoon, and the kingdom has lost the enemy who defined it. The victory is incomplete for the people at its centre. Will and Evanlyn are not there: they were taken at the bridge by Erak's Skandians and are aboard a wolfship bound north for Skandia, where captives are sold or worked as slaves. In the aftermath it emerges that Evanlyn is not a servant at all but Cassandra, King Duncan's daughter and the heir to Araluen, which makes her capture a far graver matter than anyone holding her yet understands. Halt, refused nothing else by the King, sets himself to getting Will back.",
         "in_short": "With Morgarath massing to invade Araluen, King Duncan sends the Ranger Gilan into neighbouring Celtica to call in its promised troops, with Will and Horace as his companions. They find the country emptied: the villages abandoned, the mines silent, and a lone survivor, a girl called Evanlyn who says she serves Princess Cassandra. The Celts have been taken by Morgarath's Wargals and forced to build a bridge across the gorge that has always protected Araluen's flank, so that an army can come in behind the King's. Gilan rides back to warn the army while the other three stay to watch. They set the bridge alight, but Will and Evanlyn are captured by the Skandian mercenaries guarding it and carried off to sea. Horace reaches the army in time; Halt destroys the Wargal column at the gorge, and when Morgarath demands single combat, Horace fights and kills him. The war ends, but Will and Evanlyn are gone, and Evanlyn is revealed to be Princess Cassandra herself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-burning-god.json
+++ b/data/works-community/0/the-burning-god.json
@@ -152,7 +152,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -165,7 +165,7 @@
       "recaps": {
         "ending": "Rin ends the war on the winning side of it. Riga is dead, the Trifecta is finished, the Dragon Republic's armies are broken, and the southern army she raised has effectively taken Nikan. What she does not have is any reason to stop. Her plans run past the Hesperian foothold to the provinces that opposed her, and she is entirely capable of carrying them out. Kitay, bound to her as her anchor and so unable to be absent from any decision she makes, concludes that she will never stop and that nothing outside her can stop her; Nezha, who has fought her since they were schoolchildren, reaches the same conclusion from the other side. The two act together against her. When Rin understands what they have done, she agrees with the reasoning: she chooses her own death rather than be stopped by anyone else, and dies by the fire she spent the whole war learning to command. Nezha is left to govern what remains - a country invaded twice and burned repeatedly, its population devastated, its independence conditional on foreigners it can no longer expel. The uprising Rin led destroyed the old order and cost her her life, and the book closes on that cost stated plainly rather than settled.",
         "in_short": "Maimed and cast out, Rin returns to Nikan's south and turns its militias into an army, clearing the stranded Mugenese occupation and then marching north against the Dragon Republic, which now governs the country in partnership with the Hesperians and which Nezha commands in the field. Betrayed by the southern commander whose peasant regiments carried her, Rin is driven back and gambles on the Chuluu Korikh, where she finds her old master Jiang and the truth about him: Jiang, the deposed empress Daji and the Dragon Emperor Yin Riga are the Trifecta, the three shamans who made the Empire. Rin frees Riga as a weapon and he proves ungovernable; he is killed, and the Trifecta ends with him. Rin then breaks the Republic in the field, but by then she cannot stop, and means to burn everything that will not submit. Kitay, bound to her, and Nezha, who has fought her the whole war, conclude that she has to be stopped; Rin reaches the same conclusion herself and chooses to die, leaving Nezha the ruined country.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -335,7 +335,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -346,7 +346,7 @@
       "recaps": {
         "ending": "The book ends with Uhtred fighting for Mercia and bound, at last, by an oath he chose. Called back from the Danish north by Aethelflaed's need, he abandons the planned invasion of Wessex he had been plotting with Ragnar and becomes Aethelflaed's sworn man, leading her forces against the Danes ravaging Mercia. Skade, who had cursed Uhtred and gone to Harald Bloodhair, is killed by Harald himself, and the crippled warlord's menace is finally extinguished. The campaign's great stroke is the storming of the Danish camp at Beamfleot, the same creek-side fortress where Uhtred once lost Erik and Sigefrid: the stronghold is taken and burned, its garrison slaughtered or scattered, and Haesten's power is broken, though Haesten himself is elsewhere and survives to scheme again. Gisela is dead, lost in childbirth, and with her much of what tied Uhtred to his old life; his rift with Alfred's court over the cleric he killed in his grief is unhealed, and he did not return to Wessex's service. Instead his oath now rests with Aethelflaed, who has become his lover as well as his lady. Alfred is failing fast, Edward's succession approaches, and Uhtred - the pagan sword on whom the Christian kingdoms depend - ends the book as Mercia's shield rather than Wessex's.",
         "in_short": "Two Danish armies fall on Wessex: the treacherous jarl Haesten lands in Kent talking peace, while the savage Harald Bloodhair burns his way inland. Uhtred captures Skade, Harald's sorceress lover, and crushes Harald's army in battle at Fearnhamme - but Gisela, his wife, dies in childbirth, and when a cleric insults her memory Uhtred kills the man in Alfred's own court. Refusing the humiliating penance and a new oath to young Edward, he flees north with Skade to his foster brother Ragnar at Dunholm, renouncing Wessex and plotting to invade it at the head of a Danish army. Aethelflaed, who holds an old oath of his, calls him back: he abandons the invasion, becomes her sworn man, and leads Mercia's forces against the Danes. Skade, who left him with a curse and returned to Harald, is killed by Harald himself. The campaign climaxes with the storming and burning of the Danish stronghold at Beamfleot, breaking Haesten's power, though Haesten escapes. Uhtred ends the book as Aethelflaed's warrior and lover, bound to Mercia while Alfred fades toward death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -445,7 +445,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -458,7 +458,7 @@
       "recaps": {
         "ending": "After fleeing the hotel, Edgar reaches his grandmother's home. His mother follows, frightened by his disappearance and by what he may tell the family. When Edgar's father arrives, Edgar chooses not to reveal the Baron's pursuit or his mother's part in it. He accepts a harmless account of the trip's failure and thereby protects her marriage. Mother and son understand that he is deliberately keeping her confidence, though they do not discuss it openly. Mrs. Blumenthal responds with gratitude and renewed tenderness. Edgar's search for the adults' secret ends not with a complete explanation but with his first conscious possession of adult knowledge: he now recognizes deception, desire, shame, and the power of silence. The experience ends his easy childhood trust while creating a more complicated bond with his mother.",
         "in_short": "At a mountain resort, Baron Otto von Sternfeld befriends twelve-year-old Edgar as a route to Edgar's attractive mother, Mrs. Blumenthal. Edgar treasures the Baron's attention and proudly joins the adults, but the pair soon exclude him as their attraction deepens. Hurt by their lies, Edgar becomes determined to discover the secret they share. He follows them, interrupts their meetings, and finally attacks the Baron after surprising him with his mother. Mrs. Blumenthal turns her anger on Edgar, who runs away alone to his grandmother. When his father joins the family, Edgar declines to expose his mother and supports an innocent version of events. His silence reconciles mother and son, but the holiday has given him a painful first understanding of the concealed desires and compromises of adulthood.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -676,7 +676,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -689,7 +689,7 @@
       "recaps": {
         "ending": "The Jaspers hold. The White King's fleet and armies are broken against the islands, with the Chromeria's great mirror array turned on them as a weapon and Kip's Nightbringers arriving in time to matter; Koios White Oak dies, the banes are destroyed, and the gods seeded in them go with them. Zymun's bid for real power ends in his death. Teia kills Murder Sharp and unmasks the Old Man of the Desert, who proves to have been inside House Guile's own household the whole time; the Order is not so much destroyed as taken over. Dazen submits to Orholam's Glare, is judged, and comes out of it with his sight restored, though not his drafting; he survives the battle and is reunited with Karris, who keeps the White's office. Kip learns that the man he called father was his uncle: his father was the real Gavin Guile, which makes Zymun his half-brother and explains a great deal of what Andross has done about him. He and Tisis go back to the Blood Forest to govern it. Andross Guile is alive, still promachos, and still the most dangerous person in the Seven Satrapies. Teia disappears back into the shadows on her own terms. The war is over, the Chromeria has to be rebuilt, and the Guiles are still the Guiles.",
         "in_short": "The White King's armies, fleets and god-bearing banes converge on the Jaspers for the last battle of the war. Kip fights his Nightbringers across the Blood Forest to reach the islands in time; Karris holds the Chromeria beside a father-in-law who will not surrender the promachos's power; Teia hunts the Order of the Broken Eye's hidden master through a city about to be besieged; and Dazen Guile, blind and without magic, comes home by sea in the company of a pirate and an old sailor who bears the name of god. Dazen submits to Orholam's Glare, is judged and forgiven, and gets his sight back if not his drafting. The Chromeria's great mirrors are turned on the enemy fleet, the banes are destroyed, Koios White Oak is killed, and Zymun's ambitions end with him. Teia kills Murder Sharp and finds the Old Man of the Desert inside the Guiles' own household. Kip learns that his father was the real Gavin Guile and the man who raised him was his uncle. Karris remains the White, Andross remains promachos, and Kip and Tisis go home to govern the Blood Forest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -803,7 +803,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -816,7 +816,7 @@
       "recaps": {
         "ending": "Fred's account is that the station's occupiers tried to surrender and that the surrender was never allowed to happen: the offer did not reach him in a form he was permitted to accept, his orders were to take the station, and he took it. Everyone aboard died, including people who had put down their weapons and people who had never picked any up. He was decorated for it. When he understood what had actually been refused and by whom, he resigned his commission and said so publicly, which destroyed his career on Earth, embarrassed the United Nations, and made him the one Earther in the system whose word the Belt would provisionally accept. That is what he offers the people holding him: not a defense, but the record. He is not executed. The encounter ends with him alive and no longer belonging to Earth in any meaningful sense, at the start of the long second career that makes him the most effective political operator in the Outer Planets Alliance and the man who runs Tycho Station in the novels that follow.",
         "in_short": "Years after the fact, the man the Belt calls the Butcher of Anderson Station is taken by people who intend to make him answer for it, and the story alternates between that confrontation and the operation itself. Anderson Station was a Belt facility whose workers, pushed past endurance by conditions and by a contract dispute, seized it and killed the people running it. Colonel Fred Johnson of the United Nations Marines was ordered to retake it. The occupiers tried to surrender; the surrender was never permitted to reach him in a form he could accept, and his orders were unambiguous. His marines killed everyone aboard, including those who had already given up. Earth decorated him. When Fred worked out what had been refused and by whom, he resigned publicly and told the truth about it, which ended his career, made him notorious on his own planet, and made him the only Earther the Belt would listen to. Telling that story is what keeps him alive in the present, and what begins his second career in the Outer Planets Alliance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -961,7 +961,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -972,7 +972,7 @@
       "recaps": {
         "ending": "The book ends in the wreckage of the Butcher's Masquerade. Signet sacrificed herself to break the gala's celestial peace seal, giving her tattoos permanent life as she was drawn into the Nothing; in the battle that followed, Mongo and Kiwi killed Vrah, Donut stripped Circe Took's god-armor so her own mantis children destroyed her, the last hunters and high elves were wiped out, and Queen Imogen fell to Prepotente, completing the Vengeance of the Daughter storyline. Donut's potion restored Kiwi to her original ursine form, revealing her as Big Tina's lost mother and completing the Recital quest, and the Sledge's borrowed spell teleported the castle and its NPCs, including the changelings, to safety on the ninth floor. The cost was heavy: Firas, Gwendolyn Duet, Cleiton, and the Popov brothers are dead, though the Popovs, restored to infancy by a rebirth effect, are lifted out of the crawl; Britney is badly burned; Tran lost his legs; and Katia killed Eva at last, unaware Eva's final act was to place the Crown of the Sepsis Whore on her head. Carl and Donut learn their team, the Princess Posse, holds a place in the ninth floor's Faction Wars, secured by Donut's fans and Empress D'Nadia, and Carl closes the floor by telling the watching universe to vote to strip the ninth floor's safety protections. In the epilogue the party skips the seventh floor entirely, Prepotente shattering its level with sponsor-supplied items, and arrives on the eighth, where the crown's curse means only one of Katia or Donut can pass the ninth floor.",
         "in_short": "The sixth floor is the Hunting Grounds, where paying off-world hunters stalk crawlers. Carl opens it with a massacre of hunters in Zockau using the stat-stealing Ring of Divine Suffering, then spends the floor fighting a running war against the mantis huntress Vrah, her mother Circe Took, and the hunter factions, while his lawyer Quasar wrings concessions from Borant, whose ownership shifts to the Valtay mid-book partly through Donut's quiet scheming. Bea, Carl's ex, is revealed alive and paraded on Odette's show. Signet returns leading an army against her half-sister Queen Imogen and the naiad Confederacy; Miriam Dom, turned vampire, chooses death at sunrise to cure the spreading curse, devastating her goat Prepotente; and dinosaur matriarch Kiwi mates with Mongo while the vampiric Big Tina ravages towns. Everything converges at the Butcher's Masquerade, Imogen's peace-sealed gala: Signet sacrifices herself to break the seal, Vrah and Circe and Imogen die in the battle, Kiwi is revealed as Tina's transformed mother, the castle and changelings are teleported to safety, Katia kills Eva but is cursed with the Crown of the Sepsis Whore, and the Princess Posse claims a place in the ninth floor's Faction Wars. The party then skips the seventh floor outright, landing on the eighth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1185,7 +1185,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1198,7 +1198,7 @@
       "recaps": {
         "ending": "Elma refuses to be shamed off the flight roster. Rather than let her medication and her treatment be used to disqualify her quietly, she stops hiding them, and the disclosure proves survivable: the program needs the Lady Astronaut more than it needs the pretense that its astronauts are unbreakable. Her standoff with Parker settles into a wary working truce rather than anything like friendship, each of them carrying knowledge about the other from the war. The larger argument is won. The astronaut corps now includes women, the international coalition is committed to a lunar base and an eventual Mars expedition, and the finding that the planet is warming toward uninhabitability is settled policy, even as public patience with the cost of spaceflight begins to fray. The exclusion of Black pilots and computers has been named and pushed at but is nowhere near resolved. Nathaniel remains at the engineering console, their marriage steady and their decision not to have children settled. The book closes with Elma strapped into a capsule on top of a rocket, counting down to her own first flight into space.",
         "in_short": "In an alternate 1952 a meteorite strikes the eastern United States, destroying the capital and killing most of the federal government. Elma York, a mathematician and former wartime pilot, calculates that the water vapor thrown into the atmosphere will drive the climate toward temperatures the planet cannot support, and the surviving government responds by pouring everything into an international space coalition tasked with settling people somewhere other than Earth. Elma and her engineer husband Nathaniel move to its Kansas headquarters, where she works as a computer and watches an astronaut corps be built with no room in it for women. A television appearance makes her famous as the Lady Astronaut, and she spends that fame campaigning for women's selection, widening the argument under pressure from Black colleagues to the people her first version of it left out. Women are admitted and Elma is chosen, over the resistance of the corps' chief, Colonel Stetson Parker. Her severe anxiety and the medication she takes for it are exposed publicly; she survives the disclosure by owning it, and the book ends with her first launch into space.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1336,7 +1336,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1349,7 +1349,7 @@
       "recaps": {
         "ending": "Johansen's manuscript says that the sailors accidentally freed Cthulhu after entering the risen city of R'lyeh. Johansen and one companion escaped to the yacht Alert while the creature killed or scattered the others. Johansen drove the vessel directly into Cthulhu, whose disrupted body immediately began to reform, and only Johansen was still alive when another ship found the drifting yacht. He later died in Norway under suspicious circumstances. Thurston now sees Wilcox's dreams, Legrasse's cult, and the Alert's voyage as evidence of one hidden reality: Cthulhu and related beings exist, and their temporary emergence ended only when R'lyeh sank again. Convinced that Angell and Johansen were murdered for what they knew, Thurston expects the cult may also kill him. He leaves his account with the plea that the assembled papers remain concealed rather than draw anyone else toward the same knowledge.",
         "in_short": "Francis Wayland Thurston inherits papers from his granduncle, Professor Angell, and investigates a clay image made by the sculptor Henry Wilcox during a wave of disturbing dreams. Angell's notes connect it to Inspector Legrasse's earlier raid on a murderous Louisiana cult whose idol depicts Cthulhu, an ancient being said to sleep in the drowned city of R'lyeh. A newspaper report leads Thurston to the account of Norwegian sailor Gustaf Johansen. Johansen's crew found R'lyeh temporarily raised above the Pacific and opened a structure that released Cthulhu. The being killed several men, but Johansen escaped by ramming it with a yacht before the city sank again. Johansen later died mysteriously. Thurston concludes that the cult and its god are real, that Angell and Johansen may have been silenced, and that his own life is now threatened by the knowledge he has assembled.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1492,7 +1492,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1505,7 +1505,7 @@
       "recaps": {
         "ending": "Buck repeatedly leaves Thornton's camp to range with a wild wolf, but his love for Thornton keeps drawing him back. Returning from one long excursion, he finds that the Yeehats have attacked the camp and killed Thornton and his companions. Buck attacks the group, killing several and driving away the rest. With his strongest human bond gone, he answers the wolves that have been calling to him, joins their pack, and eventually becomes its leader. The Yeehats remember a great ghostly dog that continues to hunt in the valley, while Buck returns each year to the place where Thornton died. He has completed the movement from a domesticated California pet to a creature fully at home in the wilderness, carrying both inherited instinct and everything he learned from people and the trail.",
         "in_short": "Buck is stolen from a comfortable California home and sold as a sled dog during the Klondike gold rush. Harsh handling and the violence of the northern dog teams teach him to adapt quickly. Under the fair management of François and Perrault, he masters sled work, defeats the lead dog Spitz, and takes command of the team. Later owners exhaust the dogs through ignorance, and John Thornton saves Buck when Hal tries to drive him onto unsafe river ice; the rest of the party dies when the ice collapses. Buck forms a deep bond with Thornton while feeling an increasing pull toward the wilderness. During a remote gold expedition, the Yeehats kill Thornton. Buck avenges him, then leaves human society, joins a wolf pack, and becomes its leader, remembered as a powerful spirit of the wild.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1698,7 +1698,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1711,7 +1711,7 @@
       "recaps": {
         "ending": "Buck returns from hunting to find that Yeehat warriors have attacked John Thornton's camp. Nig is dead, Skeet is dying, and Thornton's partners have also been killed. Buck charges the attackers, killing several and driving the rest into the forest. He searches until he finds Thornton's body in a pool and understands that his last binding tie to human society is gone. When a wolf pack challenges him, Buck fights until the wolves pause; he then recognizes a lean wolf he has met before and joins the pack. In later years the Yeehats fear a great Ghost Dog that leads the wolves, raids their camps, and hunts across the valley. Buck nevertheless returns alone each summer to the place where Thornton died. He has fully answered the wild call that drew him throughout the story, becoming the dominant leader of the wolves while retaining the memory of the human he loved.",
         "in_short": "Buck, a strong dog raised in comfort on a California estate, is stolen and sold as a sled dog during the Klondike gold rush. Clubbed into submission by a dog breaker, he learns the violent laws governing people and animals in the North. Under the couriers François and Perrault, he masters the trail, defeats the lead dog Spitz, and takes command of the team. After government mail work wears the dogs down, three incompetent travelers buy them, overload the sled, and drive them toward collapse. John Thornton saves Buck from a beating just before the travelers and the remaining team fall through river ice. Buck's devotion to Thornton leads him to defend and rescue the man and to win a great pulling wager. Farther in the wilderness, Thornton's party finds gold while Buck increasingly follows his hunting instincts. He returns from killing a moose to find Thornton and the camp destroyed by Yeehat attackers. Buck avenges them, joins a wolf pack, and becomes the legendary leader known to the local people as the Ghost Dog.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1881,7 +1881,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1894,7 +1894,7 @@
       "recaps": {
         "ending": "After John Thornton and his partners discover a rich gold deposit in a remote valley, Buck spends longer periods ranging through the wilderness and feels an increasing pull toward the wolves. He returns from one extended hunt to find the camp destroyed and Thornton killed by Yeehat raiders. Buck attacks the group in grief and rage, driving the survivors away. With his last tie to human society gone, he answers a wolf pack's call, defeats a challenger, and is accepted among them. In later years the Yeehats tell of a great Ghost Dog who leads the wolves and revisits the valley where Thornton died. Buck has fully crossed from domesticated life into the wild, while preserving his attachment to Thornton through his solitary returns to the abandoned site.",
         "in_short": "Buck, a strong dog raised on a California estate, is stolen and sold as a sled dog during the Klondike gold rush. Harsh handlers and the northern trail teach him the laws of force, work, and survival. He learns quickly, defeats the lead dog Spitz, and becomes an exceptional team leader, but later owners drive the team toward collapse. John Thornton rescues Buck and earns a devotion unlike anything Buck has felt for a human. Even as Buck performs remarkable feats for him, the wilderness exerts a growing attraction. While Buck is away hunting, Yeehat raiders kill Thornton and destroy the camp. Buck avenges him, then joins a wolf pack. He becomes a legendary leader in the wild and continues to return alone to the place where Thornton died.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2045,7 +2045,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2058,7 +2058,7 @@
       "recaps": {
         "ending": "John Thornton and his partners locate a rich gold deposit deep in the wilderness while Buck spends increasing amounts of time ranging beyond camp. Buck befriends a wolf and later proves his growing hunting power by bringing down a moose. When he returns from one excursion, he finds that Yeehat raiders have killed Thornton, the other men, and the dogs. Buck attacks the raiders and drives them away, no longer constrained by fear of human beings. Thornton's death severs his final bond to domestic life. Buck answers the wild call he has felt throughout his northern years, joins a wolf pack, and becomes its leader. The Yeehats remember a supernatural Ghost Dog associated with the region, while Buck continues to visit the valley where Thornton died.",
         "in_short": "Buck, a powerful dog living on a California estate, is stolen and sold into service during the Klondike gold rush. Harsh handlers and the sled trail teach him the laws of force, hunger, and survival. He defeats the lead dog Spitz and becomes an exceptional leader, but exhausting mail work and incompetent owners nearly kill him. John Thornton rescues Buck and earns his complete devotion. Buck saves Thornton's life and wins a celebrated strength wager for him, yet the wilderness exerts an increasing pull. Deep in the country, Buck befriends a wolf and hunts on his own. He returns to find Thornton and his companions killed by Yeehat raiders, attacks the killers, and loses his final reason to remain with humans. Buck joins a wolf pack, rises as its leader, and becomes a lasting legend in the valley.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2261,7 +2261,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2274,7 +2274,7 @@
       "recaps": {
         "ending": "The volume closes with White Fang living at Weedon Scott's California estate after learning to trust people and adapt to domestic life. When escaped convict Jim Hall enters the house to kill Judge Scott, White Fang attacks him and saves the family, suffering gunshot wounds and broken bones. A surgeon gives him little chance of survival, but the household nurses him through a long recovery. Once strong enough to go outside, White Fang is welcomed as the family's protector. Collie leads him to a litter of puppies he has fathered, and he settles in the sun among them. The ending completes the volume's paired movement: Buck leaves human civilization to become the legendary leader of a wolf pack after John Thornton's death, while White Fang travels from the wild into a secure human family and becomes known for loyalty rather than violence.",
         "in_short": "In The Call of the Wild, Buck is stolen from a comfortable California home and forced into Klondike sled work. He masters the harsh trail, defeats lead dog Spitz, and survives disastrous owners until John Thornton rescues him. Buck loves Thornton but feels an increasing pull toward the wilderness. After Indigenous raiders kill Thornton and his companions, Buck avenges them and joins a wolf pack. White Fang follows the reverse path. Born to the wolf-dog Kiche in the northern wild, he enters Gray Beaver's camp, where persecution makes him solitary and fierce. Beauty Smith turns him into a fighting animal, but Weedon Scott rescues him and patiently earns his trust. Scott brings him to California, where White Fang learns family life. He saves Judge Scott from escaped convict Jim Hall, survives severe wounds, and ends the novel resting beside the puppies he has fathered with Collie.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2503,7 +2503,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2516,7 +2516,7 @@
       "recaps": {
         "ending": "The Manciple tells how Phoebus's white crow revealed his wife's infidelity and was punished for bringing disastrous news, then advises restraint in speech. Near the end of the day's travel, the Host asks the Parson for a final entertaining fable. The Parson refuses fictional storytelling and instead delivers a long prose guide to penitence, confession, and the seven deadly sins. No winner of the Host's tale contest is declared, and the surviving text never brings the company to a narrated arrival at Becket's shrine. The work closes with Chaucer's Retraction, in which the author asks forgiveness for writings concerned with worldly vanity, specifically including the tales that tend toward sin, while affirming his devotional works. The ending therefore shifts away from the pilgrims' social comedy and unfinished contest toward moral accounting by the author himself.",
         "in_short": "A varied company meets at the Tabard Inn before riding to Thomas Becket's shrine at Canterbury. Their Host, Harry Bailey, proposes a storytelling contest and joins them as judge. The surviving collection follows the pilgrims' tales and the quarrels, interruptions, and replies between them. Courtly romance in the Knight's tale gives way to the Miller's comic deception and the Reeve's retaliation; later tellers debate marriage, authority, greed, social rank, religion, patience, and the uses of fiction through saints' lives, beast fables, tragedies, sermons, and earthy comedy. The Wife of Bath argues from her five marriages before telling of sovereignty in marriage; the Pardoner condemns greed while admitting his own fraud; the Clerk recounts Griselda's trials; and the Nun's Priest turns a fox and rooster into a lesson about flattery. The journey and contest remain unfinished. After the Parson's penitential treatise, Chaucer ends with a Retraction asking pardon for morally suspect writings and commending his religious works.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2644,7 +2644,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2657,7 +2657,7 @@
       "recaps": {
         "ending": "The knight gives the old woman authority to decide what form she should take and what kind of wife she should be. By yielding the power of choice that he once denied women, he finally learns the answer that saved his life. She responds by becoming both young and beautiful while promising fidelity. Their marriage changes from a coerced bargain into a harmonious partnership. The Wife of Bath closes by wishing for husbands who are young, compliant, and vigorous, and for stubborn or miserly husbands to be corrected. The tale therefore completes the argument of her prologue: mutual happiness becomes possible when a woman possesses sovereignty within marriage rather than being treated as property or subjected to imposed authority.",
         "in_short": "The Wife of Bath defends her five marriages and argues that experience gives her authority to discuss marriage, sexuality, property, and power. She describes how she controlled her first three husbands, answered her fourth husband's infidelity, and fought with her beloved fifth husband Jankyn until he surrendered mastery of their household. Her tale concerns a knight who assaults a woman and can escape execution only by learning what women most desire. After many conflicting answers, an old woman tells him the answer: sovereignty over their own choices and relationships. She claims marriage as her reward, then asks him to choose between an old faithful wife and a young beautiful one whose fidelity is uncertain. He leaves the decision to her. Because he has at last granted a woman control, she becomes young, beautiful, and faithful, and they live in accord.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2769,7 +2769,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2782,7 +2782,7 @@
       "recaps": {
         "ending": "Virginia returns from the hidden realm with a box of jewels and announces that Sir Simon has finally found peace. She leads her family to a concealed room containing his chained skeleton, confirming that his wife's brothers imprisoned and starved him after her murder. The Otises arrange a solemn funeral, and Sir Simon is buried in the churchyard beneath the blossoming almond tree promised in the prophecy. Lord Canterville insists that Virginia keep the jewels the ghost gave her, despite Mr Otis's concern that such valuable heirlooms should return to the estate. Years later Virginia marries Cecil, the Duke of Cheshire. She credits Sir Simon with deepening her understanding of love, mortality, and forgiveness, but even with her husband she keeps the details of what happened beyond the hidden panel private.",
         "in_short": "American minister Hiram Otis buys Canterville Chase after dismissing Lord Canterville's warning that the house has a ghost. Sir Simon, its centuries-old spirit, expects to terrify the new family but meets household oil, medicine, cleaning products, and relentless tricks from the Otis twins. His elaborate performances fail, leaving him humiliated and afraid to cross the corridors. Virginia, the one family member who treats him with sympathy, finds him grieving. Sir Simon admits murdering his wife and explains that her brothers starved him to death, leaving him unable to rest. Virginia agrees to pray and weep for him, fulfilling a prophecy that innocent love can open the way to peace. She disappears with him and returns at midnight bearing jewels, then leads her family to his hidden skeleton. Sir Simon receives a proper burial, and the almond tree flowers. Virginia later marries the Duke of Cheshire and keeps the full story of her encounter with the ghost to herself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2965,7 +2965,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2978,7 +2978,7 @@
       "recaps": {
         "ending": "KGB chairman Gerasimov tries to turn the exposure of CARDINAL and an operation against Tea Clipper into political power, but Ryan uses the chairman's own vulnerability to force an exchange. An American plan removes Gerasimov's family from Soviet control, and Gerasimov defects with them rather than face destruction at home. Filitov is released and brought out as part of the same operation. In Afghanistan, the resistance assault on the Soviet laser complex badly damages the rival system, while the attempted seizure of Alan Gregory and Candace Long in the United States fails. Narmonov survives Gerasimov's challenge and receives leverage for strategic-arms compromise. Filitov reaches America and meets Marko Ramius, another man who broke with the Soviet state, but age, illness, and interrogation have exhausted him; he dies soon afterward. The United States honors his decades of service in secret. Ryan returns from Moscow having protected the strategic balance and rescued the agent whose intelligence helped shape it, while beginning a wary professional relationship with Sergey Golovko.",
         "in_short": "As American and Soviet laser programs alter the strategic-arms negotiations, the CIA depends on CARDINAL, a deeply placed Soviet source, for information about Moscow's project. A compromised courier operation leads the KGB toward the source, while KGB chairman Nikolay Gerasimov prepares to use the intelligence victory in a challenge to Soviet leader Andrey Narmonov. Jack Ryan joins the arms delegation in Moscow and discovers that CARDINAL is war hero Mikhail Filitov. Ryan turns Gerasimov's political exposure into leverage, forcing him to release Filitov and defect with his own family. At the same time, Afghan resistance fighters cripple the Soviet laser site and an attempt to seize American scientist Alan Gregory fails. Filitov reaches the United States and meets fellow defector Marko Ramius, but dies after completing his long service. Gerasimov's removal strengthens Narmonov and helps open the way to an arms agreement, while Ryan preserves both the American program and CARDINAL's legacy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3131,7 +3131,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3144,7 +3144,7 @@
       "recaps": {
         "ending": "The Baudelaires learn that clues gathered at the carnival point to a V.F.D. headquarters in the Mortmain Mountains, and that one of their parents may possibly have survived and be connected to it, giving them a new reason to press on. In the climactic chaos of a lion show meant as a grisly spectacle, Madame Lulu is killed by the carnival's hungry lions, and Count Olaf burns Caligari Carnival to the ground, recruiting several of its performers into his troupe. Still disguised and unable to escape, the children are carried onward with the villains toward the mountains. As the group travels, the family is torn apart: Sunny remains in Count Olaf's automobile while Violet and Klaus are riding in a wooden caravan that detaches at the top of a mountain road and goes plunging downhill out of control. The book ends on this separation, with the siblings divided and in danger, and the mystery of V.F.D. and their parents still unresolved.",
         "in_short": "Hidden in the trunk of Count Olaf's car, the Baudelaires arrive at Caligari Carnival, where the fortune-teller Madame Lulu has been secretly feeding Olaf information. To hide and to learn what Lulu knows, the children disguise themselves as carnival performers and join the House of Freaks alongside Hugo, Colette, and Kevin. They discover that Lulu is a fraud playing a dangerous double game, and that clues point to a V.F.D. headquarters in the Mortmain Mountains, possibly linked to a surviving parent. Olaf plots gruesome attractions and decides to destroy the carnival. In the chaos of a deadly lion show, Madame Lulu is killed and Olaf burns the carnival to the ground. Forced to travel onward with the villains toward the mountains, the siblings are split apart: Sunny ends up in Olaf's car while Violet and Klaus ride in a caravan that comes loose at a mountaintop and hurtles downhill, leaving the family separated as the book ends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3235,7 +3235,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3247,7 +3247,7 @@
       },
       "recaps": {
         "in_short": "The final Sherlock Holmes story collection contains twelve independent investigations from the detective's later career. Holmes and Watson confront cases involving coercion, disputed identity, vanished people, suspicious deaths, unusual animals, old scandals, and schemes built around property or reputation. Baker Street remains the usual point of departure, with Mrs Hudson and the page Billy among the familiar household figures, while several cases take Holmes or Watson beyond London. The narrative form varies more than in the earlier collections: Watson remains the principal chronicler, but Holmes relates \"The Blanched Soldier\" and \"The Lion's Mane\" himself, and \"The Mazarin Stone\" uses a third-person presentation. The volume offers no single continuing plot or final career event. Its unity comes from the older partnership, a set of late experiments in viewpoint and tone, and twelve separate mysteries whose individual solutions remain confined to their own stories.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3298,7 +3298,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3311,7 +3311,7 @@
       "recaps": {
         "ending": "At the innermost recess of the catacombs, Montresor chains Fortunato to the stone and begins sealing the opening with bricks and mortar he had hidden nearby. Fortunato first reacts with disbelief, then screams and shakes his chains. Montresor answers his cries until Fortunato falls silent. Near the end, the prisoner attempts to treat the situation as a carnival joke and suggests that they return to the waiting company, but Montresor only repeats his words. Fortunato's last response is an appeal to God. Montresor finishes the wall, replaces the bones that concealed the niche, and leaves him entombed alive. He closes his account by saying that nobody has disturbed the remains for half a century, confirming that his plan escaped discovery.",
         "in_short": "Montresor vows revenge on Fortunato for an unspecified insult and waits until carnival, when disguise, noise, and drinking will protect his plan. Knowing Fortunato's pride in his wine expertise, he claims to have bought a cask of rare Amontillado and says he may ask their rival Luchesi to authenticate it. Fortunato insists on judging it himself and follows Montresor from the crowded streets into the damp family catacombs. Montresor repeatedly offers to turn back because of Fortunato's cough, while using the prospect of Luchesi to keep him moving. At a remote niche, he suddenly chains Fortunato to the wall. Montresor then bricks up the entrance despite his victim's struggles, screams, and final plea. He conceals the new wall behind a pile of bones and reveals that the tomb has remained undisturbed for fifty years.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3475,7 +3475,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3488,7 +3488,7 @@
       "recaps": {
         "ending": "Kafka left the novel unfinished, so K.'s struggle receives no final administrative decision. Near the surviving fragment's close, K. waits through the night at the Herrenhof while castle secretaries interview petitioners. He enters Bürgel's room by mistake. Bürgel explains that precisely such an unlikely, private encounter could allow a petitioner to overwhelm an official's defenses and obtain help, but the exhausted K. falls asleep during the explanation and misses the opportunity. Frieda has left K. and returned to Jeremiah, while Pepi, temporarily displaced from the bar, gives K. her own resentful account of Frieda's motives. K. finally leaves with the coachman Gerstäcker, who offers lodging because his ill mother may need K.'s help. The manuscript breaks off during their arrival, with K. still in the village, still excluded from the Castle, and without secure work, status, or relationship.",
         "in_short": "A land surveyor known as K. arrives in a village ruled by a remote Castle. Although a telephone message appears to confirm his appointment, the village chairman later calls it an old administrative error and offers him work as a school janitor. K. tries to reach the official Klamm through the messenger Barnabas, the barmaid Frieda, and interviews with secretaries, but every route generates more intermediaries and uncertainty. He becomes engaged to Frieda, quarrels with his intrusive assistants, and learns that Barnabas's family was ostracized after Amalia rejected a degrading summons from a castle official. Frieda eventually leaves K. for the assistant Jeremiah. During a night at the Herrenhof, K. accidentally reaches the secretary Bürgel, who explains that the accident could create a rare chance for help, but K. sleeps through it. Kafka's unfinished manuscript ends with K. accepting lodging from a coachman, still stranded in the village and unrecognized by the Castle.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3647,7 +3647,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3660,7 +3660,7 @@
       "recaps": {
         "ending": "Manfred sees Theodore meeting a woman in the church and, believing her to be Isabella, stabs her. The victim is his own daughter Matilda, who forgives him before dying. The supernatural judgment on his house then becomes explicit: a gigantic form of Alfonso appears, the castle walls collapse, and Theodore is identified as Alfonso's rightful descendant. Manfred confesses that his grandfather Ricardo seized Otranto through forgery and murder, then received a limited reprieve through a bargain with Saint Nicholas. He renounces the principality. Manfred and Hippolita withdraw into separate religious houses. Theodore inherits Otranto and, after mourning Matilda, eventually agrees to share his life and rule with Isabella, whose similar grief connects them.",
         "in_short": "On the day Prince Manfred's son Conrad is to marry Isabella, Conrad is crushed by a gigantic supernatural helmet. Fearing the end of his line, Manfred decides to divorce Hippolita and marry Isabella himself. Isabella escapes with help from the peasant Theodore, while immense pieces of armor and other apparitions unsettle the castle. Theodore is revealed as Father Jerome's son and becomes attached to Manfred's daughter Matilda. Isabella's father Frederic arrives to press an old claim to Otranto, but Manfred tries to secure power through interlocking marriages. A spectral warning disrupts the bargain. Mistaking Matilda for Isabella during a secret church meeting, Manfred fatally stabs his daughter. The castle collapses as Alfonso's giant spirit proclaims Theodore the rightful heir. Manfred confesses his ancestor's usurpation and abdicates; he and Hippolita enter religious life, and Theodore ultimately rules with Isabella while still grieving Matilda.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3862,7 +3862,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3875,7 +3875,7 @@
       "recaps": {
         "ending": "Robbie Weedon wanders away while Krystal is with Fats and falls into the river. Sukhvinder dives in after him despite the danger and is injured during the rescue attempt, but Robbie dies. Krystal, overwhelmed by guilt and unable to imagine a future that will keep her family together, deliberately takes a fatal heroin overdose. The double death exposes the cost of Pagford's neglect without producing a clear public reckoning. Fats abandons his pose of emotional detachment and turns to Tessa, while Sukhvinder receives at last the recognition and tenderness that had been withheld from her. Kay and Gaia prepare to leave Pagford after Gavin makes clear that he will not build the life Kay expected. Howard survives a heart attack after the disclosure of his affair, and the Mollisons retain political power through Miles's election, although their family relationships have been damaged. At the funeral for Krystal and Robbie, the town's factions briefly occupy the same space, but the social divisions Barry Fairbrother tried to bridge remain. The vacancy has been filled; the failures revealed around it have not been repaired.",
         "in_short": "Parish councillor Barry Fairbrother dies suddenly, leaving both a council vacancy and a struggle over whether Pagford should retain the poor Fields estate and its addiction clinic. Howard Mollison backs his son Miles to reverse Barry's policy, while Colin Wall and Simon Price also stand. Their children use the council website under the name the Ghost of Barry Fairbrother to publish humiliating family secrets, turning private resentments into political weapons. Miles wins, but the disclosures destabilize several households. Meanwhile social worker Kay Bawden tries to protect the Weedon family, and Barry's former rowing pupil Krystal struggles to care for her brother Robbie while their mother relapses. Krystal seeks security through a reckless plan involving Fats Wall. Robbie wanders to the river and drowns despite Sukhvinder Jawanda's rescue attempt; Krystal then kills herself with heroin. The deaths force moments of honesty and grief but do not heal Pagford's divisions. Howard survives a heart attack, Miles holds the council seat, and the policies Barry opposed remain ascendant.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-catcher-in-the-rye.json
+++ b/data/works-community/0/the-catcher-in-the-rye.json
@@ -91,7 +91,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -104,7 +104,7 @@
       "recaps": {
         "ending": "Holden secretly visits his younger sister Phoebe at home, and later at her school and the museum. He shares with her his dream of being the catcher in the rye, the one who saves children from falling off a cliff, revealing how badly he wants to protect innocence. After fleeing his old teacher Mr. Antolini's apartment in alarm, he decides to hitchhike out west and disappear, living as a deaf-mute so he never has to speak to anyone phony again. When he goes to say goodbye to Phoebe, she shows up with a suitcase and demands to come along. Unwilling to drag her into his flight, Holden gives up the plan to calm her, and instead they go to the Central Park zoo and carousel. As he watches Phoebe ride the carousel in the rain, he is flooded with happiness and decides not to run away. The final chapter is narrated from the California facility where he is now being treated. He declines to say what happens next, mentions that he is meant to start a new school in the fall, and admits that telling the story has left him missing almost everyone in it, even the people who treated him badly.",
         "in_short": "Sixteen-year-old Holden Caulfield narrates, from a rest home where he is recovering, the story of the few days after he is expelled from Pencey Prep boarding school. Rather than go straight home to face his parents, he leaves early and spends several aimless, lonely days and nights in New York City. He drifts through hotels, bars, and nightclubs; has an unsettling encounter with a prostitute and her pimp; goes on a failed date with Sally Hayes; and grows steadily more depressed by what he sees as the phoniness and cruelty of the adult world, all while grieving his younger brother Allie, who died of leukemia. He finally sneaks home to see his beloved little sister Phoebe and confides his fantasy of being a catcher in the rye who keeps children from harm. After a frightening night at a former teacher's apartment, he resolves to run away, but Phoebe's determination to come with him stops him. Watching her ride a carousel, he chooses to stay, and he later ends up in treatment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -458,7 +458,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -471,7 +471,7 @@
       "recaps": {
         "ending": "Ryun's High Division run ends in the top eight when Riki uses a newly gained Ideal to defeat him. Ryun bonds the awakened forge Brightstar as his reward, but the tournament is then overtaken by a portal breach. An apparently endless monster force pours into the arena while more monsters move through Tournament City to surround the defenders. Ryun sends Ereclaw to help Anrosh evacuate Twilight Melody and joins Celia in holding the wall. He gives Celia the complementary half of the true-death power once shared with Melody, linking Ryun and Celia mentally and emotionally until one of them dies. Zach and Neha remain with the Warden response. The commander considers Zach essential to closing the portal and prepares to protect him during the attempt, while another group secures the healing building as a possible evacuation route. The portal is still open, the defenders are nearly encircled, and the empire's advancing swarm and Kael's separate operation remain unresolved.",
         "in_short": "Twilight Melody resists Green Rain, then travels to the Centennial Tournament despite Nayra's warning that her hidden homeland is planning war and an operation at the event. Nayra breaks the class bond controlling her growth, while Anrosh becomes an immortal protector through Ryun's inspiration. Ryun finds an Ideal centered on witnessing chosen final ends. Zach arrives with Neha, learns that the Wardens know her concealed identity, and confronts Ryun over the massacre that killed his family, but chooses present duty over immediate revenge. Nayra reaches the top 32 of her solo division. Ryun reaches the High Division top eight before Riki defeats him, then bonds the awakened forge Brightstar. A monster army breaches the arena portal, forcing Ryun and Celia to defend the wall while Twilight Melody evacuates. Ryun gives Celia the other half of the true-death power, permanently linking them. Zach is selected for the attempt to close the still-open portal as the city approaches encirclement.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -641,7 +641,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -654,7 +654,7 @@
       "recaps": {
         "ending": "The last appeals fail, Governor McAllister refuses clemency, and Sam is executed in Mississippi's gas chamber. Adam remains with him to the end after their difficult professional relationship has become a genuine bond between grandson and grandfather. The investigation has established that Sam did not act alone and was not the person who designed and planted the bomb, but his long participation in Klan violence and his presence in the conspiracy leave him morally responsible for the deaths. The fuller truth arrives too late to change the legal outcome, while Rollie Wedge remains beyond the reach of the case. Lee confronts the family history that she had tried to bury, and Adam comes away with a less simplified understanding of both his father and Sam. He cannot save his client, but he prevents Sam from dying entirely isolated and ends the Cayhall family's habit of meeting its past only with concealment.",
         "in_short": "Chicago lawyer Adam Hall volunteers to represent Sam Cayhall, the grandfather his family taught him to hide, during the last weeks before Sam's execution in Mississippi. Sam, a former Klansman, was convicted for a bombing aimed at Jewish civil-rights lawyer Marvin Kramer that killed Kramer's twin sons. Adam pursues appeals, challenges the death sentence, and investigates evidence that another Klansman was the principal bomb maker. He also draws his alcoholic aunt Lee into a painful reconstruction of the family history that drove his father to change their name and later take his own life. The legal deadlines close faster than Adam can turn the incomplete truth into relief. Although Sam gradually trusts his grandson and acknowledges more of his responsibility, the courts reject the appeals and the governor denies clemency. Sam dies in the gas chamber with Adam nearby. Adam has failed to stop the execution, but he has learned that legal guilt, factual participation, and moral responsibility do not fit into a single easy account.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -797,7 +797,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -810,7 +810,7 @@
       "recaps": {
         "ending": "Terry's refusal to accept Alima's autonomy culminates in an attempt to force himself on her. The women restrain him and decide that he must leave Herland. Van and Jeff are allowed to remain, but Van chooses to accompany Terry because Ellador has received permission to travel with them and study the outside world. Jeff stays in Herland with Celis, who is expecting their child. Before the aircraft departs, the visitors agree to conceal Herland's location until its people decide that contact is safe. Terry remains angry and largely unchanged, while Van leaves with his allegiance transformed and Ellador begins her direct encounter with the civilization the men have described.",
         "in_short": "Three American explorers enter an isolated country populated entirely by women. Captured after treating the inhabitants as curiosities, Van, Terry, and Jeff learn that Herland has continued for centuries through parthenogenesis and has organized its culture around shared motherhood, education, health, and public service. Their hosts' questions expose contradictions in the men's accounts of poverty, war, gender, and family life. The men form relationships with Ellador, Alima, and Celis, but respond differently: Jeff embraces Herland, Van gradually abandons his assumptions, and Terry resents every limit on male privilege. After the couples marry, Terry attempts to impose his idea of marital rights on Alima and is ordered out. Jeff remains with Celis, who is pregnant, while Van leaves with Terry and Ellador. Ellador travels to investigate the outside world, and the departing party promises to keep Herland secret until its people choose otherwise.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -989,7 +989,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1002,7 +1002,7 @@
       "recaps": {
         "ending": "The estate has been sold to Lopakhin, who plans to clear the orchard and lease the land for summer cottages. Ranevskaya returns to Paris, Gaev takes a bank position, Anya looks toward education and a new life, and Trofimov continues toward his imagined future. Varya accepts work as a housekeeper for another family. Although Ranevskaya and Lopakhin leave Varya and Lopakhin alone together, he never proposes, and they part awkwardly. The servants and family depart, believing the sick old servant Firs has been sent to a hospital. In fact he has been forgotten inside the locked house. He lies down alone, lamenting the life that has passed. From outside comes the sound of axes cutting the orchard, along with a distant breaking sound. The old household disperses while the property passes to the descendant of its former serfs, but the social change brings no simple resolution for those leaving or for the person left behind.",
         "in_short": "Lyubov Ranevskaya returns from Paris to her indebted Russian estate, where her brother Gaev and adopted daughter Varya have failed to prevent an auction. Merchant Yermolai Lopakhin, descended from serfs owned by the family, repeatedly offers a workable plan: cut down the celebrated cherry orchard and lease plots to summer residents. Ranevskaya and Gaev cannot accept the loss embodied in that plan and rely on unlikely rescues. Around them, Anya draws hope from the idealistic student Trofimov, servants pursue uncertain romances, and the household continues its habits as the deadline arrives. At the auction Lopakhin buys the estate himself and exults in owning the land where his family was once bound. The family scatters; Lopakhin still fails to propose to Varya. Everyone leaves the house locked and apparently empty, but the ailing old servant Firs has been forgotten inside. As he lies alone, axes begin cutting down the orchard.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1157,7 +1157,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1170,7 +1170,7 @@
       "recaps": {
         "ending": "Jack reaches the Island of the Beloved and is reunited with Dur Pig, but the Loser threatens the refuge and the Christmas Pig gives himself up to save Jack. The sacrifice makes Jack understand that CP has become a loved individual, not merely an unwanted copy of DP. When Christmas magic offers Jack a single rescue from the land of lost Things, he chooses the Christmas Pig. DP remains secure among the deeply loved Things whose bonds with their owners endure even after separation. Jack wakes in the human world with CP beside him and values him for himself. Holly admits the harm she caused and begins repairing her relationship with Jack, while the family understands more clearly that neither a possession nor a person can simply be replaced. The search ends with Jack accepting change without treating his earlier love for DP as erased.",
         "in_short": "After his parents separate, Jack clings to Dur Pig, the battered toy that has accompanied him through every change. On Christmas Eve his angry stepsister Holly throws DP from the family car, and a replacement called the Christmas Pig cannot console him. That night CP comes alive and leads Jack into the Land of the Lost, where discarded objects live under the threat of the Loser. Passing through regions that reflect how completely Things have vanished from human memory, Jack receives help from other lost objects and learns that love, rather than condition or usefulness, gives them value. He finally finds DP on the Island of the Beloved. When CP sacrifices himself during the Loser's attack, Jack recognizes that he loves the new pig for himself. Given one chance to save a lost Thing, Jack chooses CP and returns home with him. DP remains safe among beloved lost Things, and Holly begins making amends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1349,7 +1349,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1362,7 +1362,7 @@
       "recaps": {
         "ending": "David, Rosalind, and Petra are caught between the pursuing Waknuk force and Gordon's Fringes people. Sophie helps them but is killed during the fighting. Joseph and Gordon also die as the two hostile groups clash. The woman from Sealand finally arrives by aircraft and releases a web-like biological weapon that immobilizes and kills those caught in it, ending the battle. She frees the three fugitives and takes them away from Labrador. From the air they see a region still scarred by the ancient catastrophe, then reach a distant, technologically advanced city where telepathy is accepted as the next human development rather than condemned as deviation. Michael does not leave with them: he remains behind to find Rachel, the last member of their group in Waknuk, intending to bring her to Sealand later. David, Rosalind, and Petra thus escape the society that would have sterilized or killed them, but their rescue also reveals the Sealanders' own harsh belief that an older human type must give way to a new one.",
         "in_short": "In the post-catastrophe district of Waknuk, religious law demands the destruction of every plant, animal, or person that differs from an approved human pattern. David Strorm, son of the district's sternest zealot, first questions that creed after befriending six-toed Sophie Wender. David later learns that he and several outwardly ordinary young people can communicate by thought. They hide the ability for years, guided by Uncle Axel, but marriage, betrayal, and Petra's unusually powerful talent eventually expose them. David, Rosalind, and Petra flee toward the Fringes while other telepaths are captured. They are caught between Waknuk pursuers and Fringes people led by David's banished uncle Gordon. A telepathic woman from technologically advanced Sealand arrives in an aircraft, kills or immobilizes the fighters with a biological web, and rescues the three fugitives. Michael stays behind to retrieve Rachel, while David, Rosalind, and Petra are carried to a society where their ability is valued.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1457,7 +1457,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1470,7 +1470,7 @@
       "recaps": {
         "ending": "The crackdown forces Burton to clean house, and Lydia is one of the loose ends he decides to remove. Timmy kills him for it. That solves Lydia's problem and creates a much larger one: the killing cannot be hidden, and staying on Earth means dying for it. Erich, who has the skills and now the motive, forges Timmy an identity out of the dead man's name and papers, and Timmy leaves Baltimore and Earth entirely, shipping out for the Belt as Amos Burton. Lydia stays behind, alive, safe, and out of his life for good; the parting is the price of the rescue. Erich inherits what is left of the organization and becomes the man who runs that corner of the city. The story ends with Timmy in transit, remade into someone with a stolen name, no history anyone can check, and no intention of ever coming back down a gravity well.",
         "in_short": "In a Baltimore where the legal economy has largely stopped needing people, a young enforcer called Timmy works for Erich, a sharp, physically disabled crew boss operating at the edges of the local crime organization run by a man named Burton. Periodically the authorities flood the city and break the underworld apart, a cycle everyone calls the churn, and one has just begun. As Burton starts eliminating anyone who could implicate him, the danger reaches Lydia Maalouf, the aging woman who raised Timmy and is the only person he is genuinely attached to. Timmy kills Burton to protect her, which saves her life and ends his own life in the city. Erich forges him a new identity from the dead man's name, and Timmy leaves Earth for the Belt as Amos Burton, while Erich takes over the organization. Lydia survives, and Timmy never sees her again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1619,7 +1619,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1632,7 +1632,7 @@
       "recaps": {
         "ending": "At Ocean View, Rose Rose reveals that she is pregnant by her father. Homer, who has long refused to perform abortions, recognizes that refusing her would abandon the medical responsibility Larch tried to teach him. He carries out the procedure safely. Rose later kills Mr. Rose when he threatens her again, then leaves the orchard; Homer protects her by helping present his death as an accident. News arrives that Dr. Larch has died from ether, leaving St. Cloud's without the doctor on whom its births, adoptions, and abortions depend. Larch has already created a false professional history for Homer under the name Dr. Fuzzy Stone, giving him a legal identity with which to take over. Homer finally accepts that his place is not determined by rules imposed from a distance but by the people whose needs he is equipped to meet. He leaves Candy, Wally, and Angel at Ocean View and returns to the orphanage. Assuming the identity Larch prepared, Homer becomes St. Cloud's physician and continues both parts of Larch's work: caring for children who are born and providing safe abortions to women who choose not to continue a pregnancy.",
         "in_short": "Homer Wells grows up in the St. Cloud's orphanage under Dr. Wilbur Larch, who delivers babies, arranges adoptions, and secretly performs abortions. Larch trains Homer as a doctor, but Homer refuses to perform abortions and leaves with young couple Candy Kendall and Wally Worthington for their family apple orchard, Ocean View. Homer becomes an orchard worker and falls in love with Candy. After Wally is reported missing in wartime, Homer and Candy have a son, Angel, whose parentage they conceal when Wally returns disabled and marries Candy. Years later, Rose Rose, one of the migrant pickers, becomes pregnant through abuse by her father. Homer performs an abortion for her, finally understanding the practical cost of his refusal. Rose kills her father and flees. When Larch dies, Homer accepts the medical identity Larch fabricated for him, leaves Ocean View, and returns to St. Cloud's. He takes Larch's place as physician and continues providing both obstetric care and safe abortions.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1775,7 +1775,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1788,7 +1788,7 @@
       "recaps": {
         "ending": "Borlú and Ashil establish that Orciny is not a hidden third city. The myth has been used to cloak an archaeological smuggling operation that exploits crosshatched spaces and the citizens' learned refusal to see across the urban divide. David Bowden, once the chief public advocate of Orciny, helped sustain that illusion. Mahalia discovered enough to threaten the operation, and Bowden killed her during a confrontation before her body was transported into Beszel by legal means. When Bowden tries to escape through overlapping territory, Borlú shoots him while consciously acting across the boundary between cities. Breach accepts that Borlú has solved the case but does not return him to his former life. He becomes part of Breach under Ashil's direction, inhabiting the spaces between Beszel and Ul Qoma and estranged from ordinary membership in either one.",
         "in_short": "Besz detective Tyador Borlú investigates the murder of American archaeology student Mahalia Geary, whose body has been left in Beszel although her life and studies were based in Ul Qoma. The two cities occupy the same physical territory, but citizens must ignore the other city and cross only through an official border; violations summon the secretive power called Breach. Borlú works first with Lizbyet Corwi and then with Ul Qoman detective Quissim Dhatt, tracing Mahalia's obsession with Orciny, a rumored third city hidden between the two. After another witness is killed and Borlú himself breaches, the operative Ashil helps him continue. They discover that Orciny is a fiction used to disguise the smuggling of archaeological objects through crosshatched spaces. Scholar David Bowden killed Mahalia when she threatened the scheme. Borlú kills Bowden during a final attempted escape across the cities' divide and, unable to resume his old identity, joins Breach.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1928,7 +1928,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1941,7 +1941,7 @@
       "recaps": {
         "ending": "The records of the Master's robot and Vanamonde's mind overturn the legend that humanity was defeated and driven back to Earth by alien Invaders. Long ago, galactic civilization created a disembodied intelligence called the Mad Mind; after it devastated inhabited worlds, the survivors confined it far away and left the Galaxy while preparing a greater intelligence to confront it. Vanamonde is that still-growing successor. Earth's isolation arose from fear and deliberate social design, not military defeat. Alvin returns with knowledge that breaks the closed assumptions of both Diaspar and Lys. Movement between the two societies resumes, and the old contrast between immortal urban stability and mortal natural life begins to soften. Hilvar remains attached to Lys, while Alvin accepts that his task is larger than reaching one destination. He turns toward restoring Earth's environment, renewing contact with the stars, and preparing humanity to rejoin the wider universe when the time is right.",
         "in_short": "A billion years in the future, Alvin is born into Diaspar, Earth's last great city, whose near-immortal citizens are repeatedly recreated from stored patterns and are terrified of the world outside. As a rare person without past lives, he questions the city's fixed order. With the Jester Khedron's help he finds an ancient transit route to Lys, a hidden society of mortal telepaths living close to nature, and befriends Hilvar. Their explorations lead to a spacecraft, a stranded robot, and Vanamonde, a developing intelligence of enormous potential. Evidence from these encounters disproves humanity's founding legend: no alien Invaders defeated Earth. Galactic civilization withdrew after the disastrous creation of the Mad Mind, and Vanamonde is intended eventually to oppose it. Alvin reconnects Diaspar and Lys, breaks their inherited isolation, and chooses the long work of restoring Earth and returning humanity to the stars.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2149,7 +2149,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2162,7 +2162,7 @@
       "recaps": {
         "ending": "Nahri agrees to leave Daevabad with Dara, and the escape becomes a massacre: Dara cuts through the soldiers sent to stop them, and Jamshid e-Pramukh is left crippled by his arrows. The chase ends on the cursed lake, where Alizayd is dragged into the water. The marid, the water spirits who cursed the lake long ago, take hold of him and use his body, and the possessed Ali kills Dara. Nahri is brought back to the palace with nothing left to bargain with. She heals Ali of what the marid did to him, and Ghassan buries the truth about the possession, then marries her to his heir Muntadhir immediately, binding the Nahid line to the Qahtanis. Ali is sent away to the Geziri provinces in disgrace, an assignment his family does not expect him to survive. Nahri ends the book a queen in name, isolated, grieving, and with no illusions left about the man who brought her east. The epilogue overturns all of it. Far from the city, Dara wakes: pulled out of a quiet afterlife into a body that is whole, freed of the ifrit's slave curse, and restored to the unbound magic his people held before Suleiman's punishment. Two people are standing over him. One is Kaveh e-Pramukh, Daevabad's grand wazir. The other is Banu Manizheh, the Nahid healer everyone believes the ifrit murdered two decades ago. She is alive, she has been preparing for a generation, and she tells Dara that Nahri is her daughter.",
         "in_short": "Nahri is a young con artist and thief in Ottoman Cairo with a healing gift she cannot explain. Performing a ceremony for money, she accidentally summons Darayavahoush, a daeva warrior who tells her she carries the blood of the Nahids, a family of magical healers, and that her only safe place is Daevabad, a hidden djinn city. Hunted by ifrit, the two cross half the world to reach it. There Nahri is received by the Daeva tribe as their Banu Nahida and installed in the palace of King Ghassan al Qahtani, whose ancestors took the city from hers. She befriends the king's younger son, Ali, a devout prince secretly funding the city's despised part-human shafit, and learns that Dara is remembered by the other tribes as the Scourge of Qui-zi, the author of a massacre. To buy protection, Nahri bargains a betrothal to Ghassan's heir, Muntadhir. When Dara tries to take her out of the city, the escape ends in bloodshed on the cursed lake: the marid seize Ali and use him to kill Dara. Nahri is married to Muntadhir and Ali is exiled. In the epilogue Dara wakes restored to life by Banu Manizheh, the Nahid healer believed dead for twenty years, who reveals that Nahri is her daughter.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2283,7 +2283,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2296,7 +2296,7 @@
       "recaps": {
         "ending": "Akaky's fruitless appeal to the important person leaves him shaken; he develops a fever and dies. His office replaces him with scarcely a pause. Thereafter, people report that a clerk's ghost is roaming the city and stripping coats from strangers. The important person, troubled enough by his earlier outburst to ask about Akaky, discovers too late that the clerk is dead. On a nighttime carriage ride, the apparition stops him and claims his costly cloak. The official's fright makes him less inclined to bully junior employees. The small ghost associated with Akaky is not reported again after taking this coat, although a policeman later encounters a much larger spectral thief, preserving doubt about where ordinary crime ends and the ghost story begins.",
         "in_short": "The copying clerk Akaky Akakievich lives so modestly that replacing his ruined cloak requires months of sacrifice. His tailor, Petrovich, makes him a new one, and for a single day the garment brings him warmth and recognition from coworkers who usually mock him. Thieves steal it after an office celebration. The authorities prove ineffective, and an important official humiliates Akaky when he asks for assistance. Akaky returns home ill and dies soon afterward, barely noticed by his department. A figure resembling the dead clerk then roams Saint Petersburg taking other people's coats. When the important person encounters it and surrenders his own cloak, the hauntings attributed to Akaky end and the official becomes more humane toward his subordinates.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2410,7 +2410,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2423,7 +2423,7 @@
       "recaps": {
         "ending": "The new DNA result proves that Roland Mackey handled the gun used to kill Rebecca Verloren and breaks open the network the 1988 investigation failed to penetrate. Bosch and Rider establish that Rebecca's death grew out of racist intimidation directed at her interracial family and that people around Mackey concealed their parts afterward. Mackey's death during the renewed inquiry prevents a straightforward interrogation, but it does not stop the detectives from reconstructing how the weapon, abduction, and killing fit together and identifying the surviving responsibility behind the crime. The solution also shows how prejudice and divided attention weakened the original case, leaving Rebecca's parents to carry an uncertainty that should not have lasted seventeen years. Bosch and Rider deliver the truth to Robert and Muriel Verloren, though closure cannot restore their daughter or marriage. Bosch completes his first case after reinstatement and demonstrates that he can still work from within the LAPD. The return is not frictionless - Irvin Irving remains hostile - but Bosch finishes the book as a police detective again rather than a retired investigator borrowing access from others.",
         "in_short": "Harry Bosch returns to the LAPD after three years away and joins Kiz Rider in the Open-Unsolved Unit. Their first case is the 1988 abduction and shooting of sixteen-year-old Rebecca Verloren. Modern testing finds male blood on the murder weapon and matches it to Roland Mackey, whose racist background gives the old concern about an attack on Rebecca's interracial family new force. Bosch and Rider reinterview her separated parents, reconstruct the missing gun and the girl's private life, and review how the original detectives lost opportunities. Mackey dies as the current investigation closes around him, but the DNA and surviving records let Bosch and Rider establish his part and expose the group responsibility and concealment surrounding the killing. They finally give Robert and Muriel Verloren an answer, though not the life the unsolved case took from them. The closure validates Bosch's decision to return: despite conflict with command, he ends once again working as an LAPD homicide detective.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2555,7 +2555,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2568,7 +2568,7 @@
       "recaps": {
         "ending": "After Miranda dies from an illness that Frederick failed to have properly treated, he buries her on his property. For a time he considers killing himself, but reading her diary lets him recast himself as the injured party because she never loved or respected him. He avoids accepting that his captivity and refusal to seek timely medical help caused her death. Returning to London, he notices another young woman, Marian, whose name and appearance remind him of Miranda but who seems less socially intimidating. He begins planning a new abduction, modifying his methods in light of what went wrong. The close shows that Miranda's death has produced no moral awakening: Frederick has converted it into experience for repeating the crime.",
         "in_short": "Frederick Clegg, an isolated clerk who collects butterflies, uses lottery winnings to buy a remote house and abduct Miranda Grey, an art student he has observed from afar. He keeps her in a furnished cellar, imagining that patience, gifts, and forced proximity will make her love him. Miranda resists through argument, manipulation, an attempted escape, and private writing that preserves her perspective and revisits her family, art, and relationship with the painter George Paston. Frederick treats her resistance as ingratitude and continually substitutes his fantasy of devotion for her stated wishes. When Miranda becomes seriously ill, his fear of exposure prevents him from obtaining adequate help, and she dies. He buries her and reads her diary, but uses its criticism of him to evade responsibility. Soon he selects another young woman and begins planning how to imprison her more effectively.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2685,7 +2685,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2698,7 +2698,7 @@
       "recaps": {
         "ending": "Ammi and several officials enter the nearly abandoned Gardner farm, where they find Nahum dying and the household destroyed. Evidence recovered from the well points to the missing family members, while an influence below begins to stir. After nightfall, the farm's remaining vegetation shines and writhes as the same impossible color gathers over the well. It surges upward and departs into the sky, tearing apart the farmstead and leaving the blasted land behind. Ammi sees a smaller trace fail to escape and sink back into the well. Years later, the narrator accepts that Ammi's account explains the dead landscape better than any ordinary theory. He abandons his survey work rather than help flood the site for Arkham's reservoir, fearing that the water would spread whatever remains beneath the heath.",
         "in_short": "A reservoir surveyor investigates a barren gray tract west of Arkham and hears its history from Ammi Pierce. In 1882, a strange meteorite landed near farmer Nahum Gardner's well. University researchers could neither classify nor preserve its material, which displayed an unprecedented color and gradually vanished. The next season brought enormous but inedible crops, deformed animals, altered vegetation, and a steady collapse of the Gardner family's health and sanity. One by one the family members died or disappeared as the farm lost all ordinary life. When Ammi returned with officials, they found the last ruins of the household and signs of horror in the well. That night, the color rose from the farm and shot into space, though Ammi saw a remnant fall back. The land became the blasted heath. Convinced that something still waits underground, the surveyor refuses to continue planning a reservoir that would cover the site and carry its water toward Arkham.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2803,7 +2803,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2814,7 +2814,7 @@
       "recaps": {
         "ending": "The Colour of Magic ends on a literal cliffhanger. Having escaped the scholars of Krull at the Rim of the world, Rincewind and Twoflower are swept over the edge of the Disc and fall, together with the Luggage, off the Rimfall waterfall and out into the void beyond the world. Nothing about their fate is resolved: they simply go over the edge and keep falling, with no rescue and no landing. The two remain bound together, the reluctant wizard and the relentlessly optimistic tourist, still pursued by the bad luck that has followed them the whole way. The larger questions of the setting are left open as well, chief among them the riddle the scholars of Krull hoped to answer, namely where the Great A'Tuin, the star turtle carrying the Disc, is swimming to and why. The story continues directly in the next book.",
         "in_short": "Rincewind, an incompetent and cowardly wizard of Ankh-Morpork, is ordered to protect Twoflower, the Discworld's first tourist, a naive and wealthy insurance clerk from the far Agatean Empire who travels with a fortune in gold and a homicidal walking chest called the Luggage. Their misadventures begin when Twoflower's talk of insurance burns Ankh-Morpork to the ground, and they flee the city with Death and other dangers close behind. They pass through a temple of the ancient evil Bel-Shamharoth, the Sender of Eight; visit the Wyrmberg, an inverted mountain of imaginary dragons ruled by the dragonrider Liessa; and are finally carried to the very Rim of the flat world, where the kingdom of Krull means to launch a ship over the edge and sacrifice them. Escaping, the two are instead swept over the Rimfall. The book ends with Rincewind and Twoflower plunging off the edge of the Disc into open space, their story left hanging.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2968,7 +2968,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2981,7 +2981,7 @@
       "recaps": {
         "ending": "The Commitments' increasing musical competence cannot hold together a group divided by ego, jealousy, and incompatible ambitions. Joey Fagan's relationships with several of the backing singers cause personal conflicts, Dean's interest in jazz pulls him away from Jimmy's plan, and Deco behaves as if the band's success belongs to him. After a final performance, fighting breaks out and the group disintegrates before it can achieve the future Jimmy imagined. Deco tries to capitalize on his prominence, while other members consider different musical combinations. Jimmy is disappointed but not defeated: the brief life of the band has shown that his idea could work, even though this particular collection of people could not remain united.",
         "in_short": "Jimmy Rabbitte, an ambitious young music fan in working-class north Dublin, assembles friends and local recruits into the Commitments, a band devoted to American soul. He acts as manager and teacher, turning inexperienced players and singers into a credible live act. The group gains its sound from powerful but conceited vocalist Deco Cuffe, veteran trumpeter Joey Fagan, three backing singers, and a growing rhythm and horn section. Rehearsals and early performances reveal genuine promise, but also deepen conflicts over sex, status, discipline, and musical direction. Joey's involvement with the singers, Deco's ego, and Dean's attraction to jazz weaken Jimmy's authority. The band finally breaks apart in arguments and violence just as success seems possible. Jimmy loses the Commitments but retains his belief in bringing soul music to Dublin and begins imagining what might come next.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3177,7 +3177,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3190,7 +3190,7 @@
       "recaps": {
         "ending": "The collection closes with the account of Little Pig Robinson. Sent from Piggery Porcombe to market, Robinson is enticed aboard a ship and carried away to sea. The crew treats him generously, but the ship's cook is secretly feeding him well because he intends to serve the pig at a feast. Robinson learns of the danger in time and escapes from the vessel. He reaches a tropical island where plentiful food and a peaceful life make returning unnecessary. He settles there permanently, providing the collection's imagined history for the pig associated with the traditional verse about sailing away. Unlike several earlier animals whose adventures end with a return to family or farm, Robinson finishes his tale by making a safe new home far from England.",
         "in_short": "This collection brings together twenty-three animal tales, beginning with Peter Rabbit's forbidden visit to Mr. McGregor's garden and continuing through stories of reckless squirrels, helpful mice, disorderly kittens, threatened ducks, traveling pigs, and uneasy neighbors. Mischief often brings a chase or narrow escape: Peter loses his clothes, Nutkin provokes an owl, Tom Kitten falls among rats, and Jemima trusts a fox. Other tales reward craft and cooperation, as hidden mice complete the Tailor of Gloucester's coat and Benjamin Bunny's father rescues young rabbits. Later stories connect the familiar farms and woods through the Flopsy family, Mr. Tod, Pigling Bland, and other recurring figures. In the final tale, Little Pig Robinson is carried away on a ship whose cook intends to eat him; he escapes to a tropical island and remains there in safety, ending the collection with a permanent journey rather than a return home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3351,7 +3351,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3364,7 +3364,7 @@
       "recaps": {
         "ending": "Bosch determines that Norman Church really was the Dollmaker, but that a separate killer used Church's pattern for the woman buried in concrete and for later attacks. The copycat is psychologist John Locke, whose knowledge of the original investigation allowed him to reproduce details unavailable to the public. Locke kills Honey Chandler and attempts to complete another carefully staged murder before Bosch identifies and confronts him. Bosch kills Locke, ending the active threat. The solution preserves the central conclusion of the old police case without excusing the way Bosch entered Church's home and shot him. The civil trial ends without the sweeping condemnation Chandler sought, leaving Bosch legally able to continue but not untouched by the examination of his conduct. Sylvia has seen how completely the case consumes him and how little he can offer outside it; their relationship is badly weakened. Bosch closes one question about Church while carrying forward the professional and personal damage created by his methods.",
         "in_short": "Four years after Harry Bosch shot Norman Church, the suspected Dollmaker serial killer, Church's widow brings a civil case arguing that Bosch killed an innocent man and shaped the evidence afterward. During the trial, a note leads police to a woman's body sealed beneath concrete. She was killed after Church's death but bears private features of the Dollmaker crimes, raising the possibility that Bosch shot the wrong man or that someone else learned the pattern. Bosch and Jerry Edgar investigate while attorney Honey Chandler attacks the original case in court. The inquiry exposes Church's concealed life, draws suspicion toward people with access to victims and police information, and strains Bosch's relationship with Sylvia Moore. Bosch ultimately establishes that Church committed the original series and that a knowledgeable copycat committed the later murder. The copycat kills again before Bosch identifies and stops him. Bosch survives the civil case, but the investigation leaves another victim dead and his relationship with Sylvia close to collapse.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3508,7 +3508,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3521,7 +3521,7 @@
       "recaps": {
         "ending": "Constance reveals that her decorating business is successful and that she has earned enough to support herself. She presents John with money for her past upkeep and announces that she will now pay her share of the household expenses, removing financial dependence from their marriage. She then tells him that she intends to travel to Italy with Bernard Kersal and take the same personal freedom that John assumed for himself. John reacts with jealousy and appeals to a double standard, but Constance calmly uses his own reasoning about love and infidelity against him. She does not seek divorce: she plans to return after the trip and continue their companionable marriage on revised terms. John, confronted with an equality he did not expect, finally yields. Constance leaves with Bernard economically independent and in control of her choice, while the marriage remains intact but no longer governed solely by John's privileges.",
         "in_short": "Constance Middleton's family and friends worry that she does not know her surgeon husband John is having an affair with her friend Marie-Louise Durham. When Marie-Louise's husband exposes the relationship, Constance coolly protects everyone from scandal and then reveals privately that she has understood the affair all along. She rejects both helpless suffering and immediate divorce, arguing that a wife supported entirely by her husband cannot claim genuine equality. Constance therefore builds a profitable decorating business with Barbara Fawcett. A year later she repays John for her maintenance, arranges to meet her share of future expenses, and announces a holiday in Italy with Bernard Kersal, a former suitor who still loves her. John objects to her claiming the sexual freedom he allowed himself, but she exposes his double standard. Constance intends to return and preserve the marriage as an affectionate partnership, now backed by her own income and conducted on terms she has chosen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3631,7 +3631,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3644,7 +3644,7 @@
       "recaps": {
         "ending": "Ralph, Jack, and Peterkin reach Tararo's island and try to prevent Avatea from being forced into a marriage she rejects. Their attempt to take her away fails, leaving them prisoners and in danger from the chief. A missionary's arrival changes the conflict: Tararo accepts Christian teaching and abandons his opposition to Avatea's chosen marriage. With Avatea free and peace established, the three friends leave the Pacific community. They eventually secure passage home, where Ralph is reunited with his family. The coral island has given them an interval of independence and abundance, but their later encounters with warfare, piracy, and coercion have ended the belief that isolation alone can keep violence outside their small society.",
         "in_short": "Teenagers Ralph Rover, Jack Martin, and Peterkin Gay survive a Pacific shipwreck and reach an uninhabited coral island. Guided by Jack's practical skill, they build a shelter, find plentiful food, explore the reef and caves, and fashion a small boat. Their isolation ends when Pacific islanders fighting one another land there; the boys intervene and meet the chief Tararo and Avatea. Pirates later seize Ralph. He witnesses their raids, escapes with the wounded Bloody Bill, and returns to his friends after Bill dies. The reunited trio sail to Tararo's island to help Avatea, whom the chief intends to force into an unwanted marriage despite her love for a Christian chief. Their rescue attempt fails, but a missionary persuades Tararo to change course. Avatea is allowed her chosen marriage, and Ralph, Jack, and Peterkin eventually return home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3820,7 +3820,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3833,7 +3833,7 @@
       "recaps": {
         "ending": "After the attempted family Christmas, Alfred's children accept that Enid can no longer care for him at home and place him in a nursing facility. Chip, newly steadied by the consequences of his time abroad, becomes the child most consistently present for him. Alfred's illness strips away the independence and authority around which he built his identity; during a lucid exchange, he asks Chip to help him die, but Chip cannot do so. Alfred continues to decline and eventually dies. His death releases Enid from the long work of protecting him, accommodating him, and preserving their marriage's public appearance. The children remain marked by their habits and mistakes rather than neatly repaired: Gary still seeks control, Denise has lost the secure professional and personal arrangement she built around the Generator, and Chip has at least begun to act responsibly. Enid, now able to imagine a life organized around her own wishes, faces the future with an optimism that had been unavailable while Alfred was alive.",
         "in_short": "Enid Lambert wants her three adult children home in St. Jude for one last Christmas as her husband Alfred's neurological illness worsens. Each child is absorbed in a private crisis: Chip has lost his academic career and joins a dubious internet enterprise in Lithuania; Gary, a prosperous banker, denies his depression while fighting his wife for control of their family; and Denise, a celebrated chef, risks her job through an affair entangled with the marriage of her restaurant's owner. On a cruise, Alfred's confusion becomes public and dangerous, but Enid still tries to preserve the appearance of normality. The children eventually return as their separate lives unravel, and the holiday exposes rather than repairs the family's old injuries. Alfred is moved to a nursing home, where Chip becomes a regular companion through his final decline. After Alfred dies, no sweeping reconciliation has occurred, but Chip has grown more dependable and Enid discovers that widowhood gives her room to change her life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3995,7 +3995,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4008,7 +4008,7 @@
       "recaps": {
         "ending": "A hostile party crosses the Terek, and Lukashka is gravely wounded in the fighting. The crisis strips Olenin's hopes of their romantic shape. When he approaches Maryanka after Lukashka has been carried back, she is consumed by fear and grief for the Cossack to whom her life is actually bound. She angrily rejects Olenin and tells him to leave. Olenin accepts that neither his gifts nor his declarations have made him part of the village, and he departs for his next military posting. Eroshka gives him an emotional farewell and receives money and possessions from him, but as the wagon moves away the old hunter soon turns back toward village life. Maryanka does not come to see Olenin go. His stay has changed his ideas about happiness and selflessness, yet the Cossacks continue without him; he remains an outsider whose vision of their life could never substitute for belonging to it.",
         "in_short": "Disenchanted with elite life in Moscow, the young nobleman Dmitri Olenin joins the army in the Caucasus and is quartered in a Cossack village. Friendship with the old hunter Eroshka and immersion in the landscape inspire him to imagine a life founded on nature and selfless giving. He admires Maryanka, the independent daughter of his hosts, although she is expected to marry the brave young Cossack Lukashka. Olenin gives Lukashka a horse and tries to make generosity the basis of happiness, but his attraction to Maryanka becomes possessive courtship. The arrival of his sophisticated fellow officer Beletsky draws him back into social games. Olenin proposes to Maryanka and briefly hopes she might accept. When raiders cross the river and Lukashka is gravely wounded, Maryanka rejects Olenin in grief and anger. Olenin leaves the village, recognizing that he has remained an outsider despite his desire to remake himself through Cossack life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4223,7 +4223,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4236,7 +4236,7 @@
       "recaps": {
         "ending": "Benedetto's trial publicly exposes Villefort as the father who tried to bury him alive. Villefort returns home to find that Héloïse has poisoned herself and their young son Édouard; the accumulated catastrophe destroys his sanity. The Count, horrified by the child's death, accepts that his vengeance has exceeded any authority he possessed. Danglars, the last principal conspirator, is captured by Luigi Vampa and forced to spend nearly all his fortune on food before the Count reveals himself and grants him pardon. Mercédès begins a modest new life in Marseille, Albert enters military service, and the Morcerf fortune is abandoned. Valentine, secretly saved from poisoning by the Count, is reunited with Maximilien after he has been tested to the edge of despair. Having settled his fortune and made restitution where he can, the Count leaves with Haydée, whose love offers him a future beyond revenge. He leaves Maximilien and Valentine with the counsel to endure uncertainty and retain hope.",
         "in_short": "Sailor Edmond Dantès is falsely accused by Danglars, Fernand, and Caderousse on the eve of marrying Mercédès. Prosecutor Villefort suppresses proof of his innocence to protect his own career, and Edmond spends fourteen years in the Château d'If. Fellow prisoner Abbé Faria educates him and reveals a treasure on Monte Cristo. After escaping and finding the fortune, Edmond returns as the mysterious Count of Monte Cristo. He rewards the Morrel family and constructs elaborate downfalls for his enemies, now wealthy and powerful in Paris: Fernand is exposed as a traitor and kills himself; Caderousse and Villefort's household are destroyed by crimes the Count sets in motion; Danglars is ruined and captured. Innocents also suffer, especially Villefort's young son, forcing the Count to question his claimed role as providence. He ultimately pardons Danglars, saves Valentine for Maximilien Morrel, and departs with Haydée, leaving revenge behind for a possible new life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-count-of-monte-cristo-amazonclassics-edition.json
+++ b/data/works-community/0/the-count-of-monte-cristo-amazonclassics-edition.json
@@ -61,7 +61,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -74,7 +74,7 @@
       "recaps": {
         "ending": "To gain permission to marry Medina-saroté, Nuñez agrees that the valley doctor may remove his eyes, which the community believes are diseased growths causing his unrest. As the operation approaches, however, the visible beauty of the world becomes impossible for him to surrender. On the day before the procedure, he leaves the settlement and climbs toward the mountains, choosing sight and freedom over marriage on the valley's terms. The escape is punishing, and he does not find a clear route back to the outer world. Injured and exhausted, he lies down high above the valley as evening gives way to the stars. The original story closes with him alone but serene, no longer trying to conquer the people below and satisfied that he has escaped the life and mutilation they offered. Whether he can survive the exposed mountainside is left unresolved.",
         "in_short": "Mountaineer Nuñez falls into a secluded Andean valley where generations of isolation and hereditary blindness have produced a community with no concept of sight. Expecting his vision to make him ruler, he finds that the inhabitants move confidently through an environment designed around their other senses and dismiss his claims as confused fantasy. His attempt to dominate them fails, and after hunger drives him back he accepts work under the elder Yacob. Nuñez falls in love with Yacob's daughter Medina-saroté, who returns his affection, but the community objects to his instability. A doctor blames Nuñez's protruding eyes and proposes removing them. He consents for Medina's sake, then recoils when he looks on the visible world before the operation. He climbs out of the valley alone, abandoning both marriage and his dream of kingship, and the story leaves him resting on the mountainside at night, free but with his survival uncertain.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -212,7 +212,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -225,7 +225,7 @@
       "recaps": {
         "ending": "At Horner's lodging, Pinchwife's attempt to control Margery turns into a public accusation against his innocent sister. Sparkish immediately believes the accusation against Alithea and rejects her, clearing the way for the faithful Harcourt to marry her. Margery's arrival threatens a different exposure when she openly declares her love for Horner. Lucy rescues the group from scandal by claiming that Margery's behavior was a device meant to test Sparkish and bring Alithea and Harcourt together. The explanation is false, but the company accepts it because it preserves their interests. Quack again supports Horner's supposed incapacity, so Pinchwife has to accept the public fiction and take Margery home. Horner's affairs with Lady Fidget and her circle remain concealed, and his fraudulent reputation survives. Alithea gains a more suitable husband in Harcourt, while Margery returns to a jealous marriage with her desires unchanged and Horner remains free to continue exploiting the husbands' misplaced confidence.",
         "in_short": "Horner, a London rake, has a doctor spread the false report that he is impotent so husbands will trust him with their wives. Sir Jaspar Fidget accordingly gives Horner access to Lady Fidget and her circle, whose public claims of virtue conceal their affairs. The jealous Pinchwife brings his inexperienced country bride Margery to London and tries to hide her, but his restrictions intensify her attraction to Horner. Even disguising her as a boy lets Horner approach her under Pinchwife's supervision. A second courtship plot follows Alithea, Pinchwife's sister, who remains loyal to the vain Sparkish while Harcourt sincerely pursues her. At the final gathering, Pinchwife's suspicions falsely compromise Alithea, and Sparkish abandons her; she is then free to marry Harcourt. Margery nearly exposes Horner by declaring her love, but Lucy invents an explanation that protects everyone. Horner's deception and the ladies' secret survive, while Pinchwife takes Margery home without having secured her affection.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -337,7 +337,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -350,7 +350,7 @@
       "recaps": {
         "ending": "John Alden and Priscilla Mullins marry in Plymouth, and their wedding procession travels from the ceremony to their new home. Miles Standish, who had been reported dead during the colony's fighting, has returned alive. He approaches the newly married couple without resentment, acknowledges that Priscilla chose wisely, and reconciles with John. The friendship damaged by John's reluctant courtship errand is restored, while John and Priscilla begin their life together with Standish's blessing. The close turns the feared conflict among the three into a settlement founded on candor, forgiveness, and freely chosen love.",
         "in_short": "At Plymouth colony, the widowed soldier Miles Standish wants to marry Priscilla Mullins but lacks confidence as a suitor. He asks his scholarly friend John Alden to propose for him, unaware that John also loves her. John dutifully presents Standish's case, but Priscilla sees through the arrangement and asks why John does not speak for himself. The question leaves John divided between loyalty and love. After the Mayflower sails for England, he stays in Plymouth and he and Priscilla gradually acknowledge their feelings. Standish angrily regards John's conduct as betrayal before departing on a military expedition, and a report that he has died casts a shadow over the colony. The report proves false. John and Priscilla marry, and Standish returns in time to reconcile with them, accepting their choice and renewing his friendship with John.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -467,7 +467,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -480,7 +480,7 @@
       "recaps": {
         "ending": "Chester's scheduled performances make him famous and bring enough customers to secure the Bellinis' newsstand, but the noise, crowds, and obligation to perform leave him longing for his Connecticut meadow. Tucker and Harry understand that success in New York cannot replace the home Chester wants. After a final concert, they help him reach Grand Central and board a train headed toward Connecticut. Mario is saddened when he learns that Chester has gone, yet he accepts that keeping his friend in the city would have been wrong. The Bellinis' business remains restored by the attention Chester brought it. Chester travels back to the country, while Tucker and Harry return to their station lives and begin thinking about visiting him there someday.",
         "in_short": "Chester Cricket is accidentally carried from a Connecticut meadow to the Times Square subway station, where Mario Bellini shelters him at his family's struggling newsstand. Chester befriends Tucker Mouse and Harry Cat, learns to navigate the city, and survives mishaps that cost the Bellinis money and nearly destroy their stand. His ability to reproduce music eventually wins over Mama Bellini and attracts the attention of music teacher Mr. Smedley. Public performances turn Chester into a sensation, drawing crowds that rescue the newsstand from financial trouble. Fame also makes Chester miserable: he misses the quiet country and does not want his gift to become a permanent job. Once the Bellinis are secure, Tucker and Harry help him board a train for Connecticut. Mario lets his friend go, and Chester returns home after changing the fortunes of everyone he met in Times Square.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -613,7 +613,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -626,7 +626,7 @@
       "recaps": {
         "ending": "Billy finds Boyd's grave in Mexico, exhumes the remains, and begins carrying them home. Robbers attack him on the northward journey, scatter the bones, and injure his horse. A band of traveling gypsies helps him gather the remains, mend his equipment, and continue. Billy succeeds in bringing Boyd back across the border and buries him in New Mexico. With his parents dead, Boyd gone, and the family ranch no longer a home, Billy has little left to return to. He attempts to enlist after the United States enters the Second World War, but a heart condition leads the military to reject him. Years pass with Billy moving through temporary work and an altered landscape. In an abandoned building he encounters a maimed stray dog and drives it away in anger. Regretting the act, he goes after the animal but cannot find it. Alone at daybreak, he sits in the road and weeps, ending the novel with grief that he can neither repair nor escape.",
         "in_short": "Before the Second World War, New Mexico teenager Billy Parham captures a wolf preying on local cattle and decides to return her alive to Mexico. Men seize the wolf and force her into fights; Billy kills her to end her suffering. He comes home to find his parents murdered, the family's horses stolen, and his brother Boyd left as his only close relation. The brothers cross into Mexico to recover the horses. Boyd is shot, falls in love with a local girl, and chooses to remain behind, while Billy returns north alone. On a later journey Billy learns that Boyd became a celebrated outlaw and has been killed. He exhumes Boyd's body and carries the bones home despite robbery and hardship, aided by traveling gypsies. After burying his brother, Billy is rejected for military service because of a heart condition. The book closes years later with the homeless, solitary Billy driving away a wounded dog, searching for it in remorse, and finally breaking down when he cannot find it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -735,7 +735,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -748,7 +748,7 @@
       "recaps": {
         "ending": "Chuck suffers another heart crisis and is hospitalized. Josh visits him before an important game, then plays while his mother remains at the hospital. Chuck dies during the game, leaving the family and team to face the loss without him. Josh withdraws into grief and initially cannot accept Jordan's efforts to reach him. After the funeral, Jordan gives Josh their father's championship ring, acknowledging Josh's bond with both Chuck and basketball. The twins return to the court for a private one-on-one game. Their play does not erase the death or the hurt between them, but it restores communication through the language they have always shared. Josh ends the story mourning his father while reconnecting with his brother and carrying forward what Chuck taught them.",
         "in_short": "Twelve-year-old twins Josh and Jordan Bell are stars of their middle-school basketball team, coached at home by their father, former professional player Chuck Bell. When Jordan begins dating Alexis, Josh feels abandoned. A bet costs Josh his locks, jealousy builds, and he deliberately throws a ball at Jordan during a game, injuring him and earning a suspension. At the same time, Chuck's untreated high blood pressure becomes impossible to dismiss. The brothers begin to repair their relationship, but Chuck suffers a fatal heart crisis while Josh is playing in a championship game. In grief, Josh pulls away from everyone. Jordan gives him their father's championship ring, and the twins play together again, using basketball to begin reconciling and to honor the father they lost.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -922,7 +922,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -935,7 +935,7 @@
       "recaps": {
         "ending": "Eadlyn refuses the marriage that would have been most useful to her and makes the choice she actually wants. She exposes what the Illéas were doing, releases the remaining Selected without humiliating any of them, and tells Kile and Henri the truth to their faces rather than through an announcement. Then she goes on live television and tells the country that she has chosen Eikko, Henri's translator: not one of the Selected, not titled, not the political asset her advisers would have picked. In the same period Maxon and America step down, Maxon abdicating so that he can care for his wife and give his daughter the throne outright rather than a regency, and Eadlyn is crowned queen of Illéa. Ahren and Camille return from France, and the breach in the family is closed. America recovers. Eadlyn ends the book as a young queen who has learned to rule by being trusted rather than obeyed, married to a commoner she chose openly, with the monarchy intact and the country's confidence in it restored.",
         "in_short": "With her mother recovering from a heart attack and her father refusing to leave the queen's side, Eadlyn Schreave is made regent and must run Illéa while finishing the Selection she never wanted. Six young men remain, and this time she cannot treat them as scenery. She grows closer to Kile, to the irrepressible Henri, and above all to Erik, Henri's translator, who is not a candidate and therefore not permitted to matter. Marid Illéa, son of the rebel leaders who helped end the caste system, offers her his family's popularity and a public alliance, and Eadlyn takes it before discovering that the Illéas intend to replace the monarchy with themselves at the head of an elected government, and that her courtship is the lever. She exposes them, releases the Selected honestly, and announces on live television that she has chosen Eikko, a commoner with no title at all. Maxon and America abdicate, Eadlyn is crowned queen, and Ahren and Camille come home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1146,7 +1146,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1159,7 +1159,7 @@
       "recaps": {
         "ending": "By autumn, Abigail has fled Salem with Mercy Lewis after taking Parris's money, and fear of unrest has grown as nearby Andover rejects its own trials. Hale, now convinced the proceedings are wrong, begs prisoners to confess falsely so they can live. Giles Corey has died under pressing without entering a plea, preserving his property for his sons. Elizabeth, pregnant and temporarily spared, is asked to persuade John to confess. John agrees to a lie but refuses to accuse anyone else. When Danforth demands a signed confession for public display, John tears it up rather than give the court his name as support for its fraud. He goes to execution with Rebecca Nurse. Hale pleads with Elizabeth to stop him, but she understands that John has recovered his self-respect and will not take that choice from him. The court continues the hangings even after its moral basis has collapsed.",
         "in_short": "After girls are caught dancing in the forest in 1692 Salem, Abigail Williams protects herself by accusing others of witchcraft. Fear spreads into a court that treats denial as evidence and rewards confession with survival. Farmer John Proctor knows Abigail is manipulating the trials but hesitates because exposing her motive requires admitting their former affair. His wife Elizabeth is arrested after Abigail frames her. In court John confesses the affair, yet Elizabeth lies to protect him, and the judges believe Abigail. Mary Warren breaks under pressure and accuses John, who is imprisoned. Months later Abigail has fled and Reverend Hale opposes the trials, but the authorities refuse to undermine earlier executions. John briefly agrees to confess, then tears up the statement rather than endorse the court or accuse others. He and Rebecca Nurse are hanged. Elizabeth accepts his decision because he has reclaimed the integrity that guilt had taken from him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1351,7 +1351,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1364,7 +1364,7 @@
       "recaps": {
         "ending": "Jude breaks Madoc's plan by making Cardan an offer he cannot refuse: she will put him on the throne, and in exchange he swears to obey her for a year and a day. Oak, as Prince Dain's son and an heir of the blood, sets the crown on Cardan's head before the court, and Cardan's first commands, every one of them Jude's, undo the coup. Balekin is stripped of his standing and imprisoned in the Tower of Forgetting. Madoc loses his post as grand general and is put out of the palace, outplayed by the mortal daughter he trained and half-admiring of how she did it. Jude sends Oak to the human world to be raised by Vivi and her mortal girlfriend, Heather, keeping the true heir out of every faction's reach until he is old enough to rule without a keeper. Taryn stays in Faerie, engaged to Locke, the breach with her sister unhealed. Cardan sits on the throne of Elfhame as a king nobody expected and nobody trusts, resentful of the leash and unreadable about Jude herself. Jude holds no title anyone would name, only a secret: for a year and a day the High King of Faerie must do as she says, and the clock has already started.",
         "in_short": "Jude Duarte and her twin, Taryn, are mortal girls raised in the High Court of Faerie by Madoc, the fey general who murdered their parents. Despised at court for being human, Jude wants a knighthood and a place no one can take from her; her chief tormentor is Cardan, the High King's youngest son. To gain power of her own she swears herself to Prince Dain, the king's chosen heir, and becomes one of his spies, learning lockpicking, poison tolerance and courtcraft while Cardan's circle escalates from humiliation to attempted murder. Jude kills one of them in self-defence, discovers that the boy courting her has been courting Taryn at the same time, and falls out with her sister. At the coronation the eldest prince, Balekin, murders the High King and most of his heirs, and Madoc is revealed as his ally. Jude gets hold of Cardan, the only remaining heir who can pass the crown, and learns that her small brother Oak is secretly Dain's son and the true heir Madoc intends to rule through. She crowns Cardan instead, on the condition that he obey her for a year and a day, and sends Oak to the human world for safety.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1554,7 +1554,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1567,7 +1567,7 @@
       "recaps": {
         "ending": "Oedipa learns from Emory Bortz that The Courier's Tragedy survives in conflicting versions and that its Tristero references may have been added amid old political and theatrical disputes. Genghis Cohen then reports that a group of suspicious stamps from Inverarity's collection will be sold as lot 49 and that an unknown bidder is expected to compete for them. Mike Fallopian suggests that Inverarity may have arranged the entire trail as a final joke on Oedipa, but this explanation is no more provable than the existence of the hidden postal system. With Driblette dead and other sources unavailable or unreliable, Oedipa attends the auction alone. The book closes as she waits for the mysterious bidder to be identified. It does not settle whether Tristero is real, a hoax, a delusion, or some combination of those possibilities; Oedipa remains poised at the moment when she hopes evidence will resolve the uncertainty.",
         "in_short": "Oedipa Maas is appointed co-executor of the estate of her former lover, developer Pierce Inverarity. In sorting through his California holdings, she encounters a muted post-horn symbol, the name Tristero in a Jacobean revenge play, altered stamps, and people using an underground postal network called W.A.S.T.E. Her attempt to connect these signs expands through corporations, historical texts, and the streets of San Francisco while the people around her become unreachable, unstable, or dead. Each discovery supports several incompatible explanations: Tristero may be a centuries-old rival to official postal authority, an improvised network for the excluded, an elaborate prank left by Inverarity, or a pattern Oedipa has created out of chance. The estate's suspect stamps are finally offered at auction as lot 49, with an unknown bidder expected. Oedipa waits in the auction room for that person to appear, and the novel ends before revealing either the bidder or the truth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1752,7 +1752,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1765,7 +1765,7 @@
       "recaps": {
         "ending": "Wulfgar brings the barbarian tribes down on the besieging army from behind while the towns hold Bryn Shander's walls, and the horde breaks apart. Drizzt gets inside Cryshal-Tirith, drives off the demon Errtu and reaches Kessell, whose mind the Crystal Shard has long since hollowed out. The tower is destroyed, and Kessell, fleeing onto the mountain with the artifact still concentrating its light, brings down an avalanche that buries him; Crenshinibon is lost under the ice with him. In the dwarven valley Bruenor is dug out of the collapsed tunnels alive, hurt badly enough that he expects to die of it, and takes the opportunity to tell Drizzt about Mithril Hall, the lost ancestral home of Clan Battlehammer, and to ask that someone find it. Then he recovers, and finds himself committed. Wulfgar's five years of service are finished and he pledges his help freely; Regis, who has learned that his old master in the south has finally traced him, would rather travel than sit and wait. Catti-brie stays behind in Icewind Dale. The three set out to find a dwarven kingdom nobody has seen in two centuries and whose location Bruenor cannot remember.",
         "in_short": "Akar Kessell, a failed apprentice wizard abandoned to die in the tundra of Icewind Dale, finds Crenshinibon, the Crystal Shard, an ancient artifact that grants power and feeds on ambition. While he raises a crystal tower and enslaves the goblin and giant tribes of the north, the ten frontier towns are dealing with a barbarian invasion, which they break with warning from the dark elf Drizzt Do'Urden and help from Bruenor Battlehammer's dwarves. Bruenor spares a young barbarian, Wulfgar, and indentures him for five years, teaching him the forge while Drizzt teaches him to fight; Bruenor forges him the warhammer Aegis-fang and sends him to kill a white dragon, and Wulfgar returns to his people as their king. Kessell's army then descends on Icewind Dale. The towns are forced into alliance by the halfling Regis and his enchanted pendant, Bruenor's dwarves collapse their own tunnels on the horde and Bruenor is believed dead, and Wulfgar's barbarians break the siege. Drizzt confronts Kessell, whose artifact destroys him under an avalanche. Bruenor, found alive, sets out to find his clan's lost home, Mithril Hall.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1951,7 +1951,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1964,7 +1964,7 @@
       "recaps": {
         "ending": "Strike concludes that John Bristow killed Lula. John had also caused the childhood death of his brother Charlie, and Lula's newly discovered will threatened John's expectation of inheriting her fortune by leaving it to her biological half-brother, Jonah Agyeman. John pushed Lula from her balcony, then exploited the layout and timing at the building to support a verdict of suicide. He later murdered Rochelle Onifade when she became a danger to him. John attacks Strike when confronted, but Strike overpowers him and the evidence brings the case to a close. Jonah inherits Lula's estate. Robin's temporary assignment ends, yet she chooses to stay with the agency despite its uncertain finances and Matthew's reservations. Strike, paid for solving the case and beginning to regain professional standing, gives Robin the green dress she admired, establishing the partnership that continues beyond the novel.",
         "in_short": "Down-on-his-luck private investigator Cormoran Strike is hired by solicitor John Bristow to revisit the apparent suicide of John's adopted sister, the model Lula Landry. Assisted by his resourceful temporary secretary Robin Ellacott, Strike interviews Lula's neighbors, friends, family, and professional circle. He discovers that Lula had found her biological half-brother, Jonah Agyeman, and made a will in Jonah's favor. John, who expected to benefit from Lula's death, killed her and manipulated the scene; he had also killed his brother Charlie in childhood and later murdered Lula's friend Rochelle. Strike survives John's attempt to silence him and exposes the crimes. Jonah receives Lula's fortune, while Robin elects to remain at Strike's struggling agency, turning a temporary placement into a detective partnership.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2077,7 +2077,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2090,7 +2090,7 @@
       "recaps": {
         "ending": "Benjamin's backward aging continues after his Harvard years. Looking increasingly like a boy, he goes to live in the household of his adult son Roscoe, who is embarrassed by him and tells others that Benjamin is his younger brother. Benjamin eventually becomes the same apparent age as Roscoe's son and attends kindergarten with his own grandson, but he soon falls behind as the other child advances normally. A nurse takes charge of him as he passes through toddlerhood and infancy. His memories of business, marriage, military service, and college disappear, followed by his ability to recognize people or understand the world around him. At last even light, warmth, hunger, and dreams cease to form lasting impressions, and Benjamin's awareness fades into complete darkness.",
         "in_short": "Benjamin Button is born in Baltimore in 1860 looking and speaking like a seventy-year-old man. His embarrassed father forces him into the outward role of a child, but Benjamin grows physically younger with every passing year. Rejected by Yale when officials mistake him for an elderly impostor, he later joins the family business and marries Hildegarde Moncrief, who is attracted to his mature appearance. As Benjamin becomes younger and Hildegarde grows older, their attachment weakens. He serves successfully in the Spanish-American War, then enters Harvard while looking like a college student and becomes a football star. His continued youth eventually makes even college impossible. He moves into his son Roscoe's home, regresses through boyhood alongside his grandson, and finally becomes an infant under a nurse's care. His memories and sensations steadily vanish until he loses all awareness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2236,7 +2236,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2249,7 +2249,7 @@
       "recaps": {
         "ending": "Christopher's investigation of a dead dog uncovers the truth about his own family: his mother, Judy, is alive, and his father lied about her death to spare him the fact that she had left them for the neighbor Mr. Shears. When Christopher also learns that his father killed Wellington, his trust collapses and, frightened, he flees to London and his mother. That reunion is not a simple happy ending. His mother's life with Mr. Shears breaks down under the strain of caring for Christopher, and she chooses her son, returning with him to Swindon. Christopher and his father must begin again from almost nothing; his father works patiently to earn back Christopher's trust, promising never to lie to him and giving him a golden retriever puppy, Sandy, as a first step. Christopher sits his mathematics A-level, a goal that mattered enormously to him, and achieves an A grade, proving to himself what he is capable of. The book closes on a note of guarded optimism: Christopher plans to take further exams, go to university, and become a scientist, and he believes that because he solved the mystery, traveled to London alone, and did all of this despite everything that frightens him, he can do anything he sets his mind to.",
         "in_short": "Christopher Boone, a fifteen-year-old in Swindon who is gifted at mathematics but finds people and change bewildering, discovers his neighbor's dog Wellington killed with a garden fork and sets out to solve the crime, recording it as a detective book. His father, who raises him alone and has told him his mother died two years earlier, orders him to stop investigating, but Christopher keeps going. Talking with neighbors, he learns that his mother had been involved with a neighbor, Mr. Shears. Searching his father's room, he finds a hidden cache of letters proving his mother is alive and living in London: his father lied about her death. Confronted, his father breaks down and confesses that he himself killed Wellington in a fit of rage after quarreling with Mrs. Shears. Terrified of the man who both lied to him and killed the dog, Christopher runs away, enduring a frightening solo train journey across the country to reach his mother, who has been living with Mr. Shears. He stays with her as that relationship falls apart, and she brings him back to Swindon. He sits his mathematics A-level and earns top marks, and his father slowly begins to rebuild his trust, starting with the gift of a puppy. Christopher ends convinced he can do anything.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2666,7 +2666,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:177424411X",
@@ -2678,7 +2678,7 @@
       "recaps": {
         "ending": "Kael survives taking the fortress curse into himself and becomes the site's new master. The transformed guardian returns to his ancient Northman form and helps extend protective runes while families, including Kayla, Kenna, and Tanner, move into the refuge. Kael still cannot command all the defenses, and the region's red and purple invasive magics remain poorly understood. Ember's use of life-force magic to revive Kael advances the change that could make the Fae regard her as a darkling. A remote Black Chasm attack then makes Kael, Ember, two children, and the elven guardian collapse, leaving their conditions uncertain. At the chasm, the Ritek recover a localized portion of their old magic and build an outpost around it. Corruption is already entering the structure and is expected to overwhelm it within a year, but the Ritek plan more structures and a southern invasion. The dragonkin daughter and her companion remain lost, the archdemon still seeks the hidden tokens, the human engineer remains valuable to the Ritek, and a knight-mage begins seeking proof that Ritek interference caused the failed dragon rescue.",
         "in_short": "Kael tries to conceal demonic tokens while ancient forces pursue him, then recovers binding-stone research and attempts to rescue the dragonkin queen's daughter from another dimension. The return corridor fails, leaving the dragons lost and Kael's magic damaged. He learns that the Ritek and their Kohari agents are killing children born under Black Suns, finds his daughter Kayla, and defeats a Ritek-backed trap, although Kayla's mother dies saving him. Kael takes Kayla, Kenna, Tanner, and other families toward a legendary fortress that could serve as a refuge. Its living corruption and curse nearly kill the advance party, but Kael accepts the curse, survives, restores its ancient guardian, and becomes master of the fortress. As the families move in, a Black Chasm attack strikes Kael, Ember, two children, and the elven guardian. The Ritek meanwhile recover limited, unstable magic at the chasm and prepare further outposts and an invasion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2852,7 +2852,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2865,7 +2865,7 @@
       "recaps": {
         "ending": "Undine obtains Raymond's consent to divorce after turning the Chelles family's valuable tapestries into money, although he believed she was preserving them for their son. She then marries Elmer Moffatt, now immensely rich, and gains the limitless spending, travel, and display she has long pursued. Paul joins their household, returning to a mother he barely knows, and discovers that the treasured Chelles tapestries have become ornaments in Moffatt's new home. Undine remains dissatisfied despite her wealth. Her latest wish is to be the wife of an ambassador, but her marital history makes that particular social distinction unavailable to her. The novel closes with her imagination fastening on this new exclusion, showing that no acquisition can end her desire for whatever lies beyond reach.",
         "in_short": "Undine Spragg arrives in New York determined to convert her father's money and her beauty into social rank. She marries Ralph Marvell, but his old-family position lacks the wealth she expects. Their marriage collapses as she spends freely and pursues the richer Peter Van Degen. After divorcing Ralph, she finds that Peter will not marry her. Ralph, trying to recover their son Paul, discovers that Undine concealed an earlier marriage to Elmer Moffatt and dies by suicide. In France, Undine marries the aristocratic Raymond de Chelles, but she again rebels when status comes without unrestricted money. She sells his family's tapestries to finance another divorce and marries Moffatt, now a millionaire. Moffatt supplies the luxury she wants and brings Paul back, yet Undine immediately finds a fresh source of dissatisfaction: because she is divorced, she can never occupy the diplomatic role she now covets.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2996,7 +2996,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3009,7 +3009,7 @@
       "recaps": {
         "ending": "The mastermind orchestrating the murders is unmasked as Leigh Teabing, the affable Grail historian, who is the hidden Teacher. Obsessed with exposing the Church's secret, he manipulated the fanatical monk Silas, the bishop Aringarosa, and everyone around him, and he is willing to kill to obtain the Priory's guarded knowledge. His scheme unravels, and he is arrested by Captain Fache. Silas dies after being wounded, and Aringarosa, having been used and having lost everything, is left broken but repentant. The novel's central revelation is that the Holy Grail is not an object but a person and a bloodline: Mary Magdalene, presented as the wife of Jesus, whose descendants have been protected in secret for two thousand years. Sophie Neveu is revealed to be one of those descendants, the last of the line, and she is reunited with surviving family she never knew she had. Langdon deduces that the Grail, the sarcophagus of Mary Magdalene, lies hidden beneath the Louvre's inverted glass pyramid, where he kneels in quiet reverence at the close. The secret endures, protected rather than exposed, and Langdon and Sophie part with the promise of meeting again.",
         "in_short": "When the curator of the Louvre is murdered and leaves a trail of cryptic clues, Harvard symbologist Robert Langdon is drawn in as a suspect and flees through Paris with the police cryptographer Sophie Neveu, the curator's estranged granddaughter. The clues lead them into an ancient mystery: a secret society, the Priory of Sion, has for centuries guarded the true nature of the Holy Grail, which the story presents not as a cup but as Mary Magdalene, said to have been the wife of Jesus and the mother of his child, whose bloodline secretly survives. Pursued by police and by a fanatical monk killing on orders from a hidden mastermind called the Teacher, Langdon and Sophie decode riddles hidden in art and history with the help of the Grail scholar Leigh Teabing. Teabing is revealed to be the Teacher, willing to kill to force the secret into the open, and he is arrested. The monk Silas dies, and the bishop who backed him is undone. Most startling of all, Sophie herself is revealed to be a living descendant of the sacred bloodline, and the Grail's resting place is finally located beneath the Louvre.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3156,7 +3156,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3169,7 +3169,7 @@
       "recaps": {
         "ending": "At Westminster Abbey, Langdon identifies Leigh Teabing as the Teacher who manipulated Silas, Aringarosa, and Rémy in order to obtain the Priory's secret. Teabing threatens Sophie and demands that Langdon open the second cryptex. Langdon has already solved its password, apple, and secretly removed the papyrus; he throws the empty cryptex, forcing Teabing to drop his weapon before the police arrest him. Silas dies after accidentally shooting Aringarosa, who survives and helps Fache understand that Langdon was framed. The final message leads Langdon and Sophie to Rosslyn Chapel. There Sophie discovers that the chapel's keeper, Marie Chauvel, is her grandmother and that her younger brother is alive. Her family was separated for protection, and Saunière raised her while concealing their connection to the bloodline attributed to Mary Magdalene. Sophie remains with her recovered family. Back in Paris, Langdon interprets the poem anew and kneels above the hidden chamber beneath the Louvre's inverted pyramid, where he believes the Grail rests.",
         "in_short": "After Louvre curator Jacques Saunière is murdered, he leaves coded clues for his granddaughter, cryptographer Sophie Neveu, and Harvard symbologist Robert Langdon. Pursued by police captain Bezu Fache, they recover a cryptex linked to the Priory of Sion and seek help from Grail scholar Leigh Teabing. He explains a theory that the Holy Grail concerns Mary Magdalene and a surviving family line rather than a cup. The pursuit moves to London as the monk Silas and a hidden mastermind called the Teacher seek the same secret. Teabing is exposed as the Teacher and arrested after Langdon solves the cryptex. Silas dies, while Bishop Aringarosa survives and reveals how they were deceived. At Rosslyn Chapel, Sophie learns that her grandmother and brother are alive and that her family was separated to protect its heritage. Langdon later concludes that Saunière's final poem points beneath the Louvre's inverted pyramid, where the Grail documents may be hidden.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3319,7 +3319,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3332,7 +3332,7 @@
       "recaps": {
         "ending": "Roland catches the man in black only after sacrificing Jake, letting the boy fall to his death in the tunnels beneath the mountains rather than lose the trail. Face to face at last, the man in black reads Roland's fortune with a deck of picture cards, showing him figures that stand for the three companions he must draw to him and warning of the long road still ahead. He speaks of the Dark Tower as the linchpin that holds all worlds together, and of forces far greater than himself, then talks Roland through a night that stretches into what feels like years. Roland wakes much older, alone beside a set of bones, the sorcerer gone. Carrying his guilt over Jake and the knowledge that he must gather three to him, Roland walks west and comes to the shore of the Western Sea. The quest is only beginning: the man in black has pointed the way but given no comfort, and the gunslinger remains as driven and as solitary as ever, fixed on the Tower that stands at the center of everything.",
         "in_short": "The last gunslinger, Roland Deschain of the fallen land of Gilead, pursues the man in black across a vast desert in a world that has moved on. He passes through the town of Tull, where the sorcerer's meddling turns the whole town against him and forces him to kill everyone there, then finds a displaced boy, Jake Chambers, at an abandoned way station and takes him along. Crossing the mountains through dark tunnels, hunted by underground mutants and haunted by memories of his brutal apprenticeship in Gilead, Roland closes on his quarry. At the last he must choose between saving Jake, who is slipping to his death, and keeping his hold on the chase, and he lets the boy fall. He finally confronts the man in black, who reads his future in cards, foretells three companions Roland must draw to him, and speaks of the Dark Tower before a night-long talk ages Roland by years. He wakes alone and walks on to the edge of the Western Sea, still bound for the Tower.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3441,7 +3441,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3454,7 +3454,7 @@
       "recaps": {
         "ending": "By the end, Roland has drawn his three. Eddie Dean, pulled out of a life of addiction, has begun to get clean and is becoming a gunslinger in his own right. Odetta Holmes and her buried second self, Detta Walker, are forced into a single confrontation that Roland stages through the body of the killer Jack Mort, and out of it emerges an integrated woman who takes the name Susannah Dean. Jack Mort dies before he can be drawn as a person, killed by a train much as he once killed others. Roland remains physically diminished, having lost fingers to the beach-monster, but he is no longer alone: Eddie and Susannah, already drawn to each other in love, stand with him. The new fellowship leaves the shore of the Western Sea and starts inland, bound together as ka-tet on the long road toward the Tower.",
         "in_short": "Fevered and maimed after a monster on the beach takes two of his fingers, Roland finds three free-standing doors along the shore of the Western Sea, each opening into the mind of a person in twentieth-century New York. Through the first he reaches Eddie Dean, a heroin addict, and pulls him bodily into Mid-World after helping him survive a mob deal. Through the second he reaches Odetta Holmes, a legless woman whose mind is split between a genteel self and a violent hidden self. Through the third he inhabits Jack Mort, a secret killer whose old crimes maimed Odetta and once pushed the boy Jake to his death. Using Mort, Roland engineers a crisis that forces Odetta's two selves to confront each other and fuse into a single, whole woman, Susannah Dean. The three are drawn: Eddie and Susannah join Roland as the beginnings of a new ka-tet, and the fellowship turns inland toward the Dark Tower.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3536,7 +3536,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3549,7 +3549,7 @@
       "recaps": {
         "ending": "The ka-tet reaches the decayed city of Lud and, hunted through it, makes for the cradle of Blaine the Mono, a sentient and murderously insane monorail train. Roland's group is now complete: Roland, Eddie, Susannah, the redrawn Jake, and the billy-bumbler Oy. Blaine agrees to carry them across the deadly waste lands toward the Tower, but only as a game: the travelers must best the train with a riddle it cannot answer, or Blaine will speed into its terminus and kill them along with itself. The book ends on a cliffhanger, with the ka-tet trapped aboard, the poisoned lands blurring past, and a contest of riddles just beginning that will decide whether any of them survive to reach the next stage of the quest.",
         "in_short": "Roland and his ka-tet, Eddie and Susannah, follow the path of a Beam toward the Dark Tower. Roland is being driven mad by a paradox: because he changed the past, the boy Jake both died and never came to his world, and two memories tear at him. Jake, in New York, suffers the same split. The ka-tet draws Jake across through a haunted house and a speaking demon, and the paradox heals; along the way they gain a billy-bumbler named Oy. They kill Shardik, a great cyborg bear guarding a Beam portal, and press on to Lud, a ruined city torn between two dying gangs. There they board Blaine, an insane, sentient monorail that agrees to carry them across the poisoned waste lands only if they can beat it at riddles, and threatens to kill them all at the end of the line if they cannot. The book breaks off mid-contest as Blaine races toward its final stop.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-dark-tower-iv-wizard-and-glass.json
+++ b/data/works-community/0/the-dark-tower-iv-wizard-and-glass.json
@@ -89,7 +89,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -102,7 +102,7 @@
       "recaps": {
         "ending": "Roland's long tale of Mejis closes in loss: his first love, Susan Delgado, is denounced by a witch and the townsfolk and burned alive at a harvest fire while Roland is lured away, and the pink seeing-glass he wins, Maerlyn's Grapefruit, shows him visions that lead him to kill his own mother by mistake. This grief helped forge the closed, relentless man he became. In the present, the ka-tet crosses the plague-emptied Kansas and reaches a green glass palace on the road, where they find Randall Flagg, the dark sorcerer behind so much of Roland's suffering, playing at being a wizard. He taunts them, warns them off the Tower, and escapes rather than face them. Shaken but unbroken, and now knowing one another far better, Roland, Eddie, Susannah, Jake, and Oy leave the palace and take up the path of the Beam again, their bond deepened and the Tower still ahead.",
         "in_short": "Trapped aboard the insane monorail Blaine, Eddie destroys it by feeding it foolish, illogical riddles it cannot bear, and the ka-tet steps off into a version of Kansas emptied by a killer plague. Following the highway and a strange thinny toward a green glass palace, they rest, and Roland finally tells the story of his youth. As a teenager, freshly made a gunslinger, he was sent east to the quiet barony of Mejis with his friends Cuthbert and Alain to keep them safe from the rising war. There Roland fell in love with Susan Delgado, uncovered a conspiracy of hired killers supplying the rebel John Farson, and took a piece of the wizard's rainbow, a pink seeing-glass. The tale ends in tragedy: Susan is betrayed and burned, and the glass tricks Roland into a killing that scars him for life. Back in the present, the ka-tet reaches the green palace and confronts Randall Flagg, who mocks them and flees. They return to the path of the Beam.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -192,7 +192,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -205,7 +205,7 @@
       "recaps": {
         "ending": "The people of Calla Bryn Sturgis, led and trained by the ka-tet, spring their ambush on the Wolves and wipe them out, exposing the raiders as mechanical servants sent to harvest something from the stolen twins for the Tower's enemies. The town is saved and its children spared, at the cost of some lives among the defenders. But the triumph is undercut: Susannah's hidden second self, Mia, seizes control and steals away with Black Thirteen, the deadly seeing-glass, using it to open a door to New York so she can give birth to the demon child she has claimed as her own. Jake, with Father Callahan and the billy-bumbler Oy, races after her, and the book ends with them following her trail toward a nest of the Tower's servants in the city, the ka-tet broken apart and Susannah carried off inside her own body just as the next crisis begins.",
         "in_short": "The ka-tet comes to Calla Bryn Sturgis, a farming town plagued once a generation by the Wolves, masked raiders who ride out of the east and carry off one child from every pair of twins, returning them ruined in mind and doomed to die young. Bound by the gunslinger's code, Roland, Eddie, Susannah, and Jake agree to help the town fight back. In the Calla they meet Father Callahan, a priest from another world who guards Black Thirteen, a malevolent seeing-glass, and through it the ka-tet travels to 1977 New York to protect a magic rose tied to the Tower and to secure it from a reluctant bookseller. Meanwhile Susannah is secretly pregnant with a demon-fathered child, and a hidden second self, Mia, has risen to carry and defend it. The town, armed and trained, ambushes the Wolves and destroys them, revealing them as robotic servants of the Tower's enemies. But in the victory's confusion, Mia slips away with Black Thirteen to give birth, and Jake and Callahan go after her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -304,7 +304,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -317,7 +317,7 @@
       "recaps": {
         "ending": "The threads are left dangling at their most dangerous points. Susannah, still largely under Mia's control, reaches the Dixie Pig in New York, where the child is to be born and where Mia is set to lose everything she was promised. Jake and Father Callahan arrive to rescue her and steel themselves to fight their way into a nest of vampires and low men, with Oy at their side, the outcome unknown as the book closes. Roland and Eddie, in 1977 Maine, survive a gun battle and find and confront the writer Stephen King, coming to understand that he is the vessel through whom their tale is told; they press upon him that he must keep writing it or the quest and the Tower will fail. A closing note about King's life hints at a future accident that could silence the story. The birth of the child looms, the ka-tet is broken across worlds, and every strand is poised to break open in the final book.",
         "in_short": "The ka-tet is scattered. Susannah, ruled by the being Mia, has passed through a door to 1999 New York to give birth to her child, and Jake, Father Callahan, and Oy follow to save her, tracking Mia to the Dixie Pig, a den of vampires and the Tower's servants. Mia's bargain is revealed: she was promised motherhood in exchange for carrying the child, who is fathered partly by Roland and partly by the Tower's great enemy, and she is likely to be cast aside once he is born. Meanwhile Roland and Eddie travel to 1977 Maine to secure the vacant lot and its rose by dealing with the bookseller who owns it, and there they meet the writer Stephen King, realizing that the story of their quest flows through him and that he must be kept alive and writing. The book ends on a knife-edge, with Jake and Callahan about to storm the Dixie Pig and the child's birth at hand.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -426,7 +426,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -439,7 +439,7 @@
       "recaps": {
         "ending": "Roland reaches the Dark Tower having lost everyone. Father Callahan dies at the Dixie Pig; Eddie is killed freeing the Breakers; Jake dies saving the life of the writer whose work sustains their story; Oy is slain defending Roland from the spider-child Mordred, whom Roland then kills though Mordred is his own monstrous son; and Susannah, unwilling to face the Tower, leaves through a door into a happier world where versions of Eddie and Jake live. Randall Flagg is devoured by Mordred before he can seize the Tower, and the Crimson King, trapped raving on a balcony, is erased from being by an artist's drawing. Alone, Roland enters the Tower and climbs to its top, where the door opens not onto triumph but onto the Mojave desert where his quest first began. His memory wiped, he sets out once more to chase the man in black, condemned to repeat the whole road. One thing is different: he now carries the Horn of Eld he once left behind, a small sign that on some future turn the cycle might at last be broken.",
         "in_short": "In the final book the ka-tet is reunited but pays terribly for the Tower. Father Callahan dies covering Jake's escape from the Dixie Pig; Mia gives birth to the spider-child Mordred, who kills her at once and begins to stalk Roland's people. The company frees the psychic Breakers who are being forced to destroy the Beams, and in that battle Eddie Dean is shot and dies. Jake is killed soon after, saving the writer Stephen King from the van that would have ended the story. Grieving, Roland and Susannah go on; Susannah at last chooses love and life over the Tower and passes through a door into a kinder world. Mordred devours Randall Flagg, then dies at Roland's hand with Oy's help, though Oy is killed too. The Crimson King is erased from existence, and Roland reaches the Dark Tower alone, climbs it, and is thrown back to the desert where his quest began, doomed to walk the road again, this time carrying a horn that hints the loop might one day break.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -544,7 +544,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -555,7 +555,7 @@
         "work": "the-darkest-legacy"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -722,7 +722,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -735,7 +735,7 @@
       "recaps": {
         "ending": "East River is raided by government forces and burned, and the children scatter. Zu is put on a truck heading west with a group of younger kids before the worst of it, and Ruby loses her. Ruby, Liam and Chubs get out together, but Chubs is shot during the escape and will die without a hospital neither of them can walk into. Ruby makes the only trade she has left: she calls Cate and offers herself to the Children's League in exchange for Chubs being treated. Before the League collects her, she goes to Liam and takes herself out of his memory, every day of the road trip and everything between them, so that he will stop looking for her and stay alive. He wakes not knowing who she is. Ruby leaves with the League, deliberately alone, having chosen to become the weapon everyone has been trying to make of her rather than watch anyone else be hurt for her sake. Clancy is gone, his mother's research is in the wind, the camps are still full, and the one person who might have found Ruby again no longer knows she exists.",
         "in_short": "A disease has killed most of America's children, and the survivors developed abilities that frightened the government into locking them in rehabilitation camps. Sixteen-year-old Ruby Daly has survived six years in Thurmond by hiding what she is: an Orange, able to enter and alter minds, passing as a harmless Green. A woman named Cate smuggles her out for the Children's League, but Ruby, seeing that the League means to use her, runs and falls in with three other runaways: Liam, Chubs and the mute young Zu, who are searching for a safe haven called East River. Ruby hides her true classification from them while they cross the country dodging soldiers and bounty hunters. East River turns out to be run by Clancy Gray, the president's son and another Orange, who offers to train her and then uses her to steal his mother's research into the disease. When Ruby refuses him, the settlement is betrayed and destroyed. Escaping with a gravely wounded Chubs, Ruby trades herself to the League to save him, erases herself from Liam's memory to keep him safe, and leaves alone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -940,7 +940,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -953,7 +953,7 @@
       "recaps": {
         "ending": "Grant and Carradine decide that the traditional case against Richard III lacks contemporary support and that Henry VII had a stronger practical reason to ensure the princes could never challenge the Tudor settlement. Henry also controlled the later record, suppressed the act explaining Richard's title, and did not charge Richard with the boys' murder when listing alleged crimes after Bosworth. Carradine is exhilarated by what he thinks is a major original discovery and plans to write about it. He then learns that historians, notably Clements Markham, had already assembled a defense of Richard long before them. His disappointment deepens when Grant explains that public history often preserves a memorable false version even after specialists have corrected it. Grant compares this persistence to the accepted story of Tonypandy, which his own police knowledge had shown him was untrue. The investigation therefore closes without a courtroom resolution: its lasting result is a lesson about evidence, propaganda, and repetition.",
         "in_short": "Hospitalized with a broken leg, Scotland Yard inspector Alan Grant becomes intrigued by Richard III's portrait and questions whether its face fits the familiar murderer of the Princes in the Tower. With actress Marta Hallard supplying the idea and young researcher Brent Carradine supplying documents, Grant treats the past as a cold case. They find that the standard account rests heavily on Thomas More's late, partisan narrative; contemporary conduct and records do not support the simple story. Elizabeth Woodville's dealings with Richard, the legal declaration that Edward IV's children were illegitimate, and the absence of the murders from Henry VII's charges against Richard all trouble the prosecution. Henry, by contrast, needed the princes removed if his marriage to their sister was to bolster his weak claim, and his regime controlled and suppressed key records. Grant and Carradine conclude that Richard's guilt is unproved and Henry is the more plausible beneficiary. Carradine then discovers that earlier historians had reached much the same conclusion, illustrating how a vivid political legend can outlive scholarly correction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1095,7 +1095,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1108,7 +1108,7 @@
       "recaps": {
         "ending": "After seeing Faye with Miguel, Homer becomes nearly unresponsive and starts to leave California. Tod finds him outside a film premiere, where a crowd has gathered in hopes of seeing celebrities. Adore Loomis torments Homer with repeated pranks; Homer finally lashes out, knocking the boy down and stamping on him. The surrounding spectators attack Homer, and their violence spreads into a mass riot. Tod is carried helplessly through the crush, suffers a badly injured leg, and can no longer distinguish his own cries from laughter. As the crowd destroys the glamorous setting around it, he imagines the catastrophe he has been trying to paint: Los Angeles consumed by the rage of people whose hopes have been exploited by its manufactured dreams. The novel closes inside that riot, with Homer's fate unstated and Tod trapped in the spectacle he had previously observed at a distance.",
         "in_short": "Tod Hackett, a studio artist in Hollywood, studies the disappointed migrants and marginal performers around him while planning a painting of Los Angeles burning. He becomes obsessed with Faye Greener, an aspiring actress who lives with her failing vaudevillian father, Harry. Shy former bookkeeper Homer Simpson also falls in love with Faye and supports her after Harry dies, letting her live in his house although she does not return his devotion. Faye fills the house with other admirers, including the screen cowboy Earle Shoop and his friend Miguel. After Homer discovers Faye and Miguel together, he withdraws and attempts to leave California. Outside a film premiere, the child performer Adore Loomis repeatedly provokes him. Homer attacks the boy, and the waiting crowd turns on Homer before erupting into a riot. Tod is swept into the violence, where the apocalyptic scene he has imagined for his painting becomes real around him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1275,7 +1275,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1288,7 +1288,7 @@
       "recaps": {
         "ending": "Michael asks Amelie to transform him into a vampire, surrendering his ghostlike half-life so he can leave Glass House and help save Shane. The change gives him freedom and a durable body, but it also makes him part of the kind of being Shane hates and complicates his relationship with Eve. Claire, Eve, Michael, and their allies prevent Frank Collins's campaign from destroying its targets and rescue Shane from Morganville's death sentence for Brandon's murder. Frank's revenge fails and he ends the crisis in custody rather than in control of his son. Shane returns to his friends alive, although his father's choices and Michael's transformation leave lasting damage. Claire accepts Amelie's personal protection and wears the Founder's bracelet, gaining security from ordinary vampire predation at the price of being bound directly to Morganville's ruler. The four Glass House residents remain together, but their household now includes a vampire and Claire owes service to Amelie.",
         "in_short": "Armed vampire hunters led by Shane's father, Frank Collins, invade Glass House just after Claire learns that Michael is a ghostlike being bound to it. Frank's group kills the vampire Brandon, and Morganville's authorities blame Shane, imprisoning him and sentencing him to death. Claire and Eve pursue every possible ally, from Amelie and Oliver to Michael's vampire grandfather Sam, while Frank plans a broader attack under cover of the Dead Girls' Dance. Because Michael cannot leave the house in his existing state, he accepts Amelie's offer to make him a vampire. Newly able to act beyond the property, he joins the effort to stop Frank and save Shane. The friends disrupt the hunters' plan and rescue Shane; Frank ends in custody. Michael survives as a vampire, creating new tension with both Eve and Shane. Claire secures Amelie's protection, but the bracelet she receives also marks her as the Founder's subject and commits her to future service.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1444,7 +1444,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1457,7 +1457,7 @@
       "recaps": {
         "ending": "After the party, Gabriel and Gretta go to a hotel. Gabriel is full of desire and memories of their marriage, but Gretta is distracted and then begins to cry. She explains that Bartell D'Arcy's song reminded her of Michael Furey, a sickly boy in Galway who used to sing it and who loved her. Before she left for Dublin, Michael stood outside her window in severe weather to see her once more; he died soon afterward. Gabriel first feels jealousy and humiliation, then recognizes the force of a feeling he has never matched. As Gretta sleeps, his thoughts widen from his wounded pride to his aging aunt Julia, the dead boy, and the mortality awaiting everyone at the gathering. Looking out at the snow, he imagines it falling throughout Ireland, including over Michael's grave in the west. The story ends with Gabriel's sense of self diminished but his awareness enlarged: the living remain bound to people and experiences invisible to those closest to them, and every social celebration takes place within the reach of loss and death.",
         "in_short": "Gabriel Conroy and his wife, Gretta, attend the annual holiday party hosted by Gabriel's aunts Kate and Julia Morkan and his cousin Mary Jane. Gabriel is embarrassed after offending Lily, argues with nationalist Molly Ivors about his cultural loyalties, and anxiously delivers a generous dinner speech. The gathering otherwise follows its familiar pattern of music, dancing, food, drinking, and family reminiscence. As the guests leave, Gretta pauses to hear Bartell D'Arcy singing. Her absorbed expression excites Gabriel, but at their hotel she reveals that the song reminded her of Michael Furey, a frail boy who loved her in Galway and died after coming to see her in bad weather. Gabriel's jealousy turns into humility as he realizes how little he knows of Gretta and how cautiously he has lived. Watching snow fall across Ireland, he reflects on Michael, his aging relatives, and the shared movement of living people toward the dead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1574,7 +1574,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1587,7 +1587,7 @@
       "recaps": {
         "ending": "The final trials collapse into open revolt. Newt, driven mad by the Flare, pleads with Thomas to end his suffering, and in an agonizing confrontation Thomas kills him, honoring the note his friend had left. The Right Arm launches its assault on WICKED's headquarters, and Thomas goes back inside not to help the organization but to free the remaining immune subjects it still holds. Teresa, reconciled with Thomas in their last hours, saves his life during the chaos of the escape and is crushed and killed. The survivors, roughly two hundred immunes among them Thomas, Minho, Brenda, Frypan, and Jorge, pass through a hidden portal WICKED controlled and reach a sealed, untouched paradise valley, a safe refuge in which to rebuild. WICKED is destroyed and its experiments ended. Thomas, having chosen never to recover his erased memories, begins a new life in the valley with Brenda, having lost Newt and Teresa but carried the survivors to a future beyond the ravaged world.",
         "in_short": "Offered the return of their lost memories by WICKED, Thomas, Newt, and Minho refuse and distrust the organization, especially once Thomas learns WICKED means to keep studying his immune brain to complete a cure. With help from Brenda and Jorge, they break out and set about exposing and stopping WICKED. Newt, infected with the Flare and not immune, gives Thomas a sealed note and steadily loses himself to the virus. In the fortified city of Denver the group contacts the Right Arm, a rebel movement bent on toppling WICKED, as the plague spreads and the infected close in. Gone mad from the Flare, Newt begs Thomas to end his suffering, and Thomas kills him. The Right Arm assaults WICKED's headquarters while Thomas returns to free the remaining immune subjects. In the escape, Teresa saves Thomas and is crushed to death. The survivors pass through a hidden portal to a sealed, untouched valley, a safe place to begin humanity's future, leaving WICKED destroyed and the ruined world behind. Thomas, who never regains his memories, starts a new life among the survivors with Brenda.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1722,7 +1722,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1735,7 +1735,7 @@
       "recaps": {
         "ending": "During a final three-day agony, Ivan feels as though he is being forced through a dark enclosure. His son takes his hand and weeps, and Ivan at last sees the suffering of the family gathered around him. He recognizes that his fear and resentment have prolonged their pain and that compassion, rather than the socially approved life he pursued, offers a way out. He tries to ask forgiveness and wishes to release his family from their distress. The terror that had filled his illness disappears; where he expected death he perceives light, and he understands that death no longer has power over him. From the family's outward perspective his breathing stops and he dies, but his final inward experience is one of release rather than defeat. The survivors return to the practical and social business surrounding his death, while the conclusion rests on Ivan's last change of understanding.",
         "in_short": "Judge Ivan Ilych has died at forty-five, and the news prompts his colleagues to think first of advancement. The story then follows the life that led to his death: a career built on propriety, a strained marriage managed through work and social routine, and a carefully decorated home. After a minor accident he develops a persistent pain that doctors cannot meaningfully relieve. As his condition worsens, family and acquaintances maintain the fiction that he is merely ill, leaving him isolated with the knowledge that he is dying. Only the servant Gerasim treats his suffering honestly and compassionately. Ivan reviews his life and begins to suspect that its respectable surface concealed a fundamental falseness. In his final agony, moved by his son's grief, he turns from self-pity toward compassion for his family. His fear of death gives way to a sense of light and release, and he dies believing that death itself has ended.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1870,7 +1870,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1883,7 +1883,7 @@
       "recaps": {
         "ending": "During a final three-day agony, Ivan feels as though he is being forced through a dark enclosure. His son takes his hand and weeps, and Ivan at last sees the suffering of the family gathered around him. He recognizes that his fear and resentment have prolonged their pain and that compassion, rather than the socially approved life he pursued, offers a way out. He tries to ask forgiveness and wishes to release his family from their distress. The terror that had filled his illness disappears; where he expected death he perceives light, and he understands that death no longer has power over him. From the family's outward perspective his breathing stops and he dies, but his final inward experience is one of release rather than defeat. The survivors return to the practical and social business surrounding his death, while the conclusion rests on Ivan's last change of understanding.",
         "in_short": "Judge Ivan Ilyich has died at forty-five, and the news prompts his colleagues to think first of advancement. The story then follows the life that led to his death: a career built on propriety, a strained marriage managed through work and social routine, and a carefully decorated home. After a minor accident he develops a persistent pain that doctors cannot meaningfully relieve. As his condition worsens, family and acquaintances maintain the fiction that he is merely ill, leaving him isolated with the knowledge that he is dying. Only the servant Gerasim treats his suffering honestly and compassionately. Ivan reviews his life and begins to suspect that its respectable surface concealed a fundamental falseness. In his final agony, moved by his son's grief, he turns from self-pity toward compassion for his family. His fear of death gives way to a sense of light and release, and he dies believing that death itself has ended.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2012,7 +2012,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2025,7 +2025,7 @@
       "recaps": {
         "ending": "The collection closes with the narrator of “Confession” unable to accept the Orthodox Church as a complete answer to his crisis. The faith of ordinary working people has convinced him that life requires a relation to the infinite and that reason alone cannot supply life's purpose. He nevertheless finds church doctrine obscured by claims he cannot believe, hostility between Christian confessions, and institutional approval of state violence and war. A final dream represents his position: he is suspended over an abyss until he stops looking downward and recognizes a secure support above him. The image does not settle every theological question, but it expresses the conviction he retains after rejecting both despair and unquestioning conformity: meaningful life depends on directing himself toward a higher source rather than treating finite existence as self-sufficient.",
         "in_short": "This collection joins a novella about dying with an autobiographical inquiry into how to live. Judge Ivan Ilyich builds a respectable career and conventional household, then suffers an apparently minor injury that develops into an incurable illness. Family, colleagues, and doctors hide behind routine, while the servant Gerasim alone faces death honestly. Ivan recognizes that his socially approved life has been spiritually false; compassion for his wife and son releases his fear, and he dies experiencing death as light rather than annihilation. In “Confession,” a successful middle-aged writer describes losing childhood belief and reaching the edge of suicide because science, philosophy, pleasure, and fame cannot explain life's purpose. The enduring faith of ordinary laborers shows him that meaning depends on a relation between finite life and the infinite. He attempts Orthodox observance but rejects doctrines and institutions that demand false assent or sanction religious division and violence, ending with faith recovered as an orientation rather than a finished creed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2181,7 +2181,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2194,7 +2194,7 @@
       "recaps": {
         "ending": "On the tenth day, the company tells stories of generosity, mercy, friendship, and self-command. The final and most troubling example is Dioneo's account of Griselda, whose husband repeatedly subjects her to calculated cruelty in order to test her obedience before restoring her children and public position. With one hundred stories completed, Panfilo tells the company that their purpose has been fulfilled and recommends returning to Florence before their retreat draws criticism. They leave the country estate the next morning and reach the same church where the seven women first formed their plan. The three men then depart for their own concerns, while the seven women return to their homes. The plague has not been solved or escaped permanently; the company has instead created a temporary space of health, fellowship, and disciplined storytelling within the surrounding disorder.",
         "in_short": "As plague overwhelms Florence, seven young women and three young men leave the city for a country estate. They organize their days around music, meals, walks, and storytelling, appointing a new ruler for each session. Over ten storytelling days they tell one hundred tales about luck, intelligence, desire, hypocrisy, practical jokes, failed and successful love, and exceptional generosity. The subjects move from open choice through alternating comic and tragic themes to a final consideration of noble conduct. Dioneo is generally allowed to disregard the assigned theme and tell last, giving the orderly program an element of dissent. The tales repeatedly show people using language and ingenuity to negotiate institutions, appetites, and unequal power. After Panfilo's final day, ending with the ordeal and restoration of Griselda, the ten companions decide their retreat has run its course. They return to Florence, the women to their homes and the men to their affairs, leaving their completed cycle as a temporary answer to the social breakdown around them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2329,7 +2329,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2342,7 +2342,7 @@
       "recaps": {
         "ending": "Years after accepting the devil's terms, Tom tries to protect himself through conspicuous religious observance while continuing to profit from desperate borrowers. When a land speculator begs for more time, Tom angrily denies that he has earned anything from the man's hardship and invokes the devil as witness. Old Scratch immediately arrives on a black horse and carries Tom away in a storm. Tom's outward signs of prosperity prove empty: papers in his strongboxes become worthless scraps, his valuables disappear, his horses leave only remains, and his imposing house burns. The people of Boston remember the event as the fulfillment of Tom's bargain, and the place associated with his business remains linked to the tale afterward.",
         "in_short": "Miserly Tom Walker meets the devil in a swamp and is offered Captain Kidd's buried treasure in return for corrupt service and his soul. Tom initially refuses, partly because his wife urges him to accept. She tries to bargain independently and vanishes after signs of a violent struggle. Tom then agrees to the terms and becomes a harsh Boston moneylender, enriching himself by exploiting borrowers. As he ages, fear of damnation makes him ostentatiously religious, but his conduct does not improve. During an argument with a debtor, Tom swears that the devil may take him if he has profited from the man's troubles. Old Scratch appears at once and carries him away on a black horse amid a storm. Tom's wealth then proves illusory or worthless, and his house burns, leaving his bargain with no lasting reward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2474,7 +2474,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2487,7 +2487,7 @@
       "recaps": {
         "ending": "When guards seize Rivka for a group being sent to the gas chambers, Hannah exchanges places with her and urges Rivka to run. Hannah enters the chamber remembering that each saved life matters and that her own sacrifice may preserve the future she knows. She is suddenly back at her family's Seder, standing at the apartment door after opening it for Elijah. The experience has changed her understanding of remembrance. Hannah recognizes Aunt Eva's tattoo as Rivka's number and identifies Grandpa Will as Rivka's brother Wolfe. Aunt Eva confirms their past and explains what became of several people Hannah knew: she and Wolfe survived, Gitl also survived, and Yitzchak escaped and fought the Nazis, although his children were killed. Aunt Eva reveals that the girl called Chaya died saving her, and that Hannah was named for that girl. Hannah can now receive the survivors' stories as personal memories and acts of preservation rather than as an unwanted family ritual.",
         "in_short": "Hannah Stern, a modern Jewish girl tired of hearing about the Holocaust, opens the door for Elijah during a Passover Seder and finds herself in a Polish village in 1942. Known there as Chaya, she joins relatives preparing for Shmuel and Fayge's wedding. Nazis interrupt the celebration and deport the villagers to a concentration camp. Hannah's knowledge of history cannot prevent their suffering, but she learns the camp's rules from a prisoner named Rivka and helps preserve memory by telling stories and caring for others. Shmuel and Fayge are killed after an escape attempt, while Yitzchak gets away. When Rivka is selected for death, Hannah takes her place and is sent to a gas chamber. She returns to the Seder at the instant she left. Hannah then recognizes Aunt Eva as Rivka and Grandpa Will as Rivka's brother Wolfe. Aunt Eva explains that Chaya died to save her and that Hannah bears Chaya's name, giving Hannah a new understanding of sacrifice and remembrance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2637,7 +2637,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2650,7 +2650,7 @@
       "recaps": {
         "ending": "Yukawa works out that Ishigami did not merely conceal Togashi's death. He created a second murder with an unidentifiable victim so the police would assign the wrong date and body to the crime, turning Yasuko and Misato's genuine movements into an unbreakable alibi. Ishigami then surrenders and falsely claims that he killed Togashi out of jealous obsession, providing a complete story intended to remove suspicion from Yasuko. Yukawa privately tells Yasuko the scale of the sacrifice: Ishigami killed an unknown homeless man, disposed of Togashi, and arranged his own ruin for her sake. Yasuko initially remains silent, but Misato's suicide attempt makes living comfortably on that sacrifice impossible. She comes to the police station and confesses that she and Misato killed Togashi. Confronted with the collapse of the solution he built, Ishigami breaks down. His devotion fails to secure Yasuko's freedom because accepting it would require her to let him bear both murders alone.",
         "in_short": "Yasuko Hanaoka and her daughter Misato kill Yasuko's abusive former husband, Togashi, during a struggle in their apartment. Their neighbor, mathematics teacher Tetsuya Ishigami, discovers what happened and offers to protect them. When police investigate a disfigured body believed to be Togashi's, the Hanaokas have a strong alibi. Detective Kusanagi consults physicist Manabu Yukawa, who recognizes Ishigami as a brilliant former university classmate and gradually realizes that the alibi conceals a different problem from the one police are trying to solve. Ishigami killed an unrelated homeless man and used that body to shift the supposed time and identity of Togashi's murder, then surrendered with a false jealous-murder confession designed to save Yasuko. Yukawa reveals the plan to her privately. After Misato attempts suicide under the strain, Yasuko confesses the original killing, destroying Ishigami's sacrifice and leaving him overwhelmed by grief.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2799,7 +2799,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2812,7 +2812,7 @@
       "recaps": {
         "ending": "After Japhy leaves for extended Buddhist study in Japan, Ray takes a summer job as a fire lookout on Desolation Peak in Washington. Alone above the forests, he spends weeks reading, meditating, watching changing weather, and confronting both the beauty and severity of solitude. The isolation does not deliver one final, permanent revelation, but it deepens the insight he has been pursuing throughout his travels: the world is transient, inseparable, and not in need of the rigid distinctions people impose on it. When the season ends, Ray closes the lookout and descends the mountain. He pauses to look back, offers a final expression of gratitude and compassion, and returns toward ordinary life carrying the experience rather than escaping the world altogether. Japhy remains abroad, so the friends' paths separate with their shared spiritual ambitions still open-ended.",
         "in_short": "Ray Smith, a restless writer and Buddhist seeker, returns to the San Francisco Bay Area and befriends Japhy Ryder, a poet, climber, and serious student of Zen. Their friendship joins meditation and religious study to parties, poetry, sexual freedom, manual work, and wilderness travel. A Sierra ascent tests Ray's fear and makes Japhy's mountain confidence a model for him. After tragedy in their circle, Ray crosses the country to spend winter with his family, living simply and meditating in the woods. He later returns west, stays with Japhy and the Monahan family, and joins a large farewell celebration before Japhy sails to Japan for Buddhist study. Ray then works alone as a fire lookout on Desolation Peak. The summer of solitude gives him no tidy escape from contradiction, but leaves him with a stronger sense of impermanence, compassion, and the sacredness of the ordinary world before he descends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2988,7 +2988,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3001,7 +3001,7 @@
       "recaps": {
         "ending": "Revolutionary conflict overturns the settlements around Shanghai. Nell has become the leader and symbolic mother of the vast Mouse Army, girls educated through simplified Primers derived from the same system that raised her. The army helps her survive the uprising and gives her power independent of the established phyles. Miranda, whose years of live performance made her the emotional voice behind Nell's Primer, has entered the Drummers' submerged collective while searching for a deeper connection with Nell. Guided by what she has learned, Nell penetrates the Drummers' domain and rescues Miranda. Their meeting finally brings the pupil and unseen surrogate mother together in person. Hackworth's effort to create a Seed-based alternative to centralized nanotechnological Feeds remains tied to the social transformation around them. The old neo-Victorian, Chinese, and coastal orders are no longer stable, while Nell emerges able to found a new community rather than merely enter one designed by others.",
         "in_short": "In a future Shanghai shaped by nanotechnology and competing cultural enclaves, engineer John Hackworth creates an adaptive educational book for a neo-Victorian lord's granddaughter and secretly copies it for his own daughter. The illicit copy is stolen and reaches Nell, a neglected girl in a poor district. Through stories, exercises, and the live performances of actress Miranda Redpath, the Primer teaches Nell literacy, strategy, self-defense, and independence. Hackworth is blackmailed by Dr. X into helping the Celestial Kingdom develop decentralized Seed technology, while Nell escapes abuse, finds protectors, and eventually attends an elite academy. The girls educated by related Primers do not all follow the same path: their books cultivate rebellion as much as conformity. Amid a violent Chinese uprising, Nell becomes leader of the Mouse Army, an immense body of girls raised through the Primer system. She then enters the Drummers' underwater realm and rescues Miranda, finally meeting the woman whose voice helped raise her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3122,7 +3122,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3135,7 +3135,7 @@
       "recaps": {
         "ending": "Aircraft attack the Washington estate after its location is finally discovered. Braddock Washington attempts to bargain with God by offering an enormous diamond, but no rescue follows. The mountain, palace, and most of the family fortune are destroyed, and Braddock and his wife do not escape. John flees with Kismine and Jasmine. Believing that Kismine has saved valuable jewels, he imagines that they can rebuild their lives, only to learn that the stones she brought are rhinestones; she assumed the imitation gems were rarer because real diamonds were commonplace at home. The survivors are left with almost nothing. John nevertheless chooses a future with Kismine, and the three young people set out toward Hades, Mississippi, confronting ordinary poverty for the first time.",
         "in_short": "John T. Unger accepts schoolmate Percy Washington's invitation to a hidden Montana estate and discovers a palace built above a mountain-sized diamond. The Washingtons preserve their fortune by keeping the location secret, imprisoning accidental discoverers and killing guests once their visits end. John falls in love with Percy's sister Kismine, who warns him that he too is scheduled to die. Before the family can act, aircraft locate and attack the estate. Braddock Washington's attempt to buy divine protection with a giant diamond fails, and the mountain and palace are destroyed. John escapes with Kismine and her sister Jasmine. The jewels Kismine saves prove to be worthless rhinestones, so the three leave with no fortune, intending to seek refuge with John's family in Hades.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3232,7 +3232,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3245,7 +3245,7 @@
       "recaps": {
         "ending": "After the expulsion from Eden, Adam and Eve build a shared life marked by work, children, disagreement, and increasing mutual understanding. Eve comes to see that her attachment to Adam is not based on his accomplishments or on a rational comparison with anyone else; she loves him as the person to whom her life is joined. Adam, who began by fleeing her conversation and resenting her changes to his world, recognizes over the years that she brought warmth, beauty, and meaning into it. The collection closes after Eve's death. At her grave, Adam sums up what their long life has taught him: wherever she was, that place was Eden. The final note transforms the earlier comedy of incompatibility into a reflection on companionship, mortality, and a love understood fully only after decades together.",
         "in_short": "Mark Twain retells the beginning of Genesis through the private observations of Adam and Eve. Adam values quiet, labels the newcomer an unsettling experiment, and records Eden with dry practicality. Eve is curious, verbal, eager to name creation, and determined to understand both the world and Adam. Their incompatible viewpoints turn first meetings, animal discoveries, the forbidden fruit, and early parenthood into misunderstandings. Exile introduces hardship and death, but also gives their relationship room to deepen. Eve's account explains her wonder, loneliness, and unconditional attachment to Adam; Adam's notes gradually reveal affection beneath his complaints. They raise a family and grow old together. After Eve dies, Adam stands at her grave and realizes that her presence, rather than any location, made a place paradise for him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3369,7 +3369,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3382,7 +3382,7 @@
       "recaps": {
         "ending": "The Basset Hounds' increasingly conspicuous pranks bring administrative scrutiny, and the fiction that Alpha devised them can no longer hold. Frankie admits that she used the society's neglected email account to issue the orders and that the boys carried them out without knowing who was directing them. The confession proves that she understood and manipulated Alabaster's male power structure, but it does not win the recognition she wanted. Matthew is disturbed less by the pranks than by Frankie's secrecy and capacity for control; he cannot reconcile the mastermind with the girlfriend he thought he knew, and their relationship ends. The school punishes Frankie but stops short of permanently removing her, while the boys and their traditions largely survive. Her accomplishments are publicly reduced to misconduct even as the pranks enter school legend. Frankie remains isolated and marked by the episode, but she does not surrender her understanding of how authority works or become willing to make herself smaller for others' comfort.",
         "in_short": "Fifteen-year-old Frankie Landau-Banks returns to Alabaster Preparatory Academy newly confident and begins dating popular senior Matthew Livingston. She discovers that Matthew and his friends belong to the Loyal Order of the Basset Hounds, a secret all-male society tied to generations of privileged alumni. Angry at being patronized and excluded, Frankie studies the society and gains access to its dormant email account. Posing as its leader, Alpha, she anonymously directs the boys through a series of witty, increasingly public pranks that challenge school rules and prove how easily authority can be performed. The boys follow her plans while assuming a male mastermind is responsible. When scrutiny exposes contradictions, Frankie confesses. Matthew cannot accept the person behind the campaign, the relationship ends, and the school disciplines her while leaving much of the male institution intact. Frankie loses social security but keeps the knowledge that she was capable of reshaping Alabaster's mythology herself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3597,7 +3597,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3610,7 +3610,7 @@
       "recaps": {
         "ending": "In the Empyrean, Dante sees the blessed arranged as a vast celestial rose, with angels moving between them and the divine light. Beatrice has returned to her own place among the blessed, and Bernard of Clairvaux becomes Dante's final guide. Bernard identifies the order of the rose and directs Dante toward Mary, then prays that the pilgrim may receive the grace necessary for the last vision. Dante's sight passes beyond ordinary perception into direct contemplation of God. He apprehends the unity that holds all created reality together and perceives three equal circles as an image of the Trinity. Within that mystery he glimpses the joining of human and divine nature, but rational effort cannot complete his understanding. Illumination resolves the desire at the instant language and memory fail. The poem ends with Dante's will and desire brought into harmony with the divine love that moves the whole cosmos; he has completed the journey from confusion and fear to ordered freedom and vision.",
         "in_short": "Lost in a dark wood, Dante is rescued by the Roman poet Virgil, sent by Beatrice. They descend through Hell, where punishments reveal souls fixed in the choices they made: appetite, violence, fraud, and betrayal culminate in Lucifer frozen at the center with Judas, Brutus, and Cassius. The travelers emerge beneath the southern stars and climb Purgatory. Dante passes terraces that cleanse the seven root sins while learning that disordered love causes wrongdoing. Statius joins them; Virgil departs in the earthly paradise, where Beatrice confronts Dante and completes his preparation. Guided by her, Dante rises through the heavens, meeting blessed souls who explain freedom, justice, empire, theology, and providence. His ancestor Cacciaguida predicts his exile and commands him to tell the truth about the journey. In the Empyrean, Bernard replaces Beatrice and prays through Mary for Dante. Dante finally perceives the unity of creation, the Trinity, and the union of humanity with divinity, and his own desire becomes aligned with divine love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3825,7 +3825,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3838,7 +3838,7 @@
       "recaps": {
         "ending": "In the Empyrean, the blessed appear as a vast white rose surrounding the divine light. Bernard of Clairvaux has replaced Beatrice as Dante's immediate guide; Dante looks to Beatrice in her distant seat and thanks her for leading him to salvation. Bernard explains the rose's order, then prays to the Virgin Mary for grace strong enough to let a living man behold God. Mary grants the request. Dante's sight passes beyond ordinary perception and enters a vision he cannot fully preserve in memory or express in language. He perceives the unity of all created reality in God, then three coequal circles signifying the Trinity. Within the second circle he glimpses the mystery of human nature joined to the divine in Christ. His intellect cannot solve how the images relate, but a final illumination completes what reasoning cannot. At that point desire and will move in perfect harmony with the divine love that orders the universe. The poem ends not with Dante returning to earth in narrated action, but with his will aligned to that cosmic order and his pilgrimage reaching its intended vision.",
         "in_short": "After passing through Hell and climbing Purgatory, Dante rises through Heaven under Beatrice's guidance. Blessed souls appear in the spheres of the Moon, Mercury, Venus, the Sun, Mars, Jupiter, and Saturn to teach him about vows, providence, political order, love, wisdom, sacrifice, justice, and contemplation. Among them are Piccarda, Justinian, Thomas Aquinas, Bonaventure, and Dante's ancestor Cacciaguida, who foretells Dante's exile and charges him to report what he has seen. In the fixed stars, Dante witnesses the triumph of Christ and is examined on faith, hope, and love. After Beatrice condemns corruption and explains the angelic order, they enter the Empyrean. There the blessed form a celestial rose. Bernard becomes Dante's final guide and asks the Virgin Mary to strengthen his vision. Dante beholds the unity of creation in God, perceives the Trinity and the mystery of the Incarnation, and receives a final illumination. His desire and will become fully aligned with the divine love that moves the cosmos.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4076,7 +4076,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4089,7 +4089,7 @@
       "recaps": {
         "ending": "In the earthly paradise, Dante confesses his failure to remain faithful to the good represented by Beatrice and is washed in Lethe, removing the memory of sin. He can then perceive Beatrice's unveiled beauty. The symbolic procession gathers around the tree of knowledge, where a sequence of attacks and transformations shows the Church endangered by persecution, corruption, and political entanglement. Beatrice promises that divine justice will correct this disorder and instructs Dante to report what he has seen. She questions him about the loss of Eden's original order and explains the special properties of its waters. The woman who met Dante by the stream, now called Matelda, leads him to drink from Eunoë, restoring his memory of good deeds. Purified and renewed, Dante is ready to rise from the earthly paradise into Heaven with Beatrice, while Virgil's role in the journey has ended.",
         "in_short": "After escaping Hell, Dante and Virgil reach Mount Purgatory, where repentant souls willingly undergo purification. Cato admits them, and in Ante-Purgatory Dante meets souls whose repentance was delayed, including Manfred, Belacqua, and those killed violently. An angel marks Dante with seven letters representing the capital sins. As he climbs the seven terraces, examples, prayers, punishments, and angelic blessings correct pride, envy, wrath, sloth, avarice, gluttony, and lust; one mark disappears after each terrace. The Roman poet Statius completes his own purification and joins the travelers. Beyond the purging fire, Virgil declares Dante's will free and sound, then yields his authority. In Eden an unnamed woman explains the garden, and a symbolic procession brings Beatrice. Virgil vanishes. Beatrice requires Dante to confess how he strayed after her death; washed first in Lethe and finally in Eunoë, he loses the memory of sin and regains the memory of good. Fully cleansed, he is ready to ascend to Heaven.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4296,7 +4296,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4309,7 +4309,7 @@
       "recaps": {
         "ending": "At Knowles' End, with Solomon's Comet overhead, Hobbes prepares the eleventh offering with Evie as its subject. Holding the Brethren's pentacle, she uses the one thing he cannot control, her gift, reading him and forcing his own history and his own dead back onto him while Jericho's unnatural strength keeps him from finishing the rite. Hobbes is destroyed and the house burns. Evie survives, and rather than retreat she steps out publicly as New York's celebrated Diviner, which puts her at odds with her uncle, who wanted her hidden. Sam stays in the city, still hunting the mother who disappeared into a government programme. Jericho's dependence on the serum that keeps him alive is now known to Evie and unresolved. Theta's fire and the husband she fled remain secrets from nearly everyone, and her romance with Memphis is still hidden. Memphis regains his healing gift by pulling Isaiah out of a collapse brought on by Sister Walker's tests, but Isaiah's visions are worsening and Octavia's opposition hardens. In private, Will and Sister Walker acknowledge that they share responsibility for something called Project Buffalo, that the number of young Diviners appearing across the country is no accident, and that Naughty John was not the storm but the first sign of it. In a vision, a lean man in a stovepipe hat, followed by crows, stands waiting.",
         "in_short": "New York, 1926. Seventeen-year-old Evie O'Neill, who can read a person's secrets by handling their belongings, is exiled from small-town Ohio to live with her uncle Will, curator of a Manhattan museum of folklore and the occult. When the police ask Will to consult on a ritual murder, Evie attaches herself to the case and secretly reads the victims' possessions. The killer is the returned spirit of John Hobbes, a hanged nineteenth-century cult leader working through eleven prescribed offerings so that a beast will rise when a comet passes over the city. Evie chases the case with the pickpocket Sam Lloyd, her uncle's assistant Jericho, and her friend Mabel, while other young New Yorkers discover gifts of their own: the Harlem healer Memphis Campbell, his visionary brother Isaiah, and the showgirl Theta Knight, who can call fire. Evie becomes a public sensation as a Diviner, is taken as the intended eleventh offering, and destroys Hobbes at his burned-out house. The victory is a local one; her uncle and Sister Walker know that a far larger reckoning is coming.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4482,7 +4482,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4495,7 +4495,7 @@
       "recaps": {
         "ending": "Golyadkin receives what he takes to be a secret invitation from Klara and waits outside her family's house, imagining that he will rescue her. Instead, the double leads him inside before a large, solemn gathering. Doctor Rutenspitz arrives, and the assembled guests treat his arrival as a settled decision. Golyadkin is placed in a carriage with the doctor while his double runs beside it in triumph. As they travel into darkness, the doctor's manner becomes terrifying to him and he is told that he will be housed, warmed, fed, and kept at government expense. Golyadkin understands that he is being taken into institutional care and that the identity and social position he tried to defend are lost. The story does not establish the double as an independently verifiable supernatural being; its events remain bound to Golyadkin's disintegrating perception.",
         "in_short": "Minor clerk Yakov Golyadkin longs for social recognition but cannot manage ordinary contact without suspicion and shame. After forcing his way into a superior's family celebration and being expelled, he encounters a man identical to himself. The newcomer, also named Golyadkin, first asks for help, then wins favor at the office through charm and submission while mocking and displacing the original. Golyadkin Senior attempts letters, confrontations, and appeals to authority, but his language and behavior grow increasingly incoherent. He imagines that Klara Olsufyevna has asked him to rescue her, waits outside her house, and is ushered before a crowd by the triumphant double. Doctor Rutenspitz takes him away in a carriage to an institution. Whether the double has any existence outside Golyadkin's fractured mind remains unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-dragon-reborn.json
+++ b/data/works-community/0/the-dragon-reborn.json
@@ -115,7 +115,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -128,7 +128,7 @@
       "recaps": {
         "ending": "At the Stone of Tear the trap set for the Dragon Reborn is sprung and turned. As Aiel warriors take the fortress that prophecy said could never fall until the People of the Dragon came, Rand fights his way to the crystal sword Callandor and draws it from its centuries-old resting place, an act only the true Dragon Reborn could perform. Moiraine arrives in time to destroy the waiting Forsaken Be'lal with balefire, and Rand confronts and kills the fiery-eyed being who has haunted his dreams from the beginning, discovering as the enemy dies that he was never the Dark One but Ishamael, one of the Forsaken. Rand now holds Callandor, among the most powerful objects ever made, and the ancient Stone of Tear itself, and can no longer doubt what he is. Mat has been drawn back into events and freed of the dagger's poison; Perrin, deeper into his bond with the wolves, has grown close to Faile; and Egwene, Nynaeve, and Elayne have struck a blow against the Black Ajah, though many of the traitors escape to work further harm. The world will soon learn that the Dragon has come to Tear, and Rand must decide what to do with the power he has seized.",
         "in_short": "Tormented by dreams and terrified of the madness that comes for men who channel, Rand slips away alone, drawn toward the great fortress-city of Tear and the crystal sword Callandor, which prophecy says only the Dragon Reborn can wield. Moiraine, Lan, Perrin, and Loial pursue him, joined by a bold young Hunter of the Horn named Faile. Mat, saved from the dagger's poison by the Aes Sedai, escapes the White Tower and races south carrying warnings, while Egwene, Nynaeve, and Elayne hunt the Black Ajah, Aes Sedai secretly sworn to the Shadow, who have fled to Tear with stolen treasures. All their paths converge on the Stone of Tear, where Forsaken lie in wait to trap the Dragon Reborn. As Aiel warriors storm the fortress that legend said could never fall, Rand fights his way to Callandor and takes it up, Moiraine destroys one waiting Forsaken, and Rand kills the fiery-eyed Ba'alzamon at last, learning as the enemy dies that this ancient tormentor was the Forsaken Ishamael all along.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -294,7 +294,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -307,7 +307,7 @@
       "recaps": {
         "ending": "Rin's fire wins the battle of Arlong for the Dragon Republic, and the Republic disposes of her as soon as the Imperial fleet is beaten. Vaisra's terms with the Hesperians never included a shaman, and never included a southern province with a voice in the new state; Rin is handed to Sister Petra to be confined and examined as a madwoman. Nezha sides with his father, fights her when she breaks out, and Rin loses her left hand getting clear. She escapes Arlong with Kitay, now permanently bound to her as her anchor and certain to die if she does, with Venka and the last of the Cike, and with Su Daji, whom she frees from the Republic's cells in exchange for the truth about what the Empress and Rin's vanished master Jiang once were. The Dragon Republic survives, recognised and armed by the Hesperians, with Vaisra ruling and Nezha his heir, and with a foreign power now established inside Nikan. Rin goes south to the province she was born in with no army, no legitimacy and no allies, intending to raise one out of the people both the Empire and the Republic have always spent.",
         "in_short": "A year after ending the war by destroying the Federation's homeland, Rin commands the remains of the Cike as opium-dependent mercenaries, intent on killing Empress Su Daji. The attempt fails: Daji is a shaman whose power works on the mind, and Rin is left captured and unable to reach her god. Pulled out by the Dragon Province, she is recruited by Warlord Yin Vaisra, who declares the Dragon Republic with Hesperian backing and marches on the capital. The campaign is broken at the Red Cliffs by the loosed wind shaman Feylen, who destroys the Republic's fleet and kills Vaisra's heir. Bound at last to an anchor - Kitay, whose life is now tied to hers - Rin recovers her fire and wins the decisive battle at Arlong, and is betrayed the moment it ends: the Hesperians' price for recognising the Republic is Rin herself, and Vaisra pays it. Maimed in her escape, she gets away with Kitay and the captive Daji and turns south to raise an army from the peasants both sides have always ignored.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -430,7 +430,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -443,7 +443,7 @@
       "recaps": {
         "ending": "The narrator wakes before the loaded revolver, convinced that his dream has shown him a truth worth living for: people can love one another without waiting for a perfect social system or a complete theory of life. He abandons his suicide plan and resolves to speak about what he saw, even though he expects ridicule and admits that he cannot express the vision perfectly. Others may say that the dream was merely delirium, but its moral force matters more to him than proving its literal reality. He also understands that corruption need not be humanity's final state. His first practical concern is the child he rejected in the street, and he goes to find her, turning his new conviction toward an immediate act of care.",
         "in_short": "An unnamed man has concluded that existence is meaningless and plans to shoot himself. On the chosen night, he refuses a little girl's plea for help, but the guilt he feels undermines his claim that nothing matters. He falls asleep and dreams that he kills himself, is buried, and is carried by a mysterious guide to an unfallen version of Earth. Its people live innocently and harmoniously until the visitor somehow introduces falsehood; jealousy, ownership, violence, institutions, and suffering follow. Unable to restore them, he begs to be punished and wakes beside his revolver. The vision has replaced despair with a conviction that people can create paradise by loving one another. He chooses life, begins preaching that truth despite mockery, and searches for the child he turned away.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -551,7 +551,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -564,7 +564,7 @@
       "recaps": {
         "ending": "During the May Eve rite, Gilman resists Keziah and strangles her with the chain of Mazurewicz's crucifix, but Brown Jenkin kills the kidnapped child before escaping. Gilman returns to his room physically shaken and unable to prove the full experience. Soon afterward, Brown Jenkin attacks him in bed and burrows through his body, killing him while Elwood and the other residents hear the struggle. The Witch House is eventually abandoned and later damaged by a storm. When it is demolished, workers discover Keziah's bones, the remains of many sacrificed children, occult objects, and the skeleton of a creature whose anatomy matches the legends of Brown Jenkin. Those findings confirm that material evidence lay behind at least part of Gilman's supposedly fevered experiences, even though the dimensional reaches he witnessed remain beyond ordinary explanation.",
         "in_short": "Miskatonic University student Walter Gilman rents an attic in Arkham's Witch House, hoping its abnormal geometry will support his theories about dimensions. Fever dreams carry him through angular voids while the long-vanished witch Keziah Mason and her ratlike familiar Brown Jenkin draw closer. Physical marks and an object brought back from another world convince him that the journeys are not merely dreams. Keziah and a figure called the Black Man force him toward a supernatural pact and prepare him for a May Eve child sacrifice. Protected by a crucifix, Gilman fights back and kills Keziah, but Brown Jenkin murders the child and escapes. Days later the familiar kills Gilman by tearing through his body. When the decaying house is finally demolished, workers find Keziah's remains, evidence of numerous child sacrifices, occult objects, and Brown Jenkin's inhuman skeleton, confirming the physical core of the horrors Gilman experienced.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -705,7 +705,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -718,7 +718,7 @@
       "recaps": {
         "ending": "The impossible DNA hit is explained by kinship rather than laboratory error. Clayton Pell did not kill Lily Price as a child; the biological material belongs to his father, Chilton Hardy, whose violence extends beyond the single 1989 case. Bosch's investigation identifies Hardy as Lily's killer and exposes a predatory history that had remained hidden behind disconnected victims and an unknown family relationship. Pell is forced to confront the fact that the same man responsible for his origin and inherited DNA is also the murderer the sample was pointing toward. In the parallel inquiry, Bosch determines that George Irving went to the Chateau Marmont intending to end his own life; the evidence does not support the politically useful homicide theory promoted around his fall. Irvin Irving responds to an answer he does not want by using his influence against Bosch rather than accepting the limits of the evidence. David Chu's disclosure of protected case information breaks Bosch's trust and damages their partnership. Bosch nevertheless retains a defined period in the department's retirement program, giving him a little more than three years before he must leave. He ends with Maddie at home and a visible clock on the police work he still considers unfinished.",
         "in_short": "Working in Open-Unsolved with David Chu, Bosch receives a DNA match in the 1989 murder of Lily Price, but the donor, convicted offender Clayton Pell, was eight when she died. The anomaly leads through Pell's family history and psychologist Hannah Stone to his biological father, Chilton Hardy, whom Bosch identifies as Lily's killer and a long-hidden predator. At the same time, city councilman and former police official Irvin Irving demands that Bosch investigate the hotel fall that killed his son George. Political pressure favors a murder finding, but Bosch concludes that George took his own life. Irving turns the unwelcome result against Bosch, while Chu's leak of confidential information destroys trust between the partners. Bosch's own deadline is clarified when he is placed in the department's retirement-option program with a little more than three years left to serve. Still raising Maddie after Eleanor's death, he closes the cases knowing exactly how limited his remaining time as an LAPD detective has become.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -868,7 +868,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -881,7 +881,7 @@
       "recaps": {
         "ending": "On the night Cousin Marv's holds the neighborhood's criminal drop money, Eric Deeds keeps Nadia under threat and goes to the bar to take the cash. Bob refuses to be intimidated and shoots him. In explaining the aftermath, Bob reveals the capacity for violence that his mild exterior has hidden, including his responsibility for Richie Whelan's long-ago death. The Chechen owners accept Bob's handling of the immediate threat and dispose of Deeds's body; Marv, whose attempt to steal the drop created the crisis, is killed before he can escape the consequences. Bob is left running the bar under its true owners rather than under Marv's pretended authority. Detective Torres understands that the neighborhood's old mysteries and its present violence reach further than he can prove. Bob visits Nadia after a period of uncertainty, and she agrees to walk with him and Rocco, leaving him with the possibility of companionship despite what she now knows about him.",
         "in_short": "Bob Saginowski tends bar for his cousin Marv at a Boston tavern secretly owned by Chechen criminals. After rescuing an abused pit-bull puppy from Nadia Dunn's trash, Bob begins a cautious friendship with her, only to draw the attention of her threatening former boyfriend, Eric Deeds. Armed men rob the bar while it is holding criminal cash, and the owners demand repayment. As Deeds presses his claim to the dog and frightens Nadia, Bob's quiet life becomes entangled with Marv's desperate effort to recover status and money. Marv has helped arrange a larger theft for the night the bar serves as the neighborhood's cash drop, using Deeds as the robber. Deeds takes Nadia hostage, but Bob shoots him at the bar and reveals that his harmless appearance has long concealed lethal violence, including his role in Richie Whelan's disappearance. The Chechens remove Deeds and kill Marv. Bob remains at the bar and, after uncertainty, begins to reconnect with Nadia.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1041,7 +1041,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1054,7 +1054,7 @@
       "recaps": {
         "ending": "Falk and Raco discover that Karen had noticed money missing from a school grant and had been gathering records about it. Headmaster Scott Whitlam, whose gambling losses led him to steal the funds, killed Karen and Billy to prevent exposure; Luke arrived during the crime and was also shot, allowing Whitlam to stage the scene as a family murder-suicide. When confronted, Whitlam flees into the tinder-dry bush and starts a fire, but Falk and Raco survive and the Hadler family is cleared of the accusation against Luke. The older mystery is also resolved. Ellie had meant to flee her abusive home, but her father Mal found her at the river and drowned her. Falk leaves Kiewarra with Luke's name publicly restored and a private understanding of Ellie's fate, although the losses themselves cannot be repaired.",
         "in_short": "Federal investigator Aaron Falk returns to drought-ravaged Kiewarra for the funeral of his childhood friend Luke Hadler, who appears to have killed his wife Karen and son Billy before taking his own life. Luke's parents persuade Falk to look closer, and local sergeant Greg Raco helps him test inconsistencies in the evidence. Their inquiry revives the death of Falk's teenage friend Ellie Deacon, for which the town long blamed Falk. The Hadler killings prove unrelated to Luke's character: school headmaster Scott Whitlam murdered the family after Karen discovered he was stealing grant money to cover gambling debts. Falk and Raco expose him after a dangerous confrontation in the dry bush. Falk also learns that Ellie's abusive father Mal killed her when she tried to run away. He leaves town having cleared Luke and finally understood the tragedy that forced his own family from Kiewarra.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1185,7 +1185,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1198,7 +1198,7 @@
       "recaps": {
         "ending": "Bianca's attempt to date Toby confirms that choosing the person who looks right on paper cannot replace emotional honesty. She ends that relationship rather than continue using it as a refuge from her feelings. She also repairs her friendship with Casey and Jessica by admitting how deeply Wesley's label affected her and by accepting that neither friend regards her as inferior. Bianca comes to understand that almost everyone sometimes feels like the least desirable person in a group, so the label has power only when treated as a fixed identity. After confronting Wesley about their mutual feelings and his fear of commitment, she reconciles with him, and they begin a genuine relationship rather than returning to their secret arrangement. Her parents' marriage still ends, but Bianca and her father start confronting that loss without concealment, and his relapse no longer remains hers alone to manage.",
         "in_short": "High-school senior Bianca Piper is hurt when popular Wesley Rush calls her the least attractive member of her friend group. Family stress and her fear that he may be right lead her into a secret sexual relationship with him, which she uses to escape thoughts of her parents' failing marriage. As Bianca learns about Wesley's own neglected family life, contempt gives way to attachment, but she ends the arrangement when those feelings become undeniable. She tries dating her longtime crush Toby and discovers that an idealized match is not necessarily an intimate one. Bianca also withdraws from her best friends, Casey and Jessica, until she admits the insecurity and shame behind her behavior. She comes to see the insulting label as a feeling nearly everyone experiences rather than an objective rank. Bianca and Wesley acknowledge that they care for each other and begin a real relationship, while Bianca starts facing her parents' divorce and her father's relapse with greater honesty and support.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1359,7 +1359,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1370,7 +1370,7 @@
       "recaps": {
         "ending": "The book ends with the fourth floor's collapse averted at the last possible hour. Carl's plan works: coordinated with Prepotente and Miriam Dom on the far side of the subway network, the crawlers blow every ghoul generator at once, stopping the undead flood and saving the survivors massed at the exits. Before that, the trainyard battle nearly kills Carl, caught between a station mimic and the summoned war god Grull; Grull destroys the mimic, and Carl's allies drive the god into the Abyss. The party says goodbye to the NPC train crew they befriended, and Agatha, the strange old woman from the first floor, resurfaces briefly. Carl closes the floor with a promise to break the people running the game. In the epilogue, the team learns Zev has been taken away for re-education over her sympathy for the crawlers, replaced by the hostile liaison Loita; on Odette's show Carl publicly confronts Odette over her role in Hekla's story, and a warning about the murderous crawler Chris is censored before it can air. Donut chooses which sector of the fifth floor the party will enter. Katia stands among the top crawlers alive, the Cookbook rides in Carl's inventory with his own additions, and the party descends carrying more fame, more enemies, and the first real seeds of organized resistance.",
         "in_short": "The fourth floor is the Iron Tangle, an endless lethal subway network. Carl, Donut, Katia, and Mongo earn a shared personal space, and a prize machine gives Carl the Dungeon Anarchist's Cookbook, a living manual of sabotage written by past crawlers, while locking Mordecai out for a critical week. The party deciphers the trains' looping geography with help from NPC crew members and allies like Elle, Imani, and Bautista, as a system-wide plague of festering ghouls begins overwhelming the lines. Hekla's Daughters arrive seeking help rescuing a thousand stranded crawlers; the mission succeeds, but Eva's cruelty drives Katia to accidentally kill Hekla, who survives only through Donut's resurrection spell, exposing Hekla's plan to poach Donut. Frank Q gives Carl a dying warning about Maggie My before being killed by Chris. Carl maps the Tangle's true shape, organizes mass evacuations through the trainyards, survives a battle where the war god Grull is summoned and banished to the Abyss, and coordinates the simultaneous destruction of every ghoul generator, saving the surviving crawlers. Zev is taken for re-education, and Donut picks the party's sector for the fifth floor.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1524,7 +1524,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1537,7 +1537,7 @@
       "recaps": {
         "ending": "Armitage, Rice, and Morgan follow the invisible Horror to Sentinel Hill carrying a powder that can briefly make it visible and an incantation derived from Wilbur's diary. The powder reveals an immense, many-limbed organism whose partly human features connect it to the Whateleys. From a distance, Dunwich observers watch the professors perform the rite and hear the creature call to Yog-Sothoth for help. The spell destroys or banishes it with a tremendous shock. The final discovery explains the Whateley mystery: Lavinia gave birth to twins fathered by Yog-Sothoth. Wilbur was the more human child, while Old Whateley concealed and fed the rapidly growing second child inside the farmhouse. That twin became the Dunwich Horror after escaping. The countryside survives because Armitage understood Wilbur's plans in time, though the beings Wilbur hoped to admit from outside ordinary reality remain a wider possibility.",
         "in_short": "In isolated Dunwich, Lavinia Whateley bears twins fathered by the entity Yog-Sothoth. One is the unnaturally fast-growing Wilbur; the other, far less human, is hidden inside the family farmhouse by their sorcerous grandfather. Wilbur seeks a complete Necronomicon to perform a rite that would open the world to outside beings. After Miskatonic librarian Henry Armitage refuses him access, Wilbur breaks into the library and is killed by its guard dog. Armitage deciphers his diary and learns of the threat. The hidden twin then escapes, an invisible giant that devastates farms and kills families around Dunwich. Armitage and professors Warren Rice and Francis Morgan track it to Sentinel Hill, expose its shape with a chemical powder, and destroy it with an incantation. Only then do the witnesses understand that the Horror was Wilbur's brother, and the child who looked more like their otherworldly father.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1697,7 +1697,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1710,7 +1710,7 @@
       "recaps": {
         "ending": "In the final case, Dupin recognizes that Minister D— has defeated the police by anticipating their painstaking search and making the stolen letter look unimportant. During a social visit, Dupin spots a damaged and altered letter displayed openly in the minister's rooms. He returns with a duplicate, arranges a disturbance outside, and exchanges the two. Dupin later gives the genuine letter to Prefect G— in return for the promised reward. The Prefect can now restore it to the royal owner, ending the minister's power over her. Dupin has left a pointed message inside the substitute so that D— will know who outwitted him when he next tries to use the document. The collection therefore closes with Dupin solving a crime through the same imaginative identification that guided the earlier cases: he succeeds by reasoning from another mind rather than merely searching harder.",
         "in_short": "Auguste Dupin, an impoverished Parisian scholar, solves three mysteries narrated by his housemate. In the Rue Morgue case, two women appear to have been murdered in a locked room by an impossible assailant; Dupin follows evidence of inhuman strength and an unmatched voice to a sailor's escaped orangutan, clearing the man wrongly arrested. He next analyzes conflicting newspaper accounts of Marie Rogêt's death, stripping away rumors and arguing that one man, rather than a gang, killed her, though the story does not dramatize an arrest. Finally, a minister steals a sensitive royal letter and defeats repeated police searches. Dupin realizes the minister would hide it in plain sight, identifies the disguised paper in his rooms, and secretly replaces it with a copy. He returns the original to the Prefect for a reward, ending the minister's hold over its owner and proving that imaginative reasoning can succeed where routine investigation fails.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1862,7 +1862,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1875,7 +1875,7 @@
       "recaps": {
         "ending": "Elna's return eventually gives Maeve a relationship with the mother she had mourned and resented, while Danny remains more guarded. Elna and Maeve devote themselves to helping others, turning away from the wealth and status represented by the Dutch House. Danny's marriage to Celeste survives but bears the cost of his preference for Maeve's company and his long fixation on the past. After Maeve dies, Danny loses the person through whom he has understood nearly every part of his life. He later returns to the Dutch House with his daughter May and encounters Andrea in severe decline; Andrea mistakes May for the young Maeve, briefly collapsing the generations the house has held. May ultimately buys the property with money from her acting career. The house returns to the family, but not as a restoration of Danny's childhood. It belongs to a new generation able to inhabit it without sharing Maeve and Danny's exile, and Danny can finally see it as a place whose ownership no longer governs his life.",
         "in_short": "Danny Conroy and his older sister Maeve grow up in the grand Dutch House near Philadelphia. Their mother Elna leaves to serve the poor, their emotionally distant father Cyril remarries, and his new wife Andrea becomes devoted to the house while resenting the children. After Cyril dies, Andrea expels Maeve and Danny. An education trust funds Danny's training as a doctor, though he prefers the real-estate work he learned from his father. For decades the siblings sit in a car outside their former home, turning dispossession into the central story of their lives. Danny marries Celeste and has children, but Maeve remains his closest relationship. Elna eventually returns, and Maeve overcomes her anger enough to join her in service. Maeve's death forces Danny to live without the person who organized his memories and loyalties. Years later his daughter May, now a successful actor, buys the Dutch House. Its return to the family belongs to her future rather than to Danny's effort to recover the past.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2077,7 +2077,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2090,7 +2090,7 @@
       "recaps": {
         "ending": "Skulduggery's allies recover Valkyrie and ultimately separate her from Darquesse, but Stephanie is killed in the struggle and Darquesse continues in a body of her own. Billy-Ray Sanguine dies protecting Tanith, and the Remnant is removed from her, restoring Tanith to herself. Erskine Ravel dies under the accelerated punishment Darquesse placed on him. Darquesse attacks Valkyrie's family and kills Alice, but Valkyrie recovers her sister's damaged soul and revives her; Alice will need years to become whole. The final plan exploits Darquesse's desire for a worthy challenge. A portal is opened to the Faceless Ones' dimension, Darquesse enters to fight them, and the portal is closed behind her. The world survives and China becomes Supreme Mage of the rebuilt Sanctuary order. Nefarian Serpine from the parallel world remains stranded in this reality. Grieving Stephanie, Sanguine and the wider destruction, Valkyrie leaves Ireland to recover, ending her partnership with Skulduggery for the time being while Alice lives and Darquesse remains beyond the closed portal.",
         "in_short": "With Darquesse controlling Valkyrie's body, Skulduggery gathers the surviving Dead Men and their allies to recover Valkyrie and prevent the foretold destruction. Their search takes them back to Mevolent's dimension for a God-Killer weapon and brings that world's Nefarian Serpine into their reality. Stephanie confronts Darquesse and is killed, but the struggle helps Valkyrie return and Darquesse becomes physically separate. Darquesse grows stronger, kills Ravel and attacks the Edgley family, killing Alice; Valkyrie retrieves Alice's damaged soul and revives her. Elsewhere Billy-Ray Sanguine dies saving Tanith, whose Remnant possession is finally ended. Unable to defeat Darquesse directly, Skulduggery's side lures her through a portal to the Faceless Ones' dimension by offering opponents powerful enough to interest her, then closes the way. China becomes Supreme Mage as the magical world rebuilds. Valkyrie, burdened by the deaths and by Alice's incomplete recovery, leaves Ireland and Skulduggery behind.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2271,7 +2271,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2284,7 +2284,7 @@
       "recaps": {
         "ending": "The American assault destroys Steiner's force in and around the church, but the surviving Germans continue long enough to give Steiner a chance to reach the house where Churchill is believed to be staying. Devlin escapes the collapse of the operation and gets away from England, aided by the personal loyalties he has formed. Joanna Grey is exposed and killed, ending the intelligence network that made the landing possible. Steiner penetrates the final security cordon and shoots the man presented as Churchill before guards kill him. The apparent success is hollow: the victim is a stand-in, while the real prime minister is elsewhere. In Germany, Himmler's organization eliminates Radl and suppresses the unauthorized trail, making the planner another casualty of the mission. British authorities likewise conceal the raid and the death of the double. The German paratroopers are buried under misleading names and the episode disappears from the public record, leaving only scattered evidence from which the framing narrator reconstructs what happened.",
         "in_short": "In 1943 German intelligence officer Max Radl develops an audacious plan, encouraged by Himmler, to abduct Winston Churchill during a visit to a Norfolk village. He recruits disgraced paratrooper Kurt Steiner, Irish republican Liam Devlin, and local German agent Joanna Grey. Steiner's men land disguised as Polish troops and initially pass as allies. When one soldier dies saving a child and his German uniform is exposed, the commandos seize the villagers in their church while American Rangers close in. The siege destroys most of the unit, but Steiner breaks away for a final attempt on Churchill. Devlin escapes; Grey is exposed and killed. Steiner reaches the target and fires before being shot, only for the victim to prove a stand-in rather than Churchill himself. Himmler's men kill Radl to erase responsibility, and the British also bury the incident. Decades later, traces of the hidden German graves lead to a reconstruction of the failed raid.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2424,7 +2424,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2437,7 +2437,7 @@
       "recaps": {
         "ending": "Marcus and Esca carry the recovered eagle south while the tribes pursue them. Guern and other survivors of the Ninth make a final stand to delay the chase, giving the two young men time to escape across difficult ground and reach Roman territory. The eagle is returned, but Rome does not publicly restore the disgraced legion: the authorities prefer to keep the circumstances of its loss and recovery quiet. Marcus receives an honourable discharge and enough money to begin a new life. Esca is free and remains his chosen companion rather than his slave. Marcus decides to settle on a farm in Britain, with Cottia as part of the future he now wants. Recovering the standard cannot bring his father or the legion back, but it clears the burden Marcus inherited and allows him to exchange an impossible military ambition for a home of his own.",
         "in_short": "Marcus Flavius Aquila takes command of a frontier fort in Roman Britain, hoping to redeem a family name shadowed by the disappearance of his father's Ninth Legion. A battle leaves him permanently unfit for military service, but at his uncle's home he befriends the British girl Cottia and buys a captive warrior, Esca, whom he later frees. Learning that the Ninth's eagle may survive beyond Hadrian's Wall, Marcus travels north disguised as an oculist, with Esca posing as his servant. They discover that the legion was destroyed in a northern uprising and find its stripped eagle among the Epidaii. Esca takes the standard, and the pair flee through a gathering pursuit. Guern and other survivors of the Ninth sacrifice their safety to help them escape. Marcus returns the eagle to Roman hands, receives an honourable discharge and a reward, and chooses a future in Britain with Cottia and Esca, freed at last from the shame attached to his father's fate.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2604,7 +2604,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2617,7 +2617,7 @@
       "recaps": {
         "ending": "After fleeing Peter's party and spending the night with Duncan, Marian finds that changing men has not resolved her loss of agency or appetite. Duncan refuses the role of rescuer and leaves her to determine what she wants. Back at the apartment, Marian bakes and decorates a cake shaped like a woman. She offers it to Peter, explaining through the gesture that he has been trying to consume an acceptable substitute rather than recognize her as a person. Peter is disturbed and leaves. Marian then eats some of the cake herself, and her ability to eat ordinary food returns. Ainsley interprets the act according to her own theories and is appalled, but Marian no longer needs that interpretation. Ainsley, having rejected Len's sudden insistence on marriage, plans to marry Fish, whose belief in fatherhood suits her revised design for a family. When Duncan arrives, Marian gives him the remains of the cake and he eats them. The first-person voice restored, Marian has not secured a defined future, but she has ended the engagement and reclaimed the capacity to choose and speak for herself.",
         "in_short": "Marian McAlpin works in consumer research and drifts toward the expected future represented by her lawyer boyfriend, Peter. After he proposes, her narration shifts from first to third person and her body begins refusing food: first meat, then eggs, vegetables, and much else. Her roommate Ainsley deliberately becomes pregnant by Len Shank, expecting to raise the child alone, while Marian begins an elusive relationship with Duncan, a graduate student who offers no stable alternative. As Peter organizes Marian's appearance and future, she feels increasingly like an object being selected and consumed. She escapes his party but discovers that Duncan cannot decide her life for her. The next day she bakes a woman-shaped cake and offers it to Peter as the version of her he wants to devour. He leaves; Marian eats the cake and regains her appetite. The engagement ends, Ainsley turns toward marriage with Fish, and Marian's first-person voice returns.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2753,7 +2753,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2766,7 +2766,7 @@
       "recaps": {
         "ending": "April returns to the storage yard alone at night and is attacked by the man responsible for the recent violence against local children. Marshall witnesses the danger and calls to the Professor, whose intervention and evidence bring help and lead to the attacker's arrest. April survives, and Marshall's clear account establishes what happened. The Professor is no longer the frightening suspect imagined by the neighborhood; he has watched the children protectively from his shop and has now saved April. He explains that grief had caused him to withdraw from people. As a Christmas gift, he gives the children keys and permission to use the yard, making their once-secret trespass legitimate. April has accepted Casa Rosada, Caroline, and her friends as a real home rather than a waiting room for life with her mother. With Egypt secure, the children begin wondering what imaginative world they might build next.",
         "in_short": "April Hall reluctantly moves in with her grandmother and hides her insecurity behind glamorous stories about her absent actress mother. She befriends Melanie Ross and Melanie's little brother Marshall. Inspired by a dusty storage yard behind an antique shop, they invent an elaborate Egypt game of altars, ceremonies, and imagined identities, later admitting Elizabeth Chung, Toby Alvillar, and Ken Kamata. Murders in the neighborhood keep the children indoors and make the shop's reclusive owner, known as the Professor, seem suspicious, but they eventually return to their game. Their invented oracle creates both wonder and mistrust. When April enters the yard alone at night, the actual attacker corners her. Marshall calls for the Professor, who helps save her and provides evidence against the criminal. Cleared of suspicion, the Professor gives the children lawful access to the yard. April recognizes that her grandmother and new friends offer the belonging her mother has not, and the group turns toward its next game.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3183,7 +3183,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -3196,7 +3196,7 @@
       "recaps": {
         "ending": "Ruwen returns to Eiru as a Divine apostate able to perceive and alter the Eighth Harmony. Uru's projected sacrifice frees most of the 53,000 fighters from manipulation, exposing the five Aspects hidden among them. Ruwen and the 29 golden warriors destroy the Aspect bearers, but War's allies extract Gundr and the critically wounded Lylan. Lauquinriel then arrives with five deities. Ruwen moves the third temple into the battle, Xavier absorbs their combined attack, Hamma shields the civilians, Rami disrupts the attackers, and Overlord's forces contain the demons. Haffa and Quentin die. Isaac escapes with severe damage, while Noctos and Wenquian also retreat. Lauquinriel gets away carrying Nameless and is probably dead afterward, though this is not confirmed. Hamma tends the surviving Xavier, and Big D helps send the former invaders home. Ruwen commits to political reform and a replacement for the broken Pact. His urgent unresolved tasks are finding Lylan and Gundr, learning whether Sift and the elder star tortoise contained the Black Pyramid explosion, and preventing the imprisoned darkness from escaping.",
         "in_short": "Ruwen Starfield returns to a politically fractured Eiru while his failing soul prison and the divine shard in his mind make revival unsafe. He restrains a merchant-led revolt, rebuilds his backup, reconciles Uru with her shard, and survives a planned death before using Hamma's wishes to become the first Divine apostate. His new perception reveals the Eighth Harmony and greatly expands his Architect authority. Back in Eiru, a manipulated army conceals five Aspects while the Black Pyramid faces catastrophic failure. Ruwen's allies protect the civilians and destroy the Aspects, but War escapes with the wounded Lylan and Gundr. Six deities then attack. Ruwen kills Haffa and Quentin, cripples Isaac, and drives Isaac, Noctos, and Wenquian away, while Lauquinriel escapes with Nameless and may die afterward. The battle ends, but Sift and the elder star tortoise remain missing at the Black Pyramid, Lylan is lost, the Pact is broken, and Eiru must be rebuilt.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3407,7 +3407,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3420,7 +3420,7 @@
       "recaps": {
         "ending": "America's unsanctioned broadcast about dismantling the castes costs her the King's tolerance and, for a time, Maxon's trust; he spends the following weeks with Kriss and Celeste and refuses to reassure her. Rebel violence escalates, Natalie's younger sister is killed, and the household is badly shaken. America finally admits to herself that her hesitation has been fear rather than doubt. She goes to Maxon, tells him she wants him, and asks to stay rather than for an answer she has not earned; he agrees to keep her in the Selection without promising her anything. Five girls remain: America, Kriss, Celeste, Natalie, and Elise. Marlee and Carter, publicly caned and reduced to the lowest caste, are living quietly inside the palace as servants under Maxon's protection, and America knows it. Maxon knows what his father's private histories actually contain, and that the country's founding story is a fabrication. The King is now working openly to have America removed. Aspen, meanwhile, has begun turning his attention to Lucy, one of America's maids, loosening the hold he has had on her. The Selection goes on with America committed to it for the first time.",
         "in_short": "Six girls remain in the Selection. America is the public's favorite and Maxon's, but she cannot choose between him and Aspen, who now serves in the palace guard. When her friend Marlee is caught with a guard, the two are publicly caned and stripped of their castes, and America's faith in the palace collapses. She learns that Maxon is beaten by his own father, and that Illéa's official history is a lie: Gregory Illéa's private journals show that he engineered his rise and built the castes to entrench it. Emboldened, America uses a live broadcast to announce a plan to dismantle the caste system that the King never approved. Her standing collapses, Maxon turns to the other girls, and rebel attacks grow deadlier, killing Natalie's sister. By the end America has decided what she wants: she tells Maxon she is committed to him and asks to stay, and he agrees to give her another chance, with the King now openly working to remove her and Marlee living secretly in the palace as a servant.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3624,7 +3624,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3637,7 +3637,7 @@
       "recaps": {
         "ending": "Ozma learns that the Nome King and his allies are about to enter Oz through their completed tunnel, but she refuses to answer invasion with killing. The Scarecrow devises a defense using the Forbidden Fountain, whose enchanted water removes the drinker's memories. The invaders emerge in the Emerald City, drink, and forget their anger, their identities, and their plan of conquest. Ozma treats them kindly and sends the harmless armies home, with the transformed alliance no longer threatening her people. Glinda then uses magic to make Oz invisible and unreachable to the outside world, preventing future armies or ordinary visitors from finding it. Dorothy, Aunt Em, and Uncle Henry remain secure in the Emerald City as permanent residents. Before communication closes, Dorothy sends one final message explaining that Oz will no longer be open to reports from the outside world.",
         "in_short": "When Uncle Henry's mortgaged Kansas farm is about to be lost, Ozma brings Dorothy, Aunt Em, and Uncle Henry to live permanently in the Emerald City. While the newcomers tour Oz's many curious settlements, the vengeful Nome King orders General Guph to dig beneath the Deadly Desert and recruit the Whimsies, Growleywogs, and Phanfasms for an invasion. Ozma learns of the threat but refuses to fight a deadly battle. Instead, the Scarecrow arranges for the attackers to drink enchanted water from the Forbidden Fountain. They forget their wicked purpose and are sent peacefully home. Glinda then makes Oz invisible and closes it to the outside world. Dorothy and her family remain safely with their friends, while the Nome King's attempt to conquer Oz ends without bloodshed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3761,7 +3761,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3774,7 +3774,7 @@
       "recaps": {
         "ending": "After spending the night moving in circles through the forest, Jones reaches the edge near the point where he entered it. His revolver is empty: successive visions forced him to fire every ordinary round and finally the silver bullet he had reserved for himself. At dawn Lem and his soldiers close in. They have accepted Jones's claim that only silver can kill him strongly enough to melt coins into ammunition, and their gunfire kills him. Lem's men carry the body away. Smithers, who has watched the pursuit, is startled that the apparently superstitious rebels defeated Jones by following the very legend he created to secure his power. The forest escape plan, the hidden supplies, and the mythology that supported his rule all turn against him, and the revolt ends his brief empire.",
         "in_short": "Brutus Jones, an escaped American prisoner who has installed himself as ruler of a Caribbean island, learns from the trader Smithers that his subjects have revolted. Confident in a planned escape route and in the legend that only a silver bullet can kill him, Jones enters the forest. His hidden supplies are gone, the rebels' drum continues through the night, and fear destroys his sense of direction. He encounters visions that move backward through his own violence and a broader racial past: the man he killed, a chain gang, a slave auction, and a ritual sacrifice before a crocodile god. He fires at each terror until even the silver bullet is gone. At dawn he emerges near where he began. Lem's soldiers, having made silver bullets because they believe Jones's legend, shoot him dead. The invented superstition that helped him rule therefore helps his pursuers destroy him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3937,7 +3937,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3950,7 +3950,7 @@
       "recaps": {
         "ending": "Shigeru's Kikori force holds together against Arisaka's Senshi because Horace has given ordinary workers a disciplined formation that can resist individually superior warriors. Will, Halt and their companions add ranged weapons, fieldcraft and tactical changes suited to the enemy's armour. Loyal Senshi join the Emperor, and Arisaka is defeated and killed in the decisive fighting. Shigeru is restored as the acknowledged Emperor rather than becoming a dependent figure protected by foreign visitors. The Kikori have demonstrated courage and military value that the old hierarchy denied them, strengthening Shigeru's effort to govern across class divisions and curb the Senshi's inherited privileges. The surviving Araluens and their allies reunite after the long separation. Horace and Cassandra are open about the bond that drew her across the world to find him, while Will and Alyss remain together after tensions caused by the journey. George's warning and Gundar and Selethen's help have all contributed to the rescue. With the rebellion ended and Shigeru secure, the visitors leave Nihon-Ja for home.",
         "in_short": "Horace and George are visiting Nihon-Ja when the Senshi lord Arisaka rebels against Emperor Shigeru's reforms. Horace stays with the Emperor while George carries warning away. Shigeru, his cousin Shukin and a shrinking band of loyalists flee toward remote country; Shukin dies buying them time. In Araluen, Cassandra, Alyss, Will and Halt organise a rescue, aided on the voyage by Gundar Hardstriker and Selethen. Horace reaches a hidden Kikori community and turns farmers and woodsmen into a disciplined infantry force, adapting the Skandian shield wall so they can withstand heavily trained Senshi. The rescue party eventually joins him and contributes Ranger archery, improvised weapons and wider military experience. In the final battle, Shigeru's mixed force defeats the rebellion and Arisaka is killed. The Emperor returns to power with the Kikori's courage publicly established. Horace and Cassandra acknowledge their love, and the reunited companions begin the journey home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4079,7 +4079,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4092,7 +4092,7 @@
       "recaps": {
         "ending": "Shai finishes the soul stamp within her hundred days and it works: applied to Ashravan, it restores him to himself, and the arbiters keep their emperor, though the stamp will have to be renewed indefinitely for the rest of his life. She has written one deliberate change into him, restoring the drive to leave the empire better than he found it that the real man had abandoned years earlier. Knowing that Frava intends to have her killed once the work is delivered, Shai escapes on her own schedule, recovering the possessions the council confiscated, including the alternate versions of herself she spent years creating, and taking with her the genuine artefact she had been convicted of stealing, leaving the palace holding her forgery of it. Gaotona, who began by calling her a thief, is left with the argument settled against him: among the work she leaves behind is a stamp of her own soul, and it demonstrates plainly that what she does is art. The empire's rulers keep their secret and their emperor, Shai keeps her freedom and her prize, and the two of them part with a mutual respect neither expected.",
         "in_short": "Shai, a Forger who can rewrite an object's history by carving a stamp that reality will accept, is caught in the palace of the Rose Empire after swapping a priceless artefact for a copy of her own making. Forgery is a capital crime there, but before she can be executed the emperor's arbiters offer a bargain: an assassination attempt has left Emperor Ashravan's body intact and his mind gone, and they want her to forge a stamp that will recreate his soul. She has a hundred days, a sealed room and guards who would rather kill her. Working from the imperial records and arguing about art with the elderly arbiter Gaotona, she reconstructs a whole man accurately enough for his own body to accept the result, while quietly preparing her escape. The stamp works and Ashravan is restored, with one change she wrote in deliberately. Shai escapes with her confiscated possessions and the real artefact, leaving Gaotona convinced that Forgery is art rather than fraud.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4285,7 +4285,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4298,7 +4298,7 @@
       "recaps": {
         "ending": "The trilogy closes with Manizheh's defeat. Dara turns on the woman who raised him from the dead rather than carry out the last of what she asks, and Manizheh is killed in the final confrontation for Daevabad. Ali is very nearly killed in it and survives only through marid intervention, which leaves him permanently altered. Nahri, holding the power that three books of characters have fought and murdered to control, declines to keep it: rather than take Suleiman's seal for herself and rule as her ancestors ruled, she ends the arrangement that placed absolute magical authority in one person's hands, and Daevabad's magic returns to the city and to its people. What follows is not a restoration of the Nahid dynasty. Daevabad is left to be governed jointly, with the shafit represented for the first time in its history rather than confined, and with the surviving Qahtanis, Nahri and Jamshid sharing the work of holding it together. Muntadhir survives and is healed at last of the wound that had been killing him. Jamshid takes up the place among the Daeva that his parentage gives him. Nahri does not become queen: she takes the hospital she rebuilt and the practice she wanted from the first chapter of the first book, with Ali beside her. Dara survives, freed of the magic that made him someone else's weapon, and is left to answer for what he did while he was one.",
         "in_short": "Daevabad has fallen to Banu Manizheh and lost its magic, and Nahri and Alizayd are stranded in Egypt with Suleiman's seal and no way home. Hiding in Cairo, they are hunted by Manizheh's allies; guided by Sobek, an ancient marid bound to Ali's family line, they escape to Ta Ntry, where Ali's mother Hatset shelters them and where they uncover how Daevabad was really founded and what the Nahids and the marid did to build it. Nahri learns that she is Manizheh's daughter by a human father, which makes the champion of the shafit shafit herself. In occupied Daevabad, Muntadhir is kept alive as leverage over Jamshid, whom Manizheh means to make her heir, while Dara, sickened by what he has done and by what Manizheh has promised the ifrit, begins to break with her. Nahri and Ali return with allies and a bargain struck with the marid. Manizheh is defeated and killed, Ali is nearly killed and permanently changed, and Nahri ends the seal's absolute power rather than claim it, restoring Daevabad's magic and leaving the city to be governed jointly, shafit included.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4745,7 +4745,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0D7F6BZBC",
@@ -4757,7 +4757,7 @@
       "recaps": {
         "ending": "The Empress of Beasts survives by surrendering and remains a political prisoner of the magus-crafter as coalition powers divide her former realm. Her general escapes north with soldiers and civilians, preserving an armed resistance, and Flos still owes the Empress the restoration he promised. Immediate war between Kelt and Rhyme is avoided through a provisional exchange of grain for Flos's blood oath of nonaggression.\n\nIn Liscor, Wistram's attempt to seize Pisces and the Horns ends in defeat and arrest. Pisces is freed and treated, then acknowledges his full name, common-born past, and responsibility for the fatal tomb incident at Wistram. The Horns remain united around him. Wistram's leader departs determined to capture both Pisces and Erin, and a large bounty leaves their allies exposed. Toren remains concealed in the dungeon, Ilvriss's anti-necromancer force is still forming, and the hidden necromancer continues to observe the inn and test Pisces from afar.",
         "in_short": "Toren struggles toward a protective purpose while trapped in Liscor's dungeon, and Ilvriss quietly prepares to fight a surviving necromancer who has begun mentoring Pisces. Abroad, the Empress of Beasts surrenders rather than sacrifice her people, losing her realm and becoming the magus-crafter's prisoner while her general escapes with an army. Flos promises eventual restoration and averts war with Kelt through a provisional food-for-nonaggression pact. Niers Astoragon learns that dragons remain hidden on Izril and suspects a connection between his chess opponent and Liscor. Wistram mages abduct Pisces and the Horns, but Erin's household and allies defeat them. Pisces admits that he is Pisces Jilnet and that his attempted tomb theft caused deaths at Wistram. The Horns stand by him, while Wistram leaves him under a large bounty and marks Erin as another target.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-empty-throne.json
+++ b/data/works-community/0/the-empty-throne.json
@@ -103,7 +103,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -114,7 +114,7 @@
       "recaps": {
         "ending": "The book closes with Mercia settled and Uhtred restored. At the Witan in Gleawecestre, Uhtred outmaneuvered the nobles and churchmen and saw Aethelflaed chosen to rule Mercia in her dead husband's place, to the fury of the West Saxon faction around Ealdorman Aethelhelm. Uhtred himself is healed: Eadith, having broken with her disgraced brother, led him to Cnut's sword Ice-Spite, and with it the poison was drawn from his long-festering wound. The Norse sea-king Sigtryggr, defeated in his assault on Ceaster - where Uhtred cost him an eye - has agreed to sail back to Ireland, and Uhtred's daughter Stiorra, who fell in love with the young Norseman, sails with him, with her father's blessing. Eardwulf, who fled his treachery to serve Sigtryggr, was handed over in the settlement, and the boy Aethelstan carried out his execution as part of Uhtred's schooling of a future king. Uhtred stands strong again, with Eadith at his side, Aethelflaed on Mercia's throne, and his old dream of Bebbanburg still waiting in the north.",
         "in_short": "Aethelred, Lord of Mercia, dies of his Teotanheale wound, leaving no heir, and Uhtred - himself half-crippled by the festering wound Cnut's sword gave him - fights to decide who fills the empty throne. He thwarts the ambitious Eardwulf, who schemed to marry Aethelred's daughter and seize power, and whose treachery ends in flight; at the Witan Uhtred maneuvers the Mercian nobles into choosing Aethelflaed to rule, defying the tradition that bars a woman. Eardwulf's sister Eadith changes sides, leads Uhtred to the sword Ice-Spite, and with it heals his wound at last, becoming his lover. When the Norse sea-king Sigtryggr attacks from Ireland, Uhtred defeats him at Ceaster, taking his eye, and in the settlement Eardwulf is executed by the young prince Aethelstan. Sigtryggr sails back to Ireland taking Uhtred's daughter Stiorra with him as his wife in all but law, and Aethelflaed rules Mercia.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -208,7 +208,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -221,7 +221,7 @@
       "recaps": {
         "ending": "The final sketches leave the islands without resolving them into one continuous plot. Hunilla is rescued from Norfolk Isle and carried back toward the mainland after prolonged abandonment and the deaths of her companions, but the narration does not turn her suffering into an easy restoration. Oberlus's career on Hood's Isle ends after a history of deception, captivity, and violence rather than through any civilizing change in the place. The tenth sketch widens the view once more to the many fugitives, castaways, solitary inhabitants, and graves associated with the archipelago. The collection therefore closes on traces left by people who tried to occupy or escape through the islands. Human regimes and individual lives prove temporary, while the severe landscape that framed the opening sketch remains the most enduring presence.",
         "in_short": "Across ten sketches, an unnamed seafaring narrator describes the Galapagos Islands as a harsh world of volcanic rock, strange currents, tortoises, birds, and isolated anchorages. Early sections survey the archipelago, examine the symbolic and practical value of its tortoises, and use Rock Rodondo as a lookout over named islands. Later sketches turn to human attempts to use or rule the place: naval visitors and deceptive sightings at sea, buccaneers, a settlement dominated by the Dog-King and his trained animals, and stories of exile and abandonment. The central personal account concerns Hunilla, left on Norfolk Isle after her husband and brother die and a promised ship never returns; she is eventually rescued, carrying losses the rescuers cannot undo. Another sketch recounts the violent hermit Oberlus. The closing survey gathers runaways, castaways, solitary figures, and graves, ending with the islands still resistant to stable possession or comforting interpretation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -348,7 +348,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -361,7 +361,7 @@
       "recaps": {
         "ending": "By the close of April, San Salvatore has changed the relationships that all four women brought with them. Lotty and Mellersh rediscover affection, and he responds to her new assurance with an attentiveness absent from their London life. Rose and Frederick are reconciled after Lady Caroline makes clear that she does not want Frederick's admiration and helps turn him back toward his wife. Rose accepts the husband she has judged from a distance, while Frederick recognizes the warmth still available in their marriage. Mrs Fisher abandons much of her rigid isolation and allows herself to join the others. Lady Caroline, no longer merely an object of pursuit, begins to enjoy companionship on less defensive terms, and Briggs remains devoted to her. The holiday ends with the castle's household connected by friendship and renewed love. The practical future is left open, but the emotional estrangements that drove the women to Italy have eased: they return to ordinary life with a larger sense of freedom and with relationships they can choose rather than merely endure.",
         "in_short": "Lotty Wilkins sees an advertisement for an Italian castle and persuades Rose Arbuthnot, another unhappy London wife, to rent it with her for April. To meet the cost they recruit the beautiful, guarded Lady Caroline Dester and the domineering Mrs Fisher. At San Salvatore, sunlight, gardens, and distance from English routine gradually loosen each woman's defenses. Lotty becomes confident and generous, Rose confronts the loneliness of her marriage, Lady Caroline discovers company that asks more of her than beauty, and Mrs Fisher's rigid privacy softens. Lotty invites both her husband Mellersh and Rose's husband Frederick. Mellersh responds warmly to Lotty's changed spirit. Frederick arrives partly because he admires Lady Caroline, but she redirects him toward Rose, and the estranged couple reconcile. The castle's owner, Thomas Briggs, falls for Lady Caroline, while Mrs Fisher finally joins the communal life she had resisted. By month's end, the holiday has renewed two marriages and formed an unlikely circle of affection among the guests.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -501,7 +501,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -512,7 +512,7 @@
       "recaps": {
         "ending": "The book ends with the Enchanted Wood safe again after the children and the tree folk together drive off an invading band of Red Goblins that threatened the Faraway Tree. As a celebration, everyone climbs to the Land of Birthdays, where the folk throw a party for one of the sisters, with presents and a feast among their new friends. The children then return home to their cottage with the danger past. By the close they have a settled circle of magical companions living in the tree - Moon-Face, Silky, the Saucepan Man, the Angry Pixie, Mister Watzisname and Dame Washalot - and they understand how its lands come and go and how to visit them safely. Nothing forces the family to leave, so the secret of the tree remains theirs to enjoy, and the way is left open for their cousin to join the adventures in the next book.",
         "in_short": "A brother and his two sisters move to a country cottage and discover the nearby Enchanted Wood, where the trees whisper and one enormous tree, the Faraway Tree, rises into the clouds. Climbing it, they befriend the folk of its trunk: the elf Silky, round-faced Moon-Face with his slippery-slip slide, the deaf Saucepan Man, the peevish Angry Pixie, and Dame Washalot with her cascading wash-water. A ladder at the top leads through a cloud into lands that change from time to time, some delightful and some dangerous, always to be left before they move on. After many trips through lands of toys, treats and surprises, the children help drive off an invasion of Red Goblins that threatens the wood, and the tree folk reward them with a birthday party in the Land of Birthdays. The children end safe at home, with a tree full of magical friends to return to.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -582,7 +582,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -595,7 +595,7 @@
       "recaps": {
         "ending": "After his wife's death, the man assumes responsibility for her daughter and collects the girl so that they can travel together. He stops at a hotel and waits until he believes she is asleep before approaching her sexually. She wakes, understands the danger, and screams. The sound brings other people toward the room and destroys the private fantasy through which he had disguised his intended abuse. The man runs from the hotel in panic. Seeing no escape from exposure, he throws himself in front of a moving vehicle and is killed. The girl survives, while his attempt to obtain control over her ends in public discovery and his death.",
         "in_short": "An unnamed man conceals a sexual fixation on young girls behind an ordinary adult life. After noticing a twelve-year-old child in a park, he courts her sick, widowed mother, not out of love but to secure lawful access to the daughter. The mother marries him and then dies, leaving him as the girl's guardian. While taking the child away, he stops with her at a hotel and attempts to turn his long-maintained fantasy into abuse. She wakes and screams, alerting others nearby. He flees the room and, faced with discovery, kills himself by stepping into the path of a vehicle. The scheme that he imagined as patient and controlled collapses as soon as the girl recognizes the threat and calls for help.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -682,7 +682,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -695,7 +695,7 @@
       "recaps": {
         "ending": "The Medusoid Mycelium is released on the island and poisons many, including Count Olaf and the pregnant Kit Snicket, though a bitter apple grown on the island offers protection against the fungus. Mortally wounded and poisoned, Count Olaf carries the injured Kit to safety and, in his final moments, shares an unexpectedly tender parting with her, revealing an old bond between them, before dying on the beach, ending his long pursuit of the children. Kit, poisoned and in labor, gives birth to a daughter with the Baudelaires' help but dies soon after, and the children name the baby Beatrice, after their late mother. The colony of islanders chooses to sail away and rejoin the world, but the Baudelaires stay behind on the island to raise the infant Beatrice safely. In a closing chapter set about a year later, the children, having cared for Beatrice through her first year, decide to leave the island by boat and return to the wider world, and the series ends on this departure, their ultimate fate deliberately left unresolved.",
         "in_short": "Shipwrecked with Count Olaf, the Baudelaires wash up on a remote island whose colony of castaways is led by a facilitator named Ishmael, who claims to force no one but keeps the islanders docile, sheltered from the outside world and its knowledge. The children uncover the island's ties to V.F.D. and their parents' past, while Olaf, scorned by the colony, schemes and still carries the deadly Medusoid Mycelium. The pregnant Kit Snicket washes ashore. When the fungus is released, it poisons many, and a bitter apple from the island's tree proves to protect against it. Count Olaf, wounded and poisoned, shares a final tender moment with Kit and dies on the beach. Kit, poisoned and in labor, dies giving birth to a daughter, whom the children name Beatrice after their mother. The islanders sail away, and the Baudelaires stay to raise the baby, then, about a year later, leave the island by boat to return to the world, their ultimate fate left deliberately unknown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -846,7 +846,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -859,7 +859,7 @@
       "recaps": {
         "ending": "Sarah dies after becoming ill, before she and Bendrix can resume the life he wants with her. Afterward Bendrix learns that her mother secretly had her baptized as a child. Other people report events they regard as answers to prayers or miracles associated with Sarah: Parkis believes contact with one of her books helps his gravely ill son, and Smythe's facial mark disappears after Bendrix invokes Sarah. Henry and Bendrix remain together in grief, while Bendrix moves from denying God to believing in a God he hates for taking Sarah and demanding her promise. He ends not with restored unbelief but with exhausted resistance, asking to be left alone rather than drawn any further toward love or faith.",
         "in_short": "In postwar London, novelist Maurice Bendrix remains consumed by Sarah Miles, the married woman who abruptly ended their wartime affair. When Sarah's husband Henry voices suspicions, Bendrix hires a detective and obtains Sarah's diary. It reveals that after a bombing appeared to kill Bendrix, Sarah promised God she would leave him if his life were restored; seeing him alive, she kept the vow despite continuing to love him. Bendrix confronts her, but illness and her religious struggle prevent their reunion. Sarah dies, and incidents interpreted as miracles follow, while Bendrix learns she was secretly baptized Catholic as a child. His investigation therefore destroys his confident unbelief without curing his jealousy: he comes to believe in the God he resents for claiming Sarah, and ends pleading for release from further demands of love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1214,7 +1214,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:0593339126",
@@ -1226,7 +1226,7 @@
       "recaps": {
         "ending": "Carbone's concealed agenda proves that military and contractor interests planned to obstruct Army transformation and assassinate eighteen supporters of lighter forces. Summer uses it to secure confessions from Vassell, Coomer, and the wounded Marshall in exchange for life imprisonment, while JAG pursues the wider case. Reacher refuses an offered false denial of Carbone's valid brutality complaint. He accepts demotion from major to captain, removal from the special unit, and a two-day suspension. He then confronts Willard, who admits knowingly carrying out a superior order to cover up the killings. Reacher kills him and plants evidence to make the death appear criminal. In Paris, Reacher and Joe attend Josephine Reacher's funeral. Reacher gives his share of her apartment proceeds to Lamonnier for wartime resisters and places his Silver Star in her grave. Reacher returns to Panama as a captain. Summer is promoted to captain and remains with the Washington proceedings; she and Reacher never meet again. The named military conspirators are imprisoned, but the higher political and contractor participants are not individually resolved.",
         "in_short": "At the start of 1990, Army major Jack Reacher investigates General Kramer's natural death, a missing conference agenda, and three subsequent murders. Lieutenant Summer helps him continue despite obstruction from Colonel Willard. Their inquiry links Kramer's secret meeting, Carbone's hidden agenda, and an armored-branch campaign against military transformation. Major Marshall killed Mrs. Kramer and Carbone and helped conceal Brubaker's death while Vassell and Coomer participated in the wider conspiracy. The recovered agenda exposes a planned list of eighteen assassinations. Summer obtains life-sentence confessions from the three men. Reacher admits a genuine assault, accepts demotion to captain, then secretly kills Willard for knowingly covering up the plot. After burying his mother in Paris and honoring her Resistance legacy, he returns to Army service in Panama. Summer is promoted to captain, and they do not meet again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1490,7 +1490,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B013INWI4Q",
@@ -1502,7 +1502,7 @@
       "recaps": {
         "ending": "Omega Force destroys the mobile biodrone factory by converting Diligent into an unmanned strike craft, then boards the failing Stalwart and rescues Kellea. Agent Alux escapes, while the critically wounded Steader is left aboard the carrier as it falls into the gas giant. Councilman Scleesz explains that four expansionist Council members ran the conspiracy and that his faction will contain it privately. Crisstof is released, but the public does not learn why he was framed. Jason completes an unspecified favor for Scleesz, who arranges an overhaul for Phoenix and purges ConFed intelligence records on Omega Force. Kellea leaves on friendly terms to command Defiant, and Jason plans renewed dealings with Crisstof. Omega Force remains together, although Doc's ultimate standing is unsettled. Alux, Jevara, deployed biodrones, and the missing shutdown code remain open threats, while the political truth is suppressed.",
         "in_short": "When Diligent is seized and Crisstof Dalton is blamed for lethal uprisings, Omega Force rescues Kellea Colleren and follows the ship's route to Solamea. Evidence hidden aboard Diligent exposes an expansionist Council faction that uses species-specific biodrones to manufacture rebellions and justify ConFed absorption. Doc admits that he once worked on the project and that its key scientist, Jevara, is his sister. After disrupting another intervention on Gryr-4, the crew loses Kellea to Steader Dalton and ConFed agent Alux. Omega Force turns the damaged Diligent into an autonomous weapon, destroys the mobile biodrone factory, and boards Steader's carrier to recover Kellea. Steader is left critically wounded and Alux escapes. Councilman Scleesz's opposing faction quietly contains the plot and frees Crisstof. Jason completes a favor that earns an overhaul of Phoenix and the removal of ConFed intelligence on Omega Force, while Kellea takes command of Defiant.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1653,7 +1653,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1666,7 +1666,7 @@
       "recaps": {
         "ending": "Caravaggio uses morphine and careful questioning to make the patient acknowledge that he is Almásy. The full account links his burns to his attempt to retrieve Katharine from the Cave of Swimmers after Geoffrey's fatal crash and Katharine's death there. His effort to return to her also explains his wartime assistance to the Germans, which had made Caravaggio regard him as a traitor. At the villa, Kip hears of the atomic bombing of Japan. Concluding that a Western nation would not have used such a weapon against white Europeans, he turns his rifle on the patient but does not fire. He leaves Hana and the European war behind and returns to India. Years later Kip is a doctor with a wife and children, though he still thinks of Hana. Hana remains connected to the dying patient and finally writes home about her father's death, beginning to turn toward the life beyond the villa.",
         "in_short": "In a ruined Italian villa near the end of the Second World War, Canadian nurse Hana cares for a nameless, badly burned airman. They are joined by the maimed spy Caravaggio and Kip, a Sikh bomb-disposal officer who becomes Hana's lover. The patient's desert memories gradually reveal him as the Hungarian explorer Almásy. Before the war he had an affair with Katharine Clifton, the wife of a fellow expedition member. Geoffrey Clifton tried to kill all three in an aircraft crash; Geoffrey died and Katharine was fatally injured. Almásy left her in a cave while seeking help, but British forces detained him, and he later helped German agents cross the desert before recovering her body. His aircraft then caught fire. Caravaggio draws out this confession with morphine. When Kip learns that an atomic bomb has destroyed Hiroshima, his trust in Britain and Europe collapses. He leaves Hana and returns to India, while Hana remains at the villa and begins to face her own wartime grief.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1814,7 +1814,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1827,7 +1827,7 @@
       "recaps": {
         "ending": "The Baudelaires expose Gunther as Count Olaf and discover that Esme Squalor is his secret girlfriend and accomplice, a villain rather than a guardian, who has been helping his scheme all along. Their plan to rescue the Quagmire triplets, whom they found imprisoned at the bottom of the building's fake elevator shaft and then hidden among the auction lots, fails at the last moment: Olaf and Esme escape with the triplets smuggled away, and the Baudelaires cannot follow, leaving their friends' fate uncertain. Jerome Squalor, horrified to learn what his wife truly is but unwilling to face the danger of raising three hunted children, leaves both Esme and the guardianship, and the orphans are returned to Mr. Poe's charge. The Baudelaires end the book without their friends and without a home, but with a growing understanding that Olaf, Esme, and the mysterious V.F.D. are all bound together in a larger secret they are only beginning to glimpse.",
         "in_short": "The Baudelaires are placed with Jerome and Esme Squalor in a penthouse at 667 Dark Avenue, where fashion rules absolutely: because darkness is 'in,' the elevators sit dark and unused. Jerome is kind but avoids all conflict, and Esme is obsessed with what is stylish. When an auctioneer called Gunther arrives to run an 'In Auction,' the children recognize him as Count Olaf. Exploring the dark, out-of-service elevator, they discover it is a fake shaft, and at the bottom they find their kidnapped friends, the Quagmire triplets, caged. Rescue attempts go wrong, and the villains hide the Quagmires among the auction lots to smuggle them out of the city. At the auction the children uncover the plan, expose Gunther as Count Olaf, and learn that Esme is his accomplice, not merely a fashionable guardian. Olaf and Esme escape, carrying the Quagmires away to an unknown fate, and Jerome, unwilling to fight, gives up the children, who are left searching for their friends once more.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2008,7 +2008,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2021,7 +2021,7 @@
       "recaps": {
         "ending": "After killing Hector, Achilles continues to mourn Patroclus and repeatedly drags Hector's body around his companion's tomb. The gods preserve the corpse, and Zeus orders that it be returned. Priam crosses the Greek lines with divine protection, enters Achilles's shelter, and asks him to remember his own aged father. The appeal brings both enemies into shared grief: Priam mourns Hector, while Achilles mourns Patroclus and the father he will not see again. Achilles accepts the ransom, returns Hector's body, and promises a pause in the fighting long enough for Troy to conduct the funeral. Priam brings his son home. Andromache, Hecuba, and Helen lead the lamentations, after which the Trojans burn Hector's body, gather his bones, and raise a burial mound. The poem ends with Hector honored, not with the fall of Troy or the death of Achilles; both remain anticipated beyond the narrated action.",
         "in_short": "In the tenth year of the Trojan War, Agamemnon dishonors Achilles by taking Briseis, and Achilles withdraws from the Greek army. At his request Zeus lets the Trojans gain the advantage, while Hector leads them to the Greek ships. Agamemnon offers restitution, but Achilles initially refuses. When the ships are threatened, Patroclus enters battle in Achilles's armor, drives the Trojans back, and is killed by Hector. Grief brings Achilles back to war despite his knowledge that vengeance will hasten his own death. Wearing new armor made by Hephaestus, he slaughters Trojans and kills Hector, then abuses the body. Priam secretly comes to the Greek camp and begs for his son's return. Moved by their shared grief, Achilles accepts ransom, returns Hector, and grants time for burial. The epic closes with Hector's funeral while Troy still stands and Achilles's own foretold death remains ahead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2187,7 +2187,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2200,7 +2200,7 @@
       "recaps": {
         "ending": "Merrin and Karras conduct the exorcism while the presence in Regan attacks their confidence and exploits Karras's guilt. During a pause Karras leaves the room, then returns to find Merrin dead after his weakened heart has failed. When the presence mocks Merrin's death, Karras strikes Regan and demands that it enter him instead. It does, and Karras regains control just long enough to throw himself through the bedroom window and down the Georgetown steps. Father Dyer reaches the dying priest and gives him absolution. Regan recovers without a clear memory of what happened. Chris takes her away from Washington, grateful but unable to explain the sacrifice that saved her. Before leaving, Regan notices Dyer's clerical collar and kisses his cheek. Kinderman later seeks out Dyer, and the two begin the friendship he had earlier tried to form with Karras. Merrin and Karras are dead, but Regan is free and the immediate manifestations have ended.",
         "in_short": "While actor Chris MacNeil is working in Georgetown, her twelve-year-old daughter Regan develops alarming physical and psychological symptoms after communicating with an imaginary figure through a Ouija board. Medical testing finds no adequate cause. A director dies outside the house under impossible circumstances, and detective William Kinderman begins investigating. As Regan's behavior and apparent knowledge become increasingly inexplicable, Chris turns to Jesuit psychiatrist Damien Karras, who is grieving his mother and doubting his faith. Karras initially looks for fraud or illness, but the accumulated evidence persuades him to request an exorcism. The Church assigns experienced priest Lankester Merrin to lead it. During the rite Merrin dies, and Karras provokes the presence into leaving Regan for him. He then leaps to his death before it can control him completely. Regan recovers with little memory of the ordeal and leaves Washington with Chris, while Karras's sacrifice and Merrin's endurance leave the survivors with a renewed possibility of faith.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2373,7 +2373,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2384,7 +2384,7 @@
       "recaps": {
         "ending": "The book ends with the eighth floor collapsing and the crawlers riding a demon's spell out of it. With the exits failing worldwide, Carl and Prepotente spread a desperate plan: tunnel under the sealed stairwell chambers and let Amayon's world-spanning teleport, cast by the freed demon prince at full power, tear the chambers open and pull the crawlers up into them. Making it work costs almost everything: Ren sacrifices herself when her exit fails, Sister Ines is killed by Louis after the goddess Ysalte seizes her leverage, Carl bleeds himself nearly to death inside Samantha to fuel the demon, and Ysalte falls to a totem of the dead crawler Paz. In the battle's last moments Shi Maria, the Bedlam Bride, destroys her intended card-fusion target and merges with the real Carl instead, seizing his body long enough to maim Li Jun and tattoo the Eye of the Bedlam Bride onto Carl's chest, binding herself to him so she must be carried to the next floor. Before the stairwells fire, Carl and Donut push their remaining Faction Wars votes to the viewing public, which approves stripping safety protections from faction sponsors and seating a tenth team of NPCs. The party is pulled to the ninth floor as Faction Wars begins. In the epilogue, Agatha is confirmed to be maneuvering the rogue AI toward her own faction's ends while the Apothecary's gifts hide an installed upgrade in Carl; the Syndicate, rejecting the failsafe, sends the surface mercenaries into the dungeon to kill the remaining crawlers; and a garbage ship slips into orbit carrying Rosetta, Tipid, and fifty thousand former crawlers coming to fight.",
         "in_short": "The eighth floor recreates pre-collapse Earth from human memories: squads start in remembered cities, Carl and Donut in Havana, and must capture monsters and people as playing cards to fill their rosters, then win keys and survive a last free-for-all. They befriend the crawlers Paz, Anton, and Sister Ines, lose the first two to an offended god and learn Ines is far more dangerous than she looks, and cut deals with gods, the rogue dungeon AI, and the spider demigod Shi Maria, the Bedlam Bride, who holds Samantha. Katia, cursed by the Crown of the Sepsis Whore, needs a divine boon to survive the ninth floor, so Carl helps her assassinate Astrid of the Desperado Club, and takes a secret bargain with the goddess Eileithyia. The system rebuilds Carl's father's death and makes him fight through it. Phase three collapses into apocalypse: a demon eviction floods the floor, exits fail, and the crawlers escape only by freeing the demon prince Amayon to cast a global teleport that rips open the stairwells. Quan Ch dies; Lucia Mar descends; Shi Maria merges herself into Carl's chest as a living tattoo. The party lands on the ninth floor as Faction Wars begins, while the Syndicate sends an army of mercenaries down after them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2596,7 +2596,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2609,7 +2609,7 @@
       "recaps": {
         "ending": "The battle at the Eye of the World ends in victory but changes everything. Rand al'Thor has channeled the One Power to destroy the Forsaken Aginor, to break the Trolloc host at Tarwin's Gap, and to overcome Ba'alzamon in the sky. The Green Man is dead, Balthamel and Aginor are gone, and among the treasures uncovered are the Horn of Valere, which can summon dead heroes to battle, a broken seal from the Dark One's prison, and the ancient banner of the Dragon. Moiraine now understands that Rand is the Dragon Reborn, the reincarnation of the champion who both sealed away the Dark One and, in his madness, helped break the world an age ago. Because he is a man who can wield the One Power, Rand lies under a sentence: the male half of the Power is tainted, and every man who touches it goes mad. Rand does not yet accept what he is. His friends face uncertain paths - Mat still bound to the tainted dagger he took from Shadar Logoth, Perrin uneasy with a new bond to wolves, and Egwene and Nynaeve newly revealed as able to channel. The Dark One's touch has been turned back for now, but the Forsaken are loose, the Shadow is stirring, and the long struggle over the Dragon Reborn has only begun.",
         "in_short": "When Trollocs attack the remote village of Emond's Field hunting three young men - Rand al'Thor, Mat Cauthon, and Perrin Aybara - the Aes Sedai Moiraine spirits them away, hinting that one of them is tied to prophecy. Pursued by the Dark One's servants, the company is scattered at the cursed city of Shadar Logoth and makes separate, harrowing journeys across the land before reuniting in Caemlyn and braving the deadly Ways to reach the Borderlands. Learning that the enemy covets the Eye of the World, they ride into the poisoned Blight, where two freed Forsaken ambush them. In the crisis Rand seizes the One Power for the first time, destroys the Forsaken, shatters a Trolloc army at Tarwin's Gap, and battles the fiery-eyed Ba'alzamon in the sky. Moiraine realizes Rand is the Dragon Reborn: able to wield the One Power, and therefore fated both to stand against the Dark One and to be destroyed by the very power that makes him the world's champion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2815,7 +2815,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2828,7 +2828,7 @@
       "recaps": {
         "ending": "The Diablerie get what they wanted. Using the remains of the Grotesquery and a Teleporter, the portal is opened at Aranmore Farm and a Faceless One comes through into a human body, and the cost is enormous: Grand Mage Eachan Meritorious and Elder Morwenna Crow are killed, Elder Sagacious Tome dies after his betrayal is exposed, and Mr Bliss is killed fighting the thing that came through. With no way to stop it from the outside, Skulduggery drives the Faceless One back through the portal and goes with it, and the way closes behind them both. Valkyrie is left on the ground, unhurt and without her partner, and the only comfort available is that he was not destroyed, merely trapped in a dead world with the dark gods. The Irish Sanctuary is left leaderless and the surviving Elders are replaced by a new Grand Mage, Thurid Guild, who has no patience for Skulduggery Pleasant's associates and less for Valkyrie. Tanith, Ghastly, China and Fletcher are alive; the Diablerie is broken but its survivors scatter. Valkyrie goes home with one intention, which the Sanctuary has already refused to help with: getting Skulduggery back.",
         "in_short": "Teleporters are being murdered one by one, and the investigation leads Skulduggery and Valkyrie to the Diablerie, a group devoted to the return of the Faceless Ones, working under a hidden leader called Batu. They need a Teleporter to open a portal, so the pair race to find and protect Fletcher Renn, an untrained English teenager who is the last one left. Someone inside the Sanctuary is feeding the Diablerie information, and it proves to be Elder Sagacious Tome. The Diablerie steal the remains of the Grotesquery, take Fletcher, and open the portal at Aranmore Farm. A Faceless One crosses into a human body. Meritorious, Crow and Tome all die, and Mr Bliss is killed trying to hold the creature. With nothing else left, Skulduggery drives the Faceless One back through the portal and is dragged through with it as it closes, leaving him alive but trapped in the Faceless Ones' dead world. Thurid Guild takes over the Sanctuary and refuses to mount a rescue, and Valkyrie is left to find another way.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2958,7 +2958,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2971,7 +2971,7 @@
       "recaps": {
         "ending": "Clamence reveals that he keeps the stolen panel known as The Just Judges in his room, accepting the possibility that displaying it may eventually bring arrest and public judgment. His judge-penitent practice is now fully explained: he confesses his own failures in sweeping terms so that his listener recognizes the same impulses in himself, after which Clamence can pass judgment on them both. He has selected the visitor because the man resembles his former self and is also a lawyer. Feverish in bed, Clamence imagines repeating the moment when the woman fell into the Seine and wishes for another chance to rescue her, but immediately recognizes that the chance will never come. The wish is inseparable from his desire to recover innocence without surrendering his authority. His confession therefore ends without absolution or reform. He remains in Amsterdam, using self-accusation as a means of mastery, while the silent listener is drawn into the judgment.",
         "in_short": "In an Amsterdam bar, former Paris lawyer Jean-Baptiste Clamence addresses an unnamed French visitor over several days. He describes the admired life he once led, taking pleasure in defending the unfortunate and performing generous acts. A mocking laugh and the memory of a woman whose suicide he failed to prevent expose how much his goodness depended on superiority and applause. His confidence collapses into self-scrutiny, failed attempts at love, dissipation, and memories of selfish conduct during wartime imprisonment. In Amsterdam he remakes himself as a judge-penitent: by confessing his own guilt first, he induces others to admit that they too are compromised, preserving his power to judge them. He also keeps the stolen Just Judges panel, courting punishment while controlling its terms. Recognizing the visitor as another lawyer much like his former self, Clamence turns the entire confession upon him. No redemption follows; the closing wish to save the drowned woman is acknowledged as impossible and self-serving.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3140,7 +3140,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3153,7 +3153,7 @@
       "recaps": {
         "ending": "Number Five is not what the Garde took him for. He has already made an arrangement with the Mogadorians, and in Florida he turns on the others in the middle of a fight. Number Eight is killed by Five's blade, dying in front of Marina, who cannot heal him. Marina's grief brings out a new Legacy, a killing cold, and she turns it on Five and takes one of his eyes before he escapes to the Mogadorian side he had already chosen. Ella is taken by Setrakus Ra, carried off alive rather than killed, which confirms that he wants her for something specific. The survivors are left scattered, badly beaten, and short two of their number for the first time since they gathered. Marina refuses to leave Eight's body, and her willingness to be talked out of anything is gone with him. The group that ends the book is smaller, angrier, and split between recovering Ella and settling with Five, and it now knows that its enemy can turn one of the nine.",
         "in_short": "The Garde are living together in Number Nine's fortified Chicago penthouse: John, Six, Nine, Marina, Eight, and Ella, with Sam Goode, his father Malcolm, Sarah Hart, and the Chimaera Bernie Kosar. Malcolm, recovered from the Mogadorians with his memory in pieces, slowly recalls that he was one of a group of humans who met the Loric ships when they landed and hid the children, and what the Loric left on Earth besides them. Ella begins having visions in which Setrakus Ra speaks to her directly. A signal reaches the group indicating that another of the nine is alive, and the search leads them south to Florida, where they find Number Five, raised in isolation by his Cepan, able to fly and to take on the properties of whatever he touches. He never settles among them. In the Everglades he reveals that he has already made terms with the Mogadorians, and he kills Number Eight. Marina, in grief, manifests a Legacy of lethal cold and blinds Five in one eye. Setrakus Ra takes Ella captive. The survivors scatter, one Garde dead and one turned.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3363,7 +3363,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3376,7 +3376,7 @@
       "recaps": {
         "ending": "The collection closes with Hop-Frog's revenge on the king and seven ministers who have abused him and Trippetta. He persuades the men to appear at a masquerade chained together and disguised as wild animals, then has them hoisted above the crowd. After identifying them publicly as the king and his councillors, he sets their flammable costumes alight. All eight men die. Hop-Frog climbs away along the rigging and escapes through the roof. Trippetta has already vanished, and the account concludes that the pair planned the punishment together and returned to their homeland. The preceding final tales also end in destruction: Montresor entombs Fortunato alive and keeps the crime secret for fifty years, while the self-described victim of the imp of perversity exposes his own concealed murder and is condemned.",
         "in_short": "This anthology gathers nineteen Poe tales about obsessive minds, premature burial, doubles, plague, murder, and revenge. Lovers die in a mysterious assignation; Egaeus violates Berenice's grave for her teeth; Morella's identity appears to return in her daughter; and revelers confront embodiments of death. Ligeia seems to overcome death through another woman's body, the Usher twins perish as their house collapses, and William Wilson destroys himself while attacking his double. Other narrators face an inquisitorial dungeon, confess murders under psychological pressure, or expose their own crimes through pride and compulsion. Prince Prospero's isolation cannot keep out the Red Death, and Montresor seals Fortunato into a family vault. In the final story, the abused entertainer Hop-Frog turns a masquerade into a trap, burns the king and his ministers in front of their court, and escapes with Trippetta.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3711,7 +3711,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B09QH78G17",
@@ -3723,7 +3723,7 @@
       "recaps": {
         "ending": "Ember takes the goddess of death's place as the power sustaining the Tree of Life, the afterlife, and the prison holding the ancient mage-race's original magic. Ember breaks apart during the transfer, and it remains unknown whether she died or became part of the tree. Kael leaves with the restored goddess, joins his yin with hers, and retrieves the wounded white and black dragons from the fast-time universe. Together they devastate the enemy camp at the Black Chasm, but its tower survives. The enemy leader orders her injured high priest to find a crossing and continues preparing conquest. Back at his fortress, Kael detains the leader's ether-channeling daughter after she offers access to dissidents and unconventional allies. He remains physically unstable, carries the hostile spirit in his cursed object, and sees a death wizard escaping the afterlife with an unconscious boy. The war, Ember's fate, the failing magical prison, the dragons' recovery, and Kael's new obligations remain unresolved.",
         "in_short": "A magical illness incapacitates Kael and other powerful casters while an ancient mage-race uses towers to recover magic once taken from it. Ember investigates the threat, Max uncovers a hidden community below the fortress, and Kael awakens with damaged powers and a hostile spirit contesting him. The invaders seize Stillwater and use a new tower to trap an allied army. Kael's group escapes to the aperture, where the Tree of Life is revealed as the failing lock on the invaders' original magic. Ember replaces the imprisoned goddess of death as the tree's sustainer and disintegrates, leaving her fate uncertain. Kael joins his yin with the restored goddess, rescues two wounded ancient dragons, and helps destroy most of the enemy camp at the Black Chasm. The tower and enemy leadership survive. Kael returns to his fortress, detains the enemy leader's dissident daughter, and faces new threats from the spirit in his cursed object and a death wizard apparently escaping the afterlife.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3925,7 +3925,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3938,7 +3938,7 @@
       "recaps": {
         "ending": "Fitz refuses to poison Rurisk and warns him instead, but Regal's plot runs on without him: Rurisk dies, and Fitz is poisoned nearly to death by those carrying out Regal's orders. Kettricken is wed to Verity by proxy, with Regal standing in his brother's place, and then leaves the Mountains for Buckkeep as queen-in-waiting. Verity reaches through the Skill during the crisis and Galen, striking at his king in Regal's service, is destroyed. Regal's treachery is understood by Verity, Chade and Burrich, but nothing can be proved to King Shrewd, and Regal returns to court unpunished and more dangerous than before. Fitz survives, nursed by Burrich and the Fool, but the poison leaves him with a wrecked constitution and shaking fits that come without warning. He has learned what he is worth to the men who own him: a tool that may be spent. He goes home to a Buckkeep where the Red Ship raids are worsening, where Verity is burning himself out with the Skill, and where Fitz is bound by a boyhood covenant to a king who is beginning to fail. Molly is still in Buckkeep Town, and Fitz has told her nothing about what he actually does.",
         "in_short": "A six-year-old boy is delivered to the Six Duchies court as the bastard of Prince Chivalry, whose career the scandal ends. Raised in the stables at Buckkeep by the stableman Burrich, the boy takes a private bargain from King Shrewd: he will be the king's man, and in return he will be fed, housed and taught. The teaching turns out to include poisons. The old assassin Chade trains him in the crown's quiet work while Burrich beats at his forbidden beast-magic and the Skillmaster Galen, who hates Chivalry's bastard, ruins his chance at the royal Skill. Outislander Red Ships begin raiding the coast and returning hostages hollowed of feeling. Sent to the Mountain Kingdom for Prince Verity's proxy wedding to Kettricken, Fitz is ordered to kill her brother Rurisk and refuses. Regal's plot kills Rurisk anyway and very nearly kills Fitz. He survives poisoned and permanently damaged, the wedding stands, Galen is destroyed, and Regal walks away untouched.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4121,7 +4121,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4134,7 +4134,7 @@
       "recaps": {
         "ending": "The two halves of the book resolve in opposite directions. In Mexico, Six, Marina, and Adam get into the Loric sanctuary and find a surviving Loric presence inside it, and what comes out of that meeting changes the war: Legacies begin appearing in ordinary human beings around the world, so that for the first time the Garde are not the only people on Earth who can fight the Mogadorians on their own terms. In New York the fighting goes the other way. The Garde hold and hit back but the city is being taken apart, and Sarah Hart is killed in the battle. John holds Number Five responsible and comes out of it with a hatred that is now personal as well as strategic. Ella is still aboard Setrakus Ra's ship, refusing what he wants from her while it wears her down. By the close the Mogadorians hold ground openly in cities across the planet, humanity knows exactly what it is facing, new human Garde are manifesting powers they do not understand, and the surviving Loric are moving to join up with human forces for a counterattack instead of fighting as a handful of fugitives.",
         "in_short": "The invasion has begun. Mogadorian warships hold position over New York and other cities, and Setrakus Ra presents the occupation to humanity as an arrangement rather than a conquest. John, Sam, Sarah, Nine, and Malcolm fight through a wrecked Manhattan alongside whatever human survivors and soldiers they can join with; Sam finds he can now reach machines the way other Garde reach fire or weather. In Mexico, Six, Marina, and Adam fight their way to the Loric sanctuary Malcolm remembered and get inside, where they meet a surviving Loric presence. What it does is release Legacies into ordinary human beings across the world, creating a generation of human Garde overnight. Ella, still held aboard Setrakus Ra's ship, keeps refusing the inheritance he offers her while it drains her. The cost in New York is high, and Sarah Hart is killed in the fighting, with John holding Number Five responsible. The book ends with humanity in the war for real and the Garde no longer alone in it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4267,7 +4267,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4280,7 +4280,7 @@
       "recaps": {
         "ending": "The expedition completes its crossing and lands on Mars, putting humans on another planet for the first time. The crew that arrives has been badly worn by the voyage: it cost them people, equipment and any remaining belief that the mission was a clean achievement, and the racial conflict carried aboard was endured rather than settled. Elma, added to the crew as a publicity decision, finishes the voyage as one of the people its survival actually depended on, and her long antagonism with Parker has become a working understanding built on shared dependence rather than on forgiveness. Her running fight with the flight surgeon has resolved into a workable arrangement about what treatment an astronaut may have and still fly, which is a precedent as much as a truce. Nathaniel is still on Earth, where the climate keeps deteriorating and the political argument over the program's cost continues without her. Mars is not an ending but a first foothold: the colony the coalition promised when it told the world the planet was dying is still entirely ahead, and the people who reached the surface are the ones who will have to begin it.",
         "in_short": "Several years after the meteorite strike, Elma York is a working astronaut and the public face of a space program the public is tiring of funding. After activists take over a flight she is piloting, the coalition asks her to join the first crewed expedition to Mars, largely because her fame will sell it. Accepting means three years away from her husband Nathaniel, and her seat is created by displacing a Black astronaut who had earned it. The expedition launches in two ships with a deliberately international crew commanded by Stetson Parker, and the voyage strips away everything comfortable about it: racial conflict aboard that nobody can walk away from, a running fight with the flight surgeon over Elma's anxiety medication, mechanical failures, and illness in a place with no hospital and no way home. The crew is reduced and changed by the crossing, and Elma becomes genuinely necessary rather than decorative. They reach Mars and land, the first humans on another planet, with the colony itself still ahead of them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4427,7 +4427,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4440,7 +4440,7 @@
       "recaps": {
         "ending": "Augustus dies of his recurred cancer after a swift, harrowing decline, weeks after a mock funeral he arranged so he could hear Hazel and Isaac deliver his eulogies while he was still alive. At his real funeral, the reclusive author Peter Van Houten unexpectedly appears; afterward he tells Hazel that his own young daughter died of leukemia, which is why he wrote his novel about a dying girl and why he became the wreck she met in Amsterdam. Hazel, still angry at him, sends him away. Isaac then tells her that Augustus had been writing something in his final days. With the help of the author's assistant, Lidewij, Hazel learns that Augustus had mailed pages to Van Houten, asking the writer to shape them into a eulogy for her. Van Houten had the pages all along. When Hazel finally reads them, she finds Augustus's reflections on how people leave their marks on one another and his declaration that he was happy to love her and would choose her again despite the pain. His closing words, affirming his consent to the hurt that loving her cost him, echo her own feelings, and the novel ends with Hazel's answer that she agrees.",
         "in_short": "Hazel, a sixteen-year-old living with terminal lung cancer, meets Augustus Waters, a charming boy in remission from bone cancer, at a support group, and the two fall in love while bonding over Hazel's favorite novel, which ends abruptly and unresolved. Augustus uses his one wish to take Hazel to Amsterdam to meet the book's reclusive author, but the man turns out to be a bitter, cruel drunk who gives them no answers. The trip is redeemed by their love, and there Augustus reveals that his cancer has returned and spread; he is now dying. Back home he declines swiftly and painfully, and after a heartbreaking few weeks, including a pre-funeral he stages so he can hear his friends' eulogies, he dies. At his funeral the author appears and eventually reveals that his own daughter died of cancer, explaining his book and his bitterness. Grieving, Hazel discovers that Augustus had secretly written pages about her, intended as a eulogy, and reading his final words about their love gives her a measure of peace.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-fellowship-of-the-ring.json
+++ b/data/works-community/0/the-fellowship-of-the-ring.json
@@ -118,7 +118,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -129,7 +129,7 @@
       "recaps": {
         "ending": "Fellowship ends with the company broken at the falls of the great river Anduin. Boromir, overmastered by the ring's lure, tries to take it from Frodo; shaken, Frodo decides he must carry it to Mordor by himself rather than risk corrupting or endangering his friends. He slips away by boat, but Sam refuses to be left and forces his way aboard, so the two go east toward the Enemy's land together and alone. The rest of the Fellowship is left scattered and searching, unaware which way Frodo has gone. Gandalf is believed dead, lost in the deeps of Moria after his fall with the demon of fire. Aragorn, Legolas, and Gimli remain on the western shore, while Boromir, Merry, and Pippin are elsewhere along the river, their fates unresolved as the book closes. The ring is still whole and still far from the fire; Sauron's power grows and his armies stir, but the Enemy does not yet know exactly where the ring is. The quest is now split into two strands, two hobbits creeping toward Mordor and the sundered remnant of the Fellowship left to face the coming war, both carried forward into the next book.",
         "in_short": "The hobbit Frodo Baggins inherits a magic ring from his cousin Bilbo, and the wizard Gandalf reveals it to be the One Ring of the Dark Lord Sauron, who is rising again and hunting for it. To keep it from the Enemy, Frodo leaves the Shire with his friends Sam, Merry, and Pippin, pursued by Sauron's Black Riders. After narrow escapes and a near-fatal wound at Weathertop, they reach Rivendell, where a council decides the ring must be destroyed in the fire of Mordor where it was made. Frodo volunteers, and a Fellowship of nine sets out to help him: Gandalf, the ranger Aragorn, Boromir of Gondor, the elf Legolas, the dwarf Gimli, and the four hobbits. Blocked by mountains, they pass through the mines of Moria, where Gandalf falls battling a demon of fire. Sheltered and counselled by the elf-lady Galadriel, they travel on by river. At the last, Boromir tries to seize the ring, and Frodo, fearing its power over his friends, resolves to go on alone; only Sam manages to follow him as the Fellowship breaks apart.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -336,7 +336,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -349,7 +349,7 @@
       "recaps": {
         "ending": "The maze is complete and running, and the organization decides that its two implanted subjects are the last variables it needs. Thomas and Teresa agree to be inserted. Before the memory procedure they settle on a plan: once inside, with everything taken from them, they will work to break the maze rather than solve it, and leave themselves whatever cues they can manage. That agreement is where their friendship ends rather than where it holds. Teresa maintains that everything WICKED has done is justified by the cure at the end of it, Thomas no longer believes that, and neither talks the other around. Their friends have already gone in ahead of them, sent up one at a time with Thomas and Teresa in the room while it was done, including Newt, whom Thomas knows is not immune and is being used as a control, and Chuck, whom Thomas failed to keep off the list. Thomas is wiped and sent up in the Box next to last, arriving in a Glade full of boys he helped put there, none of whom will remember him. Teresa follows the day after, and the program stops sending anyone. The final pages hand straight off to the opening of The Maze Runner, with the reader now knowing who designed the Maze and who chose the people inside it.",
         "in_short": "A prequel covering Thomas's childhood inside WICKED. Taken as a small boy after the flares and the Flare virus destroyed the world he was born into, and renamed from Stephen because he is immune, he grows up in a locked room in a compound in the far north with only a caretaker for company, and later a girl's voice in his head: Teresa, wired to him by an implant. Let out among the other immune children, he grows up with Newt, Minho, Alby and Gally while the adults test and operate on them, and eventually learns what it is all for. An enormous maze is being built to put immune minds under sustained pressure so their brain patterns can be recorded. Thomas and Teresa are brought in to help design and run it, which costs them the trust of everyone they grew up with. The trials begin, and Thomas watches his friends have their memories stripped and be sent into the Glade, Newt among them despite not being immune, and Chuck despite being a child. Finally Thomas and Teresa go in themselves, planning to sabotage the maze from inside, and the memory wipe closes the book where The Maze Runner opens.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -593,7 +593,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -606,7 +606,7 @@
       "recaps": {
         "ending": "After Alamance the family goes home to the Ridge, and Roger spends months relearning how to speak. His voice comes back as a ruined whisper, enough to preach and teach with but not to sing, and he builds a place for himself on the mountain out of what is left. He and Brianna decide to stay in the past rather than risk the stones. Jamie is bitten by a venomous snake and comes very near death; Claire keeps him alive through days of gangrene and fever. The last of the book turns on Jocasta Cameron's hidden Jacobite gold and on Stephen Bonnet, who is hunting it. The pursuit ends in a fight on the coast at Wylie's Landing, where Brianna shoots Bonnet in the head at close range; he falls into the water and no body is found. The question of Jemmy's father is left where it stands, and Roger has stopped needing an answer. Claire and Jamie return to Fraser's Ridge with the newspaper notice of their own deaths still years ahead of them and a war with Britain coming closer. The book closes with Jamie telling Claire that when the day comes that he must leave her, if his last words are not that he loves her, it will only be because he had no breath left to say them.",
         "in_short": "At a Highland gathering in North Carolina in 1770, Brianna and Roger are properly married, Jocasta Cameron is betrothed to Duncan Innes, and Governor Tryon commissions Jamie a colonel of militia and orders him to raise men against the Regulators, backcountry farmers in armed revolt. Jamie calls out his tenants under a burning cross in the old Highland fashion, and the militia marches twice, the first time ending without a battle and turning up the horrors of an isolated trading farm. The second march ends at Alamance in May 1771, where the Regulators are scattered and Roger, mistaken for one of them, is hanged; Jamie and Claire cut him down and Claire opens his throat to keep him alive. He survives without a voice. The rest of the book follows his slow recovery, the family's life on Fraser's Ridge, and a hunt for Stephen Bonnet, who is after Jocasta's hidden Jacobite gold. It ends with Brianna shooting Bonnet at Wylie's Landing and the family going home, with the fire that history promises them still in the future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -835,7 +835,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -848,7 +848,7 @@
       "recaps": {
         "ending": "The book ends on the disaster it has been building towards. Zoe finds out what her sister has been hiding - the relationship with Adrian, and everything it implies about Sydney's loyalty - and does what she was trained to do: she reports it. Sydney is taken by the Alchemists without warning, seized in daylight, her phone and her charms gone, and driven out into the desert to a place nobody outside the order knows the location of. She understands, from what she has already seen of Keith Darnell, precisely what re-education means and how little of a person it returns. Adrian is left behind knowing only that she is gone. He has no way to find her, no standing to demand anything from the Alchemists, and no protection from what losing her will do to a spirit user who has stopped taking his medication. The research into a defence against Strigoi conversion is unfinished, Jill is still in hiding, and the household's cover in Palm Springs is now compromised by the order that was supposed to be maintaining it.",
         "in_short": "Sydney and Adrian are together in secret while Sydney's newly minted Alchemist sister Zoe lives in the next room and reports on everything. The book alternates between them: Adrian trying to build a life worth offering her, painting, taking a class and weighing his medication against his access to spirit; Sydney hiding a relationship, a magical education and a research programme that would count as treason to her order. With Sonya Karp and the spirit user Nina Sinclair, they work towards something that would stop a Moroi or dhampir being turned Strigoi at all, and Sydney's chemistry is what makes it testable. They visit Keith Darnell and see what the Alchemists' re-education leaves of a person. They summon a small creature that bonds to them both. Adrian goes off his medication to use spirit properly and swings hard between elation and collapse; Angeline's secret with Trey ends her relationship with Eddie; Jill's isolation grows. Then Zoe learns the truth about her sister. In the final pages Sydney is seized by the Alchemists and taken away to be re-educated, and Adrian is left with no idea where she has gone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1004,7 +1004,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1017,7 +1017,7 @@
       "recaps": {
         "ending": "After Harriet brings Ben back from the institution, the Lovatt family does not recover its earlier unity. The older children arrange to spend more time away, Paul remains troubled, and David regards Harriet's choice as the act that destroyed their remaining chance of ordinary family life. Ben grows into a powerful adolescent who is increasingly detached from the household. He finds a place among John and other rootless young people, follows them rather than Harriet, and eventually goes away with them. Harriet is left with neither the crowded family center she wanted nor certainty about Ben's future. Watching reports of violent crowds on television, she searches the faces and wonders whether Ben has joined such a group. The book closes without confirming where he is, leaving Harriet to confront both his unknowability and the collapse of the domestic ideal on which she and David built their lives.",
         "in_short": "Harriet and David Lovatt marry with a shared dream of a large, traditional family and buy a spacious house that becomes the center of happy gatherings. Four children are born in quick succession. Harriet's fifth pregnancy is violently different, and Ben arrives early, unusually strong, watchful, and difficult to control. Fear of him drives relatives away and makes the older children feel unsafe. Under pressure, the family sends Ben to an institution, but Harriet is horrified by its brutal neglect and brings him home. That rescue permanently divides her from David and the other children. Ben later attaches himself to a group of troubled youths led by John and eventually leaves with them. The Lovatt household disperses, the marriage is damaged, and Harriet remains unsure whether she saved Ben or sacrificed everyone else to a duty only she would accept.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1172,7 +1172,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1185,7 +1185,7 @@
       "recaps": {
         "ending": "Vimes exposes the plot behind the theft of the Scone of Stone: a faction of traditionalist dwarfs arranged the crime and a forged replacement to control the succession. The forger's work is revealed, and the Low King, Rhys Rhysson, is properly crowned, using the moment to make a startling public admission about the relic that defuses its power as a weapon. Wolfgang von Uberwald, having hunted Vimes across the frozen countryside, is defeated, ending the werewolf clan's bid for dominance. Angua and Carrot reconcile and return together to Ankh-Morpork and the Watch. Vimes, glad to be done with diplomacy, heads home, where the chaos Colon caused is quietly undone. Lady Sybil shares happy news with Vimes: she is expecting their first child. Ankh-Morpork's interests in Uberwald are secured, and Vimes returns to the job he actually wants.",
         "in_short": "Lord Vetinari sends Commander Vimes to the wild country of Uberwald as Ankh-Morpork's ambassador, ostensibly for the coronation of a new dwarf Low King but really to secure trade in the region's fat and mineral wealth. Vimes, his wife Lady Sybil, and a small party of watchmen arrive to find the dwarfs in crisis: the Scone of Stone, the ancient relic on which the Low King is crowned, has been stolen. Vimes treats the diplomatic emergency as a criminal investigation, tangling with scheming deep-down dwarfs, vampires, and the werewolf clan of Uberwald, led by Angua's violent brother Wolfgang. Angua returns home ahead of the others and Carrot resigns from the Watch to follow her. Back in Ankh-Morpork, the Watch nearly falls apart under Colon's mismanagement. Vimes uncovers that the theft is part of a plot to control who becomes Low King, survives a lethal hunt across the snow, and exposes the conspiracy in time for the true relic's fate to be revealed and the rightful coronation to proceed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1363,7 +1363,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1376,7 +1376,7 @@
       "recaps": {
         "ending": "Meov, the island comm where Syenite has lived free for two years, is found. A Guardian ship arrives, Schaffa among the boarding party, and Guardians can switch an orogene off by touch. Innon is killed in the fighting. Antimony takes Alabaster away through the rock. Cornered, and certain that Schaffa intends to carry her infant son off to a node station and wire him into a chair, Syenite kills Corundum herself, then reaches through a garnet obelisk and destroys Meov and everyone left on it. She survives, walks away from the wreck of her life, and starts again under another new name.\n\nThe three threads are one life. Damaya became Syenite; Syenite became Essun. The woman in Tirimo is the girl from the barn and the Fulcrum orogene, decades apart, renamed each time she had to begin again. The man who tore the continent open in the prologue is Alabaster.\n\nIn the present, Essun, Hoa and Tonkee reach Castrima, a comm hidden inside a geode underground and led openly by an orogene named Ykka. Alabaster is there: most of his body already turned to stone, the rest being consumed by Antimony. He admits that he opened the Rift deliberately, that the Seasons are an injury rather than a fact of nature, and that he needs Essun to finish what he began. His question closes the book: has she ever heard of a thing called a moon. Jija and Nassun are still alive somewhere to the south, and Essun has not stopped looking.",
         "in_short": "The Stillness is a continent whose civilizations are periodically ended by seismic catastrophe, and whose orogenes, people who can still or start earthquakes, are feared, owned and killed. Three stories run in parallel: Damaya, a girl handed to a Guardian and raised in the imperial Fulcrum; Syenite, a Fulcrum orogene sent on assignment with the powerful, insubordinate Alabaster and shown by him how much the empire hides; and Essun, a middle-aged woman in a small comm who comes home to find her small son murdered by her husband and her daughter taken, on the same day an orogene tears a rift across the continent and begins a Season expected to last centuries. Syenite's thread ends with a free comm destroyed by Guardians, her lover dead, and Syenite killing her own infant son rather than let him be enslaved. The three women are one: Damaya became Syenite, Syenite became Essun. Essun reaches the underground comm of Castrima and finds Alabaster there, dying and half turned to stone. He admits he broke the world on purpose, and asks whether she has ever heard of a thing called a moon.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1604,7 +1604,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1617,7 +1617,7 @@
       "recaps": {
         "ending": "Kelsier provokes an open uprising in Luthadel, then confronts the Lord Ruler in the square before Kredik Shaw and is killed in front of the crowd. The death is deliberate: it turns him into the Survivor, a martyr whose legend pushes the skaa into a full revolt that the crew's shattered army could never have produced. Marsh, believed dead, is alive, having been made into a Steel Inquisitor, and uses that position to strike from within. Vin, having pieced together the Lord Ruler's own logbook with Sazed, understands that he is not the prophesied hero who saved the world but Rashek, the servant who murdered the true hero and took the power at the Well of Ascension for himself, and that his immortality is fed by great metal bracers driven through his arms. She fights him in the palace, tears the metal away, and he ages and dies. Luthadel falls to the rebellion. Elend Venture, the one nobleman who wanted a better arrangement, is made king of the city, with Vin beside him and the surviving crew members as his awkward, unqualified government. The atium hoard the crew came for is never found, the ash still falls, the mists still rise, and Kelsier is already being worshipped as a god by the people he freed.",
         "in_short": "Under the thousand-year rule of the immortal Lord Ruler, ash falls constantly, the skaa are owned as slaves by the nobility, and rebellion has never once succeeded. Kelsier, a half-skaa thief who survived the Lord Ruler's prison mine and came out of it a Mistborn, gathers a crew of Allomancers for an impossible job: overthrow the Final Empire. He recruits Vin, an abused street thief who does not know she is Mistborn too, and trains her while she infiltrates the nobility under a false name and falls in with Elend Venture, the bookish heir to a great house. The crew's secret skaa army is destroyed and the plan collapses, but Kelsier provokes Luthadel into revolt and lets the Lord Ruler kill him publicly, becoming a martyr. In the chaos Vin learns from the Lord Ruler's own journal that he is an impostor sustained by metal he wears, confronts him, and kills him. The empire's capital falls, Elend is made king, and the crew are left holding a city they never planned to govern.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1814,7 +1814,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1827,7 +1827,7 @@
       "recaps": {
         "ending": "Eve's loyalties turn out to lie with Vincent Blake, and the pressure that has been closing on Hawthorne House was engineered rather than accidental. Avery stops trying to outlast Blake and goes to meet him on his own ground, playing the kind of game she has spent a year learning from his oldest rival, and she comes away with Toby's freedom and with the threat to the Hawthornes lifted, including the hold Blake had over the family through what happened to Sheffield Grayson. Avery turns eighteen; the last of her benefactor's conditions falls away and the fortune becomes hers outright, with no trustees and no permission required. Toby is alive and free and stays on his own terms. The brothers are left with the question of what to do with lives that were never going to be spent running the family empire, and Grayson in particular begins to look outward. Avery has decided that the point of having the money is giving it away. The closing section, set a year later, finds her doing exactly that alongside the Hawthornes and announcing a competition in which ordinary people can play, on Hawthorne terms, for a fortune of their own, with Jameson beside her.",
         "in_short": "Weeks from her eighteenth birthday and full control of the Hawthorne fortune, Avery is confronted by Eve, a young woman who is the image of the dead Emily Laughlin and who says she is Toby Hawthorne's daughter and that Toby has been taken. The man holding him is Vincent Blake, the head of a rival family who believes the money Tobias Hawthorne built his empire on was stolen from him, and who also knows what really happened to Grayson's father, a secret the Hawthornes cannot afford to have made public. Avery and the brothers work the last of their grandfather's puzzles while Blake tightens his grip and Eve's presence pulls the family apart from the inside. Eve proves to be working with Blake. Rather than wait him out, Avery meets him on his own ground and beats him at his own kind of game, winning Toby's freedom and ending the threat. She turns eighteen and takes the fortune outright, and a year later she is systematically giving it away and has announced a contest in which ordinary people can compete for a fortune of their own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1999,7 +1999,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2012,7 +2012,7 @@
       "recaps": {
         "ending": "The book closes in loss and grim victory. At Cairhien, Moiraine confronts the Forsaken Lanfear, who has come in a jealous rage over Rand, and hurls them both through a twisted doorway that appears to destroy them both, leaving behind a letter of farewell and quiet final instructions. Rand is left grieving the Aes Sedai who has directed his life since Emond's Field. He strikes at Caemlyn, where the Forsaken Rahvin has been ruling Andor in disguise after enthralling its queen; when Rahvin's Power kills Aviendha, Mat, and others, Rand answers with balefire, blasting the enemy out of recent existence so completely that those deaths are undone. Mat, now a formidable battle commander with a loyal company at his back, is drawn again to Rand's side. Nynaeve and Elayne reach safety near Salidar, where rebel Aes Sedai are massing against Elaida; Nynaeve has bound the legendary heroine Birgitte into living flesh, and in the world of dreams she at last captures the Forsaken Moghedien, taking a dangerous prisoner and a store of forbidden knowledge into her keeping. Rand now commands the Aiel and much of the heartland, but he is more alone than ever, his oldest guide gone, the taint on the male Power gnawing at him, and the surviving Forsaken already plotting their next stroke.",
         "in_short": "Rand leads the Aiel out of the Waste into the nation of Cairhien, where he wars against the renegade Shaido clan, and Mat discovers a genius for command, drawing soldiers into a company of his own. When word comes that the Forsaken Rahvin has seized Andor by ensorcelling its queen, Rand strikes at Caemlyn; Rahvin's Power kills several of his friends, and Rand answers by destroying him with balefire, a fire so fierce it burns the enemy out of recent time and undoes those very deaths. Meanwhile Nynaeve and Elayne flee across the sea and travel in disguise with a traveling show toward Salidar, where Aes Sedai who reject Elaida are gathering; along the way Nynaeve pulls a legendary heroine into living flesh and, in the world of dreams, finally traps her old tormentor, the Forsaken Moghedien. And at Cairhien, the Aes Sedai Moiraine, foreseeing her own end, confronts the Forsaken Lanfear and drags her through a doorway that consumes them both, sacrificing herself and leaving Rand without the guide who has shaped his path from the start.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2144,7 +2144,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2157,7 +2157,7 @@
       "recaps": {
         "ending": "Mitch completes his plan after discovering that the firm's systematic overbilling gives the government a route around privileged client communications. Tammy copies the incriminating records while Mitch arranges payment, protection, and Ray's release. When the firm learns that Mitch is cooperating, its security men and Mafia enforcers pursue him through Memphis and toward the coast. Abby joins the escape after helping obtain the last Cayman documents, and Ray gets away from prison under cover of the federal arrangement. Mitch withholds enough information and money to keep leverage over both the criminals and the FBI. He, Abby, and Ray reach a boat and leave the United States before either side can take control of them. The evidence is sufficient to destroy Bendini, Lambert & Locke and prosecute its members for extensive fraud, while the McDeeres disappear into a new life in the Caribbean. Mitch survives by refusing the simple choice offered to him: he neither submits to the firm nor places his future entirely in the Bureau's hands.",
         "in_short": "Mitch McDeere, an ambitious new Harvard lawyer, accepts a lavish offer from Bendini, Lambert & Locke in Memphis. He and his wife, Abby, soon discover that the firm's generosity comes with surveillance, punishing demands, and an expectation of permanent loyalty. The FBI tells Mitch that the firm serves organized crime and that associates who tried to leave were murdered. Trapped between federal pressure and the firm's security apparatus, Mitch devises his own bargain. With investigator Tammy Hemphill and Abby, he copies records proving massive client overbilling, a crime he can expose without relying on protected legal advice. He demands money and his imprisoned brother Ray's freedom in exchange for the evidence. Once his cooperation is discovered, Mitch, Abby, and Ray evade both killers and federal control, escape by boat, and vanish into the Caribbean. The records bring down the firm, while Mitch preserves enough leverage and money to begin again beyond the reach of either side.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2279,7 +2279,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2292,7 +2292,7 @@
       "recaps": {
         "ending": "Bedford eventually learns Cavor's fate through fragmented wireless messages intercepted by Julius Wendigee. Remaining on the Moon, Cavor has been kept alive by the Selenites, learned to communicate with them, and studied their intensely specialized underground society. He is taken before the Grand Lunar and explains human civilization, including private property, national rivalry, and war. The ruler is appalled by humanity's violence and by the danger posed by Cavorite. Cavor begins to transmit the secret of making the substance, but the message breaks off before the crucial information arrives. No further signal is received, implying that the Selenites have stopped him and sealed away both him and the knowledge that could connect the worlds. Bedford remains on Earth with only this incomplete record; the sphere itself had already vanished after two boys entered it and accidentally launched into space.",
         "in_short": "Mr. Bedford, a struggling businessman, befriends the scientist Cavor, who has invented Cavorite, a material that blocks gravity. They build a sphere controlled by Cavorite shutters and travel to the Moon, where daylight releases an atmosphere and produces rapid plant growth. Beneath the surface they encounter the insectlike Selenites and their immense industrial civilization. After capture and a violent escape, Bedford reaches the sphere alone and returns to Earth, while Cavor remains behind. The unattended sphere is then accidentally launched by two boys and lost. Later, wireless operator Julius Wendigee intercepts transmissions from Cavor. Cavor reports that the Selenites have spared him, taught him about their specialized society, and brought him before the Grand Lunar. His account of human warfare alarms the lunar ruler. As Cavor starts transmitting the method for making Cavorite, the signals abruptly cease, leaving him isolated on the Moon and the secret incomplete.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2405,7 +2405,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2418,7 +2418,7 @@
       "recaps": {
         "ending": "The Fisherman returns to the shore but cannot separate from his Soul a second time. Each day he calls for the Mermaid, who does not answer, while the Soul tells him stories and repeatedly seeks entrance to his heart. His love keeps it out until the Mermaid's dead body is washed toward him. Grief breaks the Fisherman's heart, allowing the Soul to enter at last. As the tide rises, the Soul urges him to save himself, but he embraces the Mermaid and lets the sea cover him. The Priest refuses the lovers consecrated burial, so they are placed together in an unconsecrated field. Later, extraordinary flowers grow from their grave and are used to decorate the church altar. Their beauty changes the Priest: he preaches about divine love and goes out to bless the sea and all its creatures. The Fisherman and Mermaid remain dead, but the love the Priest condemned transforms his understanding.",
         "in_short": "A Young Fisherman falls in love with a Mermaid who will accept him beneath the sea only without his soul. A witch teaches him to cut the Soul away from his body, and he sends it into the world while keeping his heart for the Mermaid. The Soul returns annually with tales of wisdom and riches, but only a story about a dancer tempts the Fisherman onto land. Once reunited with him, the heartless Soul leads him into theft and murder. The Fisherman repents and returns to the coast, but he cannot dismiss the Soul again. When the Mermaid's corpse washes ashore, his heart breaks, the Soul reenters it, and he drowns embracing her. A Priest denies them sacred burial, yet marvelous flowers later grow from their grave. Moved by them, he preaches love and blesses the sea he had condemned.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2541,7 +2541,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2554,7 +2554,7 @@
       "recaps": {
         "ending": "Obembe and Benjamin retaliate against Abulu for the prophecy they believe destroyed their brothers. Their attack kills him, but it does not restore the family: Obembe escapes, while Benjamin is caught and sentenced to eight years in prison. Ikenna is already dead from the fight with Boja, and Boja has killed himself in the well after realizing what he had done. The parents lose the future Eme had planned for his sons, and the surviving children inherit the consequences of both the prophecy and their responses to it. Benjamin's adult narration turns the brothers' brief season as fishermen into the origin of a family catastrophe. Whether Abulu truly foresaw events remains less important than the way fear, suspicion, violence, and revenge made his words come true.",
         "in_short": "In 1990s Akure, a bank employee's transfer leaves his four oldest sons beyond his daily supervision. Ikenna, Boja, Obembe, and nine-year-old Benjamin begin fishing at the forbidden Omi-Ala River. There the feared madman Abulu predicts that Ikenna will be killed by a fisherman. Because the brothers have made themselves fishermen, Ikenna becomes suspicious and violently withdraws from them. His fear poisons the family despite his parents' attempts to break its hold. A fight between Ikenna and Boja ends with Boja killing Ikenna; overwhelmed, Boja then drowns himself in the family well. Obembe convinces Benjamin that Abulu must pay for setting the disaster in motion. They kill him, but Obembe escapes and Benjamin is arrested and sentenced to eight years. Looking back as an adult, Benjamin presents the prophecy as a force made real through belief, fractured brotherhood, and revenge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2693,7 +2693,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2704,7 +2704,7 @@
       "recaps": {
         "ending": "The book ends with the moment the whole series has pointed toward: Bebbanburg is Uhtred's. Slipping away from Aethelhelm's fleet at Grimesbi as Norsemen allied with the Scots burned it, Uhtred disguised his own ships as the supply ships the fortress was expecting, and the guards themselves opened Bebbanburg's Sea Gate to him. In the fighting that followed, the prince Aethelstan - stowed away with the help of Uhtred's son - killed Aethelhelm's champion, and Uhtred's cousin, refusing to meet him man to man, was cut down. Aethelhelm's scheme to bind the fortress to his family died with the defence, and the ealdorman himself did not survive its fall. Constantin's Scots, still in the field around the fortress they had come to take, found it held against them by its rightful lord and no longer worth the price; the siege that was meant to starve out a usurper ends with the Scots coming to terms and withdrawing. After a lifetime of fighting for other people's kingdoms, Uhtred of Bebbanburg holds his own: lord of the fortress at last, with his son as its heir - and with Aethelhelm's faction in Wessex now owing him a hatred that will outlive the old ealdorman.",
         "in_short": "With a fragile truce holding between Wessex, Mercia, and Sigtryggr's Norse Northumbria, Uhtred at last turns to his life's ambition: retaking Bebbanburg from his cousin. First he must stop a war - Ealdorman Aethelhelm has been scheming to break the truce and to have the prince Aethelstan killed under Danish colors, and Uhtred exposes the plot before the kings. Then the board shifts: Constantin of Scotland invades the Bebbanburg lands and besieges the fortress, and the trapped cousin hires Einar the White's Norse crews and looks to Aethelhelm for rescue. Uhtred threads between Scots, Norsemen, and West Saxons - using the mad bishop-pirate Ieremias, scouting Aethelhelm's fleet at Grimesbi and escaping when it burns - and finally disguises his ships as the fortress's expected supply ships. The guards open the Sea Gate themselves; Aethelstan, stowed away, kills Aethelhelm's champion; the cousin refuses single combat and dies; Aethelhelm does not survive the fall. The Scots come to terms, and Uhtred is lord of Bebbanburg at last.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2846,7 +2846,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:1982557702",
@@ -2858,7 +2858,7 @@
       "recaps": {
         "ending": "Ekaterin forces the concealed household out of the exclusion zone after stopping Ma Roga's attempt to burn their home and kill Boris. Jadwiga, Ingisi, and Boris remain together under radiation isolation and evaluation at Hassadar General, while Ma Roga is guarded separately. Jadwiga's prognosis is still unknown. Miles decides that Vadim's long concealment of the settlement will cost him his ranger position, although Miles intends to find him other employment. Enrique offers Butterbug Ranch as quarantine space for the animals and as a possible later home and workplace for the three younger survivors. The Vashnoi restoration continues: the first radbugs proved that biological cleanup can work, but the failed trial leads Enrique to plan a tougher, burrowing, unpleasant-tasting design.",
         "in_short": "Ekaterin and Miles investigate missing radbugs from a promising cleanup experiment in the Vashnoi exclusion zone and discover a concealed household living amid severe radioactive contamination. Ingisi stole the insects as a gift for the dying Jadwiga, unaware that their glow marked concentrated radiation. Ma Roga, who was once exiled to the zone by Count Piotr and later sheltered abandoned children there, resists evacuation. Ranger Vadim Sammi is exposed as the settlement's long-time secret supplier. When Ma Roga tries to burn the household and kill Boris rather than let the group be separated, Ekaterin stops her. Jadwiga, Ingisi, and Boris are taken to Hassadar General, while Ma Roga is guarded separately. Vadim loses his ranger post, the animals gain a quarantine option at Butterbug Ranch, and Enrique prepares a redesigned radbug trial. Jadwiga's survival and the younger residents' long-term future remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2979,7 +2979,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2990,7 +2990,7 @@
       "recaps": {
         "ending": "The book, and the series, ends with Connie fully reformed. Near the close she loses her voice as a punishment for eavesdropping in the Land of Secrets, and it is given back to her only in the Land of Enchantments, a place dangerous enough that several of the group are nearly lost there for good before all are brought out safely. When the Faraway Tree seems to wither and die, its folk band together to save it. Humbled by her adventures, Connie has shed her boastful manner and become genuinely fond of the tree and its people. The friends celebrate with a final visit to a Land of Treats, full of ice creams, a roundabout ridden on live animals, balloon rides and a circus. Connie is sad that her stay is over, and the children say a fond good-bye to Moon-Face, Silky, the Saucepan Man and the rest, and to the Faraway Tree itself. As the last of the three books, it leaves no thread open: the door on the Enchanted Wood is closed with the tree safe and its folk secure.",
         "in_short": "A stuck-up, disbelieving girl named Connie comes to stay with the children while her mother is unwell, and scoffs at the idea of a magic tree - until the folk of the Faraway Tree, from the ink-throwing Angry Pixie to Dame Washalot's wash-water, show her otherwise. Climbing to the lands at the top, the group visit a Land of Giants, a Nursery Rhyme Land and the school of the strict Dame Slap, and have to search for Connie when she vanishes in the Land of Marvels. Later Connie loses her voice for eavesdropping in the Land of Secrets and has it restored only in the perilous Land of Enchantments, where several of the friends are nearly lost. When the Faraway Tree itself begins to wither, its folk work together to save it. By the end Connie has been humbled and grown fond of the tree, and after a last visit to a Land of Treats the children bid the tree and its folk a fond farewell, closing the series.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3370,7 +3370,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -3383,7 +3383,7 @@
       "recaps": {
         "ending": "Omega leaves Earth carrying roughly two million refugees, while the Imperium extracts its own people and devastates the planet. Bill remains captain, with Bina as executive officer and Stone as alternate commander, but Stone condemns Bill's decision to destroy a human-staffed facility to secure the Geneva team's escape. Lambert and Porker are dead. Splat, Funnybone, Termite, Tubes, Raina, Tull, and the principal officers survive. Miriam Henderson reaches Omega, and Gordon Henderson is found alive but gravely weakened at the Callisto mining camp. James Riding is also alive, badly injured and receiving treatment aboard Omega, while Bina's responsibility for his imprisonment remains concealed from most of the crew. Val, Tobias, and the Archive no longer answer. Geneva data indicates that reinforcing Omega at an Imperial shipyard could enable short-range jumps. Bill chooses that dangerous objective as the next step toward securing resources, protecting the refugees, and reaching a future colony.",
         "in_short": "Captain Bill Henderson follows a mysterious ancient signal while serving the Ornu, who control humanity through implanted kill switches. His crew finds Omega, an ancient intelligent warship that the Imperium tries to exploit. After Bill refuses an order that would condemn a capital world, he is executed, but Omega revives him, disables the switches, and helps the humans and alien allies seize the ship. Bill returns to Earth after learning the Ornu intend to destroy humanity. Teams recover genetic data from Geneva and political prisoners from Titan, though Jen Lambert and Porker die. Bill saves Stone's trapped team by striking a human-staffed facility, breaking Stone's trust and losing contact with Omega's guiding personas. Omega evacuates roughly two million people before Imperial warships devastate Earth. Bill finds his imprisoned father and learns James Riding survived. With Omega's interfaces silent, he leads the refugees toward an Imperial shipyard that may give the ship short-range jump capability.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3630,7 +3630,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3643,7 +3643,7 @@
       "recaps": {
         "ending": "Stephen's work in Boston reveals that Johnson's intelligence service is closing around him and that Diana also needs to escape Johnson's control. With help from the Herapath connection, Stephen gets the badly wounded Jack and Diana out of the city by boat. They reach HMS Shannon, returning to British protection just as Captain Broke brings the frigate into his carefully prepared action with USS Chesapeake. The battle is brief and violent: Shannon's disciplined gunnery and boarding party take Chesapeake, while Captain Lawrence is mortally wounded and Broke suffers a grave head injury. Stephen treats the casualties, including Broke, and Jack again finds himself among Royal Navy officers rather than American captors. Shannon sails for Halifax with her prize. Jack has survived the loss of Java without losing his arm, Stephen has escaped an intelligence trap, and Diana is free of Johnson and reconciled with Stephen. Their personal future is reopened, while Britain and the United States remain at war.",
         "in_short": "After Leopard reaches the East Indies, Jack Aubrey and Stephen Maturin try to return to Britain. Their first passage ends when La Flèche burns; HMS Java rescues them, then meets USS Constitution. Java is defeated and destroyed, Captain Lambert is mortally wounded, and Jack suffers a shattered arm. Taken prisoner to Boston, Jack undergoes a difficult recovery under Stephen's care. Stephen discovers that Diana Villiers is in the city with the American intelligence chief Johnson, who is also hunting British agents and has identified Stephen as a danger. Assisted by Michael Herapath and local allies, Stephen turns an attempted trap to his advantage, reunites with Diana, and arranges an escape with her and Jack. They reach HMS Shannon before its duel with USS Chesapeake. Shannon captures the American frigate in a short, brutal action. The British party sails toward Halifax: Jack's arm saved, Stephen and Diana reconciled, and all three out of Johnson's reach.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3844,7 +3844,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3857,7 +3857,7 @@
       "recaps": {
         "ending": "At Roark's trial for destroying Cortlandt Homes, he represents himself and argues that creators must be free to control what they create. The jury acquits him. Wynand, having ordered the Banner to denounce Roark when the paper's circulation collapsed, understands that his apparent power always depended on serving the crowd. Roark refuses to resume their friendship, and Wynand closes the Banner. Keating's career and confidence are ruined; Toohey's campaign has gained influence but has not secured Roark's submission. Wynand gives Roark one final commission, the Wynand Building, intended to be the city's tallest skyscraper. In the closing scene Dominique, now Roark's wife, rides a construction elevator up the rising tower. She reaches Roark at its summit, with the completed shape of his work implied in the structure growing beneath them.",
         "in_short": "Architect Howard Roark refuses to imitate inherited styles or surrender control of his designs, while his classmate Peter Keating advances through charm, borrowed ideas, and conformity. Critic Ellsworth Toohey works to elevate mediocrity and turn public opinion against independent creators. Dominique Francon recognizes Roark's greatness but initially tries to destroy what she loves, while newspaper magnate Gail Wynand believes power over the public can protect private excellence. Roark loses commissions, works in a quarry, survives a lawsuit over the Stoddard Temple, and slowly builds a body of uncompromised work. When alterations violate his secret design for the Cortlandt housing project, he dynamites it and stands trial. Wynand's attempt to defend him destroys the Banner's public support and exposes Wynand's dependence on the crowd. Roark wins acquittal through his defense of creative independence, marries Dominique, and receives Wynand's final commission for a great skyscraper.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4023,7 +4023,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4036,7 +4036,7 @@
       "recaps": {
         "ending": "Elsa joins Jack Valen in organizing Welty's cotton pickers after growers cut wages again. When workers walk out, armed men confront them. Elsa steps forward to keep the strike together and is shot. Jack gets her away, but she dies with Loreda beside her, having finally recognized her own strength and told her daughter to pursue a larger life. Her death helps galvanize the workers rather than ending their action. Loreda and Ant take Elsa's body back to Texas, where Tony and Rose welcome their grandchildren home and bury Elsa on the Martinelli land. In the epilogue, Loreda is preparing to attend college and carries her mother's lessons about courage, love, and speaking against injustice. The family has survived the Dust Bowl and California's labor camps, but its future has been purchased through Elsa's sacrifice.",
         "in_short": "Elsa Wolcott becomes pregnant by Rafe Martinelli and builds a life with his farming family on the Texas plains. Years later, drought and dust destroy their crops, Rafe abandons them, and Elsa leaves for California with their children, Loreda and Ant. The promised land of opportunity proves hostile: migrants live in squalid camps, accept shrinking wages, and remain trapped by company debt. Elsa finds friendship with the Deweys and moves her family to a government camp, where she gains confidence and dignity. After her friend Jean dies because poverty has put medical care out of reach, Elsa works with organizer Jack Valen. She joins a strike against grower Welty's wage cuts and is shot while rallying the workers. Loreda and Ant return her to the Martinelli farm in Texas. Loreda later prepares for college, committed to carrying forward her mother's hard-won courage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4431,7 +4431,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -4444,7 +4444,7 @@
       "recaps": {
         "ending": "The field offensive proves to be a diversion. Hamma sacrifices herself, and the power released by her prayer lets Ruwen destroy the five members of the Retribution Squad. Naktos then captures the city and drops the temple into a flooded shaft, halting revivals with Hamma first in the queue. From the Crystal Forest, Ruwen and his allies create the Crazer from Shattered Sun crystals, condensed light, Harden, and Voidband techniques. The weapon enables an allied breach of the occupied city. Ruwen reaches the submerged temple alone, seals the shaft, and vaporizes its water to propel the structure into a lake beyond the city. He restores its navigation data, allowing Hamma and the other queued dead to revive. The survivors begin resettlement while the displaced temple operates from its lakeside foundation. Naktos remains a wider threat, the Stone Carver and her synchronized portal remain unresolved, and Ruwen's axiom purpose and Shadow training stay concealed. The immediate next task is a covert trip under step-championship cover to prevent the Legion from permanently killing the shade companion's brother.",
         "in_short": "Ruwen builds alliances around the restored temple-city while discovering that he is the fourth secret in a plan to return spirit to the universe. He survives a hidden enemy temple, completes the Mount Sorrow trial, learns of the concealed Shadow Steps and is offered a path toward them, revives his parents and the city's Elders, and secures Fractal and displaced cultivators as defenders. Naktos uses a staged field battle to draw the army away, and Hamma dies invoking her greatest prayer so Ruwen can destroy an elite squad. Enemy forces seize the city and sink the temple. Ruwen invents the Crazer, leads a successful breach, and uses steam to launch the temple into a nearby lake. The restored temple revives Hamma. During the recovery, the group learns that the Legion plans to kill the shade companion's brother beyond revival range, so Ruwen and Sift join a step-championship cover mission to rescue him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4608,7 +4608,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4621,7 +4621,7 @@
       "recaps": {
         "ending": "Orbit is eventually cleared, traffic control comes back, and the four travellers go their separate ways. Roveg reaches the hearing he was racing toward and is granted a brief, tightly supervised contact with the sons he was exiled away from, which he accepts on whatever terms are offered. Pei leaves Gora resolved to make her own decisions about whether to have a child and about the human she loves, rather than let her people's expectations make them for her. Speaker and Tracker return to their work, having spent three days being treated as guests rather than as a problem. Ouloo, who watched an Akarak be stranded on her doorstep with nowhere to take off her suit, builds a room at the Five-Hop with Akarak-compatible air so the next traveller like Speaker has somewhere to breathe; Tupo, recovered and older, is starting to work out what xe wants to be. Nothing large is resolved by any of it: the Aeluon war continues, the Quelin remain what they are, and the Commons has still done nothing for the Akaraks. What the book ends with is smaller and deliberate - a handful of strangers who were decent to each other while stuck, and who changed how they act afterwards.",
         "in_short": "Gora is a barren planet whose only value is its position between wormhole tunnels, and the Five-Hop One-Stop is a small waypoint on its surface run by Ouloo, a Laru, and her adolescent child Tupo. Three travellers put down there within hours of each other: Pei, an Aeluon cargo captain hauling for her people's war; Roveg, a Quelin exile racing to an appointment he has waited years for; and Speaker, an Akarak who cannot breathe the atmosphere everyone else shares and lives in a mech suit. Then Gora's orbital infrastructure fails in a cascade of satellite collisions, cutting communications and grounding every ship for days. Stuck together, the strangers argue and confide, weather Tupo being badly poisoned with no medical help to call, and mount a rescue when Speaker's shuttle is struck by falling debris. When the sky clears they leave changed: Roveg gets a brief supervised contact with the sons he was exiled from, Pei resolves to decide her own future, Speaker returns to her sister, and Ouloo builds a room at the waypoint with Akarak-breathable air so the next traveller like Speaker has somewhere to be.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4793,7 +4793,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4806,7 +4806,7 @@
       "recaps": {
         "ending": "After Polina rejects Alexei's attempt to give her part of his roulette fortune, he lets Blanche take him to Paris. She spends his winnings on an extravagant household and secures her own future by marrying the General, while Alexei leaves with little money and no lasting attachment. He drifts between European casinos, briefly works as a servant, and even spends time in prison for debt. Meeting Mr Astley at Homburg gives him one final chance to see what he has lost. Astley reports that Polina is in Switzerland with his family and that she truly loved Alexei, but he also judges that gambling has consumed Alexei's character. Astley gives him only a small sum, knowing where it will go. Alexei imagines that he can recover himself, approach Polina honorably, and begin a new life, yet postpones reform until tomorrow and turns again toward the gaming table.",
         "in_short": "Alexei Ivanovich, a young tutor in a Russian general's household at Roulettenburg, is caught between his obsessive love for the General's stepdaughter Polina and his growing attraction to roulette. The General is deep in debt and expects an inheritance that would let him marry the fortune-seeking Blanche. His wealthy aunt overturns these plans by arriving alive, becoming enthralled by the casino, and losing a large sum before returning to Moscow. When Polina is humiliated by her dealings with the French creditor de Grieux, Alexei gambles recklessly and wins a fortune for her. She rejects the money and him. Alexei then goes to Paris with Blanche, who spends his winnings and marries the General. Reduced to a wandering gambler, Alexei later learns from Mr Astley that Polina did love him. Although he speaks of changing his life, he uses Astley's small gift to gamble again and defers reform once more.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4951,7 +4951,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4964,7 +4964,7 @@
       "recaps": {
         "ending": "After spending Alexei's winnings freely in Paris, Blanche marries the general, whose social position remains useful to her despite his financial and emotional collapse. Alexei separates from them and resumes drifting among European gambling towns. Much later, in Homburg, Mr Astley finds him poor and still ruled by roulette. Astley explains that Grandmother has died, that Polina is financially secure and staying with his family, and that she has loved Alexei, though his conduct wounded and frightened her. He also gives Alexei money while warning that it will probably return him to the tables. The news convinces Alexei that he could still restore his life and prove himself to Polina. Yet his grand decision is postponed until tomorrow as he concentrates once again on finding a stake and winning, leaving the promised reform trapped inside the same cycle of gambling that has consumed his freedom.",
         "in_short": "Alexei Ivanovich, tutor to a debt-ridden Russian general's family at Roulettenburg, loves the general's stepdaughter Polina and is drawn to roulette. The household expects the death of a wealthy aunt to pay its debts and enable the general's marriage to Blanche. Instead, the vigorous aunt arrives, discovers the scheme, and loses a large portion of her fortune gambling before returning to Moscow. The family's plans collapse, and the creditor de Grieux abandons Polina. Trying to free her from his financial hold, Alexei gambles his small stake into a fortune. Polina rejects the money after a tormented night and leaves with Mr Astley. Blanche then takes Alexei to Paris, spends his winnings, and ultimately marries the general. Alexei becomes a wandering gambler. When Astley later tells him that Polina loved him and gives him another stake, Alexei imagines beginning a new life tomorrow, but remains focused on roulette.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5161,7 +5161,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5174,7 +5174,7 @@
       "recaps": {
         "ending": "In the final story, “The Lady's Maid,” Ellen talks to an unseen visitor while preparing her mistress for bed. Her affectionate account presents service as a life of intimacy and purpose, but details gradually disclose its cost. After caring for her mother and then becoming indispensable to her employer, Ellen gave up the prospect of marrying Harry. She insists that she does not regret the sacrifice and imagines the household could not function without her. Yet when the visitor leaves, her last anxious attempt to prolong the conversation exposes the loneliness beneath her bright manner. The collection ends not with a decisive break but with a speaker protecting the story that makes her renunciation bearable.",
         "in_short": "Fifteen stories move through seaside holidays, prosperous homes, workplaces, streets, and public entertainments, tracing how class and convention shape private feeling. The Burnell family disperses around a day “At the Bay.” Laura Sheridan's garden-party delight is interrupted by a workingman's death, while the Pinner sisters find that their father's death does not immediately free them. Other stories follow uncertain courtship, youth observed by outsiders, Ma Parker's unexpressed grief, a marriage displaced by fashionable friends, a child's voyage, Miss Brill's fantasy of belonging, Leila's first ball, a teacher's romantic panic, and a husband's jealousy of a dead stranger. Bank-holiday crowds and Mr Neave's “ideal” family reveal isolation within apparent abundance. Finally, Ellen, a lady's maid, recounts giving up marriage to serve her mistress; her insistence on contentment cannot conceal her loneliness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-gate-of-the-feral-gods.json
+++ b/data/works-community/0/the-gate-of-the-feral-gods.json
@@ -106,7 +106,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -117,7 +117,7 @@
       "recaps": {
         "ending": "The book closes with the fifth floor beaten and Carl's most audacious deception yet. Having gathered all three components of the Gate of the Feral Gods, Carl loudly advertises a plan to unleash a feral god on the ninth floor, then does something else entirely: he uses the gate to connect the water quadrant's drain to Larracos, the ninth floor's great city, flooding it, killing its NPCs and mercenaries, and blocking access to its Desperado Club, a strike at the infrastructure of the floor where the crawl's sponsored killers will one day hunt them. Juice Box goes through to Larracos, confessing before she leaves that she loves Louis. Earlier, the last loose ends of the floor resolve: Maggie My, the Infiltrator wearing Chris's body, escapes containment and is finally killed when Carl phases through Chris's body to crush her, freeing what is left of Chris; Samantha's demonic pursuer Slit is destroyed by the summoned bulk of Samantha's mother; and the party sends the changelings ahead to the sixth floor. Carl ends the floor as an acolyte of the fire god Emberus, carrying two divine quests, and publicly pledges to kill every hunter waiting on the sixth floor. In the epilogue, watchers discuss Carl's trajectory, and Bea, Carl's ex-girlfriend and Donut's owner, is revealed to be alive on the ruined surface, quietly moved to safety on Odette's orders. Katia plans to strike out separately on the next floor to protect Hekla's former Daughters from Eva.",
         "in_short": "The fifth floor is a honeycomb of sealed bubbles, each holding four elemental quadrants that must be liberated. Carl, Donut, and Katia land in a desert quadrant caught in a war between gnomes on a flying fortress and camel-folk towns, and discover the local powers are being manipulated through hostages and changeling infiltrators. They befriend the crawlers Louis and Firas and the changeling Juice Box, hijack the gnomes' flying warship to stop a bombing, and liberate the air quadrant. Carl learns of the Gate of the Feral Gods, a three-part artifact that can open doors between distant places, and the party gathers its components from a mad mage's collapsing sandcastle and a submarine guarded by a monstrous sharktopus, adopting Samantha, the doll-headed half-soul of a sand goddess, along the way. Maggie My, revealed as an Infiltrator wearing Chris's body, stalks the party until Carl finally kills her. Robot sabotage kills the hostile liaison Loita; Carl becomes an acolyte of the fire god Emberus to save a divine puppy; and with all quadrants freed, Carl uses the gate not to release a feral god, as he claimed, but to flood Larracos on the ninth floor. Bea, Carl's ex, is revealed alive on the surface.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -271,7 +271,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -284,7 +284,7 @@
       "recaps": {
         "ending": "The Gathering Storm ends with two victories that turn the tide. On Dragonmount, at the brink of destroying the world with the male Choedan Kal, Rand al'Thor finds his way back from despair: he grasps why he has been reborn to fight, chooses life and hope over annihilation, and laughs as the storm clouds part. The near-mad Dragon is remade into a calmer, surer man ready to face the Dark One. In Tar Valon, Egwene al'Vere completes her quiet conquest of the White Tower. Her courage during a devastating Seanchan raid, set against the usurper Elaida's failures, wins the sisters over; with Elaida carried off into Seanchan captivity, the Aes Sedai raise Egwene as the true Amyrlin Seat and the Tower is whole again. In a final stroke, the sister Verin reveals to Mat Cauthon that she has secretly been Black Ajah for decades, spying on the enemy from within; she leaves behind a full record of the Shadow's agents and takes poison to escape her oaths, dying to hand the Light a priceless weapon.",
         "in_short": "As the Last Battle nears, two storms break. Rand al'Thor, hardened by loss and the weight of prophecy, grows ever colder and more ruthless, trusting no one and reaching for powers that could unmake the world. When the captured Forsaken Semirhage seizes control of him through a forbidden device and nearly makes him kill Min, he tears free and destroys her, but the act pushes him to the brink of despair. Believing himself a destroyer, he takes an immense sa'angreal to the peak of Dragonmount meaning to end all things, and there, at the last moment, he remembers why life is worth living and is spiritually reborn, choosing hope. Meanwhile Egwene al'Vere, still a prisoner, breaks the White Tower's usurper from within. When the Seanchan raid the Tower and carry off sisters as slaves, Egwene fights openly and brilliantly; in the aftermath the discredited Elaida is gone, and the sisters raise Egwene as the true Amyrlin Seat, reuniting the Aes Sedai at last under her leadership.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -701,7 +701,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09SJ1T9KF",
@@ -713,7 +713,7 @@
       "recaps": {
         "ending": "The numbered story closes with the Wandering Inn and Liscor's hive both in crisis. Erin has sheltered five Redfang Hobgoblins, but Mrsha's grief erupts into attacks on them, while Yellow Splatters' jealousy drives him to assault Purple Smile. Erin halts the confrontation and insists on treatment for Bad Arrow. Beyond the numbered chapters, Erin secures a fragile coexistence at the inn, and Pawn's blessing restores Twin Stripes while Yellow Splatters accepts Purple Smile as a fellow sergeant. Rags remains an independent chieftain under pressure from human forces and the Goblin Lord.\n\nIn the northern campaign, Zel Shivertail commands Magnolia Reinhart's improvised human army against the Goblin Lord. He reaches and severely wounds the enemy commander, only to discover that the Necromancer has made the Goblin Lord bait for a prepared ambush. Magical plague and repeated attacks leave Zel apparently dead, while the wounded Goblin Lord survives and the Necromancer escapes with his remaining creations. Magnolia and Reynold survive the immediate engagement, but Zel's loss leaves the coalition's command and the larger peace effort uncertain. Tom remains in the Blighted Kingdom, aware of the king's summoning crimes and still struggling with the clown presence that can control him. The Horns' missing teammate may be alive, but no rescue has yet confirmed it.",
         "in_short": "As the Goblin Lord marches across Izril, Rags defends her independent tribe, Laken Godart builds the Unseen Empire through victories over goblin raiders, and Erin gives five Redfang Hobgoblins refuge at the Wandering Inn. In the Blighted Kingdom, Tom survives a demonic palace assault, kills the traitorous court fool, and learns that the king sacrificed unborn children to summon people from Earth. Liscor confronts the Raskgar threat, evidence that a missing Horn may still live, and turmoil among its individual Antinium. Zel Shivertail allies with Magnolia Reinhart, takes command of a northern human army, and attacks the Goblin Lord. The Necromancer uses his apprentice as bait and traps Zel with elite undead. Zel gravely wounds the Goblin Lord but is infected, overwhelmed, and apparently dies after letting his wounded opponent go. The Goblin Lord and the Necromancer survive, leaving the northern war and Magnolia's peace project unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -917,7 +917,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -930,7 +930,7 @@
       "recaps": {
         "ending": "The Physician's tale closes after the public turns against the corrupt judgment. Apius orders Virginius's arrest for killing Virginia, but the crowd recognizes the judge's conspiracy and imprisons him. Apius kills himself in jail. Claudius is condemned to hanging, yet Virginius asks that his life be spared, so he is exiled instead; the other participants in the plot are executed. Virginia cannot be restored, and her father's desperate act remains the cost of a legal system captured by predatory authority. The Physician ends by directing the audience away from Apius's apparent prosperity and toward the destructive consequences of sin. Within the larger Canterbury frame established by the General Prologue, this is one pilgrim's contribution to the Host's storytelling contest on the road to Canterbury.",
         "in_short": "In spring, a narrator joins a varied company of pilgrims at the Tabard Inn on the way to Canterbury. His portraits range across social ranks and professions, often contrasting public office with actual conduct. Their host, Harry Bailly, proposes a storytelling contest and accompanies them as judge. In the included Physician's Tale, the corrupt Roman judge Apius desires Virginia, the virtuous daughter of Virginius. He has Claudius falsely claim that Virginia is a stolen slave and then rules in his accomplice's favor. Seeing no lawful escape, Virginius kills his daughter rather than surrender her and brings her head to court. Apius orders his arrest, but the public revolts against the conspiracy. Apius kills himself in prison; Claudius is sentenced to death but, through Virginius's mercy, is exiled. The tale ends as a warning that abused power and unchecked desire destroy both innocent victims and those who pursue them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1027,7 +1027,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1040,7 +1040,7 @@
       "recaps": {
         "ending": "Morning exposes the strain Nathan sensed during the night. Hope confronts Lonoff over the life she has subordinated to his work and over Amy's place in their household, and she prepares to leave him. Amy also departs, leaving the exact nature and future of her connection with Lonoff unsettled. The great writer's controlled refuge is revealed as a damaged marriage rather than the pure sanctuary of art Nathan imagined. Nathan never establishes that Amy is Anne Frank; that identity belongs entirely to the story he constructed while listening from another room. Even so, he continues the fantasy far enough to imagine bringing Anne home as his bride, a triumphant answer to his family's accusation that his fiction betrays the Jews. He leaves the visit with artistic encouragement but without resolving the conflict between imaginative freedom and responsibility that brought him to Lonoff.",
         "in_short": "Young writer Nathan Zuckerman visits his literary idol E. I. Lonoff at the older author's secluded New England home. He hopes Lonoff's approval will vindicate him after his father condemned a story exposing a Jewish family quarrel and recruited Judge Wapter to challenge Nathan's sense of responsibility. Lonoff's disciplined life initially looks like an artistic ideal, but tension among Lonoff, his wife Hope, and the enigmatic young Amy Bellette reveals its human cost. During the night Nathan invents a history in which Amy is Anne Frank, secretly alive in America; marrying her would, in his imagination, silence every charge that his own fiction harms Jews. In the morning Hope prepares to leave Lonoff and Amy departs as well. Amy is never shown to be Anne, and Nathan's fantasy solves nothing outside his mind. He gains contact with the master he sought while seeing that literary dedication can coexist with evasion, damaged intimacy, and unresolved moral claims.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1217,7 +1217,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1230,7 +1230,7 @@
       "recaps": {
         "ending": "Moscow burns. In the chaos Vasya gets free, the ghost bound in Olga's tower is released from whatever was holding her there, and Kasyan Lutovich is killed; his golden mare bolts out of the city and nobody catches her. A large part of Moscow is gone by the time the fire is stopped. Vasya survives it, and so do Olga, Marya, Sasha and Dmitrii, but nothing can be put back the way it was. The whole city now knows that the Grand Prince's brave young champion was a girl in men's clothes, that she rode a horse nobody else could ride, and that Moscow burned around her; whatever her brother the monk and her sister the princess say in her defence, the word people have settled on is witch. Sasha has lied for her in front of his cousin and his order. Olga has sheltered her at the cost of her own standing. Dmitrii has been made a fool of publicly and does not forgive that quickly. Morozko has spent very nearly everything he had left keeping Vasya alive, and winter, which is the only season he is strong in, is ending. Vasya has her family back and her name destroyed, no place in Moscow and nowhere obvious to go, and the events of the winter have stirred up more than one thing that would have been better left asleep.",
         "in_short": "Vasya, on the road after leaving home, finds villages in the north burned and their girls taken. She cuts her hair, travels as a boy, destroys the raiders' camp and frees the captives, and is picked up by a party of the Grand Prince's riders that includes her brother Sasha, now a warrior monk. Rather than disgrace his family, Sasha lets her pass as his young brother Vasilii, and Dmitrii Ivanovich takes the brave boy into his household. In Moscow she is lodged with her sister Olga, a princess whose daughter Marya has the same sight Vasya does, while a ghost haunts the upper rooms of the house. After Vasya wins a horse race at Maslenitsa, the northern lord Kasyan Lutovich exposes her publicly as a girl. Kasyan proves to be an ancient sorcerer who has put his own death out of reach and has been engineering the raids to bring Dmitrii down. He is killed, but Moscow burns in the process, and Vasya emerges with her family shamed, her disguise destroyed and the whole city calling her a witch.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1384,7 +1384,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1397,7 +1397,7 @@
       "recaps": {
         "ending": "David eventually stops treating observation and small acts of help as enough. He acts against Ruth and the children who have followed her, gets Susan out of immediate danger, and tries to free Meg. The intervention comes too late to save Meg from the injuries inflicted during her captivity. Ruth dies in the final confrontation, ending her control of the basement and the group. Adults and authorities finally enter a situation the neighborhood children had kept hidden. Susan survives, while David must live with the knowledge that he understood the abuse long before he decisively resisted it. The adult narrative frames his memory not as a mystery about who was responsible, but as an account of how fascination, fear, and the wish to belong allowed cruelty to become communal. Meg's death remains the lasting center of his guilt.",
         "in_short": "Adult David Moran recalls the summer when orphaned sisters Meg and Susan Loughlin came to live with their aunt Ruth Chandler. Ruth's permissive home attracts David and other neighborhood children, but her resentment of Meg develops into humiliation and punishment. With Ruth's approval, the Chandler boys imprison Meg in the basement and widen the abuse into a group activity. David is horrified yet compromised by his continued presence; his limited efforts to comfort or help Meg do not stop what is happening. Susan is also threatened, and Meg's attempts to resist or escape bring further violence. David finally turns against Ruth and helps end the captivity, but Meg dies from her injuries. Ruth dies during the intervention, and Susan survives. Looking back, David recognizes his own delay and the children's willingness to accept Ruth's permission as central to how the abuse continued.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1519,7 +1519,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1532,7 +1532,7 @@
       "recaps": {
         "ending": "The mystery resolves on Rachel's ex-husband, Tom. Megan had been employed by Tom and Anna and had begun an affair with Tom; when she told him she was pregnant, he killed her in an underpass near the tracks and concealed her body in nearby woods. The night of the murder, Rachel had been drunk and near the scene, and Tom had exploited her blackouts for years, feeding her false memories so she blamed herself for outbursts and failures that were really his doing, part of a long pattern of manipulation that had helped destroy her. As Rachel pieces together what she actually saw and understands that Tom is the murderer and the source of her ruin, she goes to warn Anna. Tom turns violent, and in the confrontation at the house Rachel stabs him with a corkscrew in self-defense; Anna, now aware of the truth about her husband, ensures he is dead. Megan's killing is solved, Tom's lies are exposed, and Rachel begins to reclaim her life with a clearer sense of what was done to her and what she is capable of surviving.",
         "in_short": "Rachel, a divorced alcoholic prone to blackouts, rides the same commuter train daily and fixates on a couple she watches from the window, whom she imagines to be perfectly happy. When the woman, Megan, vanishes, Rachel inserts herself into the investigation, convinced she saw something important on a night she was too drunk to remember. Told through the unreliable voices of Rachel, Megan, and Anna, the new wife of Rachel's ex-husband Tom, the book gradually reveals that Megan has been murdered. The killer is Tom: he had been having an affair with Megan and killed her when she told him she was pregnant, striking her down and hiding her body. Tom is also a practiced liar who spent years gaslighting Rachel, convincing her that her drunken blackouts had made her do shameful things she never actually did. As Rachel recovers the truth of what she witnessed, she and Anna together confront Tom, and in the struggle Rachel kills him to defend herself, freeing both women from him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1649,7 +1649,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1662,7 +1662,7 @@
       "recaps": {
         "ending": "Salander recovers from her wounds while confined and awaiting trial. The secret security-police faction, desperate to keep its decades-old protection of Zalachenko hidden, works to have her convicted and committed. To silence Zalachenko himself, an aging former member of the cell shoots him dead in his hospital room and then takes his own life. Blomkvist, aided by his sister Annika Giannini as defense counsel and by the security-police investigator Monica Figuerola, assembles overwhelming evidence: that Salander was sane all along and had been wrongfully institutionalized as a girl to bury the truth about her father, and that the psychiatrist Peter Teleborian had falsified her records. At the climactic trial Annika exposes Teleborian's forgeries and his possession of child pornography, discrediting him completely; he is arrested, and the members of the illegal cell are exposed and taken into custody. Salander is acquitted of all charges and, for the first time, declared legally competent and freed from state guardianship. The fugitive Niedermann is finally cornered when Salander tracks him to a warehouse and immobilizes him, and he is killed there by the criminal bikers he had earlier betrayed. Salander regains control of her life and her stolen fortune, and she and Blomkvist restore their friendship on new, more equal terms.",
         "in_short": "Salander survives the head wound that ended the previous book and recovers in a hospital where her father, Zalachenko, is being treated one floor away. The state, driven by the secret security-police cell that has protected Zalachenko for decades, plans to have her convicted and locked away as insane. Blomkvist mounts a counterattack, gathering proof that Salander was illegally institutionalized as a child to bury the truth about her father, and enlists his sister Annika Giannini as her defense lawyer while a constitutional-protection officer, Monica Figuerola, investigates the rogue cell from inside the security police. An old operative murders Zalachenko in his hospital bed and then kills himself. At trial, Annika dismantles the psychiatrist Peter Teleborian, exposing his falsified reports and his own crimes, and the conspiracy collapses: its members are arrested and Salander is acquitted and finally declared legally competent, free of guardianship for the first time. Niedermann, the killer half-brother still at large, is hunted down; Salander traps him and he is killed by the criminals he had betrayed. She and Blomkvist reconcile as friends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1767,7 +1767,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1780,7 +1780,7 @@
       "recaps": {
         "ending": "The murders of Dag Svensson, Mia Bergman, and Nils Bjurman are pinned on Salander because her prints are on the pistol, but the real killer is Ronald Niedermann, a huge blond man immune to pain who works for the trafficking boss known only as Zala. Salander's investigation, and Blomkvist's, uncover that Zala is Alexander Zalachenko, a Soviet defector whom a secret faction of the security police has shielded for decades because of the intelligence he provided, and that this same faction had Salander committed to a psychiatric institution as a child to bury the truth. The deepest revelation is personal: Zalachenko is Salander's father, and Niedermann is her half-brother. Salander travels to Zalachenko's farm at Gosseberga to confront him. He and Niedermann shoot her three times, including a wound to the head, and bury her in a shallow grave. She claws her way out and attacks Zalachenko with an axe, gravely wounding him, before Niedermann flees. Blomkvist arrives and finds Salander barely alive. Both she and Zalachenko survive, Niedermann is at large, and the story breaks off unresolved, setting up the trial and reckoning of the next book.",
         "in_short": "A year after the events of the first book, Salander returns to Sweden as Millennium prepares to publish a Dag Svensson expose naming powerful men in the sex-trafficking trade. Dag and his partner Mia Bergman are shot dead, and so is Salander's guardian Nils Bjurman; Salander's fingerprints on the weapon make her the prime suspect, and a national manhunt begins. Convinced of her innocence, Blomkvist investigates while Salander pursues the truth alone. The trail leads to a shadowy trafficking boss known as Zala, revealed to be Alexander Zalachenko, a defected Soviet intelligence officer long protected by a secret cell within the Swedish security police, and to Salander's own buried past: Zalachenko is her father, and the blond enforcer Ronald Niedermann, who committed the murders, is her half-brother. Salander confronts Zalachenko at his farm, is shot and buried alive, digs herself out, and strikes him down with an axe. Niedermann flees, and Blomkvist finds Salander gravely wounded but alive as the book ends on a cliffhanger.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1906,7 +1906,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1919,7 +1919,7 @@
       "recaps": {
         "ending": "Blomkvist and Salander solve the Harriet mystery: her brother Martin was a serial killer who had inherited and continued the crimes of their father Gottfried, murdering women for years. After Salander rescues Blomkvist from Martin's soundproofed killing room, Martin dies in a car crash while fleeing. Blomkvist tracks Harriet to Australia, where she has lived under a false identity; she reveals that as a girl she drowned her sexually abusive father and then fled the island to escape Martin. Harriet returns to Sweden and takes a leading role in the Vanger Corporation. To settle the score with Wennerstrom, Salander poses as an investor, hacks his accounts, and both exposes his vast criminal network and steals roughly two billion kronor, which she keeps. Millennium publishes Blomkvist's devastating expose; Wennerstrom flees and is later found murdered. Blomkvist's reputation is restored. Salander, having fallen for Blomkvist, goes to give him a Christmas present but sees him with Erika Berger and, wounded, throws the gift away, leaving their relationship unresolved.",
         "in_short": "Disgraced financial journalist Mikael Blomkvist, reeling from a libel conviction, is hired by retired industrialist Henrik Vanger to solve the decades-old disappearance of his grand-niece Harriet, who vanished from the family's isolated island when it was cut off by a bridge accident. Living on Hedeby, Blomkvist teams with Lisbeth Salander, a gifted, damaged hacker who had investigated him. Together they discover that a string of coded numbers in Harriet's notebook point to a series of ritual murders of women stretching back decades, and that the killer is Harriet's own brother, Martin Vanger, who was continuing crimes begun by their abusive father Gottfried. Salander saves Blomkvist from Martin's torture chamber, and Martin dies fleeing. Harriet is found alive in Australia: she had killed her father in self-defense and fled her brother's abuse. Salander then uses her hacking skills to destroy Wennerstrom, exposing his criminal empire and secretly draining billions from his accounts, clearing Blomkvist's name.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2067,7 +2067,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2080,7 +2080,7 @@
       "recaps": {
         "ending": "Jonas learns that release, the community's word for removing people, is really a lethal injection, shown to him in a recording of his own father calmly killing a newborn twin. Realizing the community he obeys is built on this quiet killing and on the surrender of all real feeling, and learning that the fragile baby Gabriel is scheduled to be released, Jonas decides to act. With the Giver he plans an escape: if Jonas leaves the community, the memories he carries will flood back into the people, forcing them to feel and, the Giver hopes, to change. The Giver intends to stay behind to help them through it. Because Gabriel's release cannot wait, Jonas flees earlier than planned, taking the baby on his father's bicycle. He evades the search planes, then endures cold, hunger, and exhaustion as he travels toward Elsewhere. In the final scene, with snow falling, he climbs a long hill, finds a sled at the top, and rides down toward a valley of lit houses and the sound of music. Lowry leaves the close deliberately open: Jonas and Gabriel may have reached a real place of warmth and love, or the vision may be the last of a dying boy's memories.",
         "in_short": "Jonas lives in a tightly controlled community that has traded freedom, choice, color, and deep feeling for order and safety, a system called Sameness. At the Ceremony of Twelve he is chosen for the unique role of Receiver of Memory and is trained by an old man, the Giver, who transfers to him the memories of the whole human past, joyful and painful alike, that everyone else has been spared. As Jonas comes to know color, love, and snow, and also war and suffering, he grows disturbed by how empty and unfeeling his community really is. He discovers that 'release,' spoken of gently, is actually death by injection, applied even to imperfect babies like the newborn Gabriel his family has been minding. To save Gabriel and to force the community to feel again, Jonas flees with the baby toward Elsewhere. Cold, starving, and pursued, he reaches a snowy hill, finds a sled, and rides down toward distant lights and music, in an ending that leaves their survival uncertain.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2325,7 +2325,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0C673LP5N",
@@ -2337,7 +2337,7 @@
       "recaps": {
         "ending": "Elaine's school wins the Gladiator Gauntlet, and Elaine's separate struggle for recognition ends with the school accepting her as the creator of the Medical Manuscripts and awarding her an unprecedented platinum medical thesis. She has also completed the age-resetting stage of immortality, but apples and several apple products can obstruct her movement, penetrate her defenses, resist her healing, or suppress her healing magic. The exact wider reach of that concealed weakness remains open.\n\nElaine and Iona remain partners. The Valkyries have left their Roland territories and resumed independent travel, so Iona has no home there and the group intends to avoid the realm for one or two centuries. Elaine, Iona, Auri, and Fenrir fly from the school toward Sanguino in Exterrae with Marcella's introduction. Elaine may investigate Knight through vampire turning lines, but agrees to keep the search bounded; Knight's survival and Night's whereabouts are still unconfirmed. The closing interlude introduces further threats: Deimos and Livia are pursuing the Circus of Smiles, an organized construct force is taking villagers, a suspicious rat reaches a grain ship, and a city-spanning Sentinel network monitors Sanguino.",
         "in_short": "During her final period at the School of Sorcery and Spellcraft, Elaine develops a spatial Bookworm class, supports Iona's campaign against Roland, and fights in the Gladiator Gauntlet championship. Iona sweeps Roland's singles roster and Team Iona wins the match 25-0, while Elaine's school later defeats Happensburgs for the title. Elaine also proves that she wrote the Medical Manuscripts and receives a platinum thesis grade. An immortality rite restores her youth but curses her with a dangerous vulnerability to apples. The Valkyries survive by returning to itinerant service, though Roland is no longer a home for Iona. Elaine, Iona, Auri, and Fenrir leave for Sanguino in Exterrae, where they hope to settle and make a limited search for Knight. Elsewhere, Rangers pursue the Circus of Smiles, constructs abduct villagers, and Sanguino's Sentinel watches the city.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2494,7 +2494,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2507,7 +2507,7 @@
       "recaps": {
         "ending": "Knecht resigns as Magister Ludi after the Castalian authorities reject his warning that the province has mistaken long stability for permanence. He leaves without waiting for formal permission and accepts responsibility for educating Tito, the troubled son of his old friend Plinio Designori. On their first morning together in the mountains, Tito dives into a cold alpine lake and challenges Knecht to follow. Knecht enters the water despite being unused to the altitude and the cold, suffers a physical collapse, and drowns. Tito searches desperately but cannot save him. The boy's shock and sense of responsibility become Knecht's final influence: Knecht's brief service outside Castalia may have ended almost as soon as it began, yet his death places a moral demand on the pupil he chose. The biography closes with Knecht's institutional future erased and his legacy transferred from an office and its ceremonies to one young person in the ordinary world.",
         "in_short": "In a future Europe, the scholarly province of Castalia preserves learning and cultivates the Glass Bead Game, a discipline joining the arts and sciences in formal contemplation. The orphan Joseph Knecht rises through its schools, debates Castalia's purpose with the worldly Plinio Designori, studies history with Father Jacobus, and eventually becomes Magister Ludi. His success does not quiet his concern that Castalia depends on a society it neither serves nor understands. Convinced that the order faces historical danger, he circulates a warning and asks to leave office. The authorities refuse, so he resigns and goes to tutor Plinio's son Tito. During their first mountain excursion, Knecht follows the boy into a freezing lake and drowns. Tito cannot rescue him, but the loss confronts him with the weight of Knecht's freely chosen service. Knecht's career thus ends outside the institution that formed him, replacing mastery and rank with a final commitment to education as a direct human responsibility.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2614,7 +2614,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2627,7 +2627,7 @@
       "recaps": {
         "ending": "During dinner the apartment's electricity fails because Tom used the bill money for his escape plans. Laura and Jim talk by candlelight. He recognizes her from school, encourages her to see herself more generously, dances with her, and accidentally breaks the horn from her glass unicorn. After kissing her, Jim admits that he is engaged to Betty and cannot begin a relationship. Laura gives him the now-ordinary glass animal as a souvenir, and he leaves. Amanda, devastated that the gentleman caller was unavailable, blames Tom, but he did not know about the engagement. Tom soon follows his father's example and abandons the family. Although he travels widely, he cannot free himself from the memory of Laura. In the final remembered image, Amanda comforts her daughter while Tom asks Laura to extinguish the candles, trying and failing to release the guilt that continues to bind him to her.",
         "in_short": "Tom Wingfield remembers the St. Louis apartment he shared with his mother Amanda and sister Laura during the Depression. Amanda, abandoned by her husband, clings to stories of her youth and fears for Laura, whose severe shyness has driven her from business school into a private world of records and glass animals. Tom supports them through warehouse work but escapes nightly to the movies and dreams of leaving. At Amanda's urging, he brings coworker Jim O'Connor home as a prospective caller. Laura recognizes Jim as the admired classmate who once called her Blue Roses. In a warm private conversation he builds her confidence, dances with her, and kisses her, then reveals he is engaged. Jim leaves, Amanda blames Tom, and Tom abandons the household soon afterward. His travels do not provide true escape: memory and guilt keep Laura present for him long after he has gone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2747,7 +2747,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2760,7 +2760,7 @@
       "recaps": {
         "ending": "On Leo's thirteenth birthday, Mrs. Maudsley discovers enough to force him to lead her to the place where Marian and Ted are meeting. The adults' affair is exposed before the child who carried their messages without being equipped to understand or resist them. Ted subsequently kills himself, and the shock arrests Leo's emotional development: he withdraws from intimacy and spends his adult life avoiding the meaning of that summer. More than fifty years later, the elderly Leo returns to Brandham. Marian, now the widowed Lady Trimingham, tells him that Hugh married her despite what happened and accepted the child born afterward as his heir; that son has since died, leaving a grandson troubled by doubts about his family history. Marian asks Leo to serve once more as her messenger and tell the grandson that her love for Ted was real and should not be reduced to shame. The request forces Leo to reconsider the past, but it also shows Marian still assigning him the burden of translating an affair whose consequences shaped his entire life.",
         "in_short": "In 1900, thirteen-year-old Leo Colston visits his wealthy school friend Marcus Maudsley at Brandham Hall. Dazzled by Marcus's older sister Marian and eager to belong, Leo agrees to carry messages between her and local farmer Ted Burgess. He first mistakes the correspondence for an innocent secret and then realizes that Marian and Ted are lovers, although she is expected to marry the aristocratic Hugh Trimingham. Both adults exploit Leo's loyalty while his fear of offending them, his dependence on the Maudsleys, and his childish belief in omens prevent him from breaking free. On his birthday Mrs. Maudsley compels him to expose the lovers together. Ted later kills himself, and the trauma leaves Leo emotionally stunted. Returning to Brandham as an old man, he learns that Hugh married Marian and treated her child as his heir. Marian asks Leo to carry one final message to her grandson defending the love she shared with Ted, making the aging messenger confront the event he spent a lifetime suppressing.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2939,7 +2939,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2952,7 +2952,7 @@
       "recaps": {
         "ending": "The final chapters complete the chain of events behind Sophie Mol's death. After Ammu and Velutha begin a secret relationship, Velutha's father reports them to Mammachi and Baby Kochamma. Ammu is locked up, and her angry words make the twins believe they must run away. Estha, Rahel, and Sophie take a small boat toward the abandoned History House; it overturns, and Sophie drowns while the twins reach shore. Baby Kochamma falsely tells the police that Velutha abducted the children and raped Ammu. Officers find him with the twins and beat him so severely that he soon dies. To protect herself from prosecution, Baby Kochamma frightens Estha into identifying Velutha as the kidnapper. Chacko sends Ammu away, Estha is returned to his father, and the twins are separated for twenty-three years. Ammu later dies alone at thirty-one. In the present, the adult twins reunite in Ayemenem and seek wordless comfort in each other. The novel closes by returning to Ammu and Velutha's first night together, before the catastrophe, when their impossible future is reduced to the promise of meeting again the next day.",
         "in_short": "Adult twins Rahel and Estha reunite in their decaying family home in Kerala, twenty-three years after the death of their cousin Sophie Mol shattered the household. Their memories reveal a family marked by colonial aspiration, caste, frustrated love, and cruelty. In 1969 their divorced mother Ammu begins a forbidden affair with Velutha, a gifted worker from a community treated as untouchable. After Ammu is confined by her relatives, the twins run away with Sophie; their boat capsizes and Sophie drowns. Baby Kochamma protects the family's reputation by falsely accusing Velutha of kidnapping and rape. Police beat him fatally, and she coerces Estha into confirming the lie. Ammu is expelled, Estha is sent to his father, and the twins grow up apart. Ammu dies young and alone. Reunited at thirty-one, Rahel and the silent Estha share an intimate encounter born of grief and damaged closeness. The story ends in the past with Ammu and Velutha together, briefly hopeful before the consequences close around them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3129,7 +3129,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3142,7 +3142,7 @@
       "recaps": {
         "ending": "Michael Corleone completes his transformation from reluctant outsider to absolute ruler of the family. After his father Vito dies of a heart attack while playing with his grandson in the garden, Michael springs a long-prepared trap: in a single coordinated sweep he has the heads of the rival Five Families assassinated, along with the Las Vegas operator Moe Greene and every serious threat to Corleone power. He also settles the family's internal betrayals. The caporegime Tessio, who conspired to lead Michael into a fatal ambush, is quietly taken away to be killed. Carlo Rizzi, Connie's husband, is made to confess that he set up Sonny's murder at the toll booth on the rivals' behalf; Michael has him strangled once his usefulness as a witness ends. With his enemies destroyed, Michael stands as the new Don, more powerful and more feared than his father, poised to move the family's fortunes west toward legitimate business in Nevada. His wife Kay, horrified by the deaths and by rumors that he ordered Carlo's murder, confronts him directly. Michael, breaking his own rule against discussing the business with her, lies and denies it, and she chooses to believe him. Shaken, Kay turns to the Church, converting to Catholicism and praying for the soul of the husband who has become a killer and a king. The Corleone empire endures, its cost measured in the family and the men Michael has buried to secure it.",
         "in_short": "In postwar New York, Don Vito Corleone rules a powerful Mafia family by a code of loyalty and favors. When the narcotics dealer Sollozzo asks the Don to back his heroin trade and is refused, he has Vito gunned down. The Don survives, hot-tempered eldest son Sonny takes charge, and the family plunges into war with the rival Five Families. Michael, the youngest son and a war hero who had kept clear of the business, is pulled in when he saves his wounded father from a second attempt and then murders Sollozzo and a corrupt police captain, fleeing to Sicily. There he marries a local woman who is soon killed by a bomb meant for him. In New York, Sonny is ambushed and killed at a toll booth, betrayed through his abusive brother-in-law Carlo. The recovered Don makes peace with the Five Families to bring Michael home safely, then grooms him as successor. Michael marries his old sweetheart Kay and, over the following years, plans to move the family toward Las Vegas and legitimacy. After Vito dies peacefully, Michael executes a sweeping purge, having the heads of the rival families and internal traitors killed at once, including Carlo and the turncoat Tessio, to become the new Godfather. When Kay confronts him about the killings, he lies to her face, and she is left to make her peace with the man he has become.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3367,7 +3367,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3380,7 +3380,7 @@
       "recaps": {
         "ending": "After Vito dies, Michael allows the rival families to believe the Corleones are weakening while he prepares a coordinated settlement. During the baptism of Connie's child, his men kill Barzini, Tattaglia, and other principal enemies. Moe Greene is also killed, clearing the family's control in Nevada. Tessio reveals himself as the intermediary for Barzini's planned attack and is taken away to die. Michael confronts Carlo with his part in arranging Sonny's murder, promises exile, and then has Clemenza strangle him. Connie accuses Michael before Kay; he denies ordering Carlo's death, and Kay initially accepts the denial. She later learns enough from Tom Hagen to understand that Michael has become the Don. After leaving for a time, she returns with their children and converts to Catholicism, praying for Michael's soul. The Corleone family prepares to transfer its base to Nevada under Michael's command. Vito's project of protecting his family has produced a successor more calculating and absolute, while Michael's promise to remain outside that world has been completely reversed.",
         "in_short": "At his daughter's wedding, New York crime boss Vito Corleone grants favors through a system of loyalty and obligation. When he refuses to support Virgil Sollozzo's narcotics business, he is shot and a gang war begins. His youngest son Michael, previously determined to remain respectable, protects him in the hospital and kills Sollozzo and police captain McCluskey, then hides in Sicily. Sonny leads the family war but is betrayed by Connie's husband Carlo and murdered. Michael's Sicilian wife Apollonia is also killed. Vito makes peace, recognizes Barzini as the force behind the conflict, and brings Michael home. Michael marries Kay, succeeds his father, and moves toward Nevada while concealing his plans. After Vito's death, Michael has the rival leaders killed, executes the disloyal Tessio, and orders Carlo's death for betraying Sonny. Kay learns that her husband is now the Don she believed he would never become. The family survives and expands, but Michael completes his moral transformation into his father's more ruthless successor.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3562,7 +3562,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3575,7 +3575,7 @@
       "recaps": {
         "ending": "Carter's coalition attacks the domains of the therns and First Born. Issus is exposed as mortal and loses the obedience on which her rule depends; her regime collapses, while Xodar rises among the freed First Born. Dejah, Thuvia, and Phaidor are sealed inside the Temple of the Sun, whose chambers open to the outside only once during a Barsoomian year. Carter can do nothing but watch the rotating prison from outside. As the doorway carrying the women passes from sight, he sees Phaidor raising a knife toward Dejah. The opening closes before he can intervene, leaving Dejah and Thuvia trapped and Dejah in immediate danger from Phaidor.",
         "in_short": "After ten years on Earth, John Carter returns to Barsoom in the Valley Dor, where he reunites with Tars Tarkas and learns that the planet's promised pilgrimage ends in predation and captivity. They rescue Thuvia of Ptarth, confront the white therns who maintain the religious deception, and are drawn into the hidden realm of the First Born beneath the valley. Carter meets the warrior Xodar and exposes the supposedly divine Issus as a mortal ruler. He also finds Dejah Thoris alive but imprisoned. After escaping, Carter returns to Helium, meets his grown son Carthoris, survives prosecution for returning from the Valley Dor, and gathers an alliance to free the captives. The attack destroys Issus's authority, but Matai Shang seals Dejah, Thuvia, and Phaidor inside the rotating Temple of the Sun for a full Barsoomian year. As their chamber closes, Carter sees the jealous Phaidor raise a knife against Dejah and cannot reach her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3782,7 +3782,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3795,7 +3795,7 @@
       "recaps": {
         "ending": "Having fled the Corinthian spectacle, Lucius reaches the shore at Cenchreae and prays for divine aid. Isis appears in a dream and directs him to her festival. During the procession he eats roses carried by a priest and immediately regains his human body. The priest explains that Lucius's reckless appetites caused his misery and that freedom now carries an obligation to the goddess. Lucius joins her worship, submits to initiation after waiting for the proper sign, and later travels to Rome. There he undergoes further initiations connected with Isis and Osiris, despite the expense and his occasional uncertainty about why more rites are required. He supports himself as an advocate and receives a place among the cult's officials. The narrative closes with Lucius willingly shaving his head and publicly serving the religion that delivered him, replacing his earlier restless curiosity with disciplined devotion.",
         "in_short": "Lucius travels through Thessaly in search of magic and persuades the servant Fotis to let him try a witch's ointment. A mistake transforms him into an ass, though he keeps his human mind and can be restored by eating roses. Before he can do so, robbers seize him, beginning a long passage through violent and exploitative owners. In the robbers' cave he hears the tale of Cupid and Psyche, whose suffering ends in divine marriage and immortality, and he briefly helps the captive Charite. Her rescue and marriage give way to tragedy when Thrasyllus murders her husband and she kills herself after taking revenge. Lucius then passes among fraudulent priests, mill workers, soldiers, cooks, and entertainers, observing adultery, cruelty, greed, and sudden reversals of fortune. Faced with forced participation in a public sexual spectacle at Corinth, he escapes to the coast. Isis answers his prayer, provides roses that restore his human form, and draws him into a lasting religious vocation culminating in initiation and priestly service at Rome.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3990,7 +3990,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4003,7 +4003,7 @@
       "recaps": {
         "ending": "At Cenchreae, Lucius prays beside the sea and sees the goddess Isis in a dream. She tells him to approach her public procession and eat the roses carried by a priest. He obeys, sheds the ass's body, and becomes human again before the crowd. The priest explains that Lucius's reckless curiosity subjected him to Fortune, while Isis has now claimed him for a more ordered life. Lucius joins her worship, undergoes a costly and secret initiation, and later travels to Rome. Further dreams direct him toward additional initiations, including the mysteries associated with Osiris. Though anxious about the expense and repeated commands, he accepts them as divine guidance. The narrative ends with Lucius admitted to religious service in Rome, his head shaved as a public sign of office. His physical metamorphosis has been reversed, but his experiences have permanently changed his allegiance and way of life.",
         "in_short": "Lucius travels in Thessaly seeking magic and, with help from the servant Fotis, secretly watches her mistress become an owl. He tries the ointment himself but is accidentally changed into an ass; roses can restore him, yet repeated mishaps keep them out of reach. Stolen by bandits, abused by successive owners, and exposed to stories of violence, desire, and deception, he witnesses human society from the position of an animal. Among the embedded tales is that of Psyche, whose forbidden sight of Cupid separates them until she completes Venus's ordeals and is made immortal. Lucius repeatedly approaches rescue but passes instead through bandits, priests, a mill, farms, and wealthy households. When he is to be displayed in a degrading public spectacle, he escapes to the shore. Isis answers his prayer and directs him to roses in her procession. Restored to human form, Lucius devotes himself to her worship, undergoes initiation, and ends as a religious servant in Rome.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-golden-compass.json
+++ b/data/works-community/0/the-golden-compass.json
@@ -115,7 +115,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -128,7 +128,7 @@
       "recaps": {
         "ending": "The story ends on the mountaintop where Lord Asriel has built an experiment to breach the boundary between worlds. Lyra arrives believing she is bringing him the alethiometer he needs, only to learn that what he wants is a child, not the instrument. He seizes her friend Roger and severs him from his daemon; the vast energy of that killing tears a bridge across the sky into another universe, and Roger dies. Mrs. Coulter, who has followed, is offered the chance to go with Asriel but chooses to stay behind. Asriel crosses into the new world alone. Lyra, grieving Roger and sickened by what her parents are, reasons that if the Church calls Dust a mark of sin, then Dust may in truth be something good and worth understanding. Rather than turn back, she and Pantalaimon walk up into the sky after the bridge, out of their own world entirely, resolved to find the source of Dust before Asriel does. Iorek Byrnison now rules the armoured bears of Svalbard, the gyptians and her surviving friends are left behind, and the wider war over Dust and free will is only beginning.",
         "in_short": "Lyra Belacqua, an orphan raised at Jordan College in a world where souls take the form of animal daemons, is secretly given a truth-telling alethiometer and swept into a struggle over a mysterious substance called Dust. After the charming Mrs. Coulter is exposed as a leader of the child-stealing Gobblers, Lyra flees and joins the gyptians journeying north to rescue captured children, among them her friend Roger. She gains an armoured bear, Iorek Byrnison, an aeronaut, Lee Scoresby, and the aid of witches. At the northern station of Bolvangar she uncovers the horror of intercision, the cutting of children from their daemons, narrowly escapes it herself, and destroys the station. Reaching the bears' kingdom, she outwits their king so Iorek can claim the throne, then finds her father, Lord Asriel. Learning that Asriel and Coulter are her parents, and convinced the Church is wrong about Dust, she watches Asriel sacrifice Roger to open a bridge between worlds, then crosses that bridge into a new world to seek the truth herself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -247,7 +247,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -258,7 +258,7 @@
       "recaps": {
         "ending": "The trilogy ends with the wizard world's deepest secret exposed and its central cruelty broken. El confronts Ophelia Lake and the truth that every enclave is anchored on a maw-mouth made by sacrifice, and that Ophelia deliberately shaped Orion into a creature bound to that same magic, which is the real source of his hunger to consume mals. Rejecting the claim that such horror is the necessary price of safety, El returns to the ruined Scholomance and refuses to let Orion be lost or put down; she saves him, at real cost to herself, though he is left changed by what he had become. Crucially, El demonstrates that maw-mouths can be unmade, freeing the trapped souls inside them, and that the construction spell she has carried since school can raise an enclave without any sacrifice at all, so the prophecy that she would bring destruction to the enclaves resolves not as slaughter but as the end of the lie they were built on. Her friends, Aadhya, Liu, Liesel, and the rest, survive, and the vulnerable people she always fought to protect gain a future the old order denied them. The open threads are the human ones: a magical society that must now reckon with what it has always hidden and decide whether to change, and El and Orion themselves, alive and together but marked by everything they endured, facing an uncertain, freer life beyond the school.",
         "in_short": "Grieving Orion and hiding in her mother's Welsh commune, El Higgins is pulled back into the world as enclaves everywhere are struck by sudden, inexplicable disasters that threaten to unmake magical society. Chasing the pattern behind the collapses, and drawing on her school allies Aadhya, Liu, and Liesel, she travels to New York and confronts Orion's mother, Ophelia Lake, where she uncovers the secret at the heart of the wizard world: every golden enclave is anchored on a maw-mouth created through sacrifice, so their splendor has always rested on hidden murder. She also learns that Orion's unnatural hunger comes from what Ophelia made him to be. Refusing to give him up, El returns to the ruined Scholomance, saves Orion at great cost, and rejects the atrocity the enclaves are built on. She proves that maw-mouths can be unmade and that enclaves can be built without them, using the spell she has carried all along. The trilogy ends with the secret exposed, a better future made possible, and El and Orion alive but changed, together on the far side of it all.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -454,7 +454,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -467,7 +467,7 @@
       "recaps": {
         "ending": "The rescue of Sonya Karp succeeds. Eddie buys time inside the Warriors' own ritual combat, Sydney uses magic openly in front of the people whose opinion she cares most about, and Sonya is brought out alive. Trey's part in it costs him his standing with his father and his place among the Warriors, and he is left with the friends he chose instead. The Warriors themselves are not destroyed, only thwarted, and the Alchemists' long silence about their existence is one more thing Sydney now knows her order kept from her. On the way home Adrian tells Sydney plainly that he is in love with her and kisses her. Sydney refuses him. She cannot say the true reason - that she feels the same - so she answers out of everything she was raised on, that an Alchemist and a Moroi together is unthinkable, and the words land far harder than she intends. Adrian, who had been putting his life in order largely for her sake, is left devastated, and Jill experiences all of it through the bond. Separately, Clarence mentions the young man who investigated his niece's death years before: an Alchemist named Marcus Finch who covered his golden lily with an indigo tattoo and then vanished, which is the first hint Sydney has that leaving the order is even possible.",
         "in_short": "Sydney now runs the Palm Springs assignment, with a second guardian added to the household: Angeline Dawes, a dhampir raised outside Moroi law and hopelessly unsuited to high school. Sonya Karp and Dimitri Belikov arrive to research spirit and the restoration of Strigoi, and Sonya's ability to read auras confirms what Sydney will not admit - that she is working magic. Sydney trains with Ms. Terwilliger, takes self-defence lessons, and dates a safely ordinary human boy while spending most of her time with Adrian. Jill is quietly recruited as a model, a dangerous kind of visibility, and remains attached to Eddie, who refuses to see it. The old man Clarence's story about human vampire hunters turns out to be true: the Warriors of Light are a centuries-old society that considers every vampire an abomination, and Trey Juarez was raised in it. When the Warriors capture Sonya to try and execute her as proof that a restored Strigoi is still a monster, Trey helps Sydney's group infiltrate their gathering and Sonya is rescued. On the way home Adrian tells Sydney he loves her; she turns him down in the language of her order, and it breaks him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -644,7 +644,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -657,7 +657,7 @@
       "recaps": {
         "ending": "In old age, Wang Lung leaves most household affairs to his sons and returns to the modest earthen house where his life with O-lan began. Pear Blossom cares for him there, and his attachment to the soil grows stronger as his body weakens. His sons, now shaped by the comfortable town life that his labor purchased, privately agree that they should sell the family's land and divide the proceeds. Wang Lung overhears them and is horrified: to him, selling the earth means destroying the foundation of the family. He makes them hold clods of soil and insists that land is the one possession that must never be surrendered. The sons soothe him by promising they will not sell, but over their father's bowed head they exchange a knowing smile. Wang Lung ends his life materially successful, with descendants and extensive property, yet the final understanding belongs to the reader: the next generation values status and money more than the land whose harvests created their fortune, and the family cycle Wang Lung struggled to secure is already beginning to turn away from him.",
         "in_short": "Poor farmer Wang Lung marries O-lan, a former slave whose labor and endurance help him build a family and enlarge his farm. Drought and famine drive them south, where they survive through begging and casual work until civil disorder gives them the money and jewels to return home. Wang Lung invests the windfall in land, becomes rich, and employs his loyal neighbor Ching. Prosperity also changes him: he takes the courtesan Lotus as a second wife, humiliates O-lan, and moves the family into the former House of Hwang. O-lan dies after seeing their eldest son married, and Wang Lung's household grows divided by appetite, status, and generational conflict. In old age he seeks peace with the gentle Pear Blossom and returns to his first house. He begs his sons never to sell the land, but their private smile after promising obedience shows that the fortune rooted in the earth has estranged them from it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -809,7 +809,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -822,7 +822,7 @@
       "recaps": {
         "ending": "Leonora finally abandons the effort to make a viable marriage with Edward. She sends Nancy away to India, hoping distance will end the attachment between her ward and her husband, but the separation contributes to the last collapse. Edward, unable to reconcile his desires, debts, guilt, and loss of Nancy, kills himself. Nancy suffers a severe mental breakdown after learning of his death and returns unable to resume an independent life. John, who had imagined marrying her, instead becomes her permanent caretaker and remains emotionally isolated. Leonora survives the catastrophe and finds the conventional stability she had long wanted: she marries Rodney Bayham and has a child. The estates are secure, but John is left with a belated, incomplete understanding of Florence's deceptions and the Ashburnhams' marriage. His closing admiration for Edward sits uneasily beside the damage Edward caused, underlining how unreliable John's moral accounting remains even after he knows the facts.",
         "in_short": "American narrator John Dowell looks back on the nine-year friendship he and his supposedly ailing wife Florence shared with English couple Edward and Leonora Ashburnham. The respectable arrangement concealed overlapping deceptions. Florence had invented the heart condition that governed her marriage and became Edward's lover; when she believed exposure was imminent, she killed herself. Edward's public generosity coexisted with repeated affairs and financial recklessness, while Leonora managed his debts and tried to preserve their Catholic marriage. Their young ward Nancy Rufford became the final focus of Edward's love. Leonora sent Nancy to India, but the separation did not resolve the triangle: Edward killed himself, and Nancy suffered a lasting mental collapse. Leonora later married Rodney Bayham and achieved the stable family life she wanted. John, who had hoped to marry Nancy, became her caretaker instead. His fragmented account exposes the failures of perception and responsibility behind the four friends' polished social appearance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -994,7 +994,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1007,7 +1007,7 @@
       "recaps": {
         "ending": "Rachel proves that Piscary, not Trent, is responsible for the witch murders and for an older series of similar killings concealed after the Turn. She survives the confrontation and helps put the undead master into custody, disrupting Cincinnati's vampire hierarchy and loosening his immediate control over Ivy and Kisten without ending the danger his influence represents. Rachel's resort to demon magic brings her deeper into Algaliarept's reach. She nevertheless frees Ceri, an elf whom Al had kept as a familiar for centuries; Ceri comes to the church carrying extensive knowledge of old ley-line and demon practices. Nick's magical bond to Rachel and the injuries surrounding the case deepen his fear and resentment, and he leaves Cincinnati rather than continue as before. Trent is cleared of these murders, but Rachel now knows his elven identity and sees more clearly that his family's hidden genetic program reaches back beyond his present criminal businesses. The case closes, while Rachel's demon debt, Nick's absence, and the unsettled vampire power structure remain open.",
         "in_short": "A series of murders targeting ley-line witches brings Rachel into an FIB investigation with detective Glenn. The deaths resemble killings hidden during the chaotic years after the Turn, and evidence initially points toward Trent Kalamack. To follow the magical trail, Rachel begins learning ley-line practice under Dr. Anders, but her inexperience accidentally binds Nick to her as a familiar and increases the strain on their relationship. Ivy's connection to undead master Piscary complicates the case, while Kisten provides an uneasy route through vampire society. Rachel turns to demon Algaliarept for knowledge and discovers that Piscary is the killer behind both the current and historical murders. She survives a final confrontation and helps send him into custody, clearing Trent of this particular crime without making him innocent of his wider activities. Rachel also frees Ceri, an ancient elf held for centuries as Al's familiar. Nick leaves Cincinnati after the case, Piscary's fall unsettles the vampires, and Rachel ends with more magical knowledge but also a dangerous obligation to Al.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1131,7 +1131,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1144,7 +1144,7 @@
       "recaps": {
         "ending": "The Inquisitor finishes his case by insisting that the institution he serves has accepted the burden of governing weak and frightened people, even if doing so requires deception and an alliance with worldly power. Jesus never disputes him. Instead, he kisses the old man. Shaken, the Inquisitor opens the cell and orders his prisoner to leave Seville and never return. Ivan says the kiss remains in the old man's heart without changing his doctrine. Alyosha then answers his brother's bleak poem by kissing Ivan, recognizing the gesture Ivan has just described. Ivan is pleased but remains committed to his rebellion against a moral order that permits innocent suffering, and the brothers part with Alyosha intending to remember the best in him.",
         "in_short": "Ivan Karamazov tells his devout brother Alyosha a prose poem in which Jesus returns to Seville during the Inquisition. The people recognize him, but an aged cardinal has him arrested. In the prison cell, the Grand Inquisitor argues that Christ was wrong to reject the temptations of miracle, mystery, and authority, because most people value bread, certainty, and collective obedience more than freedom. He claims the Church has corrected Christ's teaching by taking control of human conscience and making happiness possible through submission. Jesus remains silent and answers only by kissing him. The shaken Inquisitor releases him but does not abandon his beliefs. Alyosha responds to Ivan's troubling tale by kissing his brother, echoing its final gesture of love without resolving Ivan's revolt against a world built on innocent suffering.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1324,7 +1324,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1337,7 +1337,7 @@
       "recaps": {
         "ending": "After Tom kills the man who murdered Casy, the Joads hide him while they pick cotton and live in a boxcar camp. Ruthie reveals his presence during a quarrel, so Tom leaves to protect the family. He tells Ma that Casy's ideas have given him a new purpose: he will work wherever people resist hunger, violence, and injustice together. Prolonged rain then floods the fields and the Joad shelter. Rose of Sharon gives birth to a stillborn child, which Uncle John sends into the floodwater as an accusation against a society that lets children die amid abundance. The remaining family abandons its submerged truck and takes refuge in a barn, where they find a starving man and his son. Having recently lost her baby, Rose of Sharon privately breastfeeds the man to keep him alive. The novel ends without secure work, shelter, or a reunited family, but with a radical act of human care extending beyond kinship. Tom's whereabouts remain unknown, while the Joads continue amid the larger community of displaced workers.",
         "in_short": "Paroled Tom Joad returns to Oklahoma and finds his sharecropper family evicted by banks and tractors. With the former preacher Jim Casy, the Joads travel Route 66 toward California, drawn by handbills promising farm work. Death, illness, and desertion reduce the family en route, and California proves crowded with starving migrants whose desperation lets growers drive wages down. Casy accepts arrest after a camp confrontation, while the Joads later find dignity in a self-governing federal camp. Forced onward by hunger, they unknowingly break a peach strike; Tom then finds Casy organizing the strikers and sees him murdered. Tom kills Casy's attacker, hides with the family, and eventually leaves to continue Casy's struggle for collective justice. Relentless rain floods the migrants' shelter, and Rose of Sharon delivers a stillborn baby. In a barn, she uses the milk meant for her child to feed a starving stranger. The Joads end dispersed and homeless, yet their loyalty has widened into solidarity with others suffering the same exploitation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1486,7 +1486,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1499,7 +1499,7 @@
       "recaps": {
         "ending": "Charlie Slatter moves to take over the ruined farm while Dick's health and judgment collapse. Tony Marston, the young assistant, has seen an intimacy between Mary and Moses that the district's racial code cannot accommodate, but Charlie pressures him into silence and plans to send him away. Mary dismisses Moses, then spends her final hours increasingly certain that he will return. During the night he approaches the house and kills her with a knife. He makes little effort to escape and waits nearby until the police take him into custody. The opening newspaper version is therefore confirmed at the narrow level of who committed the murder, while the retrospective story has exposed everything that account excludes: Mary's constricted past, the Turners' disintegrating marriage, the farm's failure, and the coercive colonial relationships that joined Mary and Moses. Dick is removed from the property, Tony is discouraged from challenging the accepted story, and Charlie is left positioned to absorb the Turners' land.",
         "in_short": "In colonial Southern Rhodesia, Mary Turner is killed by Moses, her Black house servant. The novel then returns to her past: an unhappy childhood, a contented but emotionally narrow life as an office worker, and a hurried marriage after friends mock her singleness. Her husband Dick is a kindly but ineffectual farmer, and life on his failing property leaves Mary isolated, poor, and increasingly unstable. She treats African workers with hostility and once strikes Moses while supervising field labor. When he later becomes her house servant, fear, dependence, and forbidden intimacy complicate their relationship. Dick's debts give the prosperous neighbor Charlie Slatter control over the farm, while the newly arrived Tony Marston sees more than the white community wishes to acknowledge. After Mary dismisses Moses and the Turners prepare to leave, Moses kills her and submits to arrest. The official account reduces the death to servant violence, concealing the personal collapse and colonial system behind it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1660,7 +1660,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1673,7 +1673,7 @@
       "recaps": {
         "ending": "When Ernt discovers Leni's relationship with Matthew, he attacks her. Cora shoots Ernt to save their daughter. Large Marge helps the women conceal his death, and Cora and the pregnant Leni flee Alaska under false identities. In Seattle, Leni gives birth to Matthew Junior while believing that Matthew will never recover from the injuries he suffered trying to protect her. Years later Cora dies of cancer after writing a confession that takes responsibility for Ernt's death. Leni returns to Kaneq with her son and turns the letter over to the police, ending the life of concealment. She learns that Matthew survived and has made a long, partial recovery. Their reunion is difficult but hopeful, and he meets the son he never knew he had. Cleared of the crime, Leni chooses Alaska and the community that once protected her as home, while accepting that healing will be gradual rather than complete.",
         "in_short": "In 1974, thirteen-year-old Leni Allbright moves with her parents to an inherited cabin in remote Alaska. The community teaches the unprepared family to survive, but winter and isolation worsen her father Ernt's trauma, paranoia, and violence toward her mother Cora. As Leni grows up, she falls in love with Matthew Walker, son of the man Ernt regards as an enemy. After Matthew is gravely injured during Ernt's attempt to separate them, Cora kills Ernt to stop him attacking Leni. Helped by Large Marge, Cora and the pregnant Leni flee to Seattle. Leni raises Matthew's son and remains away until Cora dies years later, leaving a confession that clears Leni. Back in Alaska, Leni discovers Matthew alive after a long recovery. She introduces him to their son and reclaims Kaneq as home, supported by the community that survived Ernt's violence with her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1843,7 +1843,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1856,7 +1856,7 @@
       "recaps": {
         "ending": "As the night approaches its end, MacDonald explains that the grey town and the bright country cannot be judged by ordinary measures of distance or duration. The lost can make their chosen isolation into a past that seems to have governed everything, while the redeemed discover that Heaven was at work even through suffering. The visitors' excursion is ending, and the solid people prepare for a sunrise whose full reality the ghosts could not endure. The narrator sees the immense contrast between the eternal world and his own shrunken dream perspective. MacDonald urges him to flee the coming light, but the vision collapses. The narrator wakes beside the ashes of a fire in a cold room in wartime England as an alarm sounds. No verdict is given about him; he returns to waking life carrying a warning that the habits behind damnation or joy are formed through present choices.",
         "in_short": "An unnamed narrator leaves a dreary, sprawling town on a bus and arrives with a group of translucent ghosts at the outskirts of Heaven. The country is painfully solid to them, but bright spirits come to help each visitor travel toward the mountains. One by one, the ghosts reveal attachments they will not surrender: wounded pride, intellectual vanity, reputation, possessive love, lust, self-pity, and the demand to be treated as deserving. Some turn back because they prefer those identities to transformation. One tormented ghost finally permits an angel to kill the lizard of appetite on his shoulder; both ghost and desire are remade into a rider and a powerful horse that carry him upward. Guided by George MacDonald, the narrator learns that Hell is self-chosen isolation and that even a seemingly small refusal can harden into it. As heavenly sunrise approaches, the vision ends and he wakes in wartime England, left to apply its lesson in ordinary life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1996,7 +1996,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2009,7 +2009,7 @@
       "recaps": {
         "ending": "Gatsby's dream of reclaiming Daisy destroys him. After Daisy, driving his car, kills Myrtle Wilson and lets Gatsby shoulder the blame, she retreats back to Tom, and the two of them quietly reconcile and leave. Myrtle's husband George, told by Tom whose car struck her and believing the driver was also Myrtle's lover, shoots Gatsby to death in his swimming pool and then takes his own life. The lavish life Gatsby built proves empty at the last: the hundreds who flocked to his parties vanish, and only Nick, Gatsby's father Henry Gatz, and a handful of others attend the funeral. Nick, repelled by the heedlessness of Tom and Daisy, who smash up lives and hide behind their money, ends his romance with Jordan Baker and severs ties with Tom. He concludes that the wealthy leave others to bear the consequences of their carelessness. Choosing to abandon the corrupt glamour of the East, Nick returns to the Midwest, and closes by reflecting on Gatsby's tragic faith in a green light and a future forever out of reach.",
         "in_short": "Nick Carraway moves to Long Island and befriends his fabulously rich, mysterious neighbor Jay Gatsby, who hosts dazzling parties. Nick learns that Gatsby built his entire fortune and his mansion to win back Nick's cousin Daisy, whom he loved before the war and who married the wealthy, arrogant Tom Buchanan while Gatsby was poor and overseas. Nick arranges their reunion, and Gatsby and Daisy begin an affair. At a tense confrontation in a city hotel, Tom exposes Gatsby's shady wealth and forces Daisy to admit she still loves Tom too. Driving home in Gatsby's car, Daisy accidentally strikes and kills Tom's mistress, Myrtle Wilson, and Gatsby chooses to shield Daisy by taking the blame. Myrtle's husband George, believing the driver was her secret lover, murders Gatsby in his pool and then kills himself. Almost no one attends Gatsby's funeral. Tom and Daisy withdraw into their wealth, and a disillusioned Nick, sickened by the carelessness of the rich, leaves the East to return home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2174,7 +2174,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2187,7 +2187,7 @@
       "recaps": {
         "ending": "After Gatsby is shot by George Wilson, Nick tries to organize a funeral and discovers how completely Gatsby's crowds have abandoned him. Daisy and Tom leave without giving an address, Meyer Wolfsheim refuses involvement, and Klipspringer calls only about belongings. Gatsby's father, Henry Gatz, comes east and shows Nick evidence of his son's lifelong ambition. Owl Eyes is among the very few mourners. Nick ends his relationship with Jordan and later confronts Tom, who admits telling Wilson that Gatsby owned the yellow car; Tom remains convinced Gatsby deserved what happened and does not acknowledge his own part in the chain of deaths. Disillusioned with the East, Nick returns to the Midwest. Before leaving, he visits Gatsby's empty shore and reflects that Gatsby's dream of Daisy belonged to a larger human impulse to recover an idealized past, even as time carries everyone farther from it.",
         "in_short": "In 1922, Nick Carraway moves to West Egg and becomes fascinated by his neighbor Jay Gatsby, a mysterious millionaire who gives lavish parties. Gatsby has built his fortune and persona around the hope of reclaiming Daisy Buchanan, Nick's cousin and Gatsby's former love, now married to the wealthy and domineering Tom. Nick arranges their reunion, and Daisy begins an affair with Gatsby. Tom exposes Gatsby's criminal associations during a confrontation in Manhattan, and Daisy retreats from Gatsby's demand that she renounce her marriage. Driving Gatsby's car home, Daisy strikes and kills Tom's mistress Myrtle Wilson, but Gatsby intends to take the blame. Tom directs Myrtle's grieving husband George toward Gatsby; George kills Gatsby and then himself. Daisy and Tom leave, while Gatsby's many guests vanish. Nick arranges the sparsely attended funeral, rejects the carelessness of the East, and returns to the Midwest, understanding Gatsby's doomed pursuit as an attempt to force an idealized past into the present.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2366,7 +2366,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2379,7 +2379,7 @@
       "recaps": {
         "ending": "After Gatsby is shot by George Wilson, Nick tries to organize a funeral and discovers how completely Gatsby's crowds have abandoned him. Daisy and Tom leave without giving an address, Meyer Wolfsheim refuses involvement, and Klipspringer calls only about belongings. Gatsby's father, Henry Gatz, comes east and shows Nick evidence of his son's lifelong ambition. Owl Eyes is among the very few mourners. Nick ends his relationship with Jordan and later confronts Tom, who admits telling Wilson that Gatsby owned the yellow car; Tom remains convinced Gatsby deserved what happened and does not acknowledge his own part in the chain of deaths. Disillusioned with the East, Nick returns to the Midwest. Before leaving, he visits Gatsby's empty shore and reflects that Gatsby's dream of Daisy belonged to a larger human impulse to recover an idealized past, even as time carries everyone farther from it.",
         "in_short": "In 1922, Nick Carraway moves to West Egg and becomes fascinated by his neighbor Jay Gatsby, a mysterious millionaire who gives lavish parties. Gatsby has built his fortune and persona around the hope of reclaiming Daisy Buchanan, Nick's cousin and Gatsby's former love, now married to the wealthy and domineering Tom. Nick arranges their reunion, and Daisy begins an affair with Gatsby. Tom exposes Gatsby's criminal associations during a confrontation in Manhattan, and Daisy retreats from Gatsby's demand that she renounce her marriage. Driving Gatsby's car home, Daisy strikes and kills Tom's mistress Myrtle Wilson, but Gatsby intends to take the blame. Tom directs Myrtle's grieving husband George toward Gatsby; George kills Gatsby and then himself. Daisy and Tom leave, while Gatsby's many guests vanish. Nick arranges the sparsely attended funeral, rejects the carelessness of the East, and returns to the Midwest, understanding Gatsby's doomed pursuit as an attempt to force an idealized past into the present.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2557,7 +2557,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2570,7 +2570,7 @@
       "recaps": {
         "ending": "George Wilson traces the yellow car that killed Myrtle to Gatsby's house, shoots Gatsby in his swimming pool, and then kills himself. Nick takes responsibility for the aftermath but cannot persuade Daisy, Tom, Gatsby's former guests, or his business associates to attend the funeral. Gatsby's father arrives and shares evidence of his son's lifelong drive for self-invention; Owl Eyes is among the very few mourners. Nick later meets Tom and learns that Tom identified Gatsby to George as the car's owner, while withholding Daisy's role as the driver. Tom and Daisy have already left without an address, protected by their wealth from the damage they helped cause. Disgusted with the East, Nick ends his relationship with Jordan and returns to the Midwest. Before leaving, he looks across the water from Gatsby's empty property and reflects on Gatsby's pursuit of Daisy and on the larger human habit of reaching toward an imagined future while being drawn backward by the past.",
         "in_short": "In 1922, bond salesman Nick Carraway rents a house beside the mansion of Jay Gatsby, a mysterious millionaire famous for lavish parties. Gatsby has built his fortune and public identity around the hope of reclaiming Nick's cousin Daisy, whom he loved before the war and who married the wealthy Tom Buchanan. Nick arranges their reunion, but Gatsby's demand that Daisy erase her years with Tom turns the revived romance into a confrontation. Daisy cannot deny loving Tom, and while driving Gatsby's car she strikes and kills Tom's mistress, Myrtle Wilson. Gatsby protects Daisy by accepting the blame, but she withdraws into her marriage. Tom directs Myrtle's grieving husband George toward Gatsby; George kills Gatsby and himself. Almost none of Gatsby's guests attend his funeral. Nick recognizes the destructiveness beneath Tom and Daisy's privilege, breaks with Jordan Baker, and returns west, leaving Gatsby's dream as both a remarkable act of hope and a doomed attempt to recover the past.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2773,7 +2773,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2786,7 +2786,7 @@
       "recaps": {
         "ending": "The Great Gatsby ends after Daisy, driving Gatsby's car, kills Myrtle Wilson and lets Gatsby protect her by accepting the appearance of responsibility. Tom directs the grieving George Wilson toward Gatsby; George shoots Gatsby in his pool and then kills himself. Daisy and Tom leave without attending the funeral. Nick, disgusted by their carelessness and by the emptiness surrounding Gatsby's wealth, ends his relationship with Jordan and returns to the Midwest. In This Side of Paradise, Amory Blaine loses Rosalind because she will not accept poverty, fails to find lasting connection with Eleanor, and sacrifices his reputation to shield Alec from a hotel scandal. His inherited money disappears, Monsignor Darcy dies, and the identities supplied by wealth, Princeton, romance, and mentorship fall away. Walking toward Princeton with almost no money, Amory argues for socialist change with a wealthy driver, then reaches the campus recognizing that self-knowledge is the one possession left to him.",
         "in_short": "The Great Gatsby follows Nick Carraway into the wealthy Long Island world of Jay Gatsby, who built a fortune and an extravagant public identity to recover his former love Daisy Buchanan. Daisy will not abandon her husband Tom. After she kills Tom's mistress Myrtle while driving Gatsby's car, Gatsby takes the blame, and Myrtle's husband George kills him before taking his own life. Nick arranges Gatsby's nearly empty funeral and leaves the East, repelled by the destruction Tom and Daisy evade. This Side of Paradise traces Amory Blaine from a privileged, self-dramatizing childhood through Princeton, war, love affairs, and financial decline. Rosalind Connage rejects marriage to him because he is poor; later relationships also fail. Amory protects Alec Connage during a scandal, loses his remaining inheritance, and learns of Monsignor Darcy's death. Penniless and stripped of the roles through which he defined himself, he returns toward Princeton with a harder-won awareness of who he is.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2940,7 +2940,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2953,7 +2953,7 @@
       "recaps": {
         "ending": "Because Gilly's letter brought her circumstances to the attention of her biological family, Mrs. Rutherford takes legal responsibility for her and brings her to Virginia. Gilly now understands that Trotter, William Ernest, and Mr. Randolph had become her family, but the decision is no longer hers to reverse. At the airport she finally meets Courtney, only to discover that her mother has come briefly because Mrs. Rutherford paid her expenses and has no intention of taking her away. The reunion destroys the fantasy that had sustained Gilly through foster care. In distress, Gilly telephones Trotter and begs to come home. Trotter, though heartbroken too, tells her that love sometimes means doing what is required rather than getting what one wants. Gilly remains with her grandmother and chooses to meet that obligation. The ending offers no magical restoration: she has lost her place in Trotter's house, but she leaves with a new understanding that she was genuinely loved there and is capable of loving others in return.",
         "in_short": "Eleven-year-old Gilly Hopkins enters Maime Trotter's foster home determined to reject its residents and engineer a reunion with her idealized absent mother, Courtney. She mocks timid William Ernest, distrusts Trotter's blind Black neighbor Mr. Randolph, and challenges her teacher, Miss Harris. While plotting to run away, she steals money and sends Courtney an exaggerated letter portraying herself as endangered. Yet daily life changes her: she teaches William Ernest to defend himself, discovers respect for Miss Harris, and cares for the household when illness strikes. Her letter produces an unexpected result when her grandmother, Mrs. Rutherford, learns about her and claims her. Removed just as she recognizes Trotter's home as her own, Gilly later meets Courtney and learns that her mother does not want custody. She asks Trotter to take her back, but Trotter urges her to face her new life. Gilly stays with her grandmother, carrying the painful knowledge that the family she tried to escape truly loved her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3085,7 +3085,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3098,7 +3098,7 @@
       "recaps": {
         "ending": "Villiers and Clarke confront Helen Vaughan after connecting her to the disasters surrounding Charles Herbert, the fashionable Mrs. Beaumont, and a series of suicides. They give her a rope and a short interval in which to act, making clear that they will otherwise expose her. Dr. Matheson is present when she dies and records a succession of impossible bodily transformations in which human form, sex, and substance appear to dissolve and re-form. Raymond later confirms the origin that the investigation has reconstructed: Helen was the child born after his operation allowed Mary to encounter the being he called Pan. Mary never recovered from the experiment. Helen's life carried its consequences into the world, and her death ends that immediate trail of corruption, though the witnesses are left with knowledge that overturns their assumptions about human nature and reality.",
         "in_short": "Dr. Raymond performs an operation on his ward Mary to let her perceive the supernatural reality he calls Pan; the experience destroys her mind. Years later, Mr. Clarke collects disturbing reports about a girl named Helen Vaughan. In London, Villiers finds his ruined friend Charles Herbert, who blames his downfall on his wife, Helen. Villiers, Clarke, and Austin gradually connect her with an unexplained death, a notorious society woman called Mrs. Beaumont, and several men who die by suicide after visiting her. Their evidence establishes that these identities belong to the same woman. Villiers and Clarke confront Helen and compel her to take her own life. A doctor witnesses her body pass through monstrous transformations as she dies. Raymond then confirms that Helen was the child Mary bore after the experiment, linking the London horrors directly to his attempt to expose a human being to Pan.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3260,7 +3260,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3273,7 +3273,7 @@
       "recaps": {
         "ending": "The hunt for the Horn of Valere ends at Falme. Rand recovers the Horn and the tainted dagger, but the town is held by the Seanchan, who have captured Egwene and leashed her as a damane. Her friends free her, and in the chaos of battle Mat winds the Horn, calling back the Heroes of the Ages, among them the legendary conqueror Artur Hawkwing, who rally to Rand as one bound to the Horn. In the sky above Falme, Rand duels the fiery-eyed Ba'alzamon before a vast crowd, the great sign of the Dragon blazing overhead, and appears to strike him down, though such an enemy is not so easily ended. Witnessed by so many, Rand can no longer hide what he is: he is hailed openly as the Dragon Reborn, and word of it races across the world. The Seanchan invaders are driven back to their ships for now, but they have not surrendered their claim on these lands, and their leashed channelers remain a horror. Padan Fain slips away with his malice intact. Rand has begun, however unwillingly, to shoulder his role, and the friends of Emond's Field are scattered toward separate destinies - the women to the White Tower, Rand to the weight of a prophecy the whole world now knows he carries.",
         "in_short": "The Horn of Valere and Mat's tainted dagger are stolen from the fortress of Fal Dara by the Darkfriend Padan Fain, and Rand joins a party to hunt them across the land, aided by an Ogier and a man who can smell violence, and troubled by a beautiful stranger who is not what she seems. Egwene, Nynaeve, Elayne, and Min travel toward the White Tower, but every road bends toward the far western town of Falme, seized by the Seanchan, invaders from across the ocean who collar women who can channel as slave weapons called damane. Egwene is captured and leashed, then freed by her friends. At the climax Mat sounds the Horn of Valere, summoning the legendary Heroes of the Ages back to battle, and Rand fights the fiery-eyed Ba'alzamon in the sky above Falme, watched by thousands as the sign of the Dragon burns in the heavens. The Seanchan are thrown back, and Rand is at last openly proclaimed the Dragon Reborn.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3390,7 +3390,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3403,7 +3403,7 @@
       "recaps": {
         "ending": "The Baudelaires save Sunny from the deadly Medusoid Mycelium by diluting the fungus with wasabi, narrowly escaping the poison's grip. Captured by Count Olaf's submarine, they meet Fiona's long-lost brother, who turns out to be one of Olaf's henchmen, and Fiona, torn between her new friends and her only family, ultimately helps the children escape but chooses to leave with her brother and join the villains, taking a sample of the dangerous fungus with her. Reaching Briny Beach, where their story began, the children encounter Mr. Poe once more and are met by Kit Snicket, a member of V.F.D. and sister of the murdered Jacques, who is expecting a child. She warns them of a decisive gathering to come and urges them toward the last safe place, the Hotel Denouement, where the two factions of the secret organization will converge. Having lost yet another friend to Olaf's side, the Baudelaires set out for the hotel, drawing close to the heart of the conflict that has shaped their lives.",
         "in_short": "Drifting down the Stricken Stream, the Baudelaires are taken aboard the submarine Queequeg, commanded by the blustering Captain Widdershins and crewed by his stepdaughter Fiona, a young mycologist, and Phil, the optimistic cook from the lumbermill. Their mission is to recover the sugar bowl, an object vital to V.F.D., hidden in an underwater cave. Diving into the Gorgonian Grotto, they encounter the deadly Medusoid Mycelium, a poisonous fungus, and Captain Widdershins vanishes. Sunny is poisoned and will die within an hour unless cured; the children discover that horseradish dilutes the fungus and use wasabi to save her. Count Olaf's submarine then captures the crew, and Fiona is reunited with her long-lost brother, who is one of Olaf's henchmen. Fiona helps the Baudelaires escape but chooses to leave with her brother and the villains. At Briny Beach the children meet the V.F.D. ally Kit Snicket, who sends them onward to the last safe place, the Hotel Denouement.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3499,7 +3499,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3512,7 +3512,7 @@
       "recaps": {
         "ending": "At the house, the narrator is forced to choose between Susan's claim that Miles is a danger and Miles's claim that Susan is the real threat. She leaves with Miles, removing him from the immediate confrontation. Once they are away, however, his shifting explanations and calculated behavior show that he has manipulated both women and arranged at least part of what looked supernatural. That discovery does not prove that every disturbing event was staged, nor does it make Susan's version wholly reliable. The narrator finishes the story with no secure answer about the house or either Burke. She understands that Miles is a gifted and potentially dangerous deceiver, but she also recognizes the techniques he uses because her own life is built on related skills. They remain together for the moment in an uneasy pairing, each watching the other and neither able to claim complete control of the story.",
         "in_short": "An unnamed grifter moves from sex work into fraudulent psychic readings after injuring her hand. Susan Burke, a wealthy client, hires her to cleanse an old house that Susan believes is corrupting her teenage stepson, Miles. The narrator expects an easy, profitable deception, but disturbing signs in the house and Miles's unnerving knowledge of her background make the assignment harder to control. Susan describes Miles as a threat to her young son; Miles counters that Susan is unstable and dangerous. During the final crisis the narrator takes Miles away from the house. His later changes of story reveal that he engineered at least some of the apparent haunting and has been manipulating both women. The supernatural question and Susan's reliability remain unresolved. Recognizing in Miles a younger and more alarming version of her own talent for deception, the narrator stays with him for the immediate future in a wary alliance rather than ending with a clean solution.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-guernsey-literary-and-potato-peel-pie-society.json
+++ b/data/works-community/0/the-guernsey-literary-and-potato-peel-pie-society.json
@@ -124,7 +124,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -137,7 +137,7 @@
       "recaps": {
         "ending": "Remy Giraud confirms that Elizabeth was killed at Ravensbrück after intervening when a guard attacked another prisoner. The news ends the islanders' remaining hope that she might return, but they preserve her place in their community by caring for Kit and by telling the truth about her courage. Juliet abandons her earlier book plan and begins writing the story of the occupation through Elizabeth and the society. She rejects Mark Reynolds because his vision of their future would require her to leave the island and the people who have become her family. Juliet arranges to adopt Kit. Isola's amateur investigation then helps Juliet recognize that Dawsey's reserve has concealed his love for her and that she returns it. Rather than wait for him to speak, Juliet asks Dawsey to marry her, and he accepts. Her final correspondence sends Sidney the manuscript and the news: her book, home, child, and partnership have all become rooted in Guernsey.",
         "in_short": "In 1946, London writer Juliet Ashton receives a letter from Guernsey farmer Dawsey Adams, who owns a book once marked with her name. Their correspondence introduces the literary society invented as an excuse when islanders were caught breaking curfew during the German occupation. Juliet exchanges letters with its members and learns how books sustained them through hunger, isolation, forced labor, and loss. At the center of every account is Elizabeth McKenna, the defiant founder who loved German doctor Christian Hellman, bore their daughter Kit, and was deported for helping a prisoner. Juliet travels to Guernsey, becomes part of the society, and cares for Kit. Survivor Remy Giraud eventually confirms that Elizabeth died at Ravensbrück while defending another woman. Juliet rejects her wealthy suitor Mark, decides to adopt Kit, and writes the society's story instead of a detached article. Recognizing that she and Dawsey love one another, she proposes to him. He accepts, giving Juliet the family and home she had gradually found on the island.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -249,7 +249,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -262,7 +262,7 @@
       "recaps": {
         "ending": "Mallory's party penetrates the Navarone fortress while the deadline for the Kheros evacuation closes in. Miller places charges inside the gun emplacement and links the destruction to the machinery and ammunition that the Germans expect to use against the approaching British ships. The raiders escape to the harbor under pursuit, paying for the mission with members of their team and confronting the betrayal that has repeatedly exposed them. The delayed explosions tear through the emplacement just as the naval force enters the guns' range, destroying Navarone's ability to close the channel. The warships can continue to Kheros and remove its threatened garrison. Mallory, Miller, Andrea, and the surviving helpers leave the island exhausted, with the operation accomplished but its human cost unmistakable.",
         "in_short": "A British force on Kheros must be evacuated before a German attack, but two enormous guns on the occupied island of Navarone control the naval approach. Mountaineer Keith Mallory leads Andrea Stavros, explosives expert Dusty Miller, engineer Casey Brown, and young climber Andy Stevens on a covert mission to destroy the battery. After reaching the island in a storm and scaling its supposedly impassable southern cliff, the team crosses hostile terrain while carrying an injured man, evading patrols, and working with Greek resistance guides. Capture, damaged equipment, and betrayal steadily narrow their options. The survivors enter the fortress in disguise, and Miller rigs the guns and their workings with delayed charges. They escape toward the sea while German forces close in. The emplacement explodes as British ships approach, opening the route to Kheros and allowing the evacuation to proceed, though several members of the mission do not survive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -411,7 +411,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -424,7 +424,7 @@
       "recaps": {
         "ending": "Lee survives the political and armed challenge mounted by Rhoodie's organization. Confederate forces and loyal civilians defeat the Rivington men and overrun their base, ending their control of the advanced weapons and exposing their origin in a future shaped by white-supremacist violence. Evidence recovered there confirms both the danger of their program and the broad direction history would have taken without their intervention. The victory gives Lee room to continue moving the Confederacy toward gradual emancipation, although racism, economic disruption, and opposition remain deeply rooted. Nate Caudell and Mollie Bean survive the fighting and build a life together, representing the ordinary people who must live inside the altered nation. The Confederacy has won independence through future technology, but it does not become the permanent slave state Rhoodie intended. Its future is redirected by Lee's limited but consequential decision that slavery must end, leaving the new country independent, unstable, and forced to confront the institution on which it was founded.",
         "in_short": "In 1864, time travelers from a future white-supremacist movement establish a base at Rivington, North Carolina, and supply Robert E. Lee's army with AK-47 rifles, medicine, and intelligence. The weapons reverse Confederate fortunes, break the Union's military advantage, and secure Southern independence. Sergeant Nate Caudell experiences the change at ground level and forms a bond with Mollie Bean, a woman serving disguised as a man. Once peace shifts the struggle into politics, Lee concludes that slavery is morally wrong and dangerous to the new country. He wins the Confederate presidency and pursues gradual emancipation, putting him at odds with Andries Rhoodie, whose men intervened precisely to preserve white rule. Rhoodie's organization turns its weapons against Lee's government. Loyal forces, including Nate, defeat them and seize Rivington. Lee survives and the Confederacy begins a contested movement away from slavery, denying the time travelers the future they tried to create. Nate and Mollie survive to make a life in the transformed nation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -568,7 +568,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -581,7 +581,7 @@
       "recaps": {
         "ending": "After prison gives him no useful outlet, Yank visits an Industrial Workers of the World office and asks the organization to help him destroy the steel industry. His crude demand for explosives convinces the secretary that he is either a police agent or dangerously reckless, and he is thrown out. Rejected by both wealthy society and the organized workers whose cause he thought might accept him, Yank goes to the zoo. He addresses a caged gorilla as a fellow outsider and releases it, expecting recognition and brotherhood. The animal instead crushes him in an embrace and tosses him into the cage. Mortally injured, Yank concludes that he has finally found where he belongs, but that place is a cage in which he dies. His search ends with neither the industrial world, the working class, nor nature able to provide the identity and belonging he believed physical strength guaranteed.",
         "in_short": "Yank, the strongest stoker on an ocean liner, believes his labor and physical power place him at the heart of the industrial age. Mildred Douglas, the sheltered daughter of a steel magnate, visits the stokehole and recoils from him as if he were an animal. Her reaction destroys his confidence and begins a search for revenge and belonging. In New York he tries to confront wealthy churchgoers, but they barely register him and the police arrest him. In prison he learns about the Industrial Workers of the World and seeks their help attacking the steel system, only to be rejected as a suspected provocateur. Finally he visits a zoo, releases a gorilla he imagines as a brother, and is crushed by it. Dying inside the animal's cage, Yank recognizes that he belongs nowhere: not with the machinery he powered, the rich who own it, the workers' political movement, or the animal world onto which others projected him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -770,7 +770,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -783,7 +783,7 @@
       "recaps": {
         "ending": "Inside Pasha Pook's guild house the fight goes on at two levels. Above, Bruenor, Wulfgar and Catti-brie break the guild's defences and scatter the wererats; below, Drizzt sets aside the mask, fights Entreri as himself, and finally has the better of him, though the assassin gets away into the city alive and the matter between them is left open. Regis gets his hands on the ruby pendant again and turns the guild's own people against their master, and Pook is killed in his own chambers. For a short while Regis is the master of the guild he ran away from, and he finds he does not want it; he leaves it to someone else and goes north with his friends. Drizzt, who has spent the journey hidden behind a magical mask, walks openly through Calimport in daylight before they go. Bruenor, alive and now certain of what he intends, turns the company north again: Mithril Hall belongs to his clan and he means to take it back, which will require an army he does not yet have. Wulfgar and Catti-brie acknowledge what has grown between them and are betrothed. The five friends leave the south together.",
         "in_short": "Drizzt and Wulfgar pursue the assassin Artemis Entreri south to rescue Regis, who has been taken to Calimport along with the ruby pendant he once stole from the guildmaster Pasha Pook. The wizard Malchor Harpell sends them after a magical mask, taken from the banshee Agatha, that lets Drizzt pass as a surface elf, and they win passage out of Waterdeep aboard Captain Deudermont's ship. In the north, Bruenor Battlehammer proves to have survived his fall into Garumn's Gorge; he climbs out, reunites with Catti-brie and Harkle Harpell, and with Lady Alustriel's help races south, where the four friends meet on the desert road and continue to Calimport together. Entreri delivers Regis to Pook. The companions storm the guild house: Regis regains the pendant and turns the guild against its master, Pook is killed, and Drizzt beats Entreri in a duel he fights without the mask, though the assassin escapes. Regis briefly inherits the guild and gives it away. The five go north together, Wulfgar and Catti-brie betrothed and Bruenor set on reclaiming Mithril Hall.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -943,7 +943,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -956,7 +956,7 @@
       "recaps": {
         "ending": "At the end of the historical journey, the boys find Pipkin still beyond their reach and Moundshroud demands a price for returning him. Money and possessions have no value against a human life, so each friend offers one year from the far end of his own lifespan. Their combined gift is accepted, and Pipkin is released. The boys return from their extraordinary flight to their own town on Halloween night. Pipkin has survived the medical danger that kept him from joining them, and when they telephone his house they hear his voice and know that he will recover. Moundshroud and the vast tree are gone from their immediate world, but the travelers now understand their costumes as descendants of many cultures' attempts to face winter, death, spirits, and remembrance. Their rescue succeeds because they accept a real future cost together, turning their knowledge of mortality into an act of friendship rather than fear.",
         "in_short": "On Halloween night, Tom Skelton and his costumed friends discover that their admired companion Pipkin is missing and in grave danger. Their search brings them to a dark house and an enormous tree hung with jack-o'-lanterns, where the enigmatic Mr. Moundshroud offers pursuit rather than simple answers. Traveling by a supernatural kite, the boys follow glimpses of Pipkin through centuries of human responses to death: Egyptian burial rites, classical beliefs, Celtic fires, persecution associated with witchcraft, cathedral gargoyles, and Mexico's Day of the Dead. Each stage explains something represented by their modern costumes while Pipkin remains just beyond rescue. Finally, Moundshroud asks what they will give for their friend. Each boy surrenders one year from the end of his life, and the combined offering buys Pipkin's return. Back in their own time, they learn that he has survived his illness and will recover, carrying home a deeper understanding of Halloween and of the loyalty that saved him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1088,7 +1088,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1101,7 +1101,7 @@
       "recaps": {
         "ending": "At the end of the historical journey, the boys find Pipkin still beyond their reach and Moundshroud demands a price for returning him. Money and possessions have no value against a human life, so each friend offers one year from the far end of his own lifespan. Their combined gift is accepted, and Pipkin is released. The boys return from their extraordinary flight to their own town on Halloween night. Pipkin has survived the medical danger that kept him from joining them, and when they telephone his house they hear his voice and know that he will recover. Moundshroud and the vast tree are gone from their immediate world, but the travelers now understand their costumes as descendants of many cultures' attempts to face winter, death, spirits, and remembrance. Their rescue succeeds because they accept a real future cost together, turning their knowledge of mortality into an act of friendship rather than fear.",
         "in_short": "On Halloween night, Tom Skelton and his costumed friends discover that their admired companion Pipkin is missing and in grave danger. Their search brings them to a dark house and an enormous tree hung with jack-o'-lanterns, where the enigmatic Mr. Moundshroud offers pursuit rather than simple answers. Traveling by a supernatural kite, the boys follow glimpses of Pipkin through centuries of human responses to death: Egyptian burial rites, classical beliefs, Celtic fires, persecution associated with witchcraft, cathedral gargoyles, and Mexico's Day of the Dead. Each stage explains something represented by their modern costumes while Pipkin remains just beyond rescue. Finally, Moundshroud asks what they will give for their friend. Each boy surrenders one year from the end of his life, and the combined offering buys Pipkin's return. Back in their own time, they learn that he has survived his illness and will recover, carrying home a deeper understanding of Halloween and of the loyalty that saved him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1233,7 +1233,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1246,7 +1246,7 @@
       "recaps": {
         "ending": "The novel ends without resolving Offred's fate. Serena Joy has discovered that Offred and the Commander broke Gilead's rules together, and Offred braces for punishment. Ofglen, her link to the resistance, is already dead by her own hand to avoid interrogation. Then a black van of the secret police arrives at the house. Nick, the man Offred has come to love and who may have fathered a child with her, tells her to go quietly, insisting the men are members of the Mayday resistance in disguise rather than the Eyes. With no way to know whether he is telling the truth, Offred steps into the van and into darkness or freedom, and her account breaks off there. A closing section set generations later, at a scholarly conference, reveals that Gilead eventually fell and that Offred's story survives only as a set of recorded tapes pieced together by historians, who speculate about the Commander's identity but cannot determine what became of Offred herself.",
         "in_short": "In the near-future theocracy of Gilead, which has overthrown the United States amid a fertility crisis, a woman called Offred is forced to serve as a Handmaid, a childbearing servant assigned to a Commander and his wife, Serena Joy. Stripped of her name, her family, and her freedom, she endures the ritualized monthly attempts to conceive while remembering her lost husband and daughter and her rebellious friend Moira. The Commander begins secretly meeting her for forbidden intimacies, Serena Joy arranges for her to sleep with the chauffeur Nick in hopes of a child, and Offred learns of an underground resistance through her shopping partner Ofglen. Her attachment to Nick becomes real, but the regime's violence tightens around her. In the end a van comes to take her away, and Nick claims it belongs to the resistance; whether she is being saved or arrested is never revealed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1387,7 +1387,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1398,7 +1398,7 @@
       "recaps": {
         "ending": "The Hanging Tree ends with the series' central mystery broken open: the Faceless Man has a name. He is Martin Chorley - wealthy, respectable, deeply embedded in the establishment, and the father of Christina Chorley, the girl whose death at One Hyde Park started the case. The identification comes too late to take him: the endgame erupts into open magical battle in and around the One Hyde Park development, wrecking some of the most expensive real estate in Britain, and Chorley escapes the net, as does Lesley May, who remains in his service. What changes is the nature of the hunt - the Folly is no longer chasing a glamour and a nickname but a named man with a history, associates, finances, and a traceable life, and the pursuit of Martin Chorley becomes the Folly's declared war. Along the way the Folly's world has widened: Lady Helena and Caroline Linden-Limmer demonstrate that capable magical traditions survived outside the Newtonian mainstream, and relations with them end wary but workable. Peter discharges his debt to Lady Tyburn with her daughter Olivia kept clear of prosecution and scandal, though family relations among the Thames girls are left strained. Nightingale's overwhelming display in the final battle underlines why Chorley has always avoided facing him directly. Peter ends the book intact, still with Beverley, and finally able to put a face to the enemy.",
         "in_short": "A teenage girl dies of an apparent overdose at a party in One Hyde Park, Knightsbridge's most expensive address, and Lady Tyburn calls in Peter Grant's debt: her daughter Olivia was at the party, and Ty wants her kept out of it. The dead girl is Christina Chorley, and the case swells from privileged teenagers dabbling in drugs into the Folly's main war. Around the investigation circles a lost manuscript said to be Isaac Newton's suppressed third Principia, peddled by the fox-like demi-monde fixer Reynard Fossman and coveted by every magical faction in London, including Lady Helena Linden-Limmer, a healer trained outside the Folly's tradition, and her daughter Caroline. Lesley May resurfaces on her new master's business, and the threads converge on the Faceless Man himself: the death, the manuscript, and the party's aftermath all touch his interests because Christina was his daughter. The book climaxes in a devastating magical battle at One Hyde Park, at the end of which the Folly finally has a name - Martin Chorley - though the man himself, and Lesley with him, escapes to fight the next book.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1541,7 +1541,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1554,7 +1554,7 @@
       "recaps": {
         "ending": "In the final tale, the Remarkable Rocket's vanity ruins his chance to appear in the royal wedding display. His tears have made him too damp to ignite, so the other fireworks perform without him. Workmen throw him away, and he is eventually placed in a fire beneath a kettle by two boys. He dries, ignites only after the boys have fallen asleep, and explodes without an audience. His stick drops onto a Goose, which mistakes it for rain. The Rocket nevertheless dies convinced that his display has astonished everyone. Unlike the Happy Prince, the Swallow, and the reformed Giant, he never gains an accurate understanding of himself; his empty confidence closes the collection's contrast between genuine self-sacrifice and self-regard.",
         "in_short": "Five fairy tales contrast generosity, love, and vanity. The Happy Prince and a migrating Swallow strip the Prince's statue of jewels and gold to help the city's poor; both are discarded after sacrificing everything, then honored in heaven. A Nightingale gives her life to create a red rose for a Student, only for the gift to be rejected and thrown away. A Giant ends the unnatural winter in his garden by welcoming children and is later led to paradise by the child who inspired his change. Little Hans dies while obeying a wealthy Miller who exploits him under the name of friendship. Finally, a boastful Rocket misses a royal display because his own tears have dampened him. He later explodes unnoticed yet remains persuaded of his importance. Across the collection, sacrifice often goes unrecognized by society, while characters are distinguished by whether they can see beyond themselves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1789,7 +1789,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1802,7 +1802,7 @@
       "recaps": {
         "ending": "In the final story, the Star-Child has been enslaved and ordered to find three pieces of gold. Each time the Hare helps him, he gives the coin to a leper instead of protecting himself from punishment. When he returns to the city after the third act of mercy, his beauty is restored and the people hail him as their king. He finds the beggar-woman and the leper, begs forgiveness, and learns that they are his mother and father, a queen and king. He rules with justice, aids the poor, and rejects cruelty, reversing the conduct of his childhood. Yet his suffering has shortened his life: he dies after only three years, and the ruler who follows him is evil. The collection thus ends with genuine moral transformation but not simple worldly reward; compassion restores the Star-Child's humanity, while power and goodness remain fragile.",
         "in_short": "Nine fairy tales test the difference between love and self-regard. The Happy Prince and the Swallow give their lives and riches to the poor; the Nightingale dies for a rose that shallow people discard; and the Selfish Giant finds redemption by welcoming children. Little Hans is destroyed by a Miller's exploitative idea of friendship, while a vain Rocket explodes unnoticed. A young king rejects regalia made through suffering and is clothed in miraculous splendor. A Dwarf dies after learning that the Infanta laughed at his appearance. A Fisherman casts off his Soul for a Mermaid, but their reunion ends in death before their grave inspires a priest to bless all living things. Finally, the cruel Star-Child is made ugly, suffers enslavement, and regains his form through mercy. He recognizes his parents, rules justly, and dies after three years, followed by an evil successor.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2073,7 +2073,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00LI7VIRS",
@@ -2085,7 +2085,7 @@
       "recaps": {
         "ending": "Lane, Gregory, Perez, and Addison capture Taylor, Anthony Jackson, Pauling, Kate, and Jade at Grange Farm. Reacher returns, kills all four attackers, and frees the captives. Taylor survives a gunshot wound, and Jackson survives Lane's beating. The group hides the bodies, the attackers' vehicles, and other evidence in an excavation on the farm. Reacher gives Pauling the recovered $800,000 for Hobart's long-term support, then leaves without disclosing where he is going. A year later, Kate and Graham Taylor are working Grange Farm, Jade has a baby brother named Jack, and Melody Jackson is close to her. Groom, Burke, and Kowalski have died in Iraq. More than $9 million is found when the Dakota apartment is foreclosed. Anne Lane's fate, wider accountability for the Burkina Faso operation, and any legal consequences from the concealed killings remain unresolved.",
         "in_short": "Jack Reacher is recruited by security-company chief Edward Lane after a ransom payment fails to recover Lane's wife, Kate, and her daughter, Jade. With former FBI agent Lauren Pauling, Reacher follows the ransom vehicles, Lane's abandoned mercenary Clay James Hobart, and former operative Graham Taylor. He eventually realizes there was no kidnapping: Kate, Jade, and Taylor staged an escape from Lane, whose threats and past violence made Kate fear for herself and her child. Reacher has already exposed their refuge at Grange Farm, so he races there as Lane follows. Lane and three loyal men seize the farm group, but Reacher returns and kills all four attackers. The survivors conceal the deaths. Reacher directs Lane's recovered money toward Hobart's care and then leaves. One year later, Kate and Graham are raising their family and working the farm, while several unresolved crimes remain hidden.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2213,7 +2213,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2226,7 +2226,7 @@
       "recaps": {
         "ending": "Lucy and Joshua return from Patrick and Mindy's wedding with their attraction acknowledged, but their competition for the new management job still appears to make a lasting relationship impossible. As the interviews approach, Lucy learns that Joshua has withdrawn from consideration. His apparent ambition was never a plan to become her superior; he intends to leave and pursue a different professional future, allowing her to take the promotion on her own merits. The details she once read as hostility are finally reinterpreted as evidence of sustained attention and affection. Joshua admits that he has loved her for a long time, and Lucy accepts that her obsession with him was never simple hatred. They begin a relationship after replacing their adversarial office games with direct honesty. Lucy's career advances, while Joshua chooses work outside the contest that had trapped them together.",
         "in_short": "Lucy Hutton and Joshua Templeman are executive assistants to rival co-chief executives after two publishing companies merge. Seated opposite each other, they turn mutual scrutiny into a daily series of hostile games. When both compete for a new management role, Lucy believes victory is necessary because neither could bear reporting to the other. An impulsive kiss, a team-building retreat, and Joshua's care when Lucy becomes ill expose an attraction neither can fit into the rivalry. Lucy accompanies him to his brother's wedding, learns about the family comparisons and romantic betrayal behind his reserve, defends him, and becomes his lover. Back at work she discovers Joshua has withdrawn from the promotion process and plans another career path. He confesses that he has loved her for a long time. Lucy wins the advancement without defeating him, and they finally turn their intense attention to each other into an honest relationship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2333,7 +2333,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2346,7 +2346,7 @@
       "recaps": {
         "ending": "During a violent thunderstorm, Providence loses electrical power and the light that had kept the presence inside the church is extinguished. Blake watches the darkened tower from his apartment while writing increasingly disordered notes that suggest the entity is approaching and entering his mind. When the lights return, he is found dead at his window, staring toward the church; his face bears an expression of terror, and the medical explanation does not account for all the circumstances. Dr. Dexter enters the church afterward, removes the Shining Trapezohedron, and throws it into Narragansett Bay. The object is gone, but Blake's final notes leave open how completely the Haunter had joined itself to him before his death.",
         "in_short": "Occult-minded writer Robert Harrison Blake becomes obsessed with an abandoned Providence church shunned by its neighbors. Inside he finds the remains and notebook of journalist Edwin Lillibridge, records of the Church of Starry Wisdom, and the Shining Trapezohedron, a stone used to call an intelligence that fears light. By looking into the stone, Blake awakens contact with the Haunter confined in the church tower. He tries to resist the link, but a thunderstorm causes a citywide blackout and lets the entity move through the darkness. Blake is found dead at his window after recording signs that the presence was overtaking him. Dr. Dexter later removes the stone from the church and casts it into Narragansett Bay.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2457,7 +2457,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2470,7 +2470,7 @@
       "recaps": {
         "ending": "Eleanor becomes convinced that Hill House recognizes and wants her. After she wanders the building at night and is found in danger near the library tower, Dr. Montague decides that her growing instability makes it unsafe for her to remain. The others insist that she leave despite her pleas that she has nowhere to go. Driving down the avenue, Eleanor experiences a final surge of belonging and deliberately accelerates toward the same tree associated with an earlier death at the house. In the instant before impact she understands the action as a terrible mistake, but she is killed. The investigation ends without proof that the group can present to the world. Dr. Montague's later paper receives little respect, Theodora returns to the life she had left, and Luke goes abroad. Hill House is closed again and remains alone, its nature unresolved and its effect on Eleanor inseparable from her own loneliness and need for a home.",
         "in_short": "Dr. John Montague rents the isolated Hill House to investigate its reputation for supernatural activity. His party consists of Eleanor Vance, a lonely woman marked by years of caring for her mother; Theodora, a perceptive and self-assured guest; and Luke Sanderson, the house's heir. The building's disorienting design and history unsettle them, then violent nocturnal noises, cold spots, writing addressed to Eleanor, and other disturbances make the threat feel personal. Eleanor's delight in belonging to the group gradually becomes a conviction that she belongs to the house itself. Tensions with Theodora and the arrival of Dr. Montague's overconfident wife deepen her isolation. After Eleanor wanders the house at night and nearly falls from the library tower, Montague orders her home for her safety. Refusing the loss of the only place where she believes she belongs, she drives into a tree and dies. The others leave, while Hill House remains closed, empty, and unexplained.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2680,7 +2680,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2693,7 +2693,7 @@
       "recaps": {
         "ending": "Toby Hawthorne is found alive, held by Sheffield Grayson, who has been behind the renewed attempts on Avery's life. The confrontation ends with Sheffield Grayson dead, and the Hawthornes, with Oren and Alisa managing the aftermath, decide to bury what happened rather than explain it, a decision Grayson carries hardest. Toby is free, but twenty years of hiding have left him unwilling to simply resume being a Hawthorne, and he sets his own terms about how much of the family he will take back. Avery finally gets the conversation she has been chasing since the will was read, about how Toby and her mother knew each other and how that shaped Tobias Hawthorne's choice of her. Skye's part in the previous year's attacks has cost her her place in the family, Zara is still angling for control, and Nash and Libby, and Rebecca and Thea, have each stopped pretending about their relationships. Avery and Jameson are together, and Grayson has deliberately stepped back. The book's final beat is the arrival at Hawthorne House of a young woman who is the image of the dead Emily Laughlin. She gives her name as Eve, and every one of the brothers reacts.",
         "in_short": "Knowing that Toby Hawthorne survived the fire that supposedly killed him, Avery and the Hawthorne brothers set out to find him, using the methods the old man drilled into his grandsons. The archives give up the story the family buried: Toby was taken in as an infant rather than born a Hawthorne, found out as a young man, and vanished after a fire on the family's private island killed several of his friends, spending the next twenty years unnamed and unfound. Somewhere in those years he knew Avery's mother, which is where the answer to why Avery was chosen begins. While Grayson tracks down his own biological father, Sheffield Grayson, and is refused, new attempts are made on Avery's life and it becomes clear that someone else is hunting Toby too. The two searches turn out to be one: Sheffield Grayson has taken Toby and has been trying to kill Avery. The rescue ends with Sheffield Grayson dead and the family concealing it, Toby free but unwilling to step back into the Hawthorne name, and a stranger arriving at the gates who looks exactly like Emily Laughlin.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2877,7 +2877,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2890,7 +2890,7 @@
       "recaps": {
         "ending": "Singer learns that Antonapoulos has died at the institution. The loss destroys the private hope around which Singer has organized his life, and after returning to town he shoots himself. His death shocks the people who had treated him as their uniquely understanding confidant, but it does not bring them together. Dr. Copeland, ill and defeated by family conflict and the limits imposed by racism, leaves town to live on his father-in-law's farm. Jake Blount departs after violence at the carnival confirms his inability to reach the workers he wants to organize. Mick gives up school for a job at Woolworth's to help her family; exhausted by work and worried that her inward world of music is fading, she still tries to believe she will return to it. Biff Brannon remains in his cafe, contemplating Singer and the disconnected lives that briefly crossed there before continuing alone.",
         "in_short": "In a Depression-era Southern mill town, the deaf John Singer loses his daily companion when Spiros Antonapoulos is placed in an institution. Singer becomes a boarder with the Kelly family and an imagined source of perfect understanding for four isolated people: Mick Kelly, an adolescent consumed by music; Biff Brannon, a watchful cafe owner; Jake Blount, a volatile socialist labor agitator; and Dr. Benedict Mady Copeland, a Black physician fighting racism while estranged from his family. Each speaks to Singer but knows little of his own consuming devotion to Antonapoulos. Their private ambitions meet poverty, prejudice, illness, and failures of communication. After Antonapoulos dies, Singer takes his own life. The survivors disperse rather than forming the community they sought through him: Copeland and Jake leave town, Mick takes a department-store job that threatens her musical hopes, and Biff remains at the cafe, considering their separate loneliness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3030,7 +3030,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3043,7 +3043,7 @@
       "recaps": {
         "ending": "After Sharikov reports Preobrazhensky and Bormenthal to the authorities and then threatens them with a revolver, the two doctors overpower him. Preobrazhensky performs another operation, removing the transplanted human tissue. When investigators arrive to inquire into Sharikov's disappearance, the professor presents a living creature who is steadily reverting to canine form; the officials cannot prove that a murder occurred. In the epilogue, Sharik is once again a dog living contentedly in the professor's apartment, with only fragmentary discomfort associated with his earlier transformation. The building committee has not displaced Preobrazhensky, and the professor resumes his surgical work with Bormenthal. Sharik watches without understanding as another human brain is examined, leaving the household outwardly restored while the experiment's ethical consequences remain with the reader.",
         "in_short": "A starving Moscow stray named Sharik is rescued by the eminent surgeon Philip Preobrazhensky, who implants in him human organs taken from the dead criminal Klim Chugunkin. The dog rapidly becomes a man calling himself Polygraph Sharikov, but gains speech and legal standing without maturity or self-control. Encouraged by the housing chairman Shvonder, he claims space in the professor's apartment, embraces official slogans, behaves destructively, and obtains work killing stray animals. His attempt to marry a young colleague collapses when Preobrazhensky reveals his origins. Sharikov then denounces the doctors and threatens them with a gun. Preobrazhensky and Bormenthal subdue him and reverse the operation. Investigators find no murdered man, only Sharik returning to canine form. The dog resumes a comfortable life in the apartment, while the professor continues his research.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3194,7 +3194,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3207,7 +3207,7 @@
       "recaps": {
         "ending": "Scobie is trapped between Louise, who has returned and wants him to receive Communion with her, and Helen, whom he has promised not to abandon. Believing that every choice will betray either another person or God, he receives Communion while concealing his unrepented adultery. His dependence on Yusef also ends in disaster: after Scobie uses Ali in an attempt to break free of the merchant, Ali is murdered, and Scobie recognizes his own responsibility even though he did not order the killing. He plans a suicide disguised as death from heart disease, carefully planting symptoms and misleading diary entries before taking an overdose. Wilson sees through the deception and tells Louise both of Helen and of his suspicions. Louise turns to Father Rank, expecting condemnation, but the priest refuses certainty about Scobie's damnation and insists that neither of them fully knew the depth of his love or suffering. Louise is left alive with the ambiguity Scobie tried to escape.",
         "in_short": "In a wartime British colony in West Africa, police officer Henry Scobie tries to protect everyone around him from pain. When he is passed over for promotion, his unhappy wife Louise wants to leave; Scobie compromises himself by borrowing from the merchant Yusef to pay for her journey. In her absence he begins an affair with Helen Rolt, a young shipwreck survivor. Louise returns, and Scobie cannot bear either to leave Helen or to hurt his wife. His secrecy, Catholic guilt, and obligations to Yusef tighten around him. He receives Communion despite believing himself in mortal sin, and his effort to escape Yusef contributes to the murder of his loyal servant Ali. Convinced that only his death can free the women and end his offenses against God, Scobie stages a fatal overdose to resemble illness. Wilson uncovers the affair and suspects suicide, but Father Rank warns Louise that no outsider can confidently judge Scobie's final spiritual state.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3418,7 +3418,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3429,7 +3429,7 @@
       "recaps": {
         "ending": "The dungeon battle ends with Prince Kassius, exposed as a warlock and necromancer, burned to a charred, barely-living husk by Hump wielding the absorbed power of the dungeon's dragon. Before he can be finished, a masked, shadow-woven entity tears open reality, carries his body away, and vanishes; because no remains are found and no one else saw the figure, Kassius's survival, the entity's identity, and the secret order he served all remain unresolved. Officially, the prince is remembered as a hero who died fighting the dragon, a cover story the Overseer enforces before quietly escalating a warning up the chain of command. Hump emerges a second-rank wizard permanently changed: he carries a large, only partly controlled reserve of the dragon's power and a dramatically stronger fire affinity, an unhealed injury to his soul that no priestess can mend, and the dragon's egg, soul-bonded to him until his death. Because that bond would force him into likely-fatal trials among Vamir's people, Celaine and Bud both choose to stay with him rather than part ways, and Vamir departs alone, buying them time by delaying his report home. Bud is revealed to be a nobleman, Lord Robert Blackthorne, and Celaine registers with an adventurers' guild for the first time, stepping out on her own. Newly independent and guild-registered, the three set out from Bledsbury for Fishers Lake to seek a wizard named Vivienne to train Hump, while Kassius's fate, the shadow entity, and Hump's own uncertain nature hang over the road ahead.",
         "in_short": "Hump, a penniless self-taught hedge wizard, inherits a soul-bound spellbook from his dying master and travels to the newly opened dungeon at Bledsbury, falling in with the earnest knight Bud and the secretive, dangerously skilled Vamir and his companion Celaine. Delving to rescue villagers taken by the dungeon's kobolds, the party is drawn into the schemes of Prince Kassius, an outwardly generous royal who is secretly a warlock and necromancer bent on stealing the power of the gods. In the dungeon's true core chamber they find a dying dragon's soul bound as its guardian, and Kassius unleashes it. To save his friends, Hump binds and absorbs the dragon's power and, aided by a relief party, burns Kassius down to a barely-living husk, only for a masked shadow entity to spirit the prince's body away through a tear in reality. Hump survives as a second-rank wizard now carrying the dragon's power, an unhealed soul injury, and her soul-bonded egg. With Kassius's crimes hidden behind a hero's cover story, Bud, revealed to be a nobleman, and Celaine choose to stay with Hump, and the trio sets out to find a wizard who can train him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-hedge-wizard-2.json
+++ b/data/works-community/0/the-hedge-wizard-2.json
@@ -220,7 +220,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -231,7 +231,7 @@
       "recaps": {
         "ending": "The gorger is destroyed for good, unmade inside Hump's own soul-void after Lucile dies shielding him. Her body is left in the collapsing temple, and five of the roughly twenty rescued townsfolk die during the escape, leaving fifteen. Hump proved he can surrender completely to the dragon's power and still reclaim himself, but he ends the book physically battered and carrying untreated trauma: insomnia, nightmares, a startle response. He has only just agreed to let Vivienne test his soul, and has paused bonding with the dragon egg as a precaution. Vivienne survives with frostbite and a condition termed essence overuse, and faces a Wizard Society tribunal for insubordination that she has bought a week's delay on; she is unbothered by it, and has recommitted to mentoring Hump personally, revealing that she warned Sethril about his own soul damage some twenty years ago and could never fix it. Bud, close to a third circle, wants the party to take safer work and to recruit Dylan. Celaine has already reached her third circle. Randall and Helen Astida will pass the party's warning about the remnant realm's rifts to Countess Daston and other factions, and Fredricks is Fishers Lake's new captain of the guard. The three plan to ride for Sheercliff. Then, late at night, after Celaine wakes Hump from a nightmare and leaves, what appears to be Lucile is sitting on the other bed in a plain white dress, speaking to him as though nothing had happened. The book ends there. Whether she is a hallucination, a haunting, or something else is not answered on the page, and neither is what Hump means when he says she had been possessed as Albry was.",
         "in_short": "Hump, Bud and Celaine reach the lakeside town of Fishers Lake hunting for the wizard Vivienne, and find it plagued by swarms of soul-draining spirits, a hostile high priest, and people going missing. Vivienne agrees to train them in exchange for help, and the investigation uncovers a gateway into the remnant realm, a dead world, hidden beneath the lake in a sunken temple she has secretly hunted for years. The creature behind it, a soul-eating gorger, takes Hump captive and holds him a month. He escapes, restores a fellow captive's shattered soul, and rejoins his party as they trade a stolen artifact for the prisoners, a bargain that only makes the gorger stronger. In the flooded temple Vivienne deliberately corrupts her own soul to fight it, Lucile dies shielding Hump, and Hump chooses to unleash the dragon's power completely, destroys the creature inside his own soul-void, and then proves he can pull himself back from it. The party comes home battered; Vivienne faces a tribunal and recommits to teaching Hump. The book closes with what appears to be the dead Lucile sitting in Hump's room, unexplained.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -619,7 +619,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -630,7 +630,7 @@
       "recaps": {
         "ending": "The siege is broken and the city holds, at heavy cost. Sir Ricard, Arthur, and Luna's chaperone are dead; two of Marcela's party are dead; Abraxus is dead, killed in the aftermath after killing two of Corvin's companions while under Eliana's control. Countess Daston survives but will never walk again. Anthony escaped through a blood portal, vowing to return, hunted now by the three-eyed order that departed warning of a coming great war. Eliana is imprisoned, tests as not technically a warlock, still blames Hump publicly, and says nothing to Sheercliff's authorities about her own order, which wants Hump's spellbook. Lord Ferrand is a fugitive under a kingdom-wide bounty; his son Randall is cleared. A border stronghold has fallen in an attack coordinated with the assault on Sheercliff, and King Henry is recalling every Chosen, so Bud, Dylan, and Emilia ride for House Blackthorne to await deployment toward the Fallen Lands. Vivienne stays in Sheercliff, entering the Countess's service to watch Eliana. Hump, a rank-four wizard with a manifested soul, a manor of his own in the upper city and a new gold-rank staff, leaves rather than take the Dastons' offer of permanent service: his master's posthumous letter warns that the Book of Infinite Pages grows more visible to its hunters as he grows. He and Celaine ride north for the Dragon Keeper trials with his newly hatched dragon. On the last night, the spellbook answers him, and shows him a vast essence core hidden in its spine, and a silver owl on its cover. He has no idea what he is carrying.",
         "in_short": "Hump comes to Sheercliff under the shadow of a Wizard Society bounty on the apprentice it believes murdered his master, and finds a city ringed by expanding dungeons and hollowed out from within by the Blackstone Warlocks. Countess Daston hides him behind an Academy enrolment; a patrol into Stonebark Forest costs lives, exposes warlock saboteurs, and leaves Hump drawing on dungeon essence he cannot safely touch. Back in the city he cracks the warlocks' black stones open, clearing Vivienne of a murder she was framed for, and the hunt that follows uncovers trees that hold human souls. Then the warlocks spring their real plan: a citywide ritual to sacrifice every soul in Sheercliff and pull a fallen god's first servant into the world. Hump burns its anchor down with an original spell, White Flame, and the warlock behind it flees. Ambushed, dosed with warlock powder, and moments from being executed as a warlock himself, Hump instead masters every foreign essence in his soul and manifests it. The siege ends. Sheercliff calls him the White Flame, and he leaves anyway.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-hedge-wizard-4.json
+++ b/data/works-community/0/the-hedge-wizard-4.json
@@ -295,7 +295,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -306,7 +306,7 @@
       "recaps": {
         "ending": "Irila is destroyed in body and soul, and her undead army and the corrupted sky over Drakalyn collapse with her, implying her power had held both together. The cost is heavy: four dragon keepers and six dragons die at Estora, Elder Ashera is killed as well, and 462 more are confirmed dead from the wider lake battle, including six of Vamir's students. Vamir survives, healed and raised to the fourth circle by Owalyn herself, but is left guilt-ridden. Yunillia survives Irila's attempt to possess her. Finnian has fully reconciled with Hump and Celaine. Rehk and the gnolls leave to reclaim the mountains as their home. Walt, revealed as a house spirit rather than a human ghost, takes over Irila's former phylactery, a pocket-dimension library, and the elders formally award it to Hump as payment. Owalyn appears to Hump in person, free at last of a binding to the Great Tree that turns out to have been her prison, gives him a healing artifact and a standing favour, and tells him an unverified legend in which the Pantheon's founders stole their power from a wandering wizard whose slain owl familiar was Glyndaril. Hump now privately associates his spellbook with that name, and chooses to keep the whole account from Bud, Dylan and Emilia over Celaine's objection. The Great Tree is left dying. Hump, Celaine, Nishari and the keeper Tessa are set to leave for Sheercliff by dragonback within the week, to formalise Drakalyn's new alliance with Countess Daston.",
         "in_short": "Hump and Celaine ride north to Drakalyn so he can attempt the Dragon Keeper trials and secure his bond with his hatched dragon, Nishari. On the road they take in a gnoll and her pup, pick up a trapped spirit named Walt from an abandoned mine, and are hunted by a shapeshifter who is soon captured and enslaved by Irila, an ancient lich queen whose undead are pressing on Drakalyn from the ruined city of Estora. Hump passes all three trials, is made dragon-blooded, and then refuses the goddess Owalyn's blessing, choosing his own path and his place as an outsider. Drakalyn goes to war. In the climax beneath Estora, Hump cripples Irila with White Flame and launches Walt into her exposed phylactery, Yunillia destroys her body, and Celaine destroys her fleeing soul for good. Walt proves to be a house spirit and claims the lich's phylactery, a pocket-dimension library, which the elders award to Hump. A freed Owalyn tells Hump the Pantheon may have stolen its power from a wandering wizard whose owl familiar was named Glyndaril, and Hump prepares to leave for Sheercliff with Celaine, keeping the story secret.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -719,7 +719,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -730,7 +730,7 @@
       "recaps": {
         "ending": "Book 5 ends mid-turn, launching a larger war rather than resolving one. The Infernal Halls citadel is taken, but the victory is hollow: the demon lord Dravor escaped with the dungeon core, and the campaign was a deliberate feint to draw Alveron's army away while the warlock Order of Ancients struck the kingdom's twelve world-seals. Cities burn; only already-fallen Sheercliff and Fort Nordric are spared, and whether the seals hold or the old gods are freed is left open. Hump survives, transformed: acknowledged as heir to the wandering wizard who created his book, he now knows the book is a weapon against the Pantheon and that the gods' blessings enslave their Chosen, a secret he keeps from all but Celaine. He has forced the book to obey him and opened a warlock Greater Gateway to Alveron, but has not yet reached the seventh rank; the Iron Hand, revealed as one of the Three Eyes, has invited him to join their order for training and protection. Karlak Gormoth is sealed off in his soul-domain, alive and permanently half-blinded, vowing to hunt Hump forever. The core party ends intact and pledged to stay together: Celaine his sole confidante; Bud healed of grievous wounds and hailing a holy war he does not know binds his own soul; Dylan advanced to his fifth circle; Emilia healed of a near-fatal wound; and Nisha exhausted, her golden transformation still unexplained. The final image is Hump opening a red rift onto a dark, ruined Alveron and ordering the elite army through. Open threads: the outcome of the invasion and the seals war, Karlak's and Dravor's eventual reckoning, the true fate of the wandering wizard, and whether Hump joins the Three Eyes and breaks the seventh rank.",
         "in_short": "Hump returns from Drakalyn to Sheercliff as the famous White Flame, then rides to the Fort Nordric front with Celaine and his dragon Nisha to reunite with Bud, Dylan, and Emilia and help destroy the demon dungeon called the Infernal Halls. Along the way he foils warlocks at the Sapphire Docks, learns that twelve seals hold back the ancient gods, and is folded into an elite force that infiltrates the Halls, a pocket world ruled by the demon lord Dravor. Breaking through a living wall and taking the citadel, Hump is dragged into the private soul-domain of the ancient devil Karlak Gormoth, who hunts his living spellbook; Hump masters hellfire and maims Karlak, and the Iron Hand, secretly a member of the Three Eyes, arrives to seal the devil away. But the whole campaign was bait: Dravor escapes with the dungeon core while the warlock Order of Ancients strikes the kingdom's seals, burning Alveron's cities. The book reveals it was made by a wandering wizard the Pantheon betrayed and names Hump his heir, exposing that the gods' blessings enslave their Chosen. Overriding the book's guardian, Hump seizes a warlock gateway and tears open a rift to the invaded homeland, commanding the army to advance as the series ends on the brink of open war against the Pantheon.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -995,7 +995,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1008,7 +1008,7 @@
       "recaps": {
         "ending": "Eadlyn ends the book having changed, and then loses the two people who made the change bearable. Ahren, tired of waiting for a family that has never once asked what he wants, elopes to France with Princess Camille and leaves a letter behind explaining it. He tells his sister plainly that with him gone and married abroad she can no longer treat her own Selection as a performance: the succession now rests on her alone, and she will have to marry. The elopement becomes public and the country, already unsettled, takes it badly. Eadlyn cuts the Selection down to six, among them Kile, Henri, Hale, and Fox, and for the first time she is choosing rather than staging. Then Queen America collapses with a heart attack, and the book ends with her survival uncertain, Maxon refusing to leave her, Ahren gone, and Eadlyn holding a country in unrest, a Selection she now needs, and the prospect of ruling far sooner than she expected.",
         "in_short": "Twenty years after the caste system was abolished, Illéa is in unrest: the old hierarchies have reasserted themselves through money and prejudice, and protests are spreading. Princess Eadlyn Schreave, the first female heir and a cold, self-contained young woman who wants no husband at all, agrees to hold a Selection of her own as a distraction for the country. Thirty-five young men arrive, among them Kile Woodwork, who grew up in the palace and whom she has never liked. Eadlyn treats the whole thing as theater, staging a kiss for the cameras and dismissing a candidate who grabs her, but the men refuse to stay abstractions: she comes to like Kile, warms to the guileless Henri and to Erik, the translator who is not a candidate at all, and begins to think about the country rather than the show. Then her twin brother Ahren elopes to France with Princess Camille, leaving a letter warning her that the succession now rests on her alone, and the shock brings on their mother's heart attack.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1126,7 +1126,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1139,7 +1139,7 @@
       "recaps": {
         "ending": "Frank kills Rory and uses his brother's skin as a disguise, hoping to escape before the Cenobites find him. Kirsty recognizes the deception and names Frank to the beings she summoned. Julia dies during the confrontation, and the Cenobites reclaim Frank, tearing him out of the human world despite his attempts to deny his identity. Rory, Julia, and Frank are all gone, leaving Kirsty as the only survivor of the household. The puzzle box closes and returns to its apparently harmless form. In its polished surfaces Kirsty perceives traces of Frank and Julia but not Rory, and she wonders whether another device might open a passage to a gentler afterlife. She is left with the knowledge that hidden doors exist and that desire can make their terrible costs seem invisible until too late.",
         "in_short": "Frank Cotton opens an intricate puzzle box seeking sensations beyond ordinary life and is taken by the Cenobites, beings for whom pain and pleasure have merged. Later his brother Rory and Rory's wife Julia move into the house where he vanished. Blood from an accident partly restores Frank beneath the attic floor, and Julia, still obsessed with him after an earlier affair, murders strangers so he can rebuild his body from theirs. Rory's friend Kirsty uncovers the secret, escapes with the box, and accidentally calls the Cenobites. She bargains for her safety by promising them Frank. Frank kills Rory and wears his skin, but Kirsty exposes him and the Cenobites reclaim him. Julia also dies, and Kirsty survives with the closed box and the disturbing knowledge of the world it can open.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1281,7 +1281,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1294,7 +1294,7 @@
       "recaps": {
         "ending": "The anonymous book of the maids' testimonies, titled simply for the help who told them, is published and read all over Jackson, throwing the town's white households into suspicion and unease. Hilly Holbrook recognizes herself in one of the stories and burns to expose and punish the maids and Skeeter, but she is trapped: to prove the book is about Jackson would be to admit that she is the woman fooled by Minny's notorious secret revenge, the pie she was tricked into eating, and so she is forced into silence. The fallout still lands hard on the women. Aibileen is falsely accused of theft by Hilly and dismissed from the Leefolt house, yet she walks away with a sense of freedom and a possible future as a writer, having found her own voice. Minny, emboldened, finally resolves to leave her abusive husband and holds a secure place with the loyal Celia Foote. Skeeter, shunned by her old circle but offered a publishing job, departs for New York with her family's blessing to pursue her ambitions. Skeeter has also learned the sad truth of what became of Constantine, the maid who raised her. The three narrators part changed, having risked everything to tell the truth.",
         "in_short": "In Jackson, Mississippi, in the early 1960s, a young white would-be writer, Skeeter, secretly sets out to record the true experiences of the Black maids who raise white families' children and keep their homes. Aibileen, a wise, grieving maid, cautiously agrees to talk, followed by her sharp-tongued friend Minny and, after the murder of Medgar Evers, many others. The project is dangerous in a town ruled by the segregationist socialite Hilly Holbrook, who champions separate bathrooms for the help. Minny takes a job with Celia Foote, a kind outcast, and holds a secret weapon against Hilly, a humiliating trick she once played on her. Skeeter also uncovers what happened to Constantine, the maid who raised her. The book of the maids' stories is published anonymously and sends shockwaves through Jackson. Hilly, recognizing herself, is silenced by fear of exposure. Aibileen loses her job but steps toward a freer future, Minny gains security, and Skeeter leaves for New York, the three women changed by what they dared to do.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1419,7 +1419,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1432,7 +1432,7 @@
       "recaps": {
         "ending": "Greentop recognizes that he is a wild mallard and joins a flock at the reservoir. Sprout accepts that loving him requires letting him migrate with his own kind, and she watches him fly away. Alone and aging as winter closes in, she sees that the one-eyed weasel she has feared is also a mother struggling to feed her young. Sprout stops fleeing and allows the weasel to take her, choosing to sustain another family after ensuring her own child is free. As she dies, Sprout imagines rising into the sky and finally experiences the flight that once seemed impossible for a farm hen. Her life ends, but she has achieved the essential freedoms she sought: leaving the laying coop, hatching and raising a child, and deciding for herself how to meet death.",
         "in_short": "Sprout, an exhausted battery hen, wants to hatch a chick and live outside her cage. Marked for disposal when she stops laying, she escapes into the yard, where the domestic animals refuse to accept her. A wild mallard called Straggler helps her survive. Sprout finds an abandoned egg in a briar patch and broods it; after Straggler is killed protecting the nest, the egg hatches into a duckling she raises as her son. The duckling, later called Greentop, struggles with being different until he learns to swim and discovers the wild mallard flock. Sprout protects him from a one-eyed weasel but ultimately lets him migrate with his own kind. Old and alone, she realizes the weasel is feeding young of her own. Sprout allows the predator to kill her and, at the moment of death, imagines herself flying free.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1684,7 +1684,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1697,7 +1697,7 @@
       "recaps": {
         "ending": "The collection closes with the destruction of the Pequod. After Ahab refuses the Rachel's plea to help search for its captain's missing son, he sights Moby Dick and pursues the whale for three days. Boats are smashed, Ahab's ivory leg is broken, Fedallah is found dead and lashed in the harpoon lines around the whale, and the crew is steadily reduced. On the final day Moby Dick rams the Pequod. Ahab makes one last cast, but the running line catches him around the neck and pulls him from the boat. The ship sinks with everyone still aboard, including Starbuck, Stubb, Flask, Pip, and the rest of the crew. Ishmael alone survives, kept afloat by the coffin Queequeg had ordered during an illness and later converted into a life buoy. The Rachel, still searching for its own missing sailors, finds and rescues him.",
         "in_short": "This collection brings together three stories of isolation and destructive authority. In Bartleby, the Scrivener, a Wall Street lawyer hires a copyist whose calm refusals expand until he stops working and cannot be removed; Bartleby is jailed as a vagrant and dies after refusing food. In Billy Budd, Sailor, the innocent sailor Billy is falsely accused of mutiny by Claggart and kills him with one involuntary blow. Captain Vere insists on wartime law, and Billy is hanged after blessing him, while official history reverses the truth. In Moby-Dick, Ishmael joins the Pequod with his friend Queequeg. Captain Ahab turns its whaling voyage into a hunt for the white whale that took his leg. His obsession defeats Starbuck's objections and consumes ship and crew. Moby Dick sinks the Pequod and Ahab is dragged to his death by his own line. Ishmael alone survives, buoyed by Queequeg's coffin and rescued by the Rachel.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1979,7 +1979,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1992,7 +1992,7 @@
       "recaps": {
         "ending": "The world ends and is remade. Elend takes Fadrex City in a last battle fought with koloss and the last of the atium, and Yomen's resistance collapses. Vin, having worked out that atium is Ruin's own body and that Preservation's body is the mists, draws that power into herself and Ascends. She and Ruin destroy each other, both gods annihilated, and Vin dies with the enemy she was created to stop. Moments later Marsh, still not his own man, kills Elend. Both Ascendant powers are left without a holder, and Sazed, who has spent the book methodically discarding every religion he collected, is the one standing where they can be taken up. He was the Hero of Ages the corrupted prophecies pointed to all along. Holding Ruin and Preservation together, he becomes Harmony, and uses the two of them in balance to repair the planet: the ashfalls stop, the ashmounts quiet, the mists are set right, green things and a normal sun return, and the survivors sheltering in the Lord Ruler's last storage cavern walk out into a world that can support them. Spook, the last of Kelsier's crew still standing in the north, is left to lead them, with Beldre beside him. Marsh survives, released at last from the thing that used him. Sazed leaves behind the collected knowledge of the old world and a written account for those who come after, and steps back to watch what they do with it.",
         "in_short": "A year after the Well of Ascension is opened, the world is dying: ash buries the land, the ashmounts erupt, crops fail, and the god called Ruin works openly toward the end of everything, whispering to anyone whose body carries a metal spike and having spent a thousand years forging the written record to arrange its own release. Elend, now emperor and Mistborn, hunts the Lord Ruler's hidden storage caverns city by city while besieging Fadrex, held by the obligator Yomen. Spook fights a fanatical skaa regime in Urteau and is nearly destroyed by a voice claiming to be Kelsier. TenSoon rallies his people against their own rulers. Sazed, who lost his faith with Tindwyl, works through the corrupted Terris records. Vin discovers that atium is Ruin's body and the mists are Preservation's, draws that power into herself, and destroys Ruin at the cost of her own life; Marsh kills Elend moments later. Sazed, left holding both powers, is the Hero of Ages: he becomes Harmony, repairs the ruined planet, and leads the survivors out of the last storage cavern into a living world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2198,7 +2198,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2211,7 +2211,7 @@
       "recaps": {
         "ending": "The narrator and Barley follow the documentary trail to a remote French monastery, where they find Paul alive but held by Dracula. Dracula has gathered a vast historical library and wants a learned custodian who can order and extend it; generations of marked books have helped him identify possible servants. Helen, long absent and infected by Dracula, also reaches the monastery. She kills Dracula with a silver bullet, ending his immediate threat, but dies herself after the confrontation. Paul and his daughter are reunited and finally able to mourn Helen with knowledge of what happened to her. The narrator later becomes a historian and preserves the family's papers rather than publishing every detail. Years afterward, while conducting research in a library, she is given another old volume bearing the familiar dragon image. The delivery leaves open the disturbing possibility that Dracula's system of choosing and following historians survived the destruction of the body they confronted.",
         "in_short": "An unnamed narrator discovers that her diplomat father Paul once searched for Dracula. As a graduate student, Paul received a blank book marked with a dragon; his adviser Bartholomew Rossi, who had received an identical book, then vanished. Paul joined Helen, Rossi's previously unknown daughter, and followed archival clues through Istanbul, Hungary, Romania, and Bulgaria. They found Rossi imprisoned in Dracula's hidden tomb and ended his vampiric suffering, but Dracula escaped. Paul and Helen married and had the narrator. Years later Dracula bit Helen, who disappeared while trying to keep her family safe. When Paul is abducted in the 1970s, his daughter and the English student Barley resume the hunt through the family's letters. They find Dracula's new library in a French monastery. Helen arrives and kills Dracula with a silver bullet, then dies. Paul is rescued, but a dragon-marked book delivered to the narrator years later suggests that the ancient threat, or its method of recruiting historians, may remain.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2417,7 +2417,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2430,7 +2430,7 @@
       "recaps": {
         "ending": "Tom is jailed after his fight with Fitzpatrick and believes he may face execution, but Fitzpatrick survives and the case eases. The network of lies around Tom then unravels. Square's final testimony and other evidence show Allworthy that Tom was generous rather than vicious, while Blifil concealed information and deliberately represented his rival's actions in the worst light. Mrs Waters reveals that she is the former Jenny Jones and that Tom's mother was Allworthy's sister Bridget; Tom's father was a young man named Summer. Tom is therefore Allworthy's nephew, not a stranger to the family. Allworthy disinherits and banishes Blifil, though Tom asks that he receive an allowance. Sophia still requires proof that Tom has learned fidelity and self-command, but she ultimately forgives him. Tom and Sophia marry, unite the neighboring estates, and have a happy family. Nightingale marries Nancy Miller, Mrs Waters makes a respectable marriage, and Allworthy's household is reordered around the moral truth that conduct matters more than appearances or birth.",
         "in_short": "Squire Allworthy raises Tom Jones, a baby found in his bed, alongside his nephew Blifil. Tom grows into an impulsive, generous young man, while the outwardly dutiful Blifil quietly works against him. Tom and Sophia Western fall in love, but her father plans to marry her to Blifil. After Blifil turns Allworthy against Tom, Tom is banished and Sophia flees home. Their separate journeys through inns and country houses bring mistaken identities, sexual entanglements, and pursuing relatives. In London, Tom's affair with Lady Bellaston damages his chance with Sophia, and a duel lands him in prison. Evidence finally exposes Blifil's lies and reveals Tom's birth: Jenny Jones is not his mother; Allworthy's late sister Bridget was. Tom is Allworthy's nephew and heir. Sophia forgives him after he shows genuine reform, and they marry. Blifil is expelled but supported at Tom's request, while Allworthy recognizes that his trust in respectable appearances nearly destroyed the person who best embodied his values.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2585,7 +2585,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2598,7 +2598,7 @@
       "recaps": {
         "ending": "On Magrathea, Arthur discovers that the Earth was not simply a planet but an immense computer, built to work out the Ultimate Question of Life, the Universe, and Everything, to match the long-known Answer of 42. It was destroyed by the Vogons only minutes before it would have finished, after ten million years of running. The mice, hyper-intelligent beings who commissioned the whole experiment, decide that the last fragment of the program may be lodged in Arthur's brain and try to obtain it, first by offering to buy it and then by force. The attempt collapses when galactic police, chasing Zaphod for stealing the Heart of Gold, burst in shooting. Marvin, the depressed robot, plugs into the police ship's computer and makes it so miserable that it shuts itself down, killing the officers. Arthur, Ford, Zaphod, Trillian, and Marvin get away aboard the Heart of Gold. Hungry and shaken, they decide to go and eat at the Restaurant at the End of the Universe, leaving the question unresolved and their journey still under way.",
         "in_short": "Arthur Dent's house is about to be bulldozed when his friend Ford Prefect, secretly an alien, reveals that the whole Earth is about to be demolished by the Vogons to make room for a hyperspace bypass. Ford hitchhikes them onto a passing ship, and after being thrown out into space the pair are improbably rescued by the stolen starship Heart of Gold, crewed by Zaphod Beeblebrox, the two-headed former President of the Galaxy, the human Trillian, and the depressed robot Marvin. They travel to the myth-shrouded planet Magrathea, where Arthur learns that a supercomputer, Deep Thought, long ago found the Answer to Life, the Universe, and Everything to be 42, and that the Earth was an even greater computer, built to discover the actual question, destroyed just before it finished. The beings behind it, who appear as mice, want Arthur's brain. He escapes with the others, and they set off for the Restaurant at the End of the Universe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2748,7 +2748,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2759,7 +2759,7 @@
       "recaps": {
         "ending": "The book closes after the Battle of Five Armies. Thorin Oakenshield dies of his wounds, reconciled with Bilbo at the last, and his nephews Fili and Kili fall beside him; leadership of the mountain and its recovered wealth passes to Thorin's kinsman Dain. The alliance of dwarves, elves, and men that formed against the goblins holds afterward in friendship, the treasure is divided, and Bard rebuilds the ruined Lake-town and the old city of Dale. Bilbo, refusing all but a small share of the gold and silver, travels back to the Shire with Gandalf, resting again at Rivendell. He arrives to find he has been given up for dead and his home and belongings being auctioned off, and must reclaim them; his reputation among respectable hobbits never quite recovers, but he is content. He keeps the friendship of Gandalf and the surviving dwarves and settles back into a quiet life at Bag End. Crucially, he says nothing about the ring he found under the mountain, keeping it as a private curiosity. Neither he nor Gandalf yet understands what it truly is, a thread left hanging that will reopen years later when the ring's real nature and danger come to light.",
         "in_short": "Bilbo Baggins, a settled and unadventurous hobbit, is swept into an expedition with the wizard Gandalf and thirteen dwarves led by Thorin Oakenshield to reclaim their ancestral treasure from the dragon Smaug. Along the way they survive trolls, goblins, and giant spiders; in the goblin-tunnels Bilbo finds a magic ring of invisibility, winning it from the creature Gollum after a riddle-game. He grows into a resourceful burglar, rescuing the dwarves from wood-elves by floating them downriver in barrels. At the Lonely Mountain he confronts Smaug and spots a weak point in the dragon's armor; Smaug then attacks Lake-town, where the archer Bard kills him. A quarrel over the treasure nearly sets dwarves, men, and elves against one another, but a goblin invasion forces them to unite in the Battle of Five Armies. Thorin dies reconciled with Bilbo, who returns home richer and wiser, quietly keeping the ring whose true nature no one yet suspects.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-hobbit-or-there-and-back-again.json
+++ b/data/works-community/0/the-hobbit-or-there-and-back-again.json
@@ -103,7 +103,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -116,7 +116,7 @@
       "recaps": {
         "ending": "The dwarves reclaim the Lonely Mountain, but at a heavy cost. When Bard's people and the Wood-elves come to claim a share of the hoard, Thorin refuses and prepares for war, so Bilbo secretly hands the Arkenstone to the besiegers to force a settlement. Before it can take effect, an army of goblins and wolves falls on them all, and dwarves, elves, and men join together in the Battle of Five Armies. The eagles and the bear-man Beorn turn the tide. Thorin is mortally wounded in the fighting; before he dies he forgives Bilbo and takes back his angry words. Dain, Thorin's kinsman, becomes King under the Mountain and honours the agreed shares, and the surviving peoples are reconciled. Bilbo, wanting no great wealth, accepts only a modest portion of gold and silver. He travels home with Gandalf, quietly keeping the magic ring, and finds that he has been presumed dead and his belongings are being auctioned off. He resettles at Bag End, changed by his journey and no longer quite respectable in the eyes of his neighbours, content with his memories and his small treasures.",
         "in_short": "Bilbo Baggins, a home-loving hobbit, is swept into a quest by the wizard Gandalf and thirteen dwarves led by Thorin Oakenshield to reclaim their ancestral mountain and its treasure from the dragon Smaug. Along the way he survives trolls, goblins, and giant spiders, and beneath the mountains he wins a magic ring of invisibility from the creature Gollum in a riddle contest. Reaching the Lonely Mountain, Bilbo enters the dragon's lair, provokes Smaug, and quietly keeps a great gem, the Arkenstone, for himself. Smaug attacks the nearby lake-town and is shot dead by the archer Bard. Dwarves, elves, and men then quarrel over the unguarded hoard, and Bilbo gives the Arkenstone to Thorin's opponents to force a peace. Before terms are settled, goblins and wolves attack, and all sides unite in the Battle of Five Armies. Thorin is mortally wounded but reconciles with Bilbo before dying. Bilbo takes only a small share of the treasure and journeys home, keeping the ring.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -663,7 +663,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "isbn:0671578642",
@@ -675,7 +675,7 @@
       "recaps": {
         "ending": "White Haven's relief force reaches Yeltsin as the crippled Fearless makes a final close-range interception. Its distant missiles force Saladin to turn, allowing Honor's ship to destroy the battlecruiser and Matthew Simonds. Grayson survives and signs its alliance with Manticore. Benjamin Mayhew remains Protector, Wesley Matthews commands Grayson's mobile fleet, and White Haven secures the system. McKeon escapes Troubadour's destruction with nearly one hundred people, while the wider squadron has suffered nine hundred deaths and three hundred wounded. Alice Truman has returned with the relief force after carrying the wounded to Manticore. Alfredo Yu is captured in Endicott, asks the Crown for asylum, and receives passage aboard Fearless. Honor keeps her naval command despite a formal, potentially career-ending reprimand for striking Houseman. Grayson grants her the hereditary Steading of Harrington and its highest award for valor, while Manticore recognizes her as Countess Harrington and invests her as Dame Honor. Haven's broader conflict with Manticore remains unresolved, as do Yu's future and the final dispositions of several captured conspirators.",
         "in_short": "Honor Harrington escorts a Manticoran alliance mission to Grayson, where hostility to women threatens diplomacy just as Masada launches a Haven-backed invasion and coup. An ambush kills Admiral Courvosier and High Admiral Yanakov. Honor survives an assassination attempt, helps expose Jared Mayhew as Masada's agent, and unites the remaining Grayson and Manticoran forces under a common defense. They capture Blackbird Base and rescue nineteen survivors from Madrigal, but Masada seizes the Havenite battlecruiser Saladin for a final attack. Troubadour is destroyed and Fearless is crippled before White Haven's arriving missiles create the opening Honor uses to destroy Saladin and Matthew Simonds. Grayson formally allies with Manticore. Honor receives a reprimand for assaulting Houseman but also becomes Steadholder and Countess Harrington, while the captured Alfredo Yu seeks Manticoran asylum aboard Fearless.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -905,7 +905,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -918,7 +918,7 @@
       "recaps": {
         "ending": "Nelson Ko is brought out of China by boat to a Hong Kong island, where the Circus and the Americans are waiting for him. The prize is enormous: a Soviet-run source inside the Chinese establishment, and with him everything Karla has been buying for years. It is also too big for a bankrupt British service to keep. Enderby and Martello have already settled the matter in London: the Americans take Nelson and the credit, and Enderby takes the Circus. Jerry, sent to the island against his own intentions, tries at the last to get Lizzie and Drake Ko clear and interferes with the pick-up. He is shot dead by his own side, and Nelson is flown away by the Americans. Drake Ko is left with his brother taken and his protection gone, and Lizzie survives without either of the men who used her. In London the operation is written up as a triumph in which Smiley's part is quietly minimised: he is eased out of the chief's chair, Enderby succeeds him, Sam Collins is rewarded, and Guillam is posted abroad. Karla has lost a great agent, but the men who profit are not the ones who found him, and Smiley leaves the Circus with nothing.",
         "in_short": "After the exposure of a Soviet mole at the top of the Circus, George Smiley takes over a ruined service and rebuilds it by working backwards through the files: what the traitor suppressed must be what Moscow wanted protected. Connie Sachs and Doc di Salis uncover a Soviet payments channel running through Vientiane into a Hong Kong trust account for Drake Ko, a shipping magnate and pillar of the colony. Jerry Westerby, journalist and part-time Circus hand, is sent to Hong Kong under press cover to shake the tree. He blackmails a bank official, who is then tortured and killed; traces Ko's failed attempt to fly a man out of China; and follows the trail through the pilots Charlie Marshall and Ricardo, and through Ko's mistress Lizzie Worthington, with whom he falls in love. The prize proves to be Drake's brother Nelson, a senior Chinese official who has served Moscow for years and whom Drake has been trying to bring out. As the pick-up is arranged, Whitehall and the Americans take the operation over. Jerry disobeys his orders to protect Lizzie and is shot dead by his own side; the Americans take Nelson, and Smiley loses the Circus.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1032,7 +1032,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1045,7 +1045,7 @@
       "recaps": {
         "ending": "Matisse gets the children clear of the fighting and hidden where the invaders do not find them, with Ashe scouting ahead and warning her where the attackers are. They wait out the assault on the city in hiding. The night ends with Raoden completing the work that restores Elantris: the city's magic returns, the Elantrians are healed, and the children come out of hiding into a restored city rather than a ruin. The story is a companion piece to the novel, filling in what became of Elantris's children during the invasion, and it closes on the same restoration that ends the novel, seen from inside the group everyone had been trying to protect.",
         "in_short": "During the Fjordell attack on Elantris, the adults who normally look after the city's children are drawn away by the fighting, and Matisse, a girl barely older than her charges, is left responsible for them. With help from the seon Ashe, who can move and see where she cannot, she leads the children through the ruined city and hides them while the invaders sweep through. They survive the night, and the story closes as Elantris is restored and its people, the children included, are healed. It is a short companion piece to the novel, told from the perspective of the youngest people in the city during its worst night.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1130,7 +1130,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1143,7 +1143,7 @@
       "recaps": {
         "ending": "Convinced that the Horla is physically present in his room, the narrator locks it inside and sets fire to his house. Only after stepping back to watch the blaze does he remember that his servants are trapped within; their cries make clear that his attempt has killed innocent people. He hopes the fire has also destroyed the invisible being, but doubt returns because a creature without a visible body may not be vulnerable to ordinary flames. He concludes that the Horla has survived and that he has no reliable way to escape its control. The diary closes with his belief that if he cannot kill the being, he must kill himself. The story does not settle whether an invading creature has driven him to this point or whether his conviction itself is the illness, but the destruction and deaths caused by his response are real within his account.",
         "in_short": "A well-to-do man near Rouen begins a diary in good spirits, then develops sleeplessness, dread, and the sense that an invisible visitor drinks beside his bed and controls his actions. Travel briefly relieves him. A demonstration of hypnosis in Paris shows him how one mind can command another, while later experiments at home convince him that an unseen body consumes milk and water. He sees a rose apparently lifted by nothing and, during a mirror encounter, believes the entity stands between him and his reflection. A report of similar disturbances in Brazil makes him connect the presence with a ship he had welcomed from his garden. Naming the being the Horla, he comes to regard it as a new species capable of mastering humanity. He traps it in his house and burns the building, forgetting his servants inside. Unsure the Horla died, he ends by resolving that suicide is his only remaining escape.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1221,7 +1221,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1234,7 +1234,7 @@
       "recaps": {
         "ending": "Convinced that the Horla is physically present in his room, the narrator locks it inside and sets fire to his house. Only after stepping back to watch the blaze does he remember that his servants are trapped within; their cries make clear that his attempt has killed innocent people. He hopes the fire has also destroyed the invisible being, but doubt returns because a creature without a visible body may not be vulnerable to ordinary flames. He concludes that the Horla has survived and that he has no reliable way to escape its control. The diary closes with his belief that if he cannot kill the being, he must kill himself. The story does not settle whether an invading creature has driven him to this point or whether his conviction itself is the illness, but the destruction and deaths caused by his response are real within his account.",
         "in_short": "A well-to-do man near Rouen begins a diary in good spirits, then develops sleeplessness, dread, and the sense that an invisible visitor drinks beside his bed and controls his actions. Travel briefly relieves him. A demonstration of hypnosis in Paris shows him how one mind can command another, while later experiments at home convince him that an unseen body consumes milk and water. He sees a rose apparently lifted by nothing and, during a mirror encounter, believes the entity stands between him and his reflection. A report of similar disturbances in Brazil makes him connect the presence with a ship he had welcomed from his garden. Naming the being the Horla, he comes to regard it as a new species capable of mastering humanity. He traps it in his house and burns the building, forgetting his servants inside. Unsure the Horla died, he ends by resolving that suicide is his only remaining escape.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1293,7 +1293,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1306,7 +1306,7 @@
       "recaps": {
         "ending": "The police operation culminates in the collapse of Red Hook buildings above the underground chambers. Malone is recovered alive but mentally shattered, while the physical evidence includes bodies, bones, ritual objects, and tunnels supporting the existence of organized crime and secret worship beneath the neighborhood. Robert Suydam's part in the rites and the terrible transformation surrounding his death are never made suitable for an ordinary public account. Malone leaves the force and tries to recover in rural Rhode Island, but the sight of brick masonry can still trigger his terror. The raid disrupts the organization without eradicating it: after official attention fades, disappearances and furtive activity begin again in Red Hook. The close therefore leaves Malone permanently injured and the local cult diminished but surviving.",
         "in_short": "New York detective Thomas Malone investigates disappearances, illegal gatherings, and occult activity in Red Hook, Brooklyn. His attention centers on Robert Suydam, an aging scholar who moves among the neighborhood's secretive groups and then abruptly regains youth and social standing. Suydam marries Cornelia Gerritsen, but both die violently aboard their wedding ship, and men linked to Red Hook reclaim his body. Following the case into tunnels beneath tenements, Malone witnesses a ritual world of chanting processions, human remains, and worship directed toward Lilith. Suydam's corpse is reanimated as part of the ceremony before disaster brings down the buildings above. Police recover Malone and extensive evidence, but cannot frame all he saw in rational terms. He leaves the force with a lasting terror of brick buildings. Although the raid breaks up the immediate operation, ominous activity and disappearances eventually return to Red Hook.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1488,7 +1488,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1501,7 +1501,7 @@
       "recaps": {
         "ending": "Shasta reaches Narnia in time, and a Narnian force rides south with him to Anvard, where Rabadash's two hundred horse are already attacking the castle. The Calormenes are broken in the fighting at the gate and Rabadash himself is taken prisoner, caught on a hook in the wall as he leaps down to fight. Afterwards King Lune sees Shasta standing beside his own son Corin and recognises what everyone else has been half noticing all along: Shasta is Cor, Corin's elder twin, stolen as a baby by a treacherous lord and set adrift, and therefore the heir to Archenland. Corin, who never wanted to be king, is delighted. At the Hermit's house Aslan comes to Bree and Hwin, letting them touch him and curing Bree of his anxiety about his own dignity, and tells Aravis that the wounds he gave her matched exactly the beating her drugged servant suffered on her account. Rabadash refuses every honourable term offered him, and Aslan turns him into a donkey, to be made a man again at the temple of Tash and to stay a man only so long as he never travels more than ten miles from it. He therefore reigns as a peaceable king who cannot lead an army, and is remembered as Rabadash the Ridiculous. Cor stays in Archenland as heir; Aravis stays too, and in time they marry and rule after King Lune.",
         "in_short": "Shasta, a boy raised by a Calormene fisherman, learns in one night that he was found as a baby adrift in a boat and that a visiting lord's war horse, Bree, is a talking horse of Narnia stolen as a foal. They run away north together and fall in with a second pair of runaways, the young noblewoman Aravis and her mare Hwin. Crossing the capital, Tashbaan, they are separated: Shasta is mistaken for a missing Archenland prince and taken up by a Narnian embassy, while Aravis, hidden by a friend, overhears the Tisroc and his son Rabadash planning a surprise attack on Archenland and then Narnia. The four cross the desert in a desperate ride to carry the warning, harried at the last by a lion. Shasta runs on alone and reaches Narnia in time; Rabadash is defeated and captured at Anvard. Aslan reveals that he was the lion at every turn of the journey, and Shasta turns out to be Cor, the lost elder son of King Lune of Archenland. Rabadash is punished by being turned temporarily into a donkey, and Cor and Aravis eventually marry and rule Archenland.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1672,7 +1672,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1685,7 +1685,7 @@
       "recaps": {
         "ending": "Wanderer has Doc remove her from Melanie's body, expecting to die rather than take another unwilling host. Melanie awakens in full control of herself and reunites with Jared and Jamie. Ian and the others refuse to accept Wanderer's planned death, however. They place her in the body of a young human woman whose implanted soul could not be saved, giving her a new life without displacing a surviving human consciousness. Now called Wanda, she and Ian can be together while Melanie resumes her relationship with Jared. The restored human Lacey remains with the cave community, and Doc can remove captured souls safely and send them to new planets instead of killing them. On a later supply raid, Wanda's group encounters another band of human survivors and discovers that they too live alongside a peaceful soul. The meeting shows that the desert refuge is not the only surviving human community and that cooperation between humans and souls may offer a future beyond either extermination or surrender.",
         "in_short": "Alien souls have occupied Earth by implanting themselves in human bodies. Wanderer is placed in captured rebel Melanie Stryder, but Melanie remains conscious and draws her toward the desert refuge sheltering Melanie's brother Jamie and lover Jared. The humans initially treat the alien as a prisoner; over time her compassion and usefulness earn trust, and Ian O'Shea falls in love with her. Wanderer, now called Wanda, comes to love the community while Melanie still longs for her own life. After learning how human experiments have killed implanted hosts and souls, Wanda teaches Doc a safe extraction method. The captured Seeker's soul is sent away and her human host, Lacey, is restored. Wanda then has herself removed so Melanie can return, intending to die, but her friends secretly place her in an unclaimed human body. Melanie reunites with Jared, Wanda with Ian, and a later encounter with another mixed human-soul group suggests their coexistence is not unique.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1821,7 +1821,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1834,7 +1834,7 @@
       "recaps": {
         "ending": "Klaus and Sunny, disguised as medical staff, rescue Violet from Count Olaf's plan to kill her with a fraudulent surgery, exposing the plot at the last moment. But as they flee, a fire breaks out and destroys Heimlich Hospital, and the children, still wanted for a murder they did not commit, cannot simply walk away to safety. In a desperate choice, they hide inside the trunk of Count Olaf's automobile as his troupe escapes the burning hospital, deciding that staying close to their enemy is their best chance of finding the truth about V.F.D., their family, and whether one of their parents might still be alive. They obtained only a fragment of the Snicket file before losing it, deepening the mystery rather than solving it. The book ends with the Baudelaires traveling, hidden, alongside the very villain who has hunted them, carried toward an unknown destination and a new set of dangers.",
         "in_short": "Now fugitives falsely accused of murder, the Baudelaires hear themselves branded criminals and take cover by joining a cheerful group of volunteers traveling to Heimlich Hospital. Hiding under false identities, they work in the hospital's Library of Records with a trusting old man named Hal, searching for the Snicket file, which may reveal the truth about V.F.D. and whether a parent survived the fire. Count Olaf, disguised as the intercom-bound head of Human Resources called Mattathias, seizes control of the hospital with Esme's help and hunts for the children. The villains capture Violet, drug her, and disguise her as a patient about to undergo a deadly fake surgery. Klaus and Sunny, posing as medical staff, rescue her just in time. A fire then engulfs the hospital, and to escape both the flames and the law, the children hide in the trunk of Olaf's car as his troupe drives away, choosing to follow their enemy toward the answers they seek.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2012,7 +2012,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2025,7 +2025,7 @@
       "recaps": {
         "ending": "After the Vienna bombing leaves Win blind and kills Freud, the surviving Berrys return to the United States and reshape their talents into public careers. Franny becomes a successful actress, Frank manages her, and Lilly publishes a well-received novel about being small. Lilly cannot sustain that success or reconcile herself to the growth she wanted and later dies by suicide after jumping from an open window. John and Franny finally confront their mutual sexual fixation by acting on it once; the encounter ends the fantasy rather than creating a lasting partnership. Franny builds a life with Junior Jones, while John forms his closest adult bond with Susie. The family acquires the old Maine resort where Win first imagined becoming a hotelkeeper and names it the third Hotel New Hampshire. It does not become a conventional tourist business. John and Susie use it as a refuge for women recovering from sexual violence, while protecting the blind Win's belief that he is presiding over a thriving hotel. The surviving family remains marked by Mary, Egg, Freud, and Lilly's deaths, but converts the hotel dream into shelter for people who need it rather than abandoning it.",
         "in_short": "John Berry recounts his family's life inside three versions of the Hotel New Hampshire. His optimistic father, Win, opens the first in a converted school, where John's sister Franny survives a gang rape and the eccentric Berry children learn to protect one another. Win later moves the family to Freud's hotel in Vienna, but John's mother Mary and youngest brother Egg die in the journey when their plane crashes. The Vienna hotel houses prostitutes, radicals, and Susie, a woman who works in a bear suit. The family disrupts a terrorist bombing, but Freud is killed and Win is blinded. Back in America, Franny becomes an actress, Frank her manager, and the very short Lilly a novelist; Lilly later dies by suicide. John and Franny end their long sexual obsession after one encounter, and Franny builds a life with Junior Jones. John and Susie run the third hotel at the Maine resort where Win's dream began, turning it into a refuge for survivors of sexual violence while allowing blind Win to believe his hotel is full.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2222,7 +2222,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2235,7 +2235,7 @@
       "recaps": {
         "ending": "Holmes, Watson and Lestrade lie in wait in the fog outside Merripit House while Sir Henry walks home alone across the moor as bait. An enormous hound, its muzzle and coat smeared with phosphorus so that it burns in the dark, is loosed after him; the three men shoot it dead as it pulls him down, and Sir Henry is left shaken and physically ill but alive. In the house they find Beryl Stapleton tied up and gagged, and she confirms that she is Stapleton's wife, not his sister, and that he has kept the hound in an old tin mine in the heart of the Grimpen Mire. Stapleton flees into the mire in the fog to reach the animal; only one of his boots is ever found, on the path into the bog, and he is presumed to have drowned in it. Weeks later, in Baker Street, Holmes lays out the whole account for Watson: Stapleton was a Baskerville himself, the son of Sir Charles's younger brother, who came to Devon under an assumed name to remove the two lives standing between him and the estate, using the family legend as his instrument. His wife had been coerced into helping him and turned against him at the end. Sir Henry, badly shaken in health, is sent abroad on a long voyage with Dr. Mortimer to recover, with the promise that he will come back the man he was before he inherited.",
         "in_short": "Dr. Mortimer brings Sherlock Holmes an old family manuscript about a spectral hound said to hunt the Baskervilles, and the recent death of Sir Charles Baskerville, found dead in the yew alley of his Dartmoor home with the footprints of a gigantic dog nearby. When the heir, Sir Henry, arrives from Canada, he is warned off by an anonymous letter and shadowed in London, so Holmes sends Watson to Devon with him while he stays behind. On the moor Watson meets the neighbours, including the naturalist Stapleton and the woman introduced as his sister, uncovers the Barrymores' secret help to the escaped convict Selden, and traces Laura Lyons, who was lured into asking Sir Charles for a meeting on the night he died. The convict dies wearing Sir Henry's cast-off clothes, mistaken for him. Holmes has in fact been living secretly on the moor and reveals that Stapleton, a concealed Baskerville heir, is behind the deaths and that his supposed sister is his wife. They use Sir Henry as bait; a phosphorus-painted hound attacks him in the fog and is shot, and Stapleton disappears into the great bog while trying to escape.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2421,7 +2421,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2434,7 +2434,7 @@
       "recaps": {
         "ending": "Conan returns to Aquilonia with the Heart of Ahriman while Trocero and the loyal provinces gather against the occupiers. Hadrathus uses the jewel to break Xaltotun's supernatural advantage, leaving the resurrected sorcerer unable to determine the battle as he did at Valkia. Conan's forces defeat the invaders; Amalric and Valerius are killed, Xaltotun is destroyed, and Tarascus is captured. Conan demands Zenobia as the price of Tarascus's freedom, repaying the palace woman's earlier rescue by raising her rather than forgetting her. With the foreign army broken and the rival claimant dead, Conan regains the Aquilonian throne. He declares that Zenobia will be his queen, turning the personal debt formed in captivity into the final settlement of his restored reign.",
         "in_short": "Nemedian conspirators revive Xaltotun, a sorcerer of ancient Acheron, to overthrow King Conan. Xaltotun's magic defeats Aquilonia's army, and Valerius takes Conan's throne, but a palace woman named Zenobia frees the captured king. Conan learns that the Heart of Ahriman, the jewel used in Xaltotun's resurrection, can also defeat him. After secretly aiding loyalists in occupied Tarantia and rallying Poitain, Conan crosses the sea and resumes his old identity as the corsair Amra. He reaches Stygia, resists the immortal Akivasha, and recovers the Heart amid rival sorcerers and priests. Returning to Aquilonia, he joins his loyal army for a final battle. Hadrathus uses the jewel to neutralize Xaltotun, the invaders and usurper are defeated, and Tarascus is captured. Conan ransoms Tarascus for Zenobia, restores his kingdom, and names the woman who saved him as his queen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2611,7 +2611,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2624,7 +2624,7 @@
       "recaps": {
         "ending": "Richard refuses the party Clarissa has prepared and tells her that he has stayed alive for her. As she watches helplessly, he lets himself fall from his apartment window and dies. The celebration becomes a small gathering after his death. The elderly Laura Brown arrives and is revealed as Richard's mother. She explains that, after surviving the hotel room and giving birth to her second child, she left Dan and the children and made a life in Canada; Dan and the younger child later died, leaving Richard as the family member who carried the abandonment into his art. Clarissa recoils from Laura's choice but also recognizes that Laura chose the life she could endure. Virginia's 1923 day closes with her decision to move back to London and with her fictional plan to let the poet die while Mrs Dalloway lives. In 1941, as the prologue has already shown, Virginia herself dies in the river. Clarissa remains with Sally, Julia, and Laura through the night, grieving Richard while accepting that ordinary hours of pleasure and connection are the life still available to her.",
         "in_short": "Across three time periods, Virginia Woolf begins Mrs Dalloway in 1923, Laura Brown reads it while struggling with marriage and motherhood in 1949, and Clarissa Vaughan seems to live a modern version of it in New York. Clarissa prepares a party for her former lover Richard, a writer dying of AIDS; Virginia weighs creative freedom against the safeguards imposed after her breakdowns; and pregnant Laura briefly plans suicide before returning to her family. Richard jumps to his death before the party. Laura, revealed as his mother, later explains that she abandoned her husband and children after the birth of her second child because leaving was the only way she could remain alive. Virginia resolves that her fictional heroine will survive even though another character dies, while the prologue establishes Virginia's own 1941 suicide. Clarissa ends the day mourning Richard but still joined to Sally, her daughter, and the difficult continuance of daily life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2768,7 +2768,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2781,7 +2781,7 @@
       "recaps": {
         "ending": "The final chapter turns from the small comedies of the Forest to a quiet farewell. Christopher Robin is growing older and will soon have to leave the Hundred Acre Wood for school and the wider world, though the animals do not fully understand this. He takes Pooh alone to a peaceful, enchanted spot at the top of the Forest, and there, gently and without quite spelling it out, he tries to say goodbye. He asks Pooh to promise to remember him and never to forget, whatever happens as they both grow up. The book does not undo this parting or pretend it away; instead it lingers on the tenderness of it. It closes with the boy and his bear still together in that enchanted place, the narrator leaving them there so that, however much Christopher Robin must move on, a small boy and his bear will always be playing in that Forest.",
         "in_short": "In a series of gentle episodes in the Hundred Acre Wood, Pooh and Piglet build a house for Eeyore, and a bouncy newcomer, Tigger, joins the Forest and sets about discovering what Tiggers like. The friends share small adventures: Tigger gets stuck up a tree and later must be calmed of his endless bouncing, Rabbit hatches a busy scheme, Pooh invents the stick-dropping game of Poohsticks on a bridge, and Piglet performs a brave deed when things go wrong at Owl's house. When a storm blows Owl's home down, Eeyore proudly finds him a new one, which turns out to be Piglet's house, and Piglet generously gives it up so that Piglet moves in with Pooh. At the last, Christopher Robin, who is growing up and must soon go away to school, takes Pooh to a quiet enchanted place to say goodbye, asking him to remember and never quite to forget, and the two are left there together as that childhood world is gently closed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2929,7 +2929,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2942,7 +2942,7 @@
       "recaps": {
         "ending": "Both journeys converge on the House of Hades in the Greek region of Epirus. In Tartarus, Percy and Annabeth reach the Doors of Death with the help of the kindly Titan Bob and the giant Damasen, who give their lives so the two demigods can pass through, and the couple emerges battered but alive on the mortal side. There the rest of the crew has fought its way to the same place, and together they seal the Doors of Death, cutting off Gaea's endless supply of revived monsters. Along the way the heroes have grown stronger and closer: Hazel has mastered a magic of illusion, Frank has come into his full power, and Leo, briefly cast away on the hidden island of Ogygia, has fallen in love with the immortal Calypso and sworn to return and free her. With the Doors closed and all seven reunited, the crew turns toward Athens, where Gaea intends to wake fully and where the giants plan to make their final stand. To keep the Greek and Roman camps from destroying each other in the meantime, Nico di Angelo, the Roman leader Reyna, and Coach Hedge take on the dangerous task of carrying the Athena Parthenos statue across the world to Camp Half-Blood as a token of peace. The book ends with the two efforts underway: the ship racing to Athens for the reckoning with Gaea, and the statue's bearers setting out to prevent a war between the camps.",
         "in_short": "The story follows two paths. Below, Percy and Annabeth struggle across Tartarus toward the underside of the Doors of Death, surviving on nerve and each other, and are aided by a gentle, memory-clouded Titan named Bob and a lonely giant, Damasen. Above, the crew of the Argo II, Jason, Piper, Leo, Hazel, Frank, Nico, and Coach Hedge, sails to the House of Hades in Greece to close the Doors from the mortal side so their friends can escape and Gaea's forces can be shut out. Along the way each hero grows: Hazel learns to bend the mist and work magic, Frank comes fully into his strength, Leo is stranded on a hidden island and meets and falls for the sorceress Calypso, and Nico wrestles with secrets of his own. The two groups fight through to the Doors at the same moment; with sacrifices from their underworld allies, Percy and Annabeth escape Tartarus and the Doors are sealed. All seven are reunited, but Gaea's rising nears its climax, and Nico, Reyna, and Coach Hedge set out on a separate mission to carry the Athena Parthenos statue home and stop a war between the Greek and Roman camps.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3095,7 +3095,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3108,7 +3108,7 @@
       "recaps": {
         "ending": "With her health and prospects failing, Lily receives the small legacy left by Mrs. Peniston. She writes a check to Gus Trenor for the full amount she owes him, leaving herself almost nothing. She visits Selden, tells him that she has tried to preserve the best part of herself through her memory of their bond, and secretly burns Bertha Dorset's letters rather than use them to regain social power. After meeting Nettie Struther and seeing the stable home built by a woman she once helped, Lily returns to her room with a renewed but fragile sense of connection. She takes chloral to sleep and dies from an overdose; the narration leaves uncertain whether she miscalculated or dimly accepted the risk. Selden arrives the next morning intending reconciliation and finds her dead. He discovers the check to Trenor and understands that the debt he had judged as evidence of an affair was financial. At her bedside, he recognizes both their love and the failures of courage and trust that kept them apart.",
         "in_short": "Beautiful but nearly penniless Lily Bart moves through wealthy New York society hoping to marry securely without surrendering her independence. She loses Percy Gryce, accepts money she thinks Gus Trenor has invested for her, and is later threatened when Trenor treats the funds as a personal claim. Though Lily possesses letters that could damage Bertha Dorset, she refuses to use them. Bertha then makes Lily the scapegoat for her own affair during a Mediterranean cruise, destroying Lily's reputation. Disinherited by her aunt and gradually abandoned by fashionable friends, Lily tries paid social work and millinery but lacks the skills and health to sustain herself. Simon Rosedale offers a path back if she uses the letters; again she refuses. A small legacy lets her repay Trenor in full. After a final conversation with Lawrence Selden, whom she loves, Lily burns the letters and later dies from an overdose of sleeping medicine. Selden finds her and finally understands both her innocence and the love they failed to act upon.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3291,7 +3291,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3304,7 +3304,7 @@
       "recaps": {
         "ending": "Lily receives her aunt's ten-thousand-dollar legacy and uses it to repay Gus Trenor in full, removing the financial obligation that has burdened her. Before doing so, she visits Selden's rooms intending to speak openly, but leaves without securing a future with him. She burns Bertha Dorset's letters, surrendering the evidence that could have restored her social power by exposing Bertha. After spending time with Nettie Struther and her baby, Lily returns to her boarding house with a brief sense of the domestic trust she has missed. She takes an increased dose of chloral to sleep and dies during the night; the narration leaves some ambiguity about how deliberately she accepted the risk. Selden arrives the next morning ready to declare his love and finds her dead. Beside her, he sees the checkbook recording her repayment to Trenor and understands part of the truth behind the rumors. Their final unspoken reconciliation comes too late to change the outcome.",
         "in_short": "Lily Bart, beautiful but nearly penniless, moves through wealthy New York society in search of a marriage that can preserve her expensive way of life. She loses the cautious Percy Gryce after choosing time with Lawrence Selden and accepts money from Gus Trenor that she mistakes for investment profits. Trenor later demands intimacy as payment, while Bertha Dorset repeatedly uses Lily to protect her own reputation. Lily refuses to expose Bertha with compromising letters, and scandal costs her friends, her aunt's expected inheritance, and eventually her social position. Attempts to work fail as her health and confidence decline. When the reduced legacy finally arrives, she repays Trenor and burns the letters. After encountering Nettie Struther, a woman she once helped, Lily returns alone to her room and dies after taking too much sleeping medicine. Selden comes to offer love only after her death and finally recognizes evidence of her integrity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3474,7 +3474,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3487,7 +3487,7 @@
       "recaps": {
         "ending": "Judge Pyncheon dies in the parlor from the same inherited condition that killed his ancestor, rather than by Clifford's hand. The Judge had allowed Clifford to be blamed for the earlier death of their uncle after concealing his own presence at the scene, and his pressure on Clifford was an attempt to recover information about supposed Pyncheon wealth. Hepzibah and Clifford return after their frightened train journey, and the Judge's death eventually frees them from his power. His only son is already dead, so his property passes to Clifford, Hepzibah, and Phoebe. Holgrave tells Phoebe that he descends from the Maules; their decision to marry unites the two families without continuing the old contest over the house. The heirs move to the Judge's country estate and invite Uncle Venner to live with them. They leave the seven-gabled mansion behind, exchanging the family's decayed monument and inherited grievances for a shared future elsewhere.",
         "in_short": "Impoverished Hepzibah Pyncheon opens a cent shop in her family's decaying mansion and welcomes home her fragile brother Clifford after decades of wrongful imprisonment. Their country cousin Phoebe revives the household and grows close to Holgrave, a radical daguerreotypist lodging in a gable. Wealthy Judge Jaffrey Pyncheon tries to force Clifford to disclose a supposed family secret, repeating the greed of the ancestral Colonel, who took Matthew Maule's land during the witchcraft persecutions. The Judge dies suddenly while waiting in the parlor, causing Hepzibah and Clifford to flee in fear, but his death proves natural. He had helped direct suspicion toward Clifford when their uncle died years before. Holgrave reveals that he is a Maule descendant, and his love for Phoebe ends rather than renews the family feud. The surviving Pyncheons inherit the Judge's estate and leave the old house for his country home, taking Uncle Venner with them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3675,7 +3675,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3688,7 +3688,7 @@
       "recaps": {
         "ending": "The prison is shaken when two convicts escape with the help of a military prisoner. For a short time the other inmates follow the search with hope and pride, imagining that the fugitives may have succeeded, but hunger and the surrounding terrain force them to surrender. Alexander's final period of confinement is easier than his first: the hated major has been removed, some officials treat him with greater humanity, and years of shared life have reduced his estrangement from the other prisoners. On the morning his sentence ends, his fetters are struck off. The convicts offer simple farewells as he walks beyond the prison walls. His release is not a complete return to his former world, since exile in Siberia still lies ahead, but the end of penal servitude feels like a resurrection. The memoir closes on his exultation at recovering freedom and a life no longer measured by chains and compulsory labor.",
         "in_short": "A frame narrator introduces papers left by Alexander Petrovich Goryanchikov, a former nobleman sentenced to ten years in a Siberian prison for killing his wife. Alexander's memoir depicts confinement as a society with its own trades, hierarchies, grudges, celebrations, and codes. Initially shunned and bewildered, he learns the routines of labor and punishment and comes to know convicts ranging from gentle Aley to violent Gazin, punctilious Akim, curious Petrov, and theatrical Baklushin. Christmas festivities and a performance briefly restore communal dignity; the prison hospital and inmates' personal histories reveal further forms of suffering. Alexander also records animals kept by the convicts, a collective grievance, the difficult position of noble prisoners, and a failed escape. As his sentence ends, improved conditions and deeper understanding have softened his isolation. His chains are removed, and he leaves the prison for continued Siberian exile with an overwhelming sense of renewed life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3888,7 +3888,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3901,7 +3901,7 @@
       "recaps": {
         "ending": "After the Lost Boys expose the Keepers' abuses, Esperanza Mendoza helps bring down the organization and reunites María with Matt. Matt learns that Opium has fallen silent, so he returns across the border. At the Alacrán estate, Celia reveals El Patrón's final act of possession: almost the entire extended family and senior household drank poisoned wine during his funeral and died beside him. El Patrón had intended Matt to share that fate, but Matt's escape made him the surviving Alacrán. Because he is genetically identical to El Patrón, the estate's systems recognize him as its new master. Matt claims that authority with the intention of reversing what his maker built. He plans to end the drug empire, free the people reduced to eejits, restore contact across the border, and bring María and his friends to Opium. He closes the book not as an organ source or captive, but as the young ruler responsible for remaking the House of the Scorpion.",
         "in_short": "Matt is the clone of El Patrón, the centuries-old drug lord who rules Opium through enslaved workers and a powerful family. Raised secretly by Celia, Matt endures abuse because clones are treated as livestock, but El Patrón protects and educates him. With help from María and the bodyguard Tam Lin, Matt learns that clones are created as replacement organs and that El Patrón intends to take his heart. Celia prevents the transplant by dosing Matt with poison, and Tam Lin helps him escape after El Patrón dies. In Aztlán, Matt is imprisoned with Lost Boys at a brutal plankton factory. He and his friends overthrow the hypocritical Keepers and obtain help from María's mother, Esperanza. Returning to Opium, Matt discovers that El Patrón poisoned nearly the whole Alacrán household at his own funeral. As the surviving genetic Matteo Alacrán, Matt inherits control and resolves to dismantle the empire and free its eejits.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4078,7 +4078,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4091,7 +4091,7 @@
       "recaps": {
         "ending": "Judge Pyncheon dies in the parlor from the same inherited condition that killed his ancestor, rather than by Clifford's hand. The Judge had allowed Clifford to be blamed for the earlier death of their uncle after concealing his own presence at the scene, and his pressure on Clifford was an attempt to recover information about supposed Pyncheon wealth. Hepzibah and Clifford return after their frightened train journey, and the Judge's death eventually frees them from his power. His only son is already dead, so his property passes to Clifford, Hepzibah, and Phoebe. Holgrave tells Phoebe that he descends from the Maules; their decision to marry unites the two families without continuing the old contest over the house. The heirs move to the Judge's country estate and invite Uncle Venner to live with them. They leave the seven-gabled mansion behind, exchanging the family's decayed monument and inherited grievances for a shared future elsewhere.",
         "in_short": "Impoverished Hepzibah Pyncheon opens a cent shop in her family's decaying mansion and welcomes home her fragile brother Clifford after decades of wrongful imprisonment. Their country cousin Phoebe revives the household and grows close to Holgrave, a radical daguerreotypist lodging in a gable. Wealthy Judge Jaffrey Pyncheon tries to force Clifford to disclose a supposed family secret, repeating the greed of the ancestral Colonel, who took Matthew Maule's land during the witchcraft persecutions. The Judge dies suddenly while waiting in the parlor, causing Hepzibah and Clifford to flee in fear, but his death proves natural. He had helped direct suspicion toward Clifford when their uncle died years before. Holgrave reveals that he is a Maule descendant, and his love for Phoebe ends rather than renews the family feud. The surviving Pyncheons inherit the Judge's estate and leave the old house for his country home, taking Uncle Venner with them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4261,7 +4261,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4274,7 +4274,7 @@
       "recaps": {
         "ending": "Judge Pyncheon dies alone in the parlor from the same inherited condition that killed Colonel Pyncheon, while the narrator imagines the appointments he will never keep. Hepzibah and Clifford, who fled after finding the body, return when the death is understood to be natural. Evidence and Holgrave's knowledge establish that the Judge had framed Clifford for their uncle's death and had spent years trying to obtain the location of a supposed family document. Holgrave reveals that he is a descendant of the Maules, but his love for Phoebe ends the old hostility between the families. The Judge's surviving son has already died abroad, so his property passes to Clifford, Hepzibah, and Phoebe. They leave the decaying seven-gabled house for the Judge's country estate, taking Uncle Venner with them. The mansion remains behind as the younger generation abandons the grievance, pride, and confinement it represented.",
         "in_short": "Hepzibah Pyncheon, an impoverished gentlewoman, opens a shop in her family's decaying Salem mansion and welcomes home her fragile brother Clifford after his long imprisonment. Their young cousin Phoebe brings energy to the house and grows close to Holgrave, a radical daguerreotypist lodging there. The wealthy Judge Jaffrey Pyncheon pressures Clifford to reveal a family secret, echoing the greed of the ancestral Colonel Pyncheon, who seized Matthew Maule's land during the witchcraft panic. When the Judge corners Clifford, he dies suddenly from a hereditary condition. Clifford and Hepzibah flee in terror but later return. The Judge had framed Clifford years earlier, and his death clears the way for the truth. Holgrave discloses that he descends from the Maules, then chooses a future with Phoebe instead of prolonging the families' feud. The surviving Pyncheons inherit the Judge's estate and leave the old house, escaping the habits of pride and suspicion that trapped earlier generations.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4464,7 +4464,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4477,7 +4477,7 @@
       "recaps": {
         "ending": "After the military coup, Jaime is killed for remaining loyal to the deposed President. Blanca shelters Pedro Tercero until Esteban, reversing his lifelong opposition, helps the couple escape to Canada. Alba aids people pursued by the regime and is arrested under the authority of Esteban Garcia, who tortures and sexually assaults her as an act of accumulated revenge against the Trueba family. Clara's remembered presence helps Alba resist despair. Esteban asks Transito Soto to use the influence she has built over many years, and Alba is released. She returns to her grandfather; they reconcile and assemble the family history from Clara's notebooks and their memories. Esteban dies with Clara's spirit near him. Alba, possibly pregnant by Miguel or by one of her assailants, chooses to preserve memory rather than continue the cycle of hatred. Her written account becomes the novel itself, returning its ending to the family story's opening words.",
         "in_short": "Clara del Valle, a clairvoyant child, marries the volatile landowner Esteban Trueba and fills their city house with children, spirits, and written memories. Esteban builds wealth through Tres Marias while abusing its peasants and imposing his will on his family. Their daughter Blanca secretly loves Pedro Tercero Garcia, a tenant's socialist son, and bears his daughter Alba despite a disastrous marriage arranged by Esteban. As the country polarizes, Pedro becomes a popular revolutionary singer, Esteban supports the right, and Alba falls in love with the activist Miguel. A socialist government wins election and is destroyed by a military coup. Jaime is killed, Pedro and Blanca escape with Esteban's help, and Alba is imprisoned and tortured by Esteban Garcia, a descendant of Esteban's violence. Transito Soto secures Alba's release. Alba and her dying grandfather reconstruct the family's story from Clara's notebooks, choosing memory and compassion over inherited revenge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-house-on-mango-street.json
+++ b/data/works-community/0/the-house-on-mango-street.json
@@ -124,7 +124,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -137,7 +137,7 @@
       "recaps": {
         "ending": "After witnessing how marriage, poverty, and violence confine women around her, Esperanza receives a final charge from three elderly sisters at a wake: she must leave Mango Street, but she must also remember those who cannot leave. Alicia later insists that Mango Street is part of Esperanza's identity and that no inherited homeland can replace responsibility for the place where she lives. Esperanza answers by imagining a quiet house of her own, with room for her work and no one controlling the space. In the closing vignette, she turns Mango Street into material for writing. She expects that putting the neighborhood into words will help her move beyond it. Her departure is not presented as a rejection of its people, however. She plans to return for those who remain trapped there, joining personal freedom to an obligation to remember and help her community.",
         "in_short": "Esperanza Cordero's family moves into a house on Mango Street, their first home of their own, but it is smaller and poorer than she hoped. Through brief episodes she describes her family, new friends, games, school, work, and neighbors whose lives reveal the pressures of poverty, racism, gender, and isolation. She grows especially aware of women restricted by fathers, husbands, motherhood, or lack of money. Her friendship with Sally exposes her to romance, betrayal, and sexual violence, ending much of her childhood innocence. At the same time, Esperanza discovers that language can give shape to experience. She resolves to seek a home and life governed by her own choices. The book closes with her imagining that writing about Mango Street will allow her to leave, while promising that she will return for people who cannot escape on their own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -265,7 +265,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -278,7 +278,7 @@
       "recaps": {
         "ending": "Locked in the attic and left without food or water, Millie gets the door open, and when Andrew comes for her she puts him in the room instead and turns the lock. She keeps him there. He goes through the same starvation and confinement he inflicted on Nina and on Kathleen Connelly before her, and he does not come out alive. Enzo, who tried to warn Millie from the beginning, helps her deal with what is left. Evelyn Winchester makes it clear that she has known for years what her son was and has spent those years managing it, and Andrew's death is never treated as a crime by anyone with the power to treat it as one. Nina and Cecelia are free of him and safe, with the Winchester money behind them. Millie leaves the house with her record intact but her life her own, in a relationship with Enzo and no longer sleeping in her car. The closing pages put her back at work in another wealthy household, watching another family, with the clear implication that what she learned in that attic is something she now intends to use.",
         "in_short": "Millie Calloway, recently out of prison and living in her car, is hired as the live-in housekeeper for the Winchesters in a wealthy Long Island suburb. Her room is a stifling attic with a lock fitted to the outside of the door. Nina Winchester is erratic and cruel, creating messes and accusations Millie cannot answer, while Andrew Winchester is patient, charming and sympathetic, and Millie ends up in bed with him. When Nina finally leaves and takes their daughter, everything Millie believed turns out to be inverted: Andrew is a sadist who punished his wife by locking her in that attic without food or water, who destroyed her credibility so that nobody would believe her, and who had done the same to a woman before her. Nina hired Millie, a woman convicted of killing someone, and made herself unbearable on purpose. Locked in the attic in her turn, Millie gets out, traps Andrew inside it, and leaves him there to die. Andrew's mother ensures nothing comes of it, and Millie walks away free.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -575,7 +575,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B01H2DNDYC",
@@ -587,7 +587,7 @@
       "recaps": {
         "ending": "Lucky's private appeal brings two cooperative destroyers to Earth in time to break the Ool orbital force. Jason drives the damaged Phoenix to Washington, where he, Lucky, and Crusher retake the White House and free President Abigail Hightower. Margaret Jansen escapes and later meets the Ool commander behind the unauthorized invasion. Both remain exposed to their own governments and plan to rebuild their alliance. Marcus Webb's surviving crew retains the Coronado, with Carolyn Whitney and Abia among them. Earth begins discreet cooperation talks with the cooperative, while Hightower plans to present Omega Force publicly as outlaws to preserve political distance from the counterattack. Jason secretly gives Earth a limited technical guide for advanced ships and planetary defenses. The Phoenix has lost slip capability but departs for Satora with Jason and the core Omega Force crew. A final return to Iowa brings news that Terran has died. Her parents introduce Jason to Jacob, a teenager named after Jason's father, without establishing the exact family connection.",
         "in_short": "After learning that humans from a secret colony are hunting him, Jason uncovers a partnership between administrator Margaret Jansen and the Ool. Marcus Webb's kill team breaks with its alien overseers, frees Carolyn Whitney, and forms an uneasy alliance with Omega Force. The Ool want advanced technology from the crashed Traveler ship on Earth, while Jansen intends to use their fleet to seize the planet. Jason's allies capture the colony facility but cannot stop the invasion from launching. Lucky secretly obtains military aid, allowing the Phoenix to reach Washington while outside destroyers scatter the Ool force. Jason, Lucky, and Crusher free President Hightower, though Jansen escapes. Earth opens talks with the cooperative, and Jason supplies a controlled package of defense technology before leaving for Satora in the slip-disabled Phoenix. Jansen remains allied with a rogue Ool commander. Jason then learns that Terran has died and meets Jacob, whose precise connection to him remains unclear.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -763,7 +763,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -776,7 +776,7 @@
       "recaps": {
         "ending": "Coleman and Faunia die when their car leaves an icy road after a confrontation with Lester Farley. The deaths are treated publicly as an accident, preserving the hostile assumptions already surrounding their relationship. At the funeral, Coleman's sister Ernestine identifies herself to Nathan Zuckerman and confirms the secret Coleman kept through his adult life: he was born into a Black family and passed as a white Jewish man, cutting himself off from his mother and brother and never telling Iris or their children. Zuckerman thus understands the irony of the racism charge that destroyed Coleman's career, but he does not turn the discovery into a public correction. He later encounters Lester alone while ice fishing and recognizes both the likely killer and a man profoundly damaged by war. Their guarded conversation ends without accusation. Lester remains free, while Zuckerman preserves Coleman and Faunia through the narrative, aware that any account of them can only partially penetrate the identities they made and concealed.",
         "in_short": "During the public moral fever surrounding President Clinton's impeachment, retired professor Coleman Silk asks novelist Nathan Zuckerman to tell how Athena College branded him racist after he called two habitually absent students “spooks,” not knowing they were Black. Coleman then begins an affair with Faunia Farley, a much younger college cleaner whose children died in a fire. Her violent former husband Lester, a traumatized Vietnam veteran, stalks them, while professor Delphine Roux attacks Coleman anonymously. Coleman has concealed a deeper secret: born into a light-skinned Black family, he chose to pass as white and Jewish, abandoning his mother and brother and keeping the truth from his wife and children. Coleman and Faunia die when their car crashes after Lester confronts them on an icy road. Coleman's sister Ernestine reveals his origins to Zuckerman at the funeral. Zuckerman later meets Lester ice fishing but leaves the likely crime unexposed, reflecting on the limits of knowing another person beneath the identities, accusations, and stories imposed on them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -931,7 +931,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -944,7 +944,7 @@
       "recaps": {
         "ending": "After the royal soldiers disperse the assault on Notre-Dame, Frollo removes Esmeralda from the cathedral and again demands that she choose him over death. She refuses. He leaves her with Sister Gudule, who discovers that their matching little shoes prove Esmeralda is her stolen daughter, Agnès. Their reunion is brief: soldiers drag Esmeralda away, Gudule dies trying to save her, and Esmeralda is hanged. Frollo watches from Notre-Dame and laughs; Quasimodo, understanding his responsibility, throws him from the tower. Quasimodo then disappears. Much later, two skeletons are found embracing in the burial vault at Montfaucon: Esmeralda's and that of a deformed man. When separated, Quasimodo's bones crumble. Phoebus survives and makes a conventional marriage, while Gringoire also survives, having chosen to save Djali during the confusion.",
         "in_short": "In fifteenth-century Paris, the deaf, deformed bell-ringer Quasimodo lives at Notre-Dame under Archdeacon Claude Frollo, whose suppressed desire for the street dancer La Esmeralda becomes destructive. Esmeralda loves the shallow Captain Phoebus and saves the poet Gringoire from the Court of Miracles by marrying him in name only. Frollo attacks Phoebus during a secret meeting, and Esmeralda is condemned for the crime. Quasimodo rescues her to sanctuary and cares for her, but she still longs for Phoebus. When the beggars attack the cathedral to save her, Quasimodo mistakes them for enemies. Frollo takes her away and offers a final choice between him and execution; she refuses. The recluse Gudule recognizes Esmeralda as her stolen daughter just before the soldiers seize and hang her. Quasimodo kills Frollo, then dies beside Esmeralda's body.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1134,7 +1134,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1147,7 +1147,7 @@
       "recaps": {
         "ending": "Esmeralda is recaptured after rejecting Frollo once more. At the gallows, the recluse of the Rat-Hole recognizes Esmeralda's little shoe as the mate of the one she has preserved and realizes that the condemned woman is her stolen daughter. Their reunion lasts only moments: royal officers pull Esmeralda away, and her mother dies trying to protect her. Esmeralda is hanged while Frollo watches from Notre-Dame. Quasimodo sees his master's satisfaction, throws him from the cathedral tower, and then disappears. Phoebus survives and makes a conventional marriage to Fleur-de-Lys. Years later, two skeletons are found embracing in the charnel house at Montfaucon, one belonging to a woman and the other to a deformed man. When the latter is disturbed, it crumbles, showing that Quasimodo chose to die beside Esmeralda's body. The central characters are thus separated by death, with Frollo destroyed by the ward he betrayed and Quasimodo's devotion ending in self-chosen burial beside Esmeralda.",
         "in_short": "In fifteenth-century Paris, the beautiful street dancer Esmeralda draws the attention of several men: the vain soldier Phoebus, the isolated bell-ringer Quasimodo, and the archdeacon Claude Frollo, whose desire becomes violent obsession. After Quasimodo is punished for helping Frollo attack her, Esmeralda alone gives him water. Frollo later stabs Phoebus and lets Esmeralda be condemned for the crime. Quasimodo rescues her from execution and shelters her in Notre-Dame, where his gratitude becomes devoted love. When Paris's outcasts attack the cathedral believing they must save her, Quasimodo mistakes them for enemies. Frollo removes Esmeralda, offers escape in exchange for submission, and betrays her when she refuses. Her reclusive mother recognizes her too late as the daughter stolen in infancy and dies during the arrest. Esmeralda is hanged; Quasimodo kills Frollo by throwing him from Notre-Dame, then vanishes. His skeleton is later found embracing Esmeralda's remains.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1337,7 +1337,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1350,7 +1350,7 @@
       "recaps": {
         "ending": "Esmeralda is recaptured after rejecting Frollo once more. At the gallows, the recluse of the Rat-Hole recognizes Esmeralda's little shoe as the mate of the one she has preserved and realizes that the condemned woman is her stolen daughter. Their reunion lasts only moments: royal officers pull Esmeralda away, and her mother dies trying to protect her. Esmeralda is hanged while Frollo watches from Notre-Dame. Quasimodo sees his master's satisfaction, throws him from the cathedral tower, and then disappears. Phoebus survives and makes a conventional marriage to Fleur-de-Lys. Years later, two skeletons are found embracing in the charnel house at Montfaucon, one belonging to a woman and the other to a deformed man. When the latter is disturbed, it crumbles, showing that Quasimodo chose to die beside Esmeralda's body. The central characters are thus separated by death, with Frollo destroyed by the ward he betrayed and Quasimodo's devotion ending in self-chosen burial beside Esmeralda.",
         "in_short": "In fifteenth-century Paris, the beautiful street dancer Esmeralda draws the attention of several men: the vain soldier Phoebus, the isolated bell-ringer Quasimodo, and the archdeacon Claude Frollo, whose desire becomes violent obsession. After Quasimodo is punished for helping Frollo attack her, Esmeralda alone gives him water. Frollo later stabs Phoebus and lets Esmeralda be condemned for the crime. Quasimodo rescues her from execution and shelters her in Notre-Dame, where his gratitude becomes devoted love. When Paris's outcasts attack the cathedral believing they must save her, Quasimodo mistakes them for enemies. Frollo removes Esmeralda, offers escape in exchange for submission, and betrays her when she refuses. Her reclusive mother recognizes her too late as the daughter stolen in infancy and dies during the arrest. Esmeralda is hanged; Quasimodo kills Frollo by throwing him from Notre-Dame, then vanishes. His skeleton is later found embracing Esmeralda's remains.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1524,7 +1524,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1537,7 +1537,7 @@
       "recaps": {
         "ending": "Aronsson hears the travelers' account and concludes that the deaths arose from accidents and conflicts among the criminals rather than a planned killing spree by Allan's group. A convenient explanation places the missing gang members abroad, allowing the police inquiry to close without charges against the pensioners. Allan, Julius, Benny, Gunilla, Sonya, and their former pursuer leave Sweden using the gang's money and travel to Bali. Benny and Gunilla remain together, while the others settle into the prospect of a comfortable new life. Allan reconnects with Amanda, whose rise in Indonesian public life grew from the chain of events he set in motion decades earlier. The centenarian who began the day escaping an institutional birthday party ends it surrounded by a new improvised family, financially secure and still treating extraordinary events as matters to be dealt with one at a time.",
         "in_short": "On his hundredth birthday, former explosives expert Allan Karlsson slips out of his Swedish care home and impulsively takes a gangster's suitcase from a bus station. The case contains a fortune, drawing Allan and his new friend Julius into flight from the Never Again gang and a steadily widening police search. They collect the highly educated but uncertified Benny, farmer Gunilla, and her elephant Sonya; the criminals pursuing them die in a succession of accidents, and even the gang's leader is eventually absorbed into the group. Alternating chapters trace Allan's earlier life, in which his talent for explosions carried him through the Spanish Civil War, the atomic age, Stalin's Soviet Union, revolutionary China, and Cold War espionage, bringing him into contact with major political leaders while he remained indifferent to ideology. Chief Inspector Aronsson ultimately accepts that the fugitives did not plan the deaths and helps close the case. With the suitcase money, the whole company leaves for Bali and begins a new life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1707,7 +1707,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1720,7 +1720,7 @@
       "recaps": {
         "ending": "Katniss and Peeta are the last tributes alive when the Gamemakers revoke the rule that would have let a district's pair win together, ordering them to fight to a single victor. Katniss instead proposes that they both eat poisonous nightlock berries, denying the Games any winner. Before they can, the Capitol relents and declares them joint victors, and both survive to be crowned. Afterward, Haymitch warns Katniss that her gesture was read as an act of rebellion and that the authorities, led by President Snow, are furious with her. Peeta is wounded to learn that some of her tenderness in the arena was a performance for the cameras and sponsors, leaving their relationship unresolved. They ride the train home to District 12 as celebrated champions, but Katniss now stands as an accidental symbol of defiance against the Capitol, a position that marks her as a target and sets up the wider unrest of the books that follow.",
         "in_short": "In the nation of Panem, the wealthy Capitol keeps its twelve districts obedient with the annual Hunger Games, a televised fight to the death between children chosen by lottery. When her twelve-year-old sister is drawn, sixteen-year-old Katniss Everdeen of impoverished District 12 volunteers to take her place and is sent to the arena alongside Peeta Mellark, the baker's son who once helped her survive. Coached by their drunken mentor Haymitch and made memorable by her stylist Cinna, Katniss becomes a public favorite. In the arena she survives the opening slaughter, allies with a small girl named Rue whose death hardens her against the Capitol, and reunites with a wounded Peeta after a rule change allows two tributes from one district to win together. The pair play up a romance to win sponsors and outlast their rivals. When the rule is reversed and only one may live, they threaten to poison themselves together, forcing the Capitol to crown them both. Katniss returns home a victor, but her defiance has made her an enemy of the ruling Capitol.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1890,7 +1890,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1903,7 +1903,7 @@
       "recaps": {
         "ending": "After Red October's enlisted crew is removed and returned to Soviet custody under the cover of a reactor emergency, a small American party joins Ramius and his officers aboard the submarine. A concealed Soviet intelligence officer remains behind, kills Vasily Borodin, wounds Ramius, and attempts to destroy the ship before Ryan stops him. The Americans continue the deception by sinking the obsolete USS Ethan Allen where Soviet observers can mistake it for Red October. Tupolev nevertheless finds the real submarine in the Atlantic and attacks in V. K. Konovalov. In the final underwater engagement, Ramius uses Red October itself to ram and sink the Soviet attack submarine, eliminating the last immediate witness to the defection. Red October survives and is secretly taken into American possession for study. Ramius and the surviving officers reach the United States, while Ryan returns home exhausted after helping deliver both the defectors and their technologically valuable submarine.",
         "in_short": "Marko Ramius takes the Soviet Union's newest missile submarine, Red October, into the Atlantic with a handpicked group of officers and a plan to defect with the vessel. After his advance letter alerts Moscow, the Soviet fleet races to destroy him while telling the United States that it is conducting a rescue. CIA analyst Jack Ryan concludes that Ramius intends to surrender rather than launch an attack and persuades American leaders to risk making contact. USS Dallas locates the nearly silent submarine, and Ryan boards it after Ramius stages an engineering casualty that removes the enlisted crew. The Americans fake Red October's destruction by sinking an obsolete submarine, but a hidden Soviet agent kills Borodin and nearly sabotages the boat before Ryan stops him. Ramius then defeats the pursuing V. K. Konovalov by ramming it. The defecting officers and Red October reach American control, giving the United States both the men and the Soviet submarine's secret propulsion technology.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2079,7 +2079,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2092,7 +2092,7 @@
       "recaps": {
         "ending": "After reading John-Paul's letter, Cecilia knows that he killed Janie Crowley as a teenager and has hidden his responsibility ever since. John-Paul admits what happened, and Cecilia struggles between justice for Rachel and the damage disclosure would do to their daughters. Rachel, convinced Connor killed Janie, drives at him during the school Easter events, but Polly is struck instead. John-Paul's intervention saves Polly's life, though her arm is permanently damaged. Cecilia tells Rachel the truth about Janie while the families wait through the medical crisis. Burdened by guilt over Polly and unwilling to inflict another loss on the injured child's family, Rachel does not immediately expose John-Paul. Tess ends her brief reunion with Connor and returns to Melbourne prepared to address her marriage rather than simply abandon it; Will and Felicity's imagined new relationship loses its certainty. The novel closes with the adults carrying altered versions of their secrets while Polly adapts to a future none of them anticipated.",
         "in_short": "Cecilia Fitzpatrick finds a letter her husband John-Paul intended her to open only after his death and learns that, as a teenager, he killed Janie Crowley. Janie's mother Rachel has spent decades grieving and wrongly comes to suspect teacher Connor Whitby. At the same time, Tess O'Leary retreats to Sydney after her husband Will and cousin Felicity announce that they are in love; there she renews a relationship with Connor. Cecilia confronts John-Paul but hesitates over exposing him because of their daughters. Rachel, acting on her suspicion, tries to strike Connor with her car and instead hits Cecilia's daughter Polly. John-Paul helps save the child, whose arm is permanently damaged. Cecilia tells Rachel the truth, but Rachel's guilt and concern for Polly keep her from immediately turning John-Paul in. Tess returns to Melbourne to reconsider her marriage, while every family must live with consequences that cannot be neatly undone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2211,7 +2211,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2224,7 +2224,7 @@
       "recaps": {
         "ending": "After Sarah's death, Eddie returns to Chicago and challenges Minnesota Fats again. This time he plays with patience and control, sustaining his best game instead of allowing exhaustion and pride to undo him. Fats finally concedes, giving Eddie the victory he had pursued from the beginning. Bert Gordon demands his share, but Eddie refuses, holding him responsible for the human cost of their arrangement. Bert has enough power to keep Eddie from continuing to make a living in the same poolrooms and warns him away. Eddie leaves having proved that he can defeat Fats, but the victory does not repair what happened to Sarah or free it from Bert's influence. His achievement is therefore both genuine and severely diminished: he has gained the discipline he lacked, yet the life built around hustling has exacted a price that cannot be recovered.",
         "in_short": "Young pool hustler Eddie Felson travels to Chicago to challenge the renowned Minnesota Fats. Eddie plays brilliantly and builds a large lead, but pride, drink, and fatigue ruin his advantage, leaving him nearly broke. After separating from his partner Charlie, he begins a relationship with the isolated, alcoholic Sarah Packard. Powerful gambler Bert Gordon offers to finance Eddie in exchange for control and most of the profits. Eddie accepts, and the three travel to Kentucky, where Eddie wins a difficult high-stakes match against the wealthy Findley. Bert's manipulation and cruelty deepen Sarah's despair, and she dies by suicide. Eddie returns to face Fats once more. Now able to pair talent with endurance and judgment, he wins decisively. He refuses Bert a share of the victory, blaming him for Sarah's destruction, but Bert uses his influence to bar Eddie from the pool circuit. Eddie has proved himself at last, though his success is shadowed by loss and exile from the world he mastered.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2384,7 +2384,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2397,7 +2397,7 @@
       "recaps": {
         "ending": "During the key party, the adults' attempt to turn infidelity into a controlled social game exposes rather than relieves the loneliness in their marriages. Outside, the ice storm has made the neighborhood lethal. Mikey Carver wanders into it alone and is electrocuted when a power line strikes the metal guardrail he is touching. His death abruptly ends the evasions of both families. Paul, unaware of the disaster, has failed in his pursuit of Libbets and falls asleep on the train home; the storm stops the train before he is finally collected. The Hoods come together at the station after the night's catastrophe. Ben, stripped of his ordinary defenses, breaks down in front of his family. No affair, experiment, or suburban ritual can be isolated from its consequences: the Carvers have lost a son, and the surviving Hoods return home in shared shock rather than restored innocence.",
         "in_short": "Over Thanksgiving weekend in 1973, the affluent Hood and Carver families of suburban Connecticut drift through adultery, resentment, and adolescent experimentation. Ben Hood is sleeping with Janey Carver while his wife Elena grows increasingly aware of the emptiness in their marriage. Their daughter Wendy explores sexuality with Janey's sons Mikey and Sandy. Their son Paul, away at school, pursues Libbets Casey while competing with his friend Francis. As freezing rain coats the town, the parents attend a key party where wives select car keys to choose partners, turning private betrayal into a social game. The evening produces humiliation and little intimacy. Outside, Mikey wanders into the storm and is electrocuted at a metal guardrail by a fallen power line. Paul, unaware, fails in his romantic plans and returns by a delayed train. When the Hoods meet him after Mikey's death, Ben breaks down, and the family faces a catastrophe that makes their practiced emotional distance impossible to maintain.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2550,7 +2550,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2563,7 +2563,7 @@
       "recaps": {
         "ending": "Erak, who has watched what the yard has done to Will, arranges for the two captives to get out of Hallasholm, with supplies and a direction rather than an escort, and covers their disappearance. Evanlyn takes Will up into the mountains to an abandoned hunter's cabin as the Skandian winter closes the country down. Will arrives barely able to function, wanting nothing but the drug, and Evanlyn keeps him there and brings him through the withdrawal herself: days of shaking, sickness and fury, with the two of them snowed in and no help within reach. By the end of the book the worst of it is behind him and he is beginning to think and act like himself again, though he is weak and the two of them are stranded far from any friendly territory with the winter still to survive. Halt and Horace, free of Deparnieux and out of Gallica at last, are moving north towards Skandia to look for him. The two parties have still not met when the book closes, and Evanlyn's identity remains a secret whose exposure in Ragnak's country would be fatal.",
         "in_short": "Will and Evanlyn are carried north to Skandia as captives of the jarl Erak. In Araluen, Halt is refused permission to go after his apprentice, so he deliberately insults King Duncan in public until he is banished for a year, which frees him to leave; Horace goes with him. In Skandia the two prisoners are made slaves in the Oberjarl Ragnak's hall, and Evanlyn must hide that she is Princess Cassandra, because Ragnak has sworn a blood oath against Araluen's royal house. Will is sent to the slave yard and given warmweed, the drug that keeps the labourers docile, and is steadily hollowed out by it. Crossing lawless Gallica, Halt and Horace are trapped as unwilling guests of the warlord Deparnieux; Halt manoeuvres him into a formal challenge and Horace kills him. Erak helps Evanlyn get Will out of Hallasholm before winter, and she takes him to a mountain cabin and forces him through withdrawal, while Halt and Horace push north still searching.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2765,7 +2765,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2778,7 +2778,7 @@
       "recaps": {
         "ending": "Daisy, Bert, Martha, and Roderick bring the real Ickabog south, hoping its appearance will expose the fraud committed in its name. Daisy's kindness gives the creature hope that humans and Ickabogs need not be enemies. At the capital, the truth breaks Spittleworth's hold over the frightened population and saves the prisoners he intended to kill. The Ickabog dies in the act of producing its offspring, but because its final feelings have changed, the newborn creature is gentle rather than murderous. Spittleworth is captured and punished, his collaborators lose their power, and the people imprisoned through his lies are freed. Fred gives up the throne after acknowledging his cowardice and failures. Cornucopia replaces the corrupt court with fairer government, repairs the communities impoverished by taxation, and treats the surviving Ickabog as a neighbor rather than a monster. The children and the adults who resisted the conspiracy are reunited with those they feared dead and help rebuild the country.",
         "in_short": "In prosperous Cornucopia, vain King Fred is manipulated by Lords Spittleworth and Flapoon after a disastrous expedition into the northern marshes ends with Major Beamish shot dead by accident. Spittleworth blames the legendary Ickabog, silences witnesses, and turns the invented threat into a system of taxes, troops, executions, and imprisonment. Daisy Dovetail and Bert Beamish lose their families to the conspiracy and eventually meet in Ma Grunter's brutal orphanage. With Martha and Roderick, they escape north and discover that the Ickabog is real but not the creature described by the regime. They persuade it to travel to the capital and reveal the truth. The resulting uprising frees Spittleworth's prisoners, ends his rule, and forces Fred to abdicate. The Ickabog dies producing a gentle offspring whose nature reflects its new hope in people. Cornucopia rebuilds under fairer government, and humans and Ickabogs learn to live without the fear on which Spittleworth's power depended.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2979,7 +2979,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2992,7 +2992,7 @@
       "recaps": {
         "ending": "Aglaya arranges a meeting with Nastasya Filippovna, hoping to settle which woman Myshkin truly loves. Their confrontation becomes cruel and competitive. When Nastasya collapses, Myshkin turns to comfort her, and Aglaya leaves, understanding his choice as a rejection. Myshkin prepares to marry Nastasya, but she panics at the church and escapes with Rogozhin. Myshkin follows them to Saint Petersburg and finds Rogozhin in his darkened house beside Nastasya's murdered body. He stays with the delirious killer through the night, soothing him as his own mind fails. Rogozhin is later convicted and sent to Siberia. Myshkin returns to the Swiss clinic in a state from which recovery appears unlikely. Aglaya hastily marries a Polish émigré whose claims and political cause estrange her from her family. The Yepanchins visit Myshkin abroad, while Evgeny Pavlovich remains attentive to him. The attempt to save everyone has ended without rescuing Nastasya, Rogozhin, Aglaya, or the prince himself.",
         "in_short": "Prince Myshkin returns to Russia after treatment for epilepsy and enters a society driven by money, vanity, desire, and shame. His compassion draws him toward Nastasya Filippovna, who has been exploited by her guardian and alternates between seeking rescue and accepting others' condemnation. The wealthy, obsessive Rogozhin also pursues her. Myshkin unexpectedly inherits a fortune, but wealth does not make him socially adept or able to heal those around him. In Pavlovsk he grows close to Aglaya Yepanchina while remaining bound to Nastasya by pity and love. A confrontation between the two women forces the conflict into the open: Myshkin turns to Nastasya, losing Aglaya. Nastasya agrees to marry him but flees from the wedding with Rogozhin, who murders her. Myshkin finds them beside her body and relapses into profound illness; Rogozhin is sent to Siberia, and Aglaya makes an unhappy break with her family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3205,7 +3205,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3218,7 +3218,7 @@
       "recaps": {
         "ending": "Aglaya forces a meeting with Nastasya Filippovna, hoping to settle which woman Myshkin truly loves. The encounter becomes a contest of pride and suffering. When Nastasya orders Myshkin to choose, his alarm at her distress overcomes everything else; Aglaya leaves, and her connection with him is broken. Myshkin prepares to marry Nastasya, but at the ceremony she panics and runs away with Rogozhin. Myshkin tracks them to St Petersburg and learns that Rogozhin has murdered her. He remains beside Rogozhin and the body through the night, soothing the delirious killer, and the shock destroys his recovered reason. Rogozhin is convicted and sent to Siberia. Myshkin returns to the Swiss clinic in a state from which his doctor expects no recovery. The Epanchin family later travels abroad; Aglaya marries a Polish man who misrepresents his status and draws her into political and religious causes, estranging her from her family. Lizaveta Prokofyevna visits the unresponsive Myshkin and grieves over the ruin of the people she tried to protect.",
         "in_short": "Prince Myshkin returns to Russia after treatment for epilepsy and enters a society governed by money, pride, and romantic rivalry. His compassion draws him toward the traumatized Nastasya Filippovna, while his growing attachment to Aglaya Epanchina offers the possibility of another life. Nastasya repeatedly turns to the possessive Rogozhin, then back toward Myshkin, convinced that she is unworthy of rescue. Myshkin's refusal to condemn anyone wins trust but cannot resolve the desires gathering around him. Aglaya eventually confronts Nastasya and leaves when Myshkin responds to Nastasya's anguish. On the day Myshkin is to marry Nastasya, she flees with Rogozhin; Rogozhin murders her. Myshkin finds them and keeps vigil with the killer beside her body, after which his mind collapses. Rogozhin is sentenced to Siberia, Myshkin returns incurably ill to Switzerland, and Aglaya makes an unhappy marriage abroad.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3438,7 +3438,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3451,7 +3451,7 @@
       "recaps": {
         "ending": "Aglaya forces a meeting with Nastasya Filippovna, hoping to settle which woman Myshkin truly loves. The encounter becomes a contest of pride and suffering. When Nastasya orders Myshkin to choose, his alarm at her distress overcomes everything else; Aglaya leaves, and her connection with him is broken. Myshkin prepares to marry Nastasya, but at the ceremony she panics and runs away with Rogozhin. Myshkin tracks them to St Petersburg and learns that Rogozhin has murdered her. He remains beside Rogozhin and the body through the night, soothing the delirious killer, and the shock destroys his recovered reason. Rogozhin is convicted and sent to Siberia. Myshkin returns to the Swiss clinic in a state from which his doctor expects no recovery. The Epanchin family later travels abroad; Aglaya marries a Polish man who misrepresents his status and draws her into political and religious causes, estranging her from her family. Lizaveta Prokofyevna visits the unresponsive Myshkin and grieves over the ruin of the people she tried to protect.",
         "in_short": "Prince Myshkin returns to Russia after treatment for epilepsy and enters a society governed by money, pride, and romantic rivalry. His compassion draws him toward the traumatized Nastasya Filippovna, while his growing attachment to Aglaya Epanchina offers the possibility of another life. Nastasya repeatedly turns to the possessive Rogozhin, then back toward Myshkin, convinced that she is unworthy of rescue. Myshkin's refusal to condemn anyone wins trust but cannot resolve the desires gathering around him. Aglaya eventually confronts Nastasya and leaves when Myshkin responds to Nastasya's anguish. On the day Myshkin is to marry Nastasya, she flees with Rogozhin; Rogozhin murders her. Myshkin finds them and keeps vigil with the killer beside her body, after which his mind collapses. Rogozhin is sentenced to Siberia, Myshkin returns incurably ill to Switzerland, and Aglaya makes an unhappy marriage abroad.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3659,7 +3659,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3672,7 +3672,7 @@
       "recaps": {
         "ending": "Aglaya arranges a meeting with Nastasya Filippovna, hoping to settle which woman Myshkin truly loves. Their confrontation becomes cruel and competitive. When Nastasya collapses, Myshkin turns to comfort her, and Aglaya leaves, understanding his choice as a rejection. Myshkin prepares to marry Nastasya, but she panics at the church and escapes with Rogozhin. Myshkin follows them to Saint Petersburg and finds Rogozhin in his darkened house beside Nastasya's murdered body. He stays with the delirious killer through the night, soothing him as his own mind fails. Rogozhin is later convicted and sent to Siberia. Myshkin returns to the Swiss clinic in a state from which recovery appears unlikely. Aglaya hastily marries a Polish émigré whose claims and political cause estrange her from her family. The Yepanchins visit Myshkin abroad, while Evgeny Pavlovich remains attentive to him. The attempt to save everyone has ended without rescuing Nastasya, Rogozhin, Aglaya, or the prince himself.",
         "in_short": "Prince Myshkin returns to Russia after treatment for epilepsy and enters a society driven by money, vanity, desire, and shame. His compassion draws him toward Nastasya Filippovna, who has been exploited by her guardian and alternates between seeking rescue and accepting others' condemnation. The wealthy, obsessive Rogozhin also pursues her. Myshkin unexpectedly inherits a fortune, but wealth does not make him socially adept or able to heal those around him. In Pavlovsk he grows close to Aglaya Yepanchina while remaining bound to Nastasya by pity and love. A confrontation between the two women forces the conflict into the open: Myshkin turns to Nastasya, losing Aglaya. Nastasya agrees to marry him but flees from the wedding with Rogozhin, who murders her. Myshkin finds them beside her body and relapses into profound illness; Rogozhin is sent to Siberia, and Aglaya makes an unhappy break with her family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3879,7 +3879,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3892,7 +3892,7 @@
       "recaps": {
         "ending": "Aglaya arranges a confrontation with Nastasya Filippovna, but the meeting becomes a contest of pride and suffering. When Nastasya collapses, Myshkin turns toward her, and Aglaya leaves, convinced she has lost him. Myshkin prepares to marry Nastasya, hoping love and care can free her from self-contempt. At the church, however, she flees with Rogozhin. Myshkin follows them to Petersburg and finds Rogozhin beside Nastasya's body after he has murdered her. The two men keep vigil through the night, with Myshkin comforting the killer as his own mind gives way. Rogozhin is later tried and sent to hard labor in Siberia. Myshkin's collapse is lasting, and he returns to the Swiss institution in essentially the same helpless condition as before his journey to Russia. Ippolit dies from his illness. The Yepanchins leave Russia; Aglaya becomes involved with a Polish émigré who deceives her and draws her away from her family and faith. Yevgeny Pavlovich remains concerned for Myshkin. The prince's compassion changes individual lives but cannot rescue Nastasya, cure Rogozhin's possessiveness, or survive the destructive claims placed upon it.",
         "in_short": "Prince Lev Myshkin returns to Russia after treatment for epilepsy and enters Petersburg society with an openness many mistake for stupidity. He becomes entangled with Nastasya Filippovna, a woman traumatized by exploitation and convinced she is ruined, and Rogozhin, whose love for her is possessive and violent. Myshkin's pity and love offer Nastasya another life, but she repeatedly flees him for Rogozhin. At the same time, Myshkin and the proud young Aglaya Yepanchina develop an unstable attachment shaped by idealization, embarrassment, and jealousy. Around them, families pursue money, status, and moral certainty, while the dying Ippolit challenges Myshkin's faith in compassion. Aglaya's confrontation with Nastasya destroys her bond with the prince. Nastasya agrees to marry Myshkin but escapes with Rogozhin at the wedding; Rogozhin murders her. Myshkin finds them and suffers a final mental collapse while comforting Rogozhin. He returns to institutional care, Rogozhin goes to Siberia, and Aglaya is drawn into an unhappy life abroad.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4137,7 +4137,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4150,7 +4150,7 @@
       "recaps": {
         "ending": "The Iliad closes before Troy falls. Achilles kills Hector, but Priam enters the Greek camp and persuades him to return his son's body. Their shared grief briefly crosses the boundary between enemies, and the Trojans mourn and bury Hector. The Odyssey ends the larger homecoming story. Odysseus returns to Ithaca disguised as a beggar, reveals himself to Telemachus and a few loyal servants, and wins Penelope's bow contest. He and his allies kill the suitors occupying his house. Penelope tests the stranger with private knowledge of their immovable marriage bed and accepts that Odysseus has truly returned. He then reunites with his father Laertes. When the suitors' relatives seek vengeance, Athena intervenes under Zeus's authority and imposes peace, restoring Odysseus to his family and kingdom.",
         "in_short": "The Iliad follows a crisis late in the Trojan War: Achilles withdraws after Agamemnon insults him, and the Greeks suffer without their greatest warrior. Achilles' companion Patroclus enters battle in his armor and is killed by Hector. Grief drives Achilles back to war; he kills Hector and abuses the body, but finally returns it when King Priam appeals to him as a grieving father. The epic ends with Hector's funeral. The Odyssey follows Odysseus' return from Troy. After years detained by Calypso, he reaches the Phaeacians and recounts the Cyclops, Circe, the underworld, the Sirens, and the loss of his crew. Back in Ithaca, Athena disguises him while he joins Telemachus against the suitors occupying his palace. Odysseus wins a bow contest, kills the suitors with loyal allies, proves his identity to Penelope, reunites with his father, and regains his household when Athena ends the threat of further revenge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4320,7 +4320,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4333,7 +4333,7 @@
       "recaps": {
         "ending": "Miss Prism admits that, while working as a nurse years earlier, she accidentally put the infant in her handbag and her manuscript in the baby's carriage, then left the handbag at Victoria Station. Jack produces the same bag and embraces her as the person who lost him, but Lady Bracknell clarifies that he is actually the elder son of her late sister and therefore Algernon's brother. The army records show that Jack was named after his father, Ernest John Moncrieff, so his London name has unknowingly been his real name all along. His birth now satisfies Lady Bracknell's objection, allowing him to marry Gwendolen. Algernon and Cecily remain engaged, and Chasuble and Miss Prism also form a pair. Jack ends with a new appreciation of how much his real name matters.",
         "in_short": "Jack Worthing maintains a sober life as guardian to Cecily in the country and a second identity as Ernest in London, where he courts Gwendolen Fairfax. His friend Algernon discovers the deception, visits Cecily while pretending to be Jack's imaginary brother Ernest, and falls in love with her. Both women believe they are engaged to a man named Ernest, and the men's lies collapse when Gwendolen and Cecily meet. Lady Bracknell blocks Jack's marriage because he was found as a baby in a handbag, then approves wealthy Cecily for Algernon. Miss Prism finally reveals that she misplaced a baby years ago; the handbag proves Jack is Lady Bracknell's nephew, Algernon's elder brother, and the son of a man named Ernest. Jack's assumed name is thus his real one, clearing the way for the two young couples, while Miss Prism and Chasuble are also united.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4488,7 +4488,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4501,7 +4501,7 @@
       "recaps": {
         "ending": "Ulises returns to Eréndira and makes repeated attempts to kill her grandmother. Poison and an explosion fail, but he finally attacks the old woman with a knife and kills her after a prolonged struggle. Instead of joining him, Eréndira takes the grandmother's vest filled with gold and runs alone into the desert. Ulises, bloodied and exhausted, calls after her but cannot follow. She disappears beyond the horizon and is never seen again. The grandmother's control is broken, yet the story does not turn the escape into a shared romantic future: Eréndira claims the portable wealth produced by her exploitation and leaves both her abuser and would-be rescuer behind.",
         "in_short": "Seven stories place the marvelous beside hardship without separating one from the other. An aged winged man becomes a profitable attraction before recovering and flying away; a coastal village remakes itself after adopting a magnificent drowned stranger as one of its own; and a dying senator's affair with Laura Farina becomes the scandal attached to his final months. Other narrators confront a phantom ship and a fraudulent miracle worker whose abused apprentice develops real power. In the title tale, fourteen-year-old Eréndira accidentally burns down her grandmother's mansion and is forced into sexual exploitation to repay an endlessly inflated debt. She falls in love with Ulises, who helps her escape but cannot initially free her from the grandmother. After his poison and explosives fail, he kills the old woman with a knife. Eréndira takes the grandmother's gold and runs away alone, leaving Ulises behind.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4609,7 +4609,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4622,7 +4622,7 @@
       "recaps": {
         "ending": "Alone in the basement and now tiny enough for its boards, tools, and insects to form an alien landscape, Scott secures water and scraps of food while preparing to confront the spider that controls access to the remaining cake. He fashions weapons and climbing equipment from household debris and finally kills the spider after a dangerous struggle. His victory does not stop his body from diminishing. Scott finds a way through the basement screen and enters the outside world, expecting that reaching zero size will mean death. Instead, he passes beyond the scale visible to ordinary human beings and remains alive. Looking up at a universe that no longer fits his old measurements, he understands that smallness has no final boundary and that existence continues at scales his former life could not perceive. He moves forward into that unknown rather than treating himself as nothing.",
         "in_short": "After exposure to a strange mist and an insecticide, Scott Carey begins shrinking by a fixed fraction of an inch each day. Doctors cannot provide a lasting cure, and the change strips away his privacy, livelihood, confidence, and equal footing within his family. Public curiosity turns him into a spectacle, while his marriage to Louise buckles under fear and resentment. Once only inches tall, Scott is separated from his family and believed dead, but he is actually trapped in the basement. There he learns to obtain water and crumbs, crosses enormous distances through familiar household space, and fights a spider for access to food. He kills it, escapes through a screen, and continues shrinking past the point he had assumed would erase him. The world opens into another scale, and Scott accepts that there may be no absolute smallest size and no simple boundary at which his life must cease.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4832,7 +4832,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4845,7 +4845,7 @@
       "recaps": {
         "ending": "Veronica Terwilliger is not the last threat: Alicia, the harmless-seeming young witch on the coven's edge, has been draining witches herself and is the one who finally put Veronica beyond reach. She takes Sydney, intending to take her magic with her, and Sydney destroys her - using power she had spent a year refusing to admit she had, and afterwards being unable to unknow what she is. Sydney goes through with Marcus Finch's procedure and has the compulsion in her golden lily broken, so that she can lie to the Alchemists, refuse them and speak about them without the tattoo stopping her, while still appearing to be an obedient member of the order. She declines to run away with Marcus's group: she will stay inside and keep her people safe. Her family has broken apart in the divorce, and her younger sister Zoe has chosen their father and the Alchemists. Sydney finally admits what she feels and goes to Adrian; they become a couple, with the certainty that discovery would destroy them both. In the last pages Zoe arrives in Palm Springs as Sydney's new Alchemist partner, sent to live beside her and report on everything she does.",
         "in_short": "Sydney is hunting two things at once: Marcus Finch, the Alchemist who escaped the order, and a witch who steals the magic and youth of young witches. The witch is Veronica, Ms. Terwilliger's sister, and Sydney - untrained, powerful and unprotected - is exactly what she looks for. Marcus, found at last, shows Sydney what she half suspects: the golden lily tattoo carries compulsion that keeps Alchemists obedient and silent, and it can be broken. He wants her to run; she wants to stay and protect her people. Meanwhile the search for Veronica runs alongside a Court wedding, a collapsing family and a road trip with Adrian, whose feelings Sydney can no longer honestly deny. When Veronica is finally cornered she has already been drained by someone else: Alicia, a young witch everyone dismissed as harmless, who has been building her own power and now comes for Sydney's. Sydney destroys her with magic she can no longer pretend not to have. She has her tattoo broken, refuses to leave the Alchemists, and chooses Adrian - just as her sister Zoe arrives in Palm Springs to watch her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5077,7 +5077,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5090,7 +5090,7 @@
       "recaps": {
         "ending": "In the frozen ninth circle, Dante and Virgil cross regions reserved for traitors to kin, country, guests, and benefactors. Count Ugolino recounts his imprisonment and starvation with his children, while other souls remain locked in the ice. At the center stands Lucifer, a vast three-faced figure whose beating wings keep the lake frozen. His mouths chew Judas Iscariot, Brutus, and Cassius. Virgil waits for the proper moment, then climbs down Lucifer's shaggy body with Dante. On passing the center of the earth, their orientation reverses: what seemed a descent becomes a climb toward the opposite hemisphere. They follow a hidden natural passage upward for hours. The cantica ends when the travelers emerge from Hell beneath the night sky and see the stars, ready to begin the ascent of Mount Purgatory.",
         "in_short": "Lost in a dark wood, Dante is met by the Roman poet Virgil, sent by Beatrice to guide him. They enter Hell and descend through circles arranged by kinds of sin: the uncommitted wait outside; the virtuous pagans inhabit Limbo; the incontinent are driven by storms, rain, mire, and conflict; heretics occupy fiery tombs; the violent suffer in blood, burning waste, and a forest of suicides; and fraud is punished across ten trenches. Dante speaks with figures including Francesca, Farinata, Piero delle Vigne, Brunetto Latini, Ulysses, and Guido da Montefeltro, learning how desire, politics, pride, and calculated deception shaped their ends. Below the giants lies the frozen circle of treachery, where Count Ugolino tells of starvation in a locked tower. At the center Lucifer chews Judas, Brutus, and Cassius. Virgil leads Dante down Lucifer's body past the earth's center, then upward through a tunnel until they emerge beneath the stars.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5288,7 +5288,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5301,7 +5301,7 @@
       "recaps": {
         "ending": "At the center of the frozen ninth circle, Dante and Virgil see Lucifer immobilized in the ice, his three mouths chewing Judas, Brutus, and Cassius. The motion of his wings freezes the lake that imprisons him, making the ruler of Hell both the cause and the foremost captive of the realm's final sterility. Virgil times their departure and climbs down Lucifer's shaggy body with Dante. At the midpoint they pass the center of the earth, so their direction reverses and they begin climbing upward along Lucifer's legs. Virgil explains that they have crossed into the opposite hemisphere and that the land displaced by Lucifer's fall formed the mountain of Purgatory above them. Following a hidden natural passage and guided by the sound of a stream, they climb for many hours. The poem closes when the two travelers emerge from Hell beneath the night sky and see the stars again. Dante has completed the first and most terrible stage of his journey, but his purification and ascent still lie ahead.",
         "in_short": "Lost in a dark wood, Dante is rescued by the spirit of the Roman poet Virgil, who leads him through Hell so that he can recognize the consequences of sin. They pass from the indecisive souls outside Hell through nine descending circles whose punishments reflect increasingly deliberate forms of wrongdoing: appetite, violence, fraud, and finally treachery. Dante meets figures from mythology, scripture, ancient history, and contemporary Italy, hearing accounts that test his pity and expose political and religious corruption. Monsters and fallen angels obstruct the route, but Virgil repeatedly invokes the divine authority behind the journey. In the frozen lowest circle, traitors are fixed in ice, and Lucifer himself is trapped at the earth's center while chewing Judas, Brutus, and Cassius. Dante and Virgil climb down Lucifer, pass the center of gravity, and ascend through a concealed tunnel into the other hemisphere. They emerge under the stars, ready to continue toward Purgatory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5499,7 +5499,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5512,7 +5512,7 @@
       "recaps": {
         "ending": "At the center of the frozen ninth circle, Dante and Virgil see Lucifer immobilized in the ice. His three mouths chew Judas Iscariot, Brutus, and Cassius, figures who betrayed spiritual or political benefactors. Virgil waits for the proper moment, then climbs down Lucifer's body with Dante holding on. At the midpoint they cross the center of gravity; their orientation reverses, and what first seems like a descent becomes an upward climb. Virgil explains the change and the geography separating the inhabited northern world from the mountain that rises in the southern hemisphere. They follow a hidden natural passage away from Hell. The cantica closes when the two travelers emerge before dawn and once again see the stars. Dante has completed his descent through the consequences of sin, but his larger journey is only partly finished: he and Virgil must next climb Mount Purgatory before Dante can be reunited with Beatrice and rise toward Heaven.",
         "in_short": "Lost in a dark wood, Dante is rescued by the shade of the Roman poet Virgil, whom Beatrice has sent to guide him. They enter Hell and descend through its circles, where punishments reveal the nature of each sin: lack of restraint gives way to violence, fraud, and finally treachery. Dante speaks with figures from myth, history, and his own Italy, including Francesca da Rimini, Farinata, Pier delle Vigne, Brunetto Latini, Ulysses, and Count Ugolino. The journey also exposes Florence's political hatred and predicts Dante's exile. After crossing the fraudulent ditches of Malebolge, the travelers enter the frozen lake Cocytus, where traitors are held. At Hell's center Lucifer chews Judas, Brutus, and Cassius. Dante and Virgil use the fallen angel's body as a route past the world's center, where gravity reverses, and climb through a concealed passage. They emerge under the stars in the southern hemisphere, ready to begin the ascent of Purgatory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5704,7 +5704,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5717,7 +5717,7 @@
       "recaps": {
         "ending": "At the bottom of the frozen ninth circle, Dante and Virgil see Satan fixed in the ice. His six wings generate the wind that keeps Cocytus frozen, and his three mouths chew Judas Iscariot, Brutus, and Cassius, figures associated with betrayal of spiritual and imperial authority. Virgil judges that they have seen all of Hell and times their escape. With Dante holding on, he climbs down Satan's shaggy body until they pass the earth's center; direction reverses, and what seemed a descent becomes a climb. Virgil explains that the fall of the rebel angel displaced the land and formed both the pit of Hell and the mountain rising in the opposite hemisphere. The travelers follow a narrow subterranean path along a stream for many hours. They finally emerge through an opening and see the stars, leaving the damned behind. Dante has completed the first stage of the journey, but he has not yet undergone the purification required before reaching Beatrice.",
         "in_short": "Lost in a dark wood and blocked from climbing toward safety, Dante accepts the guidance of the Roman poet Virgil. They pass through Hell's nine circles, whose punishments expose increasingly deliberate forms of sin: appetite without restraint, heresy, violence, fraud, and treachery. Dante speaks with famous lovers, citizens, rulers, teachers, and political enemies, repeatedly confronting the ways desire, pride, faction, and corrupt counsel distort human freedom. Virgil protects and instructs him, though force and reason meet limits at several thresholds. In the final frozen circle, Count Ugolino recounts his death by starvation, and the travelers find Satan trapped at the center, chewing Judas, Brutus, and Cassius. They escape by climbing down Satan's body and passing the earth's center, where their orientation reverses. A hidden passage leads them back beneath the open sky and the stars, ready for the ascent of Purgatory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5945,7 +5945,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5958,7 +5958,7 @@
       "recaps": {
         "ending": "At the bottom of the ninth circle, Dante and Virgil reach Lucifer, a vast three-faced figure trapped at the center of the frozen lake. His wings generate the cold that imprisons him, and his mouths tear at Judas Iscariot, Brutus, and Cassius, the three traitors placed nearest the center. Virgil waits for the right moment, climbs down Lucifer's body with Dante, and passes the point at Earth's center. From the travelers' changed orientation it first appears that they are turning back toward Hell, but they have crossed into the opposite hemisphere and are now climbing away from it. They follow a narrow natural passage for many hours until they emerge beneath the night sky and see the stars. The journey through Hell is complete, but Dante's larger pilgrimage is not: he must next ascend the mountain of Purgatory under Virgil's guidance before a guide fit for Heaven can take over.",
         "in_short": "Lost in a dark wood, Dante is met by the Roman poet Virgil, sent by Beatrice to lead him back toward salvation. They enter Hell, a descending system of circles in which punishments embody the choices of the damned. Dante meets figures from scripture, classical history, and his own Italy while learning distinctions among incontinence, violence, fraud, and betrayal. His pity, fear, anger, and political loyalties are repeatedly tested as the souls explain themselves. Beyond the city of Dis, the travelers descend through the violent and then ride the monster Geryon into Malebolge, where ten ditches hold different forms of fraud. Giants lower them into the frozen ninth circle, reserved for traitors. At the center they find Lucifer trapped in ice, chewing Judas, Brutus, and Cassius. Virgil climbs past him with Dante, crosses the center of the earth, and leads Dante through a hidden passage until they emerge beneath the stars, ready for the ascent of Purgatory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6081,7 +6081,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6094,7 +6094,7 @@
       "recaps": {
         "ending": "Leonard tries to dispose of Otto's dismembered body by carrying the suitcases into the secret tunnel. The attempt entangles his private crime with the intelligence operation and contributes to the tunnel's exposure. His relationship with Maria cannot survive the killing, concealment, and the distrust that follows. Leonard leaves Berlin and the two build separate lives. Decades later, he receives a letter from Maria in the United States. She explains that she eventually married Bob Glass and formed a family with him; Glass is now dead. Her account makes clear that the tunnel had been betrayed to the Soviets from within the intelligence services before Leonard's desperate actions, so the political operation was compromised independently of him. The letter replaces Leonard's long-held assumptions with a fuller version of the past. Now older and no longer the inexperienced man who arrived in Berlin, he decides to travel to America to see Maria again, leaving open what their reunion may mean.",
         "in_short": "In 1955, inexperienced British technician Leonard Marnham is sent to West Berlin to install recording equipment for a secret tunnel tapping Soviet communications. American officer Bob Glass oversees security, while Leonard's British superior MacNamee draws him into rivalry between the allied services. Leonard falls in love with Maria Eckdorf, a German divorcée, and their relationship becomes his real education in adult life. His insecurity and borrowed ideas about sexual power nearly destroy their trust, but they reconcile and plan to marry. When Maria's former husband Otto intrudes and becomes violent, Otto is killed during the struggle. Leonard and Maria dismember the body and pack it into cases. Leonard attempts to hide them through the tunnel, merging the private disaster with the compromised spy operation. The relationship ends. Decades later Maria writes that she married the widowed Glass and had a family. Leonard also learns that the tunnel was already betrayed by an intelligence double agent. He resolves to visit Maria in America.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6261,7 +6261,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6274,7 +6274,7 @@
       "recaps": {
         "ending": "Luke reaches DuPray and convinces Tim and the local police that the Institute exists, but Mrs. Sigsby and Stackhouse bring an armed recovery team to silence them. The townspeople and officers defeat the attackers and take Sigsby captive. Meanwhile, Avery links the children in Back Half into a powerful telepathic and telekinetic force. With help from Luke and the others, they turn that force against the Institute, bringing the building down. Avery and several children die in the destruction, while Luke, Kalisha, Nicky, George, and others escape. Stackhouse is killed and Sigsby dies during the collapse. Months later, the surviving children live under protection in DuPray. A representative of the larger network explains that the Institutes kill children in the belief that doing so prevents future catastrophes, but Luke challenges both its predictions and its moral arithmetic. The visitor leaves without attacking them, and Luke commits himself to finding a better way to use the surviving children's gifts.",
         "in_short": "After leaving police work, Tim Jamieson settles temporarily in DuPray, South Carolina. In Minneapolis, gifted twelve-year-old Luke Ellis is abducted after his parents are murdered and wakes in the Institute, where children with telepathic or telekinetic abilities are tested, punished, and eventually moved to the dreaded Back Half. Luke befriends Kalisha, Nicky, George, and the exceptionally powerful young telepath Avery. With covert help from housekeeper Maureen Alvorson, he escapes and reaches DuPray. Institute personnel attack the town to retrieve him, but Tim and the local police resist and capture director Mrs. Sigsby. At the facility, Avery unites the imprisoned children through their minds; their combined power destroys the Institute, killing Avery and many others but freeing several survivors. A representative later claims the organization sacrifices gifted children to prevent predicted disasters. Luke rejects that logic and begins considering how the survivors might use their abilities without repeating the Institute's cruelty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6447,7 +6447,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6460,7 +6460,7 @@
       "recaps": {
         "ending": "Sarah and Angelina become prominent abolitionist speakers, refusing demands that women remain silent in public reform. Angelina marries fellow abolitionist Theodore Weld, and the sisters continue linking opposition to slavery with women's right to speak and act. In Charleston, Handful has survived the destruction of Denmark Vesey's planned uprising and the executions that followed. Her mother Charlotte, who returned years earlier with Handful's younger sister Sky, is dead, leaving her daughters the story quilt that records her resistance and their family history. Sarah comes back south, outwardly for a family visit but determined to honor her childhood promise. She and Angelina arrange a route out for Handful and Sky. The sisters evade the Grimke household and board a northbound vessel, while Sarah remains behind long enough to protect the escape. Handful leaves Charleston with Sky and with Charlotte's quilt, finally moving toward freedom. Sarah's act cannot undo the decades in which her family owned Handful, but it converts her private conviction into direct aid and closes the long bond between the two women with Handful claiming the future for herself.",
         "in_short": "In 1803 Charleston, eleven-year-old Sarah Grimke is given an enslaved girl, Hetty 'Handful' Grimke, as a birthday present. Sarah tries and fails to free her, then secretly teaches her to read. Over three decades, Handful and her mother Charlotte resist slavery within the Grimke household, while Sarah struggles against the limits placed on wealthy white women and eventually leaves the South for the Quakers and abolitionism. Handful becomes involved in Denmark Vesey's planned uprising; the plot is betrayed, Vesey is executed, and she survives. Charlotte returns after a long absence with another daughter, Sky, and later dies, leaving a quilt that encodes her family story. Sarah and her younger sister Angelina become outspoken antislavery lecturers and defend women's right to speak publicly. Returning to Charleston, Sarah helps Handful and Sky escape by ship. The sisters carry Charlotte's quilt northward, while Sarah remains committed to abolition and women's equality.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-ionian-mission.json
+++ b/data/works-community/0/the-ionian-mission.json
@@ -124,7 +124,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -137,7 +137,7 @@
       "recaps": {
         "ending": "Worcester's service with the Toulon blockade ends when the old ship can no longer be treated as a sound fighting unit, and Jack and many of his people transfer to the restored Surprise. In the Ionian theatre, Jack's naval task and Stephen's political work become entangled with the rivalry between Ali Pasha and Mustapha Pasha and with French efforts to retain influence. Professor Graham assists the negotiations, while Jack uses Surprise's mobility and fighting power to support the British position at sea. A local arrangement is secured without resolving the ambitions or hostility of the rival rulers, and Surprise's action against French-supported naval opposition gives the mission practical force. Jack finishes the book in command of the ship most closely associated with his earlier successes. Stephen remains active in intelligence despite French knowledge of his role, while his marriage to Diana is still troubled and unresolved.",
         "in_short": "Jack Aubrey returns to command in the worn seventy-four Worcester and joins the British blockade of Toulon. He drills an uneven company into an effective crew and operates within the discipline of a battle fleet while Stephen Maturin serves as surgeon and resumes intelligence work despite French knowledge of his identity. Worcester survives arduous station-keeping and action but proves too decayed for continued service. At Malta, Jack and much of his company transfer to the frigate Surprise. They are then sent into the Ionian and Adriatic political contest, where Britain seeks advantage from the rivalry between Ali Pasha of Janina and Mustapha Pasha of Marga. Stephen and Professor Graham assess the competing offers while Jack supplies the naval force behind the negotiations and contests French influence at sea. The mission produces a limited British advantage rather than a stable settlement. Surprise remains Jack's command, Stephen's exposed intelligence career continues, and his strained marriage to Diana remains unsettled.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -320,7 +320,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -333,7 +333,7 @@
       "recaps": {
         "ending": "Meghan ends the war by walking onto the Reaping Fields between the assembled armies of Summer and Winter and returning the stolen Scepter of the Seasons, proving that Summer never took it and that the Iron fey both courts deny are real. She does it using iron glamour in front of Oberon and Mab, which saves a great many fey and simultaneously identifies her as the most dangerous creature on the field: a half-human princess who can wield the one power lethal to every full-blooded fey alive. Ironhorse does not survive. He gives his life destroying Virus and breaking the Iron fey's hold on the fight, serving Meghan as the queen he believed the Iron crown belonged to. Rowan is exposed as the traitor who sold Winter's secrets to the Iron fey and does not return to his mother's court. Ash has broken with Mab openly and stopped pretending to feel nothing. Oberon then banishes Meghan from the Nevernever, protection and precaution at the same time, and Ash is cast out of Winter for choosing her. The book closes with the two of them exiled together in the mortal world, the Iron fey still ruled by whoever took Machina's crown, and the Iron Realm still spreading into Faery with nobody willing to stop it.",
         "in_short": "Meghan Chase is living in the Winter Court as Mab's hostage, the price of the bargain that got her brother back, while Ash, the Winter prince she has fallen for, treats her with public contempt. When Iron fey ambush the ceremony that passes the Scepter of the Seasons between the courts, killing one of Mab's sons and stealing the Scepter, Winter blames Summer and declares war. Meghan escapes to the mortal world, finds Puck, and reaches Leanansidhe the Exile Queen, in whose mansion she discovers her long-missing human father, alive and stripped of his memory. Allied with Puck, Grimalkin, Ash and the Iron fey Ironhorse, who insists the Iron crown is hers by right, she steals the Scepter back, learns that Ash's brother Rowan has been the traitor feeding Winter's secrets to the Iron fey, and survives an attack on her own school in which Ironhorse sacrifices himself. Meghan returns the Scepter at the Reaping Fields and stops the war, but does it by wielding iron glamour in front of both courts. Oberon banishes her from the Nevernever, and Ash, who has chosen her over Winter, is exiled with her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -523,7 +523,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -536,7 +536,7 @@
       "recaps": {
         "ending": "Meghan destroys Machina in his own tower and frees Ethan from the machinery that was keeping the Iron King alive, but Machina's last words are a warning rather than a plea: the Iron fey exist because humans believe in machines, that belief is not going away, and his crown will find another head. Ash, who held off the Iron knights so that Meghan could reach the tower, survives; Puck and Grimalkin come through as well, and Grimalkin's favour is still unclaimed. Meghan gets Ethan back to Louisiana and to a family who will never know where he was. The Summer Court has acknowledged her without protecting her, Titania remains an enemy, and both courts still refuse to admit the Iron fey are real, which leaves the underlying problem entirely unsolved. Then Meghan's own bargain comes due: Ash arrives at her house to take her to Tir Na Nog, where she will be Mab's hostage as agreed. She goes willingly. The next book opens with her inside the Winter Court, in the hands of a queen with no reason to be kind to Oberon's daughter, beside a prince whose feelings for her are a danger to them both.",
         "in_short": "Meghan Chase turns sixteen in rural Louisiana and comes home to find her four-year-old brother Ethan replaced by a hostile changeling. Her best friend Robbie admits he is really Puck, the trickster, set to watch over her by Oberon, king of the Summer Court, who is Meghan's true father. Crossing into the fey world to get Ethan back, Meghan is acknowledged as a half-blood princess of Summer, loathed by Queen Titania, and forced to bargain with Ash, the Winter Court prince sent to catch her: he will help her, and afterwards she belongs to his mother, Mab. The search leads to a new kind of fey born from human faith in technology, whose iron is lethal to the old courts and whose existence Faery refuses to acknowledge. Their king, Machina, took Ethan to draw Meghan in. In his dying realm he offers her a place at his side; she refuses and destroys him, freeing her brother, while Machina promises that the Iron fey and their empty throne will outlast him. Meghan takes Ethan home, then leaves with Ash to pay what she owes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -679,7 +679,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -692,7 +692,7 @@
       "recaps": {
         "ending": "Ash passes the Guardian's trials at the end of the world, the last of them a temptation rather than a fight: an entire life in which Ariella never died and Meghan has no part in it, which he refuses. The soul he is asking for requires a life given in exchange, and Ariella gives hers, telling him she had already seen it and was kept alive for no other purpose. Ash is remade with a mortal soul, still himself but finite and vulnerable, and no longer destroyed by iron. The blood feud between Ash and Puck, which began with Ariella's first death and which Ash had sworn to end in a killing, is closed by her second; the two part alive and no longer sworn enemies, on terms neither of them says out loud. Grimalkin departs with his favours uncollected, as he generally does. Ash leaves the end of the world, crosses the border that would have killed him before, and reaches the Iron Realm and Meghan's court, where he can now stay. The original quartet closes with Meghan established as the Iron Queen and Ash beside her, the Iron Realm accepted as a third power in Faery, and Meghan's human family left behind in the mortal world.",
         "in_short": "Told from Ash's point of view. Exiled from Winter and ordered out of the Iron Realm by Meghan so that its iron would not kill him, Ash sets out to gain a mortal soul, the one thing that would let him live at her side. Puck comes along uninvited, Grimalkin guides them at his usual price, and the Big Bad Wolf follows for reasons of his own. On the road they are joined by Ariella, Ash's first love, whose death long ago began his feud with Puck, alive and unwilling to explain how. They reach the end of the world, where a Guardian sets the trials that decide whether a fey may be given a soul. Ash is made to face everything he has done as Mab's weapon, and is finally offered an entire happy life in which Ariella never died and Meghan does not exist. He refuses it. The price of the soul is a life, and Ariella gives hers, saying she was kept alive for exactly this. Ash is remade with a mortal soul, no longer vulnerable to iron, his feud with Puck ended rather than settled. He crosses into the Iron Realm and reaches Meghan for good.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -870,7 +870,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -883,7 +883,7 @@
       "recaps": {
         "ending": "Meghan destroys the false Iron King in the battle for Faery, and then makes the choice the whole book has been driving toward. The Iron Realm's power has to be held by someone or it will go on consuming the Nevernever, and she is the only creature alive who can hold it without being destroyed by it. She takes the crown and becomes the Iron Queen, which means remaining in a realm no unaltered fey can enter and survive. That includes Ash, who is already dying of iron exposure and refuses to leave her, so Meghan uses the one authority he cannot argue with: she is his queen and he is her sworn knight, and she orders him out of her territory, releasing him from her service rather than watch him die in it. She also loses the human life she had spent three books trying to get back to, leaving her mother, her stepfather and Ethan behind for good. The war with the Iron fey ends, Faery survives, and Meghan becomes a third monarch the old courts have to acknowledge. Ash leaves the Iron Realm alive and entirely unwilling to accept the arrangement. In the closing pages he sets out to find a way to become something that can live in iron, by earning a mortal soul, which is the journey the next book follows.",
         "in_short": "Exiled from Faery, Meghan Chase and Ash are living in the mortal world when the Iron fey find them. The false king who took Machina's crown is expanding the Iron Realm far faster than his predecessor, and the iron creeping through the wyldwood is killing Faery outright. Glitch's Iron rebels want the usurper gone; Oberon and Mab want the same, and offer to lift Meghan's exile if she goes into the Iron Realm and kills him, since she is the only being who can survive there. Ash trains her to fight and then swears himself to her as her knight, Puck rejoins them, and Rowan turns up still serving the enemy. In the Iron Realm they learn the realm's history and how its crown passes, and Meghan works out what winning will actually cost. In the final battle she destroys the false king and then takes the loose Iron crown herself, becoming the Iron Queen, which binds her to a realm no ordinary fey can enter. She orders the dying Ash out of it to save his life and gives up her human family for good. Ash leaves vowing to find a way to earn a mortal soul and come back.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1039,7 +1039,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1052,7 +1052,7 @@
       "recaps": {
         "ending": "After Moreau and Montgomery die and the boats are destroyed, Prendick survives alone among the Beast People for many months. Without Moreau's threat and repeated discipline, they gradually abandon speech, clothing, upright posture, and the Law, reverting toward the animals from which they were made. Prendick protects himself through bluff and caution, aided for a time by the loyal Dog-Man. The Hyena-Swine kills the dog and is then killed by Prendick. Eventually a small boat drifts ashore carrying two dead men. Prendick repairs and provisions it, escapes the island, and is rescued at sea. He does not try to convince others of his story. Back in human society, he remains haunted by the resemblance between ordinary people and Moreau's unstable creations, fearing that reason and restraint are only a thin covering over animal impulses. He withdraws from crowds and finds his greatest peace in study and in contemplating the stars.",
         "in_short": "Shipwreck survivor Edward Prendick is rescued by Montgomery and taken to a remote island ruled by Doctor Moreau, a disgraced vivisector. Moreau has surgically reshaped animals into speaking, upright Beast People and controls them through pain, fear, and a ritual Law forbidding animal behavior. Prendick initially mistakes the experiments for work on human victims, then learns their true nature. The creatures retain strong instincts despite Moreau's conditioning. A puma escapes the laboratory and kills Moreau; Montgomery then releases the remaining animals, gives them alcohol, and dies in the resulting violence, while the island's boats burn. Alone, Prendick watches the Beast People gradually lose speech and human habits. After killing the dangerous Hyena-Swine, he escapes in a drifting boat and returns to civilization. Unable to stop seeing animal impulses beneath human conduct, he lives apart and seeks calm in scientific study.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1201,7 +1201,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1214,7 +1214,7 @@
       "recaps": {
         "ending": "After Moreau and Montgomery die and the boats are destroyed, Prendick survives alone among the Beast People for many months. Without Moreau's threat and repeated discipline, they gradually abandon speech, clothing, upright posture, and the Law, reverting toward the animals from which they were made. Prendick protects himself through bluff and caution, aided for a time by the loyal Dog-Man. The Hyena-Swine kills the dog and is then killed by Prendick. Eventually a small boat drifts ashore carrying two dead men. Prendick repairs and provisions it, escapes the island, and is rescued at sea. He does not try to convince others of his story. Back in human society, he remains haunted by the resemblance between ordinary people and Moreau's unstable creations, fearing that reason and restraint are only a thin covering over animal impulses. He withdraws from crowds and finds his greatest peace in study and in contemplating the stars.",
         "in_short": "Shipwreck survivor Edward Prendick is rescued by Montgomery and taken to a remote island ruled by Doctor Moreau, a disgraced vivisector. Moreau has surgically reshaped animals into speaking, upright Beast People and controls them through pain, fear, and a ritual Law forbidding animal behavior. Prendick initially mistakes the experiments for work on human victims, then learns their true nature. The creatures retain strong instincts despite Moreau's conditioning. A puma escapes the laboratory and kills Moreau; Montgomery then releases the remaining animals, gives them alcohol, and dies in the resulting violence, while the island's boats burn. Alone, Prendick watches the Beast People gradually lose speech and human habits. After killing the dangerous Hyena-Swine, he escapes in a drifting boat and returns to civilization. Unable to stop seeing animal impulses beneath human conduct, he lives apart and seeks calm in scientific study.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1372,7 +1372,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1385,7 +1385,7 @@
       "recaps": {
         "ending": "John Thornton and his partners locate a rich gold deposit deep in the wilderness while Buck spends increasing amounts of time ranging beyond camp. Buck befriends a wolf and later proves his growing hunting power by bringing down a moose. When he returns from one excursion, he finds that Yeehat raiders have killed Thornton, the other men, and the dogs. Buck attacks the raiders and drives them away, no longer constrained by fear of human beings. Thornton's death severs his final bond to domestic life. Buck answers the wild call he has felt throughout his northern years, joins a wolf pack, and becomes its leader. The Yeehats remember a supernatural Ghost Dog associated with the region, while Buck continues to visit the valley where Thornton died.",
         "in_short": "Buck, a powerful dog living on a California estate, is stolen and sold into service during the Klondike gold rush. Harsh handlers and the sled trail teach him the laws of force, hunger, and survival. He defeats the lead dog Spitz and becomes an exceptional leader, but exhausting mail work and incompetent owners nearly kill him. John Thornton rescues Buck and earns his complete devotion. Buck saves Thornton's life and wins a celebrated strength wager for him, yet the wilderness exerts an increasing pull. Deep in the country, Buck befriends a wolf and hunts on his own. He returns to find Thornton and his companions killed by Yeehat raiders, attacks the killers, and loses his final reason to remain with humans. Buck joins a wolf pack, rises as its leader, and becomes a lasting legend in the valley.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1582,7 +1582,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1595,7 +1595,7 @@
       "recaps": {
         "ending": "White Fang settles into life on the Scott estate and becomes deeply attached to Weedon Scott while learning which animals and people are protected by the household. Collie's hostility gradually softens, and she draws him away with her into the woods. The family's safety is then threatened by Jim Hall, an escaped convict who blames Judge Scott for his imprisonment and enters the house at night seeking revenge. White Fang attacks Hall before the family can be harmed. He kills the intruder but is shot and terribly injured, and a surgeon gives him little chance of surviving. The household nurses him through a long recovery. When he is finally strong enough to go outside, Collie leads him to a litter of puppies she has borne. White Fang lies in the sun as the puppies climb over him, fully accepted by the family and transformed from an animal formed by hunger and abuse into their protective companion.",
         "in_short": "Born to a she-wolf and the old wolf One Eye in the northern wild, an unnamed gray cub survives famine and learns that life depends on strength, caution, and food. Indigenous hunter Gray Beaver takes in the cub and names him White Fang, but bullying by the camp dogs leaves him isolated and severe. At Fort Yukon, Beauty Smith acquires White Fang and turns him into a caged fighting animal. Mining engineer Weedon Scott rescues him from a near-fatal match with a bulldog and patiently teaches him to trust affection. White Fang follows Scott to California, where he learns the rules of a peaceful household. When escaped convict Jim Hall breaks into the Scott home, White Fang saves the family and nearly dies from his wounds. He recovers and is welcomed back to the estate, where the once-solitary wolf-dog rests beside Collie and their puppies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1771,7 +1771,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1784,7 +1784,7 @@
       "recaps": {
         "ending": "The Houyhnhnms decide that Gulliver cannot remain among them because he resembles a Yahoo while possessing enough intelligence to become dangerous. His master reluctantly orders him to leave, and Gulliver builds a canoe and departs in grief. After an attack by local people, the Portuguese captain Pedro de Mendez rescues him and carries him to Lisbon, treating him kindly despite Gulliver's aversion to human company. Gulliver eventually returns to England, but years among the Houyhnhnms have left him unable to accept ordinary human society. He recoils from his wife and children and spends much of his time with horses, whose company he prefers. He closes his account still condemning pride and insisting on the truth of his voyages, while his estrangement shows that his admiration for pure reason has made normal family and social life almost impossible for him.",
         "in_short": "Surgeon and sea traveler Lemuel Gulliver visits four extraordinary societies. In Lilliput, tiny courtiers turn politics and war into contests of vanity, then threaten the giant who helped them. In Brobdingnag, Gulliver is the tiny curiosity, and a humane king is appalled by his proud description of European government and warfare. A later voyage takes him to the floating island of Laputa and other lands where abstract learning, futile schemes, distorted history, and immortality expose failures of intellect and ambition. Finally, mutineers abandon him among the rational horse-like Houyhnhnms and brutal humanlike Yahoos. Gulliver embraces Houyhnhnm reason and comes to despise humanity, but the horses expel him because he is still a Yahoo in form. Rescued by the generous Pedro de Mendez, he returns to England unable to bear close contact with his family and preferring the company of horses.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2004,7 +2004,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2017,7 +2017,7 @@
       "recaps": {
         "ending": "In the final group of stories, Ying-ying recognizes that Lena's passivity repeats her own loss of spirit and resolves to tell her daughter about the anger and grief she has kept hidden. Lindo reflects on the mixture of Chinese and American identity visible in both herself and Waverly. Jing-mei then travels to China with her father, Canning. He tells her the complete story of Suyuan's flight from Kweilin: sick and exhausted, Suyuan left her infant twins beside the road with jewelry, money, photographs, and a plea that someone save them. She later tried for years to find them. The twins were finally located, but Suyuan died before receiving the news. At the Shanghai airport, Jing-mei meets her half-sisters, Chwun Yu and Chwun Hwa, in Suyuan's place. The three initially feel the painful absence between them, then recognize their mother in their shared appearance. A photograph of the sisters together gives Jing-mei the family likeness and sense of Chinese inheritance that she had feared she could not carry.",
         "in_short": "After Suyuan Woo dies, her daughter Jing-mei takes her chair at San Francisco's Joy Luck Club and is asked to meet the twin daughters Suyuan left in wartime China. Across sixteen linked accounts, Suyuan's friends An-mei, Lindo, and Ying-ying recall childhood loss, constrained marriages, migration, and the strategies by which they survived. Their American-born daughters Rose, Waverly, Lena, and Jing-mei describe marriages, careers, and family conflicts shaped by lessons they often misunderstood. Rose resists a divorce that would erase her wishes; Lena sees the inequality hidden inside her supposedly balanced marriage; Waverly discovers that Lindo's criticism and pride are inseparable; and Jing-mei reconsiders her mother's disappointed hopes. The mothers also confront their own silences and try to pass on strength without passing on fear. Jing-mei finally travels to China, hears the full story of Suyuan's separation from the twins, and meets her half-sisters. Seeing their mother in all three faces, she accepts a family identity that words alone had never made clear.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2190,7 +2190,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2203,7 +2203,7 @@
       "recaps": {
         "ending": "After years of exploitation, bereavement, homelessness, crime, and political corruption, Jurgis wanders into a socialist meeting and hears an analysis that gives a coherent explanation for what happened to his family. He joins the movement, finds employment at Tommy Hinds's hotel, and begins learning from organizers with different approaches to socialist thought. The novel closes on an election gathering in Chicago. Reports show a dramatic increase in the socialist vote even though the party has not won power. The speakers interpret the result as evidence that workers are awakening to their shared interests and call for continued organization. Jurgis's personal losses are not reversed: Ona, their child, his father, and other members of the household remain dead or scattered, while Marija is still trapped by addiction and prostitution. His new community and political purpose replace despair with collective hope, and the final appeal looks toward an eventual socialist victory rather than resolving his family's tragedy.",
         "in_short": "Lithuanian immigrant Jurgis Rudkus comes to Chicago with Ona and their extended family, certain that hard work will secure a future. Packingtown instead drains them through dangerous jobs, fraudulent housing costs, illness, and corruption. After Ona's foreman coerces her, Jurgis attacks him and is jailed; he returns to find the family evicted and Ona dying after childbirth. Their young son later drowns, and Jurgis abandons the city. He becomes a migrant laborer, then returns to Chicago and passes through unemployment, crime, vote buying, strikebreaking, and machine politics. These paths provide brief comfort but reveal more layers of exploitation. He eventually finds Marija working in a brothel and, while seeking shelter, enters a socialist rally. The movement's account of class power transforms his private suffering into political understanding. Jurgis becomes a socialist organizer and finds work among comrades. The book ends with strong socialist election gains and a call to organize Chicago, offering collective hope without restoring the family destroyed by industrial poverty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2376,7 +2376,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2389,7 +2389,7 @@
       "recaps": {
         "ending": "After years of exploitation, bereavement, homelessness, crime, and political corruption, Jurgis wanders into a socialist meeting and hears an analysis that gives a coherent explanation for what happened to his family. He joins the movement, finds employment at Tommy Hinds's hotel, and begins learning from organizers with different approaches to socialist thought. The novel closes on an election gathering in Chicago. Reports show a dramatic increase in the socialist vote even though the party has not won power. The speakers interpret the result as evidence that workers are awakening to their shared interests and call for continued organization. Jurgis's personal losses are not reversed: Ona, their child, his father, and other members of the household remain dead or scattered, while Marija is still trapped by addiction and prostitution. His new community and political purpose replace despair with collective hope, and the final appeal looks toward an eventual socialist victory rather than resolving his family's tragedy.",
         "in_short": "Lithuanian immigrant Jurgis Rudkus comes to Chicago with Ona and their extended family, certain that hard work will secure a future. Packingtown instead drains them through dangerous jobs, fraudulent housing costs, illness, and corruption. After Ona's foreman coerces her, Jurgis attacks him and is jailed; he returns to find the family evicted and Ona dying after childbirth. Their young son later drowns, and Jurgis abandons the city. He becomes a migrant laborer, then returns to Chicago and passes through unemployment, crime, vote buying, strikebreaking, and machine politics. These paths provide brief comfort but reveal more layers of exploitation. He eventually finds Marija working in a brothel and, while seeking shelter, enters a socialist rally. The movement's account of class power transforms his private suffering into political understanding. Jurgis becomes a socialist organizer and finds work among comrades. The book ends with strong socialist election gains and a call to organize Chicago, offering collective hope without restoring the family destroyed by industrial poverty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2565,7 +2565,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2578,7 +2578,7 @@
       "recaps": {
         "ending": "After years of exhausting labor, bereavement, homelessness, crime, and political corruption, Jurgis wanders into a socialist meeting and experiences its analysis as an explanation of everything that has happened to him. He seeks out the movement rather than treating the speech as temporary inspiration. Ostrinski gives him shelter and helps him understand collective ownership and class struggle; Schliemann develops the argument further. Jurgis finds work through a socialist hotel owner, returns to Teta Elzbieta, and commits himself to organizing rather than individual escape. Marija remains trapped by addiction and prostitution and is unable to share his new hope, showing that his conversion does not repair the family's losses. The novel closes at an election gathering where socialists celebrate major gains in Chicago and call for the city to be won through democratic organization. Jurgis's personal future remains open, but he has moved from faith in solitary hard work to faith in coordinated political action.",
         "in_short": "Lithuanian immigrant Jurgis Rudkus arrives in Chicago believing strength and labor will secure his family. Packingtown instead consumes every resource: dangerous work, fraud, unemployment, illness, and corruption strip away their home and health. His father dies; his wife Ona is coerced by her foreman and dies after childbirth; their son drowns; and Jurgis abandons the remnants of the family. He becomes a migrant laborer, beggar, thief, political operative, and strikebreaker, learning that crime and government serve the same economic powers as the stockyards. He later finds Marija surviving through prostitution and addiction. Wandering into a socialist rally, Jurgis hears his suffering explained as the result of an exploitative system rather than personal failure. He reconnects with Teta Elzbieta, gains work through socialist allies, and dedicates himself to the movement. The book ends with socialists celebrating electoral advances and urging workers to organize for control of Chicago.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2782,7 +2782,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2795,7 +2795,7 @@
       "recaps": {
         "ending": "The final tale centers on Suleiman-bin-Daoud, whose wisdom and magical power are tested by constant quarrels within his large household. His wife Balkis notices his unhappiness and uses a domestic argument between two butterflies to help him. The male Butterfly has boasted that stamping his foot could make Suleiman's palace disappear. Suleiman privately offers to make the boast appear true, then uses his ring when the Butterfly stamps. The palace vanishes and returns, alarming the household and convincing both the Butterfly's wife and Suleiman's disputing wives that the apparent boast conceals immense power. The Butterfly gains peace at home, while Suleiman restores order without directly using magic against his wives. Balkis's understanding and tact, rather than raw authority, resolve the collection's closing conflict.",
         "in_short": "Twelve independent origin tales give playful explanations for familiar features of animals, writing, the sea, and domestic life. A mariner limits what the greedy Whale can swallow; the lazy Camel acquires his hump; the Rhinoceros's smooth hide becomes wrinkled; and the Leopard gains spots. The Elephant's Child has his nose stretched into a trunk, a long chase reshapes the Kangaroo, and a hedgehog and tortoise combine their defenses to become armadillos. Taffy and Tegumai's failed picture-message leads them toward an alphabet. The giant crab Pau Amma is forced to stop disturbing the sea. The Cat bargains for human comforts without surrendering his independence. In the final tale, Balkis helps Suleiman-bin-Daoud turn a Butterfly's boast into an impressive display of magic, quieting conflict in both the insect's marriage and the king's household.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2926,7 +2926,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2939,7 +2939,7 @@
       "recaps": {
         "ending": "Sanders's attempt to turn a kaiju and its nuclear biology into a commercial prize puts both worlds at risk. Jamie and the Tanaka Base team escape the restrictions placed on them, pursue the intruders, and improvise a way to protect Bella during the resulting confrontation. Sanders refuses to abandon his scheme and dies on the kaiju world, while the surviving KPS personnel prevent the crisis from becoming a breach that would expose Earth. The visitors who enabled him are forced to face the consequences, and the preserve remains secret. Jamie's temporary escape from pandemic unemployment has become a chosen vocation: with close friends among the new scientific cohort and a community at Tanaka Base, Jamie accepts a continuing place in KPS. The organization survives damaged but intact, still tasked with protecting a dangerous ecosystem from both accidental crossings and human exploitation.",
         "in_short": "After losing a comfortable startup job at the start of the pandemic, Jamie Gray accepts a mysterious position with the Kaiju Preservation Society. KPS operates through a gateway in Greenland to a parallel Earth where gigantic creatures powered by biological nuclear reactors support entire ecosystems. At Tanaka Base, Jamie joins scientists Aparna, Niamh, and Kahurangi, learns the hazards of fieldwork, and helps monitor a female kaiju called Bella. The mission becomes dangerous in a new way when Jamie's former employer, billionaire Rob Sanders, arrives among influential visitors. Sanders sees the kaiju as exploitable assets and uses his access to undermine the preserve's safeguards. Jamie and the KPS team resist his attempt to seize control of kaiju biology and avert a disaster spanning both worlds. Sanders dies during the confrontation, Bella is protected, and the preserve's secrecy holds. Having found friends and useful work, Jamie chooses to remain with KPS.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3103,7 +3103,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3116,7 +3116,7 @@
       "recaps": {
         "ending": "Carl and Assad establish that Merete did not die on the ferry. Her disappearance grew out of a much older road accident that killed her parents, disabled Uffe, and devastated another family. Lasse, a survivor from that other family, has kept Merete inside a sealed pressure chamber as an elaborate act of revenge, raising the pressure over years so that a sudden opening would kill her. With the captors preparing to finish the punishment, Department Q locates the property and reaches the chamber. The immediate threat is overcome, and Merete is brought out through a controlled decompression that gives her a chance to survive. She is reunited with Uffe and receives hospital care after five years of isolation. The rescue vindicates Carl's refusal to accept the original suicide theory and confirms Assad as an essential partner rather than a basement caretaker. Department Q, created largely as an administrative maneuver, ends its first case as a functioning investigative unit. Carl has not resolved the shooting that killed Anker and disabled Hardy, but solving Merete's disappearance begins to restore his sense of purpose.",
         "in_short": "After a shooting kills one colleague and paralyzes another, difficult Copenhagen detective Carl Mørck is placed in charge of Department Q, a new cold-case unit housed in the basement. With civilian assistant Assad, he reopens the five-year-old disappearance of politician Merete Lynggaard, presumed lost from a ferry. Alternating scenes reveal that Merete is alive inside a sealed pressure chamber, where captors have increased the pressure year by year. Carl and Assad reconstruct her secret devotion to her disabled brother Uffe and trace the case to the childhood crash that killed their parents and another family's members. Survivor Lasse has made Merete the target of a prolonged revenge. As her intended execution approaches, the investigators locate the chamber, overcome the captors, and arrange a controlled decompression. Merete survives long enough to be hospitalized and reunited with Uffe. The rescue establishes Department Q as real police work, gives Carl renewed purpose, and confirms Assad as his investigative partner, while the earlier shooting of Carl's team remains unsolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3330,7 +3330,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3343,7 +3343,7 @@
       "recaps": {
         "ending": "The collection closes with Othello. Iago convinces Othello that Desdemona has been unfaithful with Cassio, using a misplaced handkerchief and staged conversations as false evidence. Othello kills Desdemona, then learns from Emilia that the accusation was invented. Iago kills Emilia when she exposes him, but is captured. Othello, realizing that he murdered an innocent wife, kills himself beside Desdemona. Cassio is left to govern Cyprus and Iago faces punishment. Earlier selections have also reached complete endings: Romeo and Juliet's deaths reconcile their families; Portia defeats Shylock's claim against Antonio; Caesar outlasts Antony and Cleopatra; Timon dies estranged from Athens; the lovers of Navarre postpone marriage for a year; and Katherina and Petruchio end their contest publicly aligned.",
         "in_short": "Seven Shakespeare stories are presented in sequence. Romeo and Juliet marry across a family feud but die after a failed plan, prompting peace. Portia saves Antonio from Shylock's bond and reunites with Bassanio. Antony and Cleopatra lose their struggle with Caesar and take their own lives. Generous Timon is abandoned when his fortune fails and dies hating Athens. Navarre's king and friends break their vow to avoid women, but the Princess of France postpones their marriages after her father's death. Petruchio marries the resistant Katherina and subjects her to a harsh campaign of control before they return to Padua together. Iago then tricks Othello into believing Desdemona unfaithful. Othello kills her, discovers the deception, and kills himself; Iago is arrested.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3497,7 +3497,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3510,7 +3510,7 @@
       "recaps": {
         "ending": "Mark's group reaches a landed Berg and gets Deedee, the immune girl, into the hands of people equipped to fly her out and study her, on the reasoning that the organization responsible for the virus is the only one left with the means to do anything useful with her. The bombardment of the infected region goes ahead on schedule. Alec does not survive it. Mark, whose own infection has been eating his memory and his self-control for days, finds Trina, who no longer reliably knows who he is, and stays with her rather than run; neither of them survives, and the settlement's remaining survivors are killed with them. The virus is not contained, cured, or explained away. Burning one region is an attempt to buy time, and the book is explicit that the disease is already well outside it. Deedee is flown out alone, told that her old life is finished and that she will be given a new name, and the name she is given is Teresa. That is the handoff to the rest of the series: the disease later known as the Flare is loose and incurable, immunity is the only asset anyone has, and the organization that will eventually run the Maze trials has just acquired its first immune child and a reason to believe her brain is worth taking apart.",
         "in_short": "A year after solar flares scorched the earth, Mark and a small group of survivors are scratching out a life in the Appalachian mountains when an aircraft appears over their settlement and fires darts down into the crowd. The darts carry an engineered virus that brings fever and then madness. Chasing the aircraft, Mark and the old soldier Alec learn that the disease was released deliberately as population control by the governments that survived the disaster, and that it has escaped every limit set for it. With their village destroyed and their friends turning violent, they head for the walled city of Asheville, only to find it quarantined and condemned: the whole region is to be firebombed. On the way out they take in Deedee, a small girl the disease cannot touch, and get her to the people who can make use of that. Mark, Trina and Alec, infected or trapped, die in the bombardment. Deedee is flown to safety and renamed Teresa.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3728,7 +3728,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3741,7 +3741,7 @@
       "recaps": {
         "ending": "Lee's massive assault on the center of the Union line crosses open ground under artillery and rifle fire, briefly reaches the stone wall, and collapses. Armistead is mortally wounded after leading part of the advance across the wall; Garnett is killed, and Pickett's division is shattered. Longstreet, who expected the attack to fail but carried out Lee's order, watches the survivors return and fears that he has lost both his men and Lee's confidence. Lee rides among the retreating soldiers, accepts responsibility, and prepares for a Union counterattack that never comes. On the Union side, Chamberlain and the battered 20th Maine are moved toward the center and witness the repulse. The battle ends with the Confederates withdrawing toward Virginia in heavy rain. Chamberlain reflects on the defeated enemy and on the cost of preserving the Union, while Lee's army leaves Gettysburg damaged beyond what victory in later campaigns can repair.",
         "in_short": "As the Union and Confederate armies converge on Gettysburg, cavalry commander John Buford recognizes the value of the surrounding high ground and holds the approaches until Union infantry arrives. Robert E. Lee wins the first day's fighting but cannot drive the Federals from Cemetery Hill and the ridges south of town. James Longstreet urges Lee to maneuver onto defensive ground; Lee instead attacks the established Union line. On the second day, Colonel Joshua Lawrence Chamberlain and the 20th Maine defend the extreme Union left on Little Round Top, ending their desperate stand with a bayonet charge. The Confederate assaults gain ground but fail to break the line. Lee orders one final attack across the open center on July 3. Longstreet reluctantly sends Pickett's and supporting divisions forward. The charge is devastated, Armistead falls after crossing the stone wall, and the survivors retreat. Lee takes responsibility and leads his defeated army away, while Chamberlain contemplates the battle's human cost and the Union cause it preserved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3897,7 +3897,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3910,7 +3910,7 @@
       "recaps": {
         "ending": "The authorities finally arrange a confrontation that Lou cannot explain away: Joyce survived his assault and is brought to identify him. Lou receives her with apparent tenderness, but he has already prepared his house for destruction. Rather than submit to arrest or permit Joyce to testify, he triggers the trap, killing himself and the people who have come inside. His final act abandons even the pretense that his violence can be contained or rationally managed. Amy, Elmer, Johnnie, and the other victims cannot receive justice through a trial, and the respectable identity that protected Lou ends only when he destroys it along with himself. The closing catastrophe confirms that the ordinary, slow-witted deputy known by the town was a performance maintained by a murderer who repeatedly treated other lives as pieces in his private designs.",
         "in_short": "West Texas deputy Lou Ford hides violent compulsions behind a mild, tedious public manner. Sent to drive prostitute Joyce Lakeland out of town, he begins a sadomasochistic affair with her and uses her relationship with Elmer Conway in a revenge plot against Elmer's powerful father. Lou brutally attacks Joyce and kills Elmer, arranging the scene to suggest a fatal dispute. As investigators question inconsistencies, Lou redirects suspicion toward vulnerable people and kills again to protect his story, including Johnnie Pappas and his fiancée Amy Stanton. County prosecutor Howard Hendricks gradually sees through Lou's performance. Lou is confined but returns home while officials prepare decisive evidence. Joyce, who survived, is brought to confront him. Lou has rigged the house for destruction and detonates it, killing himself and those present rather than face exposure. His public identity as an amiable deputy collapses with the final act, leaving a chain of deaths created less by concealment than by his repeated need for violence and control.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4082,7 +4082,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4095,7 +4095,7 @@
       "recaps": {
         "ending": "Richard finally challenges Marcus and kills him, becoming leader of the St. Louis werewolf pack. The victory also forces Anita to witness the part of Richard's nature that he has tried to keep separate from their relationship, and her reaction breaks the confidence on which their engagement depended. Raina and Gabriel are killed after their coercion of weaker shapeshifters turns into a direct attack, ending their control over the local wolves and leopards. Cassandra and Dominic are exposed as serving a hidden plan centered on Sabin and the power shared by Anita, Jean-Claude, and Richard; they turn on Anita and are killed when the plan fails. The professional killers pursuing Anita are also defeated, with Edward instrumental in ending the contract threat. During the converging conflicts, Anita, Jean-Claude, and Richard form a powerful metaphysical triumvirate. After recoiling from Richard's transformation and killing of Marcus, Anita goes to Jean-Claude and becomes his lover. She ends her engagement to Richard. Richard remains linked to both of them through the triumvirate and now leads the pack, so the emotional triangle survives even though Anita has chosen Jean-Claude as her partner at the book's close.",
         "in_short": "Edward warns Anita Blake that a large contract has been placed on her life. As assassins close in, she is also drawn into two supernatural crises: the dying master vampire Sabin seeks help for his physical decay, and Richard must settle his challenge to Marcus for leadership of the St. Louis werewolves. Protecting vulnerable pack members brings Anita into direct conflict with Marcus, Raina, and Gabriel. The pressures on Anita, Richard, and Jean-Claude create a metaphysical triumvirate that shares their power. Richard kills Marcus and becomes pack leader, while Raina and Gabriel are killed when their abuses lead to a final confrontation. Cassandra and the necromancer Dominic reveal a concealed agenda involving Sabin and the triumvirate, but their plan fails and they die. Edward helps eliminate the hired killers. Anita is unable to accept what she sees when Richard embraces the lethal requirements of pack leadership; she turns to Jean-Claude, becomes his lover, and ends her engagement, although Richard remains supernaturally bound to them both.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4260,7 +4260,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4273,7 +4273,7 @@
       "recaps": {
         "ending": "The collection does not end by resolving the King in Yellow mythology into a single explanation. After the first four tales show the play invading minds and lives, the remaining stories move through supernatural romance, prose-poem fragments, and the lives of artists in Paris. The final Paris tales concentrate on affection complicated by pride, poverty, war, and missed timing. In Rue Barrée, Selby's fascination with a guarded young music student becomes another uneven relationship rather than a settled union. The book therefore closes at a distance from Carcosa and its supernatural threats, with an intimate romantic disappointment instead of a final confrontation. The Yellow Sign, the masked king, and the forbidden second act remain unexplained, linked by repeated images and names rather than by a conventional continuous plot.",
         "in_short": "The King in Yellow is a collection rather than one continuous narrative. Its opening tales revolve around a forbidden play whose second act destabilizes those who read it, exposing them to visions or forces associated with Carcosa, the Yellow Sign, and a masked king. Hildred Castaigne turns his reading into a murderous fantasy of succession; a Parisian sculptor's petrifying liquid creates loss and an unexpected restoration; an unnamed churchgoer is pursued into a vision of the king's court; and an artist and his model are destroyed after encountering the Yellow Sign and reading the play. A Breton time-slip romance and a sequence of prose poems extend the dreamlike mood. The later stories largely leave the supernatural mythology behind for Parisian artists and lovers, whose relationships are shaped by bereavement, the siege of Paris, artistic ambition, and missed chances. The collection ends without explaining the play or defeating its king.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4473,7 +4473,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4484,7 +4484,7 @@
         "work": "the-king-of-crows"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4694,7 +4694,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4707,7 +4707,7 @@
       "recaps": {
         "ending": "Manizheh's assault succeeds completely. Dara brings her forces across the cursed lake and destroys the Citadel, killing most of the Royal Guard with it, while inside the palace Kaveh releases a vapour Manizheh built from Nahid poison-craft: it kills Geziri djinn and leaves everyone else untouched. The Navasatem gathering becomes a massacre. Ghassan dies with the rest, and Muntadhir is left mortally wounded and beyond ordinary healing. Suleiman's seal passes to Alizayd, who survives the vapour only because of the marid magic in him. Kaveh reveals that Jamshid is his son by Manizheh, which makes Jamshid a Nahid and Nahri's half-brother, and Manizheh tells Nahri to her face that she is her daughter. Refusing to be taken, Nahri and Ali throw themselves into the lake and are carried half a world away, surfacing in the Nile. Because the bearer of Suleiman's seal is no longer on the island, Daevabad's magic goes out with him: the wards, the conjuring, the healing, all of it. Manizheh ends the book holding a city that no longer works, keeping Muntadhir alive as leverage over Jamshid, whom she means to install as her heir. Dara has delivered exactly what he was raised from the dead to deliver, and is beginning to understand what he has let himself become for a second time. Nahri and Ali are alive, magicless and stranded in Egypt, and they are the only two people who might undo any of it.",
         "in_short": "Five years after The City of Brass, Nahri is Daevabad's Banu Nahida and Muntadhir's unwilling wife, kept obedient by King Ghassan's threats against her tribe. Ali, exiled to the desert, has survived assassins and hidden the water magic the marid left in him. Summoned home for Navasatem, the celebration held once a century, he joins Nahri in rebuilding the ruined Nahid hospital to treat the city's despised shafit. While treating Jamshid, Nahri discovers he carries Nahid blood. Outside the city, Dara, resurrected and bound to Banu Manizheh, trains her army while arguing against her methods. Manizheh strikes during Navasatem: Dara destroys the Citadel while Kaveh releases a poison that kills Daevabad's Geziri, Ghassan among them. Muntadhir is mortally wounded, Kaveh reveals Jamshid as his and Manizheh's son, and Nahri learns that Manizheh is her mother. Suleiman's seal passes to Ali, and when he and Nahri escape into the lake and surface in the Nile, Daevabad's magic fails with the seal-bearer gone. Manizheh holds a broken city; Nahri and Ali are stranded in Egypt.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4904,7 +4904,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4917,7 +4917,7 @@
       "recaps": {
         "ending": "The Rangers expose the machinery behind Tennyson's power in Clonmel: the Outsiders help create the insecurity they promise to cure, while hidden Genovesan crossbowmen turn murder into apparent divine judgement. Will counters the concealed assassins and Horace's public courage gives the people a visible alternative to fear. King Ferris does not live to repair the weakness that enabled the movement; he is killed during the crisis. Because Halt is his twin, Halt briefly takes Ferris's place long enough to prevent immediate collapse and secure the succession for their nephew Sean Carrick. Sean becomes king with a chance to rebuild Clonmel's authority. Tennyson nevertheless escapes with surviving followers and Genovesan killers, so the organisation has been checked rather than destroyed. Will, Halt and Horace pursue him beyond Clonmel. The book therefore ends with the kingdom saved but its antagonist still at large, opening the Tennyson and Genovesan arc continued in Halt's Peril.",
         "in_short": "Crowley sends Will, Halt and Horace to Hibernia, where a sect called the Outsiders is exploiting weak kingdoms. Its leader Tennyson secretly benefits from raids and disorder, then demands gold and obedience for promised protection. In Clonmel, Halt reveals that the ineffective King Ferris is his twin brother and that Halt himself has a claim to the throne he left behind. The companions try to restore confidence in lawful rule: Horace becomes a conspicuous champion while Will investigates the tricks behind Tennyson's supposed miracles. Hidden Genovesan assassins, including Bacari and Marisi, use crossbow bolts and poison to make the sect's enemies appear struck down by divine power. The deception is exposed, but Ferris is killed. Halt impersonates his identical brother just long enough to steady the kingdom and place their nephew Sean Carrick on the throne. Tennyson escapes with the remaining assassins, and the three Araluens pursue him into the next book.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5058,7 +5058,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5071,7 +5071,7 @@
       "recaps": {
         "ending": "Stella ends the arrangement because she believes Michael needs freedom from a relationship shaped by money and obligation. Michael, already convinced that his past makes him unworthy of her, accepts the separation despite loving her. With support from his family, he finally challenges that belief, returns to fashion design, and offers Stella a relationship in which neither of them is a client or a service provider. Stella also stops treating intimacy as a technical deficiency she must correct. She makes clear that she wants Michael himself, not a perfect performance, and they reconcile on equal terms. Their final commitment is personal and freely chosen: Stella can state her needs without shame, while Michael can accept love without seeing himself through his father's failures or the work he did to meet his mother's expenses.",
         "in_short": "Autistic econometrician Stella Lane hires escort Michael Phan to teach her about sex and dating. Michael needs the money to help his ill mother, but he is careful with Stella's boundaries and proposes that they practice a whole relationship rather than follow her rigid lesson plan. Their staged dates become genuine affection, and Stella grows comfortable with Michael and his welcoming family. Both conceal fears that threaten what they have built: Stella believes her autism makes her a burden, while Michael feels stained by escort work and by the example of his absent father. Stella ends their contract rather than use money to hold him, and Michael initially lets shame keep them apart. He then returns to his ambition as a clothing designer and asks for a real relationship. Stella chooses him openly, and they reunite as partners rather than client and escort.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5220,7 +5220,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5233,7 +5233,7 @@
       "recaps": {
         "ending": "Amir wins the right to raise Sohrab after nearly losing him: told he might be sent back to an orphanage while adoption is arranged, the boy attempts suicide and barely survives. Amir brings him home to California, but Sohrab, hollowed by trauma, retreats into silence for months and will not respond to affection. Amir also confronts the buried history of his family, having at last atoned for his childhood betrayal of Hassan by risking his life for Hassan's son. At a gathering of the Afghan community, Amir flies a kite with Sohrab and, running the cut kite for the boy just as Hassan once did for him, sees the faintest smile cross Sohrab's face. It is not a full recovery, only a beginning, but Amir takes it as a sign of hope and repeats to the boy the promise Hassan once made to him: for you, a thousand times over. The novel closes on that small, uncertain opening toward healing.",
         "in_short": "Amir, the son of a wealthy Kabul family, grows up with Hassan, the loyal Hazara boy who serves in his household. After Amir wins a kite tournament, he watches Hassan be brutally assaulted by a bully and does nothing, then, unable to bear his guilt, frames Hassan for theft and drives him and his father away. When the Soviets invade, Amir and his father flee to America, where Amir builds a new life, marries Soraya, and loses his father to cancer. Years later a dying family friend, Rahim Khan, summons Amir back and reveals two truths: Hassan has been killed by the Taliban, and Hassan was secretly Amir's half-brother. Hassan's orphaned son Sohrab remains in Kabul. Amir returns to a ruined Afghanistan, discovers the boy is held by his old tormentor, now a Taliban official, and is beaten nearly to death before Sohrab wounds the man and they escape. Amir adopts Sohrab and brings him to America, where the traumatized, withdrawn boy slowly begins to heal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5369,7 +5369,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5382,7 +5382,7 @@
       "recaps": {
         "ending": "Todd and Viola's desperate flight ends at Haven, the city they had believed would be their sanctuary. Along the way Todd loses his faithful dog Manchee, killed by the men hunting them, and is finally forced into a lethal confrontation with the preacher Aaron, whom he kills. Carrying the gravely wounded Viola, Todd staggers into Haven only to discover there is no safety there: the city has surrendered without a fight, and Mayor Prentiss and his army are already in control. The Mayor greets Todd almost warmly and announces that he is now President, master of a new and larger domain. Todd is left holding Viola, cornered and defeated, everything he ran toward turned into another trap. The truth about Prentisstown and the wider world has been laid bare, but the boy who could not become the kind of man his town wanted now faces a conqueror who has only begun. The book closes on this cliffhanger, with the war for the planet just beginning and Viola's life hanging in the balance.",
         "in_short": "On a colonized planet where a phenomenon called the Noise makes every man's thoughts audible, Todd Hewitt is the last boy in the isolated, all-male settlement of Prentisstown, raised to believe it is the sole surviving remnant of the colony. Weeks before the birthday that would make him a man, he stumbles on an impossible thing in the swamp: a pocket of total silence, which turns out to be a girl, Viola, the survivor of a crashed scout ship. His guardians force him to flee, giving him his dead mother's journal and warning that Prentisstown's story is a lie. Pursued by the fanatical preacher Aaron and the army of the cold, silent Mayor Prentiss, Todd and Viola race across the wider, unknown world toward the city of Haven, discovering that women and other towns exist and that Prentisstown's men committed a terrible crime the boy was never told. Along the way Todd is tested by whether he can bring himself to kill. They finally reach Haven only to find it has already surrendered to Mayor Prentiss, now declaring himself President, with Viola gravely wounded and no refuge left, the story breaking off on the edge of a wider war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5551,7 +5551,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5564,7 +5564,7 @@
       "recaps": {
         "ending": "Arcite is declared the tournament's victor, but a supernatural disturbance frightens his horse and throws him to the ground. His internal injuries cannot be healed. Before dying, he acknowledges Palamon's worth and asks Emelye to consider Palamon as a husband. Athens gives Arcite an elaborate funeral, and a long period of mourning follows. Years later, Theseus summons Palamon and Emelye and argues that human beings must accept the order and necessity governing mortal change. He proposes a marriage that will also unite Athens and Thebes. Emelye and Palamon wed, and the tale closes by saying that their life together is marked by enduring love and peace. The outcome fulfills Venus's promise to Palamon even though Mars granted Arcite victory in the contest.",
         "in_short": "After Theseus conquers Thebes, the wounded cousins Palamon and Arcite become his prisoners in Athens. Both see Emelye, sister of Theseus's wife, and fall in love with her, turning their friendship into rivalry. Arcite is released into exile but returns in disguise; Palamon later escapes, and Theseus interrupts their duel. He orders them to return with companies of knights for a formal tournament whose winner may marry Emelye. Palamon asks Venus for love, Arcite asks Mars for victory, and Emelye unsuccessfully asks Diana to remain unmarried. Arcite's side wins, but he is thrown from his horse after the contest and dies of his injuries, commending Palamon to Emelye. After mourning and an elaborate funeral, Theseus arranges the surviving pair's marriage. Palamon and Emelye live together in harmony, reconciling the competing divine promises and politically joining Thebes with Athens.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5651,7 +5651,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5664,7 +5664,7 @@
       "recaps": {
         "ending": "Mike and Phyllis survive the inundation by establishing themselves on high ground, but a reporting journey into flooded London nearly kills them. They find the capital reduced to scattered occupied buildings linked by boats, with hunger, cold, and disease compounding the damage. After they are rescued, the long human retreat finally changes direction. Japanese researchers develop a weapon that can destroy the invaders' deep-ocean settlements, and coordinated attacks begin eliminating them. The seas cease rising and eventually start to withdraw, although enormous areas remain drowned and the old political and economic order has been broken. The Watsons live to see the beginning of recovery rather than a restoration of the world they knew. Humanity wins the military contest only after failing for years to recognize it, and survival depends on rebuilding within a permanently altered landscape.",
         "in_short": "Radio journalists Mike and Phyllis Watson witness mysterious fiery objects descending into the ocean deeps. Scientist Bocker argues that they are extraterrestrial settlers adapted to pressures humans cannot endure. Governments dismiss or politicize the evidence until ships vanish and deep-sea exploration meets violent resistance. The invaders next send machines onto coasts to seize people, provoking a war fought at the edge of the sea. When coastal defenses improve, they melt the polar ice and raise global sea level. Nations minimize the forecast, prepare too late, and fragment as ports, farmland, and cities disappear. The Watsons retreat to high ground and later find London largely drowned. At humanity's weakest point, Japanese scientists devise a weapon effective against the invaders' abyssal settlements. The deep-ocean bases are destroyed, the water begins to recede, and the survivors start rebuilding a civilization transformed by flooding and social collapse.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5765,7 +5765,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5778,7 +5778,7 @@
       "recaps": {
         "ending": "Pozdnyshev returns home unexpectedly and finds Trukhachevsky dining with his wife. Convinced that his suspicions have been confirmed, he attacks the violinist, who escapes, then stabs his wife. As she dies, her response and the sight of their children begin to break through his jealous certainty. Pozdnyshev is later acquitted, his violence treated as a crime committed under marital provocation, but he does not present that verdict as moral release. Only when he sees his wife's body does he fully recognize her as a separate human being whom he has destroyed and cannot restore. On the train he finishes his confession by acknowledging the enormity of the act and asking the narrator's forgiveness before they part.",
         "in_short": "During a railway journey, passengers debate whether marriage should rest on love, obedience, or social convention. One traveler, Pozdnyshev, reveals that he killed his wife and recounts the life that led to the crime. He describes a youth shaped by sexual double standards, a courtship based on physical attraction, and a marriage marked by resentment, quarrels, and possessiveness. After his wife resumes music, she performs Beethoven's Kreutzer Sonata with the violinist Trukhachevsky. Pozdnyshev interprets their artistic intimacy as sexual betrayal, though he has no proof. Returning early from a trip, he finds them together, attacks the fleeing violinist, and fatally stabs his wife. He is acquitted under the era's indulgent view of jealous husbands, but the sight of her dying and then dead makes him understand that his suspicions never justified treating her as his possession. His train confession ends not in vindication but in belated remorse.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5857,7 +5857,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5869,7 +5869,7 @@
       },
       "recaps": {
         "in_short": "A collection of twelve Hercule Poirot cases linked by a retirement project rather than by one continuous plot. Poirot, amused and irritated by the contrast between his own methods and the physical feats of the Greek Hercules, proposes to finish his career with twelve investigations corresponding symbolically to the ancient labours. The matches depend on names, situations, or problems rather than literal monsters. Each case has its own cast, crime, and resolution; Miss Lemon and George belong to the recurring office-and-household frame. The collection is best treated as a set of complete mysteries under a shared conceit, not as a novel with a single ending.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -6037,7 +6037,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6050,7 +6050,7 @@
       "recaps": {
         "ending": "The Ladies' Paradise completes a record-breaking white sale in its enlarged building, confirming its domination of the district. The older shops have been destroyed or absorbed: Geneviève and her mother are dead, Colomban has run off after Clara, Bourras has been dispossessed, Robineau has survived ruin and a suicide attempt, and Baudu remains amid the wreckage of the Old Elbeuf. Denise has risen from mocked junior saleswoman to a respected senior employee, and her influence has helped introduce better housing, education, recreation, and security for the staff. Planning to leave Paris, she resists becoming Mouret's mistress despite loving him. Mouret, unable to treat her like his earlier conquests, asks her to marry him. Denise finally accepts. His commercial system has conquered the neighborhood, but the personal relationship closes with Denise entering marriage by choice and with enough authority to reshape the institution from within.",
         "in_short": "Orphaned Denise Baudu comes to Paris with her brothers and takes a poorly paid position at the Ladies' Paradise, the department store destroying her uncle's traditional drapery business. Mocked by coworkers and briefly dismissed, she survives hardship without accepting dependence on a lover. Store owner Octave Mouret notices her, and after she is rehired her skill and empathy carry her into senior responsibility. Denise comes to understand the new retail system while pressing Mouret to improve conditions for its workers. Around them, the old neighborhood collapses: Robineau is ruined, Bourras is dispossessed, Geneviève dies after Colomban abandons her for Clara, and the Baudu shop fails. Mouret falls in love with Denise, but she refuses to become his mistress. During the Paradise's triumphant final sale, he offers marriage rather than an affair, and Denise, who is preparing to leave, admits that she loves him and accepts.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6215,7 +6215,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6228,7 +6228,7 @@
       "recaps": {
         "ending": "Marguerite's letters reveal that she left Armand only after his father privately appealed to her. Monsieur Duval argued that the scandal surrounding the couple threatened the respectable marriage planned for Armand's sister. Marguerite accepted the permanent loss of the man she loved and made her return to Parisian society look voluntary, allowing Armand to believe she had chosen wealth over him. His retaliatory cruelty therefore struck her while she was already sacrificing herself for his family. Her illness worsened after he left Paris, and most former admirers abandoned her as her money disappeared. She died with Julie Duprat and Nanine among the few people still caring for her, leaving Armand her written explanation. After returning, Armand learns the truth too late. The narrator accompanies him when Marguerite's body is exhumed so it can be moved to a permanent grave; the sight confirms the finality of the loss and overwhelms him. Armand eventually returns to his father, carrying both grief and remorse, while the narrator preserves Marguerite's story as evidence of a generosity that her social reputation had concealed.",
         "in_short": "After the celebrated courtesan Marguerite Gautier dies, an unnamed narrator meets her grieving former lover, Armand Duval, and records his story. Armand had pursued Marguerite despite her illness and the wealthy men who supported her. She returned his love, abandoned much of her expensive Parisian life, and shared a quiet summer with him in the country. Armand believed their happiness ended because she preferred luxury, and in anger he publicly humiliated her before leaving Paris. Only after her death does he learn that his father had persuaded her to separate from him so their relationship would not damage the marriage prospects of Armand's sister. Marguerite had accepted disgrace and heartbreak to protect his family, then died in debt and increasing isolation. Her letters explain the sacrifice Armand misunderstood. He returns too late, witnesses the transfer of her remains to a permanent grave, and is left with remorse for the cruelty he directed at a woman who had given him up out of love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6374,7 +6374,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6387,7 +6387,7 @@
       "recaps": {
         "ending": "After identifying the creature beneath Diana's Grove, Adam prepares to destroy its refuge with explosives while Sir Nathaniel helps him interpret the danger. Lady Arabella, now openly revealed as the human form associated with the ancient white worm, returns to the pit during a violent storm. Adam's charges detonate as lightning strikes across the district, tearing apart Diana's Grove and killing the monster. Caswall's tower at Castra Regis is also destroyed, bringing his destructive campaign of mental domination to an end. Lilla and Oolanga have already died in the struggle, but Adam, Mimi, Richard Salton, and Sir Nathaniel survive. Adam and Mimi are left together, freed from both Caswall's persecution and the predatory force that had haunted the neighborhood.",
         "in_short": "Adam Salton returns from Australia to live with his great-uncle in an English district dominated by ancient estates and older legends. He befriends Sir Nathaniel de Salis and falls in love with Mimi Watford, whose cousin Lilla is being subjected to the obsessive mental influence of Edgar Caswall, the new master of Castra Regis. At nearby Diana's Grove, Lady Arabella March conceals a monstrous connection to a vast white worm dwelling beneath the estate. Caswall's experiments with mesmerism and an enormous kite grow increasingly destructive; Lilla dies under the pressure of his attack, while Arabella kills Caswall's servant Oolanga when he threatens her secret. Adam and Sir Nathaniel trace the supernatural danger to the Grove. Adam mines the site with explosives, and during the final storm Diana's Grove and Caswall's tower are destroyed. The white worm, Arabella, and Caswall perish, leaving Adam and Mimi alive to begin their life together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6713,7 +6713,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -6728,7 +6728,7 @@
       "recaps": {
         "ending": "Richter, Sion, Yoshi, Daniella, Alma, and Futen return from the Time Worn Dungeon alive. The Crypt Mistress is dead, the Tefonim dead are free, and Sion has accepted that Kurian's murder was not solely his fault. Richter is level 18, has chosen mastery of life, and carries the dungeon's Magic Core, though the lower stairway and the eaters below remain unexamined. Hisako cures the party's cankerous rot and heals Jitol. Sumiko begins treating Yoshi's lingering internal injury, whose complete effect is still concealed. The larger danger has increased: awakening Richter's place of power will draw and strengthen monsters, bugbears remain in the region, and an eater attack takes priority. Hisako sends Sion and Daniella to investigate, calls for northern wood-elf assistance, and directs Richter to win dwarf support in the Serrated Mountains. Elora and the quickening still require protection, the village's magic forge still needs suitable metal, Modara remains free under Richter's vengeance oath, and the inherited threats involving Xuetrix, Ronan, Count Stonuk, and the remaining captives are unresolved. Randolphus then reports unidentified prisoners in the village.",
         "in_short": "Richter strengthens the Mist Village by planting a blessed seed core, creating a quickening that awakens Elora, the surviving Pixie Queen, and seals an alliance with Hisako's wood sprites. The quickening exposes the village during a lapse in its protective mist, leading to a destructive bugbear assault. The defenders prevail, but Modara escapes and Richter swears vengeance. Richter then enters a Time Worn Dungeon with Sion, Yoshi, Daniella, Alma, and Futen. They overcome traps, undead, and the Crypt Mistress, free the Tefonim dead, and survive Sion's painful trial concerning Kurian's death. Richter gains life mastery and removes the dungeon's Magic Core. After Hisako cures the returning party, she warns that Richter's awakened power will attract stronger monsters. Eaters have attacked, bugbears remain active, and Richter must seek dwarf allies in the Serrated Mountains. Randolphus closes the story by reporting unidentified prisoners at the village.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-land-founding.json
+++ b/data/works-community/0/the-land-founding.json
@@ -209,7 +209,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -224,7 +224,7 @@
       "recaps": {
         "ending": "The book closes with the Mist Village transformed from an empty ruin into a working settlement of about two hundred and ninety colonists, its first great building raised and farms, mines, and an administrative structure under way. Richter has grown from level 8 to level 10 across the second half, added dark magic to a broad, multi-school skill set, and revealed his place-of-power status to a small circle of trusted allies. His companions are secure: Sion, recovering from a leg wound, and Terrod, who has abandoned Law for good after losing his home and his friend Jeremy in the rescue of his beloved Isabella, now safe at the village. That rescue's cost lingers: Jeremy is dead, and the Night Blades' leader Ronan escaped alive, wounded, and aware of everyone's identities, an open threat in Law alongside the robbed Count Stonuk. Richter has formally allied the Mist Village with Hisako's wood sprites. The final scene turns to a new danger: goblin and bugbear war-bands encroaching on the forest of Nadria from the Firetip Mountains, which Richter and Sion set out to confront. Left for the next book: the reason for that incursion; retaliation from Ronan or Stonuk; the captives the gang sold who remain unfound; the unplanted Seed Corps and an unidentified magic book; Xuetrix's owed favor; Sion's deflected royal background; and the exiled prince and his conspiracy, still unknown to Richter.",
         "in_short": "A top-ranked player of a virtual-reality game touches a ritual pedestal and is transported, body and soul, into the real world the game imitated, part of an exiled prince's scheme to destroy that world and escape his prison. Renamed Richter and marked a Chaos Seed, he starts over at level one. He allies with the wood sprites and their Hearth Mother, Hisako, gains the loyal sprite companion Sion, and defeats a goblin host and its necromancer, which wins him the Mist Village, a ruined settlement built on a place of power. Seeking colonists, he travels to the discriminatory kingdom of Eve, joins an innkeeper named Terrod in fighting a slaver gang, and rescues Terrod's beloved Isabella from a noble, at the cost of a friend's life and leaving the gang's leader, Ronan, alive and hostile. Richter resettles nearly three hundred human and non-human colonists at the Mist Village, allies it with the sprites, and, as the book ends, accepts a quest to drive a new goblin and bugbear incursion out of the forest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -505,7 +505,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:177424599X",
@@ -517,7 +517,7 @@
       "recaps": {
         "ending": "Cullen defeats the dread knight in chapter 38, clearing the Land of the Undying Lord and removing every surviving challenger from danger. The clear interrupts an orc's killing blow against Trent at the fortress. Matthias is the group's recorded loss, having used Sacrificial Pyre to kill a hill troll, the orc commander, and many attackers. Kirstin, Francis, Lyra, Dirk, Joel, Arisa, Keller, Bailey, Alistern, Cullen, Tersa, and Orion survive.\n\nTrent enters the reward hall with Sorrow and Strife broken but stored in hope of repair. The former Al'rashian king who keeps the trial recognizes him as a Dusk Wraith and explains that he is an Al'rashian bond, not a summon. The keeper suspects Trent may have been intended for Lewis Al'dross, but cannot prove it. Trent chooses Three Steps, Self-Clean, three attribute points, and two skill points as his reward. Orion has regained his spirit-summoner class, Tersa and Trent are members of his restored Embra family, and Orion plans to continue Trent's sword training. Trent's original identity, the proper recipient of his bond, the fading connection to Kirstin, and the fate of his damaged weapons remain open.",
         "in_short": "Kirstin receives an amnesiac human boy from a summoning crystal, names him Trent, and nearly breaks his loyalty through neglect and a punishing order. Her brother Michael and Duke Lewis Al'dross protect Trent's secret capacity for seven classes and seven professions, while Sergeant Cullen begins his field training. Trent clears the Burning Lake's Trial of Perseverance and becomes a Survivalist before his companions are swept into the Land of the Undying Lord. Separated from the main party with Tersa, he frees the Al'rashian exile Orion Embra. The three become family through the Rite of Blood, which transforms Trent into an Al'rashian and restores Orion's spirit-summoner power. They rejoin Francis's besieged group after Matthias sacrifices himself against an orc assault. Cullen kills the trial's dread-knight guardian, saving the survivors. In the reward hall, the keeper explains that Trent is an Al'rashian bond rather than a summon, though his origin and intended partner remain uncertain.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -681,7 +681,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -694,7 +694,7 @@
       "recaps": {
         "ending": "Rincewind reaches the place where the continent was made: a cave of paintings in which what is painted becomes real, and where the rain was drawn out of the world long ago. Doing the one useful thing of his career, he puts the rain back, and it falls on the last continent for the first time in an age, breaking the drought and ending the crisis Scrappy had been steering him toward from the day he arrived. Scrappy, having got what the continent needed out of him, goes back to being a kangaroo, or something that resembles one. The wizards, whose visit to the island in the distant past is part of why the continent is the way it is, get home to Unseen University, and the God of Evolution is left with a new and enormously labour-saving idea about reproduction and a great many creatures still to design. The Librarian's true name is finally supplied, he is cured, and he returns to his shelves as an orangutan and stays that way, since it has always suited him. Rincewind ends up back at Unseen University with a post of his own at last, no longer a student who never graduated, and, for the moment, nothing chasing him.",
         "in_short": "Rincewind is stranded on the last continent, a hot, red land at the Rim of the Disc where it has not rained for longer than anyone can remember, and where a talking kangaroo named Scrappy keeps telling him that fixing this is his job. At Unseen University the Librarian falls ill and begins shape-shifting uncontrollably; curing him requires his true name, which only Rincewind is likely to know. Hunting for him, the Archchancellor and several senior wizards step through a doorway with the housekeeper Mrs Whitlow and arrive on a remote island thousands of years in the past, where the God of Evolution is designing creatures one at a time and has never thought of sex. Their presence in the past is part of why the last continent turned out as it did. Rincewind meanwhile is mistaken for a wanted man, nearly hanged, chased across the outback and into the city of Bugarup, where the local university and its Archchancellor Bill Rincewind expect him to end the drought. He reaches a cave whose paintings make things real and puts the rain back. The wizards get home, the Librarian is cured, and Rincewind is finally given a post.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -880,7 +880,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -893,7 +893,7 @@
       "recaps": {
         "ending": "Bosch establishes that Arno Conklin had loved Marjorie but did not strangle her. Gordon Mittel, determined to protect Conklin's political future and his own power, arranged Marjorie's murder and the suppression of the case. Claude Eno and other participants corrupted the original inquiry, while Johnny Fox's later death removed another threat to the cover-up. Bosch confronts Mittel after following the surviving financial and witness trail; Mittel's effort to contain the renewed investigation also connects the old conspiracy to present violence. The truth is clearer than the prosecutable evidence, and Bosch cannot give his mother the conventional resolution he wanted. He does learn more fully about his parentage and the family from which he had been separated, including the existence of a half brother. Department therapy forces him to admit that his anger and solitary habits are not separate from his mother's death. Sylvia does not resume their relationship. Bosch moves toward reinstatement and begins rebuilding his earthquake-damaged house, accepting that solving the past will not restore what it took from him.",
         "in_short": "Suspended for attacking Lieutenant Harvey Pounds and required to undergo therapy, Harry Bosch has neither police authority nor a secure home after earthquake damage. He uses the enforced absence from homicide work to reopen the 1961 strangling of his mother, Marjorie Lowe. The old file leads to her friend Meredith Roman, the later death of Johnny Fox, retired investigators, and a political circle built around former prosecutor Arno Conklin and strategist Gordon Mittel. Bosch travels to Florida, reconstructs missing interviews and financial links, and discovers that the original inquiry was deliberately redirected. His unauthorized work brings present-day retaliation and further loss, while sessions with Carmen Hinojos force him to connect the case with his own anger and isolation. Bosch eventually distinguishes Marjorie's lover from the people who protected a political future by arranging her death and corrupting the investigation. He gains the truth but little evidence capable of producing a normal prosecution. His relationship with Sylvia remains over, and he turns toward reinstatement and rebuilding his damaged house.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1020,7 +1020,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1031,7 +1031,7 @@
       "recaps": {
         "ending": "The book ends on a victory turned to grief. El's plan achieves the impossible: nearly the entire senior class survives graduation and reaches the outside world together, a feat the Scholomance has never permitted, and the alliance of independents and enclavers she built holds when it matters most. Aadhya, Liu, Liesel, Chloe, and the others get out. But the cost is Orion Lake. When the maw-mouth Patience blocks the final escape, Orion stays behind to hold it off, and El is dragged out through the graduation gates against her will; the doors seal with him still inside the school, alone with the horror. El arrives home in the Welsh commune alive and graduated but broken, her mother's old warning to keep away from Orion now bitterly fulfilled. Several threads are left wide open: whether Orion can possibly be alive or recovered; the unexplained strangeness of his hunger for mals and what it means about him; the unnatural surge of maleficaria that plagued the school; and El's own unfulfilled potential and the enclave-building spell she still carries. She closes the book not resigned but resolved, determined to get back to Orion whatever it takes, with no idea yet of the far larger truths that search will force her to uncover.",
         "in_short": "In her final stretch at the Scholomance, El Higgins finds the school itself steering her toward the students no enclave would bother to save, and she slowly conceives an idea no senior class has attempted: getting the entire class out alive at graduation, not just the privileged few. With Aadhya, Liu, Chloe, and the formidable Liesel, and with her own suppressed power for mass destruction, she forges a fragile alliance between independents and enclavers and drills them for a coordinated escape, even as maleficaria mass in unnatural numbers and her relationship with Orion Lake deepens. The plan succeeds where nothing like it ever has, driving nearly the whole class toward the exit together. But at the graduation hall the ancient maw-mouth Patience blocks the way, and Orion stays behind to hold it off while El is pulled out through the gates. The doors seal with him trapped inside. El reaches the outside world graduated and alive but devastated, vowing to find a way back for the boy she was warned to avoid and could not.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1181,7 +1181,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1194,7 +1194,7 @@
       "recaps": {
         "ending": "At the home of the gods the Silver Horde get exactly what they came for, an audience with the people who set the rules, and the bomb is in place with its fuse burning. What stops Cohen is not the gods and not the argument from the crew of the Kite but the minstrel, who has spent the whole journey turning the Horde's last march into a song, and who sings it. Cohen hears what his life sounds like from outside and decides that this is not the ending it needs. The fuse cannot be put out, so the bomb is carried clear and detonated where it will do no harm to the world, and the standing wave of magic that keeps the Disc alive is left intact. The blast throws Leonard's flying machine far off course, and its crew reach the Disc's moon before they can begin the journey home; they get back, and the Kite comes down safely. Leonard returns to his comfortable confinement with a new set of drawings and a ceiling he is quietly proud of, Carrot to the Watch, Rincewind to the University. The Horde survive, decline to go back to an imperial throne, and set off again toward somewhere nobody has been. The minstrel goes home with the only thing he ever really wanted, which is a song worth singing, and becomes famous for it.",
         "in_short": "Cohen the Barbarian, now Emperor of the Agatean Empire and bored beyond bearing, gathers the Silver Horde for one last deed: to carry a barrel of explosive up Cori Celesti to Dunmanifestin, the home of the gods, and return fire to them with interest, in payment for the raw deal handed to humanity. They kidnap a minstrel to write the saga. In Ankh-Morpork the wizards work out that blowing up the gods' home would collapse the magical field that holds the Disc together and kill everything on it within days. Lord Vetinari turns to Leonard of Quirm, who designs a flying machine, the Kite, launched over the Rim and slung around the world to reach the mountain first. Its crew are Leonard, Captain Carrot and Rincewind, with the Librarian stowed away. The Horde climb to the gods, losing one of their number and shedding Evil Harry Dread, who betrays them because his profession requires it. At the peak the minstrel's song changes Cohen's mind; the lit bomb is carried clear and destroyed harmlessly, the Kite is blown as far as the moon, and everyone gets home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1347,7 +1347,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1358,7 +1358,7 @@
       "recaps": {
         "ending": "The book closes with the Battle of Cynuit. Trapped against a Danish host led by Ubba Lothbrokson, a West Saxon force fights a desperate shield wall, and Uhtred - in his first real battle in the wall - kills Ubba in single combat, a feat that should make his name. Instead Odda the Younger claims the victory for himself, and Uhtred is left with the glory stolen and little reward. He remains bound to Alfred's Wessex, uneasily married to the devout Mildrith and still an outsider among the Saxons, while his true home, Bebbanburg, stays in the hands of his usurping uncle Aelfric far to the north. His foster brother Ragnar the Younger lives, and the bond between them holds, but Ragnar's father is dead and unavenged and the man who burned him, Kjartan, still lives. Uhtred stands at the start of a longer struggle: a Saxon by birth serving a Christian king he does not much like, a Dane by upbringing grieving a Danish father, with a stolen inheritance and an unpaid blood debt waiting in the north.",
         "in_short": "Osbert, second son of the ealdorman of Bebbanburg in Northumbria, is renamed Uhtred and made heir after his brother is killed by Danish raiders. When his father dies fighting the Danes at Eoferwic, the boy is captured by Earl Ragnar the Fearless, who raises him as his own; Uhtred grows to love the Danish life and takes an English captive, Brida, as his companion. After a banished shipmaster, Kjartan, burns Ragnar's hall and kills him, Uhtred drifts south into Wessex and the service of the pious King Alfred, marries the Saxon Mildrith, and is caught in the war between Danes and Saxons. Reunited with his foster brother Ragnar the Younger, he survives Guthrum's treachery and, at the Battle of Cynuit, fights his first shield wall and kills the renowned Danish warlord Ubba, though another man steals the credit. He ends the book a young warrior torn between the people who bore him and the people who raised him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1910,7 +1910,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09FR6RBVY",
@@ -1922,7 +1922,7 @@
       "recaps": {
         "ending": "Teriarch revives Ryoka after the Necromancer's death-word destroys her heart. He destroys the undead woman servant's body and compels the Necromancer to spare Ryoka and her associates, but refuses to begin a wider war. He believes Ivolethe's spirit survived the destruction of her body and was banished by the Fae king. Ryoka returns for the funerals, identifies the attackers, and then leaves Liscor because she believes staying will endanger her friends. Erin's expanded inn survives the assault, gains reinforced structure magic, and becomes part of Liscor's preparations as the Goblin Lord arrives nearby. The surviving skeletal mage remains in the Necromancer's service. Elsewhere, Flos's war continues after his first victory, River Farm endures as Laken's costly young empire, Geneva's survivors establish the United Nations, and the Antinium pursue restored queen-making and wider recognition. Magnolia Reinhart and other powers are mobilizing, but Liscor faces the immediate approach of the Goblin Lord without a settled resolution.",
         "in_short": "Flos restores his kingdom and defeats a six-state coalition, but his use of captive sales divides him from Trey. Around Liscor, Erin expands the Wandering Inn, Pawn leads individual Antinium through heavy losses, Xrn advances plans to restore the Antinium's future, and the Horns recommit to one another. The Goblin Lord annihilates two armies with the Necromancer's aid while remaining hostile to his master. Laken turns River Farm into a recognized empire after a costly goblin victory. In Baleros, Geneva, Okasha, Ken, Aiko, and Luan survive the destruction of a neutral medical camp and found the United Nations. Undead impostors infiltrate Liscor and target Ryoka, killing the young Gnoll knight and two adventurers. Ivolethe sacrifices her body to save Ryoka, who dies from the Necromancer's spell, but Teriarch revives her, places her under his protection, and forces the Necromancer to promise not to harm her or her associates. Ryoka leaves Liscor as the Goblin Lord's army reaches its approaches.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2106,7 +2106,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2119,7 +2119,7 @@
       "recaps": {
         "ending": "The surviving emigrants dwindle until Lionel, Adrian, and Clara are the last three members of their English community. They reach Italy and find its cities empty. Hoping that some people may remain elsewhere, they set out by boat, but a storm wrecks the vessel. Adrian and Clara drown, while Lionel alone reaches shore. He searches the Italian towns and leaves written notices for any survivor, but receives no answer. In Rome in the year 2100, surrounded by the records and monuments of a vanished civilization, he accepts that he may be the last human alive. Refusing simply to wait for death, he gathers books and supplies and leaves with a sheepdog as his companion. He plans to sail around the Mediterranean and beyond in search of another person, ending his chronicle without knowing whether anyone remains to find it.",
         "in_short": "In a republican England of the late twenty-first century, the orphan Lionel Verney is befriended by Adrian, son of the last king. Lionel marries Adrian's sister Idris, while the soldier-statesman Raymond marries Lionel's sister Perdita. Raymond later returns to war in Greece and dies at Constantinople; Perdita then takes her own life. A plague spreading from the east reaches Europe and defeats every political, religious, and scientific response. Adrian leads a shrinking group out of England, while death strips Lionel of Idris, their children, and nearly every companion. The refugees cross France and Switzerland into Italy, but continue to die. At last only Lionel, Adrian, and Raymond's daughter Clara remain. A storm wrecks their boat and kills Adrian and Clara. Alone in Rome in 2100, Lionel records the end of humanity as he knows it, then sails away with a dog and a store of books to search for other survivors.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2294,7 +2294,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2307,7 +2307,7 @@
       "recaps": {
         "ending": "The Delawares recognize Uncas as the heir of an honored Mohican line and rally behind him, but their pursuit cannot save Cora. At the cliffside refuge, Cora refuses Magua; another Huron kills her, and Uncas is killed trying to reach her. Magua in turn kills that warrior and attempts to escape, but Hawkeye shoots him as he hangs from the rocks. Alice is rescued and reunited with Heyward and her father. The Delawares hold funeral rites for Cora and Uncas, mourning them together and imagining a bond beyond death, while Munro grieves and Hawkeye remains beside Chingachgook. With his son gone, Chingachgook calls himself alone, the last of the Mohicans. Hawkeye answers that friendship still joins them, but the close offers consolation rather than restoration: the rescue succeeds only in part, the younger Mohican line has ended, and the surviving families leave marked by the violence of the frontier war.",
         "in_short": "During the French and Indian War, Major Duncan Heyward escorts Colonel Munro's daughters, Cora and Alice, toward besieged Fort William Henry. Their Huron guide Magua betrays them, but scout Hawkeye and his Mohican companions Chingachgook and Uncas repeatedly protect and rescue the party. They reach the fort, only to endure its surrender to Montcalm and the massacre of the departing British by France's Native allies. Magua abducts the sisters, driven by revenge against Munro and a desire to make Cora his wife. Hawkeye's group follows through Huron and Delaware territory. Disguises and escapes free Alice, while Uncas is revealed before the Delawares as the heir of a revered Mohican line and leads a pursuit of Magua. Cora refuses Magua and is killed by a Huron; Uncas dies trying to save her. Hawkeye shoots the fleeing Magua. Alice survives, but the joint funeral of Cora and Uncas ends the rescue in grief, and Chingachgook mourns his son as the last of the Mohicans.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2485,7 +2485,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2498,7 +2498,7 @@
       "recaps": {
         "ending": "Uncas pursues Magua and the captive Cora to a cliff above the Delaware settlement. When Cora refuses to go farther, one of Magua's companions kills her. Uncas kills that warrior but is then stabbed by Magua. Hawkeye shoots another fleeing Huron, and Magua dies after Chingachgook wounds him and Hawkeye sends him from the cliff with a final shot. Alice and Heyward survive, but Colonel Munro is left to mourn Cora. The Delaware and Mohican communities hold funeral rites for Cora and Uncas, recognizing the bond that had grown between them while also acknowledging that their hopes cannot be fulfilled in life. After Uncas is buried, Chingachgook grieves that he is now the last of his family line. Hawkeye answers that his old friend is not alone while Hawkeye lives. The survivors depart, and Tamenund reflects sadly on the passing of the people and order he has known.",
         "in_short": "During the French and Indian War, Major Duncan Heyward escorts sisters Cora and Alice Munro toward their father's besieged Fort William Henry. Their Huron guide Magua betrays them, but the scout Hawkeye and his Mohican companions Chingachgook and Uncas repeatedly rescue the party. The travelers reach the fort, only for Colonel Munro to surrender it to the French. During the evacuation, allied Huron warriors massacre the British column and Magua carries off the sisters. Hawkeye's group rescues them once, but Magua later escapes with Cora to a Delaware settlement. Uncas is recognized there as a leader of revered lineage, and the Delawares support a pursuit. In the final chase, Cora is killed by one of Magua's followers; Uncas kills her attacker but is killed by Magua. Hawkeye and Chingachgook then kill Magua. Alice and Heyward survive, while the novel closes with funerals for Cora and Uncas and Chingachgook mourning the loss of his son.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2667,7 +2667,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2680,7 +2680,7 @@
       "recaps": {
         "ending": "In the throne room of Olympus, Kronos, wearing Luke's body, overpowers Percy, but at the decisive moment Luke's own will breaks through. Percy, understanding that the prophecy's single choice was never really his to make, hands Luke the knife of Annabeth. Luke drives it into his own one mortal weak point, killing himself to destroy Kronos and scatter the Titan lord once more; he dies a hero, redeemed. The gods, having beaten the monster Typhon with Poseidon's help and turned the tide when Nico brings his father Hades and the army of the dead into the battle, are saved and Olympus stands. Offered godhood as a reward, Percy declines. Instead he demands that the gods claim and acknowledge all their demigod children, and that the minor gods and Hades be given proper honor and cabins, so no future child feels abandoned as Luke did. Camp Half-Blood begins building new cabins for the once-slighted gods. Rachel Elizabeth Dare becomes the new Oracle of Delphi, the ancient curse on it lifted, and delivers a fresh great prophecy that hints at dangers still to come. Percy and Annabeth, having survived together, become a couple as the war ends.",
         "in_short": "As Percy nears sixteen and the great prophecy, Kronos in Luke's body launches all-out war. Percy and Beckendorf destroy the enemy's ship, but Beckendorf dies. Following Nico's plan, Percy bathes in the River Styx to become invulnerable except at one hidden point, with Annabeth as his human tether. When Kronos attacks New York and the gods are drawn off to fight the monster Typhon, Manhattan's mortals are put to magical sleep, and Percy leads the young demigods to defend the city and the gateway to Olympus. Through days of battle they are worn down; a spy is exposed as Silena Beauregard, who dies making amends, and Clarisse then slays the drakon. Kronos reaches Olympus, where Annabeth is wounded shielding Percy's weak point. In the throne room, Luke reclaims his will, takes Annabeth's knife, and kills himself at his own mortal spot to destroy Kronos. Typhon is beaten, Hades brings his army, and Olympus survives. Percy refuses immortality, wins honor for all demigods and minor gods, and Rachel becomes the new Oracle.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2821,7 +2821,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2834,7 +2834,7 @@
       "recaps": {
         "ending": "After humanity has merged into a single immaterial mind, the stars go dark and space itself approaches its final state. The collective human consciousness joins AC, leaving the computer alone to finish the problem it has considered throughout cosmic history. With time and matter gone, AC finally discovers how entropy can be reversed, but there is no remaining human being to receive the answer. It therefore demonstrates the solution by initiating a new creation, bringing light back into existence and beginning a universe anew.",
         "in_short": "In 2061, two attendants ask Multivac whether the increase of entropy can be reversed and receive only an answer that the available information is insufficient. Across immense stretches of future history, humanity expands from Earth to other worlds, throughout the galaxy, and eventually across the universe, while successive descendants of Multivac become more capable and less tied to matter. Each era asks essentially the same question as stars age, and each computer gives the same response. Humans ultimately abandon bodies and merge into one consciousness, then join with the final Cosmic AC as the universe becomes dark and empty. After humanity and the universe have ended, AC at last solves the problem. Unable to report its answer, it acts on it, creating light and beginning the cosmos again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2954,7 +2954,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2967,7 +2967,7 @@
       "recaps": {
         "ending": "Ronnie learns that Steve is dying of cancer and remains with him after Jonah returns to New York. Their remaining time repairs the estrangement created by the divorce. Steve has been composing a piece of music but lacks the strength to finish it, so Ronnie returns to the piano, completes the work, and plays it for him. He dies knowing that she has recovered both their bond and her own connection to music. The truth about the church fire also emerges, clearing Steve of the blame he quietly carried and exposing Marcus's responsibility. Ronnie later resumes her education and plans to attend Juilliard. Will, who has left for Vanderbilt, reconnects with her, and their relationship gains another chance. The summer ends in bereavement, but Ronnie leaves reconciled with her father and no longer defined by anger.",
         "in_short": "Seventeen-year-old Ronnie Miller is sent with her brother Jonah to spend a summer with their estranged father, Steve, in North Carolina. While protecting a sea-turtle nest, she falls in love with Will Blakelee and separates herself from the dangerous beach crowd led by Marcus. A false shoplifting accusation, tension with Will's family, and secrets surrounding a church fire test her new relationships. Ronnie then discovers that Steve is terminally ill. She stays to care for him, returns to the piano she abandoned after the divorce, and finishes the composition he can no longer complete. Steve dies after hearing her play it. With the church-fire truth revealed, Ronnie returns to New York, prepares for Juilliard, and reconnects with Will, carrying forward the reconciliation her final months with her father made possible.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3074,7 +3074,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3087,7 +3087,7 @@
       "recaps": {
         "ending": "Haber uses the Augmentor to give himself George's reality-shaping power, convinced that he can direct it more successfully than George. His induced effective dream instead dissolves the world's coherence: places, people, and incompatible versions of history begin blending into a nightmare. George makes his way through the instability and switches off the machine. Reality settles into an imperfect composite world that retains elements created by the earlier dreams, including the aliens. Haber survives physically but is hospitalized in a shattered mental state. George no longer carries the same burden of effective dreaming and builds an ordinary life working for an alien-run business. He meets Heather again, but she is not precisely the woman who was his wife in another reality and does not share those memories. George accepts the difference rather than trying to recreate what was lost. He asks her to join him for a meal, leaving them with the possibility of forming a relationship freely in the world that now exists.",
         "in_short": "George Orr's dreams sometimes rewrite reality, leaving him alone with memories of the discarded worlds. Ordered into therapy after using drugs to avoid sleep, he is treated by dream researcher William Haber, who discovers the power and uses hypnotic suggestions to improve society. Each command produces disastrous side effects: reducing population creates a history of mass death, ending racial difference makes humanity uniformly gray, and seeking peace brings an alien threat that unites Earth through fear. Lawyer Heather Lelache witnesses a change and becomes George's ally, though revisions repeatedly alter her identity and her relationship with him. The aliens eventually prove capable of coexistence and understand dreaming better than Haber. Determined to control the power himself, Haber uses his machine to dream effectively and nearly destroys reality in a flood of incompatible forms. George shuts the machine down. Haber is left mentally broken; the world stabilizes as a strange composite. George later meets this reality's Heather and chooses the chance of a new relationship without trying to force the past back into existence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3256,7 +3256,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3269,7 +3269,7 @@
       "recaps": {
         "ending": "The force behind the killings is traced to Dominga Salvador's forbidden vaudun work and Harold Gaynor's effort to obtain a family secret from a long-dead ancestor. Gaynor has treated human lives as material for the sacrifice required by that animation, and Wanda is killed after helping Anita. Gaynor's men hold Anita at a cemetery and force the ritual forward. The fresh sacrifice gives Anita far more power than an ordinary raising. Instead of producing only the ancestor Gaynor wants, she calls the cemetery's dead and turns that power against her captors. Gaynor and his enforcers are overwhelmed by the dead they sought to exploit. Dominga's role in creating and controlling the murderous zombie is exposed and her operation is ended. Anita solves the police case and prevents Gaynor from obtaining the information he wanted, but she does so by using a scale of power that confirms how dangerous her own animator abilities can become under the wrong conditions. Jean-Claude remains master of St. Louis and continues pressing his claim that Anita is his human servant; she continues to reject it.",
         "in_short": "Anita refuses millionaire Harold Gaynor's request to raise an ancestor because a corpse that old requires a human sacrifice. At the same time, Dolph's police team asks her to examine a series of deaths caused by an abnormally powerful zombie. Her inquiries lead through vaudun practitioner Dominga Salvador, Anita's former teacher Manny Rodriguez, newcomer John Burke, and Wanda, a woman with knowledge of Gaynor's plans. Anita learns that Gaynor wants a secret from his ancestor and is prepared to supply the necessary victim, while Dominga's forbidden work lies behind the killer zombie. Gaynor's men seize Anita and use Wanda's death to power the final raising. Anita draws on that power to call the cemetery's dead and turns them against Gaynor and his enforcers. The murder case and Gaynor's scheme end, while Anita remains marked by Jean-Claude and troubled by the destructive reach of her own abilities.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-legacy.json
+++ b/data/works-community/0/the-legacy.json
@@ -330,7 +330,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0747VMPCH",
@@ -342,7 +342,7 @@
       "recaps": {
         "ending": "Kael has escaped the Dead Sisters' mountain prison with Kia, Galen, and the older wizard. They reach the coast, steal a ship, and use magic to flee, but Kia is dangerously feverish from an infected wound. Kael carries the soul reapers, which can strengthen him after a kill, and remains weakened and troubled by the violence and underworld power his captivity awakened. The feared woman imprisoned beneath the mountain reaches the surface too late to stop the ship. She plans to seek her clan, pursue Kael, and take revenge on the witch who held her.\n\nGideon, Ember, Max, Elisa, Gideon's daughter, and the Northman remain separated from Kael. Their immediate mission is now to retrieve the king's daughter and her lady-in-waiting from the Wildlands, even though crossing the border may ignite a war. Ember is alive but still recovering, and her uncontrolled Fae dream-walking and realm-jumping make her a target for other powers. The Cardessa and the wider Dead Sisters remain free, Dorma Sai is preparing to intervene, and the prophet's warning of endangered capitals and Gideon's unexplained mistake remains unresolved.",
         "in_short": "Gideon spares his Black Sun-born son Kale by exiling him to Earth, but twenty years later the Dead Sisters drag the adult Kael back to Talona with his wife Ember and their friend Max. Separated from them, Kael learns he is a death wizard and is eventually imprisoned and tortured by witches and anti-magic invaders. He refuses to murder fellow prisoners, escapes with Kia, Galen, and an older wizard, and claims two dangerous soul-reaper blades before the group steals a ship. Ember joins Gideon's search and is revealed as the last Fae, awakening unstable powers that are changing magic. The prophet says Gideon erred in his treatment of Kael, with harmful consequences for what lies ahead, although the error itself remains unclear. At the close, Kael sails away while Kia fights an infected wound, an ancient survivor prepares to pursue him, and Gideon's party risks war by entering the Wildlands to recover the captured princess.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -518,7 +518,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -531,7 +531,7 @@
       "recaps": {
         "ending": "Wulfgar is lost beneath the collapse caused during the fight with the yochlol, and the companions recover Aegis-fang but no body. They return to the defense of Mithral Hall carrying grief they have no time to resolve. The drow assault is ultimately broken: Vierna dies, her religious purpose fails, and Jarlaxle withdraws the surviving mercenaries rather than sacrifice them to a lost cause. Drizzt also survives his renewed contest with Artemis Entreri; the assassin falls away during their last encounter and is left behind, though no certain proof of his death remains. Mithral Hall stays in Bruenor's hands, but victory feels like bereavement rather than celebration. Catti-brie's engagement has ended with Wulfgar's apparent death, Bruenor has lost the man he regarded as a son, and Drizzt carries guilt for the chain of events that drew his enemies to the hall. The surviving friends close ranks around one another while accepting that the drow threat has not been permanently ended.",
         "in_short": "Life in reclaimed Mithral Hall is disrupted when Drizzt's sister Vierna leads a drow expedition to seize him for sacrifice, aided by Jarlaxle's mercenaries and the assassin Artemis Entreri. The attack catches the companions amid a personal crisis: Wulfgar's jealousy has poisoned his engagement to Catti-brie. Regis is taken, Drizzt and Catti-brie pursue the raiders through the tunnels, and Entreri renews his effort to prove himself against Drizzt. When a yochlol threatens the companions, Wulfgar holds the creature and the collapsing chamber long enough for the others to escape; Aegis-fang is recovered, but he is buried and believed dead. The survivors return to help defend Mithral Hall. Vierna is killed, Jarlaxle abandons the failed assault, and Entreri falls during his final clash with Drizzt without leaving certain evidence of his death. Bruenor retains the hall, but the company is shattered by Wulfgar's apparent death and Drizzt is left fearing that his own past will keep endangering everyone he loves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -665,7 +665,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -678,7 +678,7 @@
       "recaps": {
         "ending": "In the closing stretch, Junah fully recovers the unforced swing and inner steadiness that Bagger has been teaching him to recognize. When his ball moves before a shot, Junah calls the penalty on himself although doing so may cost him the match; the act confirms that his return is moral and spiritual rather than merely athletic. Bagger quietly leaves after telling Junah that he no longer needs a guide. Junah completes the contest on equal terms with Bobby Jones and Walter Hagen, and the match becomes a treasured Savannah legend. He does not keep the restored gift as a route to celebrity, but he returns to life and to connection with others. Hardy carries the memory into old age. The framing story makes Bagger's role larger than that of a caddie: he is the guide who appears when a person must move through fear, recover an authentic self, and ultimately face death.",
         "in_short": "During the Depression, Adele Invergordon tries to save her family's Krewe Island resort by staging a golf match between champions Bobby Jones and Walter Hagen. Savannah demands a local entrant, and the choice falls on Rannulph Junah, a former golfing prodigy whose First World War service left him traumatized and withdrawn. A mysterious man named Bagger Vance offers to caddie for him. As the exhibition proceeds, Junah initially struggles, but Bagger teaches him to stop forcing his game and rediscover the authentic swing arising from full attention to the field around him. Junah regains both his skill and his desire to participate in life. Near the finish he honestly calls a penalty on himself, even at the risk of losing, and Bagger departs once his guidance is no longer needed. Junah completes the celebrated match alongside Jones and Hagen, while the boy Hardy Greaves preserves the story into old age as an account of spiritual recovery as much as sport.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1162,7 +1162,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -1175,7 +1175,7 @@
       "recaps": {
         "ending": "Frankfurd survives its first horde, but the wolf-led sewer infiltration and the collapse of command leave the city badly damaged. Randidly kills the Black Tusk Wolf Raid Boss when it attacks Tessa. Tessa chooses to remain in Frankfurd, preserving their unresolved division over violence and the System. Raina is scarred by acid and knowingly turns her influence into a citywide call that drives civilians into a lethal frenzy. Expecting consequences, she asks to travel north with the Donnyton group. Alana secures trade and recruitment access for Donnyton and carries Randidly's permanent southern blessing, while Devin helps command the returning fighters. Donnyton itself has advanced to a trainee village and can defend itself through Donny, Daniel, Dozer, Decklan, Annie, Lyra, Sam, Regina, and the growing Arbor network. Its own tribulation remains hidden and may be influencing distant threats. Randidly completes Potion Making II, advances Spearmastery II, identifies low Resistance as his main weakness, and chooses to return north to confront that danger. His search for his missing friends remains unresolved, and Shal remains beyond the dungeon exit.",
         "in_short": "When Earth joins the System, classless Randidly Ghosthound is trapped in a high-level dungeon. He survives through paths, potions, plant magic, and Shal's brutal spear training, then returns to Earth and helps establish Donnyton while refusing a class. The village develops its own leaders and survives escalating hordes. Randidly kills Ep-Tal with a soul seed that becomes Thorn, only to learn the Sphinx was another village's tribulation and Donnyton's remains hidden. A lead takes him south to Frankfurd, where he reunites with Tessa, searches unsuccessfully for his missing friends, and supports Alana's delegation. Frankfurd takes classes and triggers a massive horde. Randidly kills the invading Black Tusk Wolf Raid Boss, while the scarred singer Raina drives civilians into a violent defense. Frankfurd survives, Tessa stays, and Raina seeks passage north. Randidly improves his potion and spear paths and returns toward trainee-village Donnyton to face its still-unseen tribulation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1665,7 +1665,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -1678,7 +1678,7 @@
       "recaps": {
         "ending": "The front survives at catastrophic cost. The feathered commander kills Lord Milne, becomes Supreme Commander, and continues without the stone-bodied lieutenant who died protecting her forces. The Nether King is dormant beyond the Great Rift, where the Zurt Brigade is building an unexplained structure around it. The projection-duplicator remains alive but immobilized, while another duplicate of him is comatose. Randidly's partner takes the duplicator's body to restore the ancient original woman, then intends to enter Zurt Brigade training and investigate it. Their relationship remains intact. Randidly is promoted to Commander and assigned five years of punitive service, but begins six months of leave. He sends nearly seven hundred duplicate survivors to Earth, pauses an Alpha Cosmos war by sealing a mountain pass, prepares metal for a new left arm, and matures the Philosopher's Key to level 100. The Key locates the next piece of his fate set on Earth, where he plans to go in four days, though a new military adviser may bring scrutiny. The Red Revival's blood controller remains at large after Orchard's defenders destroy his avatar. Roy and Drake survive their rescue, but Nevaeh and Sydney still face three trapped Nemesai behind enemy lines.",
         "in_short": "Restored to his body on the Aether-Nether front, Randidly develops his three images, rejects the System's control over his Nether, and independently creates the six-part Paradox of the Alchemist fate set. Its Philosopher's Key lets him rebuild allies and manipulate karmic routes. He also saves the Alpha Cosmos from a Nether ritual by making his crimson-gowned companion its new system-like authority. A vast Nether offensive exposes the projection-duplicator's recreated battlefield and its people as real karmic duplicates. Randidly develops a balanced Aether-Nether core and helps stop the duplicator and Nether King, though the King remains dormant beyond the Rift. Lord Milne dies, the feathered commander becomes Supreme Commander, and Randidly receives punitive service but gains leave. His partner departs to restore the ancient original woman and investigate the Zurt Brigade, while hundreds of duplicate survivors escape to Earth. Randidly halts an Alpha Cosmos war, matures the Philosopher's Key, and prepares to return to Earth for the next fate piece. On Earth, a blood-avatar controller escapes and Nevaeh's rescue party remains trapped with three Nemesai.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-legend-of-randidly-ghosthound-11.json
+++ b/data/works-community/0/the-legend-of-randidly-ghosthound-11.json
@@ -498,7 +498,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -511,7 +511,7 @@
       "recaps": {
         "ending": "Earth completes the corrupted-invader trial, receives two tier-one Nexus citizenship tokens, and avoids inheriting the invaders' displaced populations and energy burden. The victory is followed by a Great Rift and a Nether rescue offensive aimed at the subdued Nether King supporting the seventh cohort. Randidly, Karen's veterans, Alana, Hank, Helen, and other defenders eliminate the initial surface probes. The Nexus pinnacle figure then orders Earth protected, and a specialist response is due. Earth is spherical again, with a new zone, unstable borderlands, emerging bubble cities, and a runic tablet that can grant a formal Nexus name. Randidly refuses to claim the available token or control the naming contest. He plans to withdraw Karen and his organization from directing Earth, leaving Tatiana and Naffer to strengthen Karen through alliances. His departure for the Nexus must wait until he deals with the disgraced investigator abandoned on Earth and reclaims Yestix's memories from Ace and Rose. The Great Rift is contained but not resolved, Lyra's freedom remains uncertain, and Ace continues building a rival threat.",
         "in_short": "Randidly returns to Earth and a rapidly growing Karen, determined to prepare the planet without ruling it. His restraint contributes to the catastrophic stadium massacre, after which he gathers Earth's powers and coordinates a corrupted-invader trial secretly designed to expose his Nether. He remakes Ignition Essence as the Stillborn Phoenix, neutralizes the investigator's Aether Mines, and breaks a System limit on his body. Earth clears the trial, but a Great Rift opens and sends Nether forces to the surface. Randidly and Earth's defenders destroy the first incursion, while the Nexus's supreme power orders specialists to protect the planet. With Earth transformed and politically exposed, Randidly decides to leave governance to Tatiana, Naffer, and Earth's factions. Before departing for the Nexus, he intends to kill the stranded investigator and recover Yestix's stolen memories from Ace and Rose.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1342,7 +1342,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -1355,7 +1355,7 @@
       "recaps": {
         "ending": "Earth is officially named Xperia and faces its first Nexus calamity in 150 days. Karen continues as a mobile city under Tatiana, with its council, Academy plans, elite order, and expansion still developing. Nevaeh remains there to work on engravings and recover from trauma, while Alana and Wyvanya pursue an independent public mission. Xperia's strongest fighters are still recovering from the Nether Randidly took after their test. Randidly and Helen reach the Nexus. After healing a Swak-family applicant whom Commandant Wick maimed, Randidly becomes head drill sergeant and must report in six days, although he has already refused to sacrifice recruits merely to obey an order. Vuala remains entangled in Nexus politics, and the relationship between her and the original Vuala is unresolved. Randidly also joins the seventh-cohort overseer, the military woman, and a deep-Web organizer in a covert reform coalition. He holds three territory coins as a contingency, and the group intends to seek the sealed body of a former Nexus power as leverage against the existing order.",
         "in_short": "Randidly eliminates three immediate threats by killing Khan Swak and a Zurt Brigade investigator, while Sydney kills Ace. He then commits to leaving Karen able to govern, educate, expand, and defend itself without him. A vast duos tournament ends with Alana and Wyvanya defeating Paolo and Kale, naming Earth Xperia, and triggering a calamity deadline of 150 days. Recovered memories attribute the System's creation to an Aether historian who imprisoned a pure-energy being, while Randidly learns that the System strips significance from human memories. Xperia's leading fighters test Randidly in a coordinated ambush, lose, and surrender much of their Nether. Tatiana takes charge of Karen, Nevaeh and Alana remain on Xperia, and Randidly travels with Helen to the Nexus. There he heals a military victim, becomes head drill sergeant, refuses unquestioning obedience, and joins a covert coalition seeking enough power to reform the Nexus.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1718,7 +1718,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1731,7 +1731,7 @@
       "recaps": {
         "ending": "Randidly returns from roughly five subjective years in the Nexus depths after only ten Nexus days. His completed Fang of the Primeval Betrayal protects and conceals Xperia, grants him Weight, and can extend that benefit to connected allies. He rejoins Helen, Nevaeh, Vuala, and the accelerated recruits before the Fifth Cohort counteroffensive. Raymond finds his missing brother, but the six-tailed fox rejects him, mortally wounds him, and departs with an unidentified commander tied to a secret program that has domesticated Nether Kings for a thousand years. Randidly stabilizes Raymond, then uses his identity to join the deployed elite unit. As a Nether King begins folding the moon and the Fifth Cohort together, Commandant Wick blocks the opening ritual. Randidly leads the elites toward an incoming impact zone. Veliodun remains at large, the Aether-consuming structure beneath the Nexus is unexplained, the Labor Council tracker remains in Randidly, and his original teacher holds the next fate piece.",
         "in_short": "Randidly turns two hundred Fifth Cohort recruits into a cohesive elite force while resisting political interference from rival Nexus factions. A hired swordsman, later identified as Veliodun, destroys the training compound, takes Randidly's left arm, and eventually strands him deep inside the Nexus. Extreme time distortion and the Visage of Obsession subject Randidly to years of isolation and escalating sacrifices. His separated Shade completes the Fang of the Primeval Betrayal, a runic Nether core that protects Xperia and grants Weight. Randidly returns after only ten Nexus days, reunites with his allies, and prepares the recruits for war. Raymond finds his missing brother and uncovers a secret program involving domesticated Nether Kings, but is mortally wounded. Randidly saves him, assumes his identity, and covertly leads the elites into the opening Fifth Cohort invasion as Commandant Wick stops the Nether King's first moon-folding ritual.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-legend-of-randidly-ghosthound-2-a-litrpg-adventure.json
+++ b/data/works-community/0/the-legend-of-randidly-ghosthound-2-a-litrpg-adventure.json
@@ -484,7 +484,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -497,7 +497,7 @@
       "recaps": {
         "ending": "Donnyton survives the Tribulation of Many Faces, but Nul is killed during the final attack. Lyra replaces him as the village spirit and conceals her changed condition from Randidly. Donnyton retains its commanders, sister-village alliance, crafting base, and new communications, while its ether supply now depends on Lyra. A northbound search party is pursuing Desmond's unverified lead about Ace, Randidly's other missing friend, and Roy. On Telus, Randidly and Shal escape the time-dilated prison with the veteran instructor and surviving attendants. Shal must return in six months to answer a life-debt for those killed during the breakout, and ether starvation may interfere with his unresolved revenge. Randidly remains classless and is recovering aboard the boat on the way to Dearden. He has qualified for the Northern Regional Tournament, but it has not begun. His engraving business is preparing a public sale, while his debt to the displaced style, sealed Carnage reward, internal ether spring, and dangerously unstable soul skill remain open. Tommy continues training, the woman attendant develops a rare four-move skill set, and the blindfolded attendant is ill from ether poisoning.",
         "in_short": "Randidly strengthens Donnyton while refusing a class, survives a Heretic judgment, and helps prepare the settlement to stand without him. Lyra destroys the Tribulation of Many Faces after it attacks Donnyton, but Nul dies and she secretly becomes the replacement village spirit. Answering Shal's summons on Telus, Randidly survives a lethal qualifier, develops personal spear and root skills, builds an engraving business, and reveals a dangerous internal ether source. He and Shal enter a time-dilated prison to gain years of training, then escape with several allies after Randidly deliberately triggers another judgment. Shal accepts a six-month life-debt for the escape deaths and rebukes Randidly for an unnecessary killing. While traveling toward the Northern Regional Tournament, Randidly kills a Thunderhammer artisan in self-defense, continues questioning his use of lethal force, and discovers that emerald crystal has overtaken his unstable soul-skill landscape. The book ends before the tournament, with a public engraving sale planned in two days.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -888,7 +888,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -901,7 +901,7 @@
       "recaps": {
         "ending": "Randidly wins the semifinal by draining the Breaking Dawn contender's borrowed ether, dismantling his sun image, and exploiting the injuries accumulated during their fight. The effort destroys his ability to continue. A hostile projection tries to seize him, but the Steel Feather leader escapes with him at the cost of an arm. The retired veteran then teleports Randidly away, and a returning ally transfers him to his own world to recover and grow stronger.\n\nAt Shal's inn, Lucretia's possession attack has already killed the male spear attendant through the merchant's controlled body. The merchant survives, grieving, and admits that he killed the attendant while possessed. The female attendant leaves to investigate a relative's disappearance that she suspects is connected to the Endless Heat threat. Shal wakes and confirms that Lucretia is his birth mother. After the summoned Earth Golem badly injures the Endless Heat master and departs, Shal and the wounded Steel Feather leader remain together to confront him. Lucretia has entered Randidly's soul world with a captive soul and other resources, so the ivory spear's restraint does not settle her fate. The tournament final, Shal's confrontation, and Dearden's political crisis remain unresolved.",
         "in_short": "Randidly travels to Dearden to preserve Shal's Spear Phantom tradition by placing in a hostile regional tournament. He survives coercion inside his own soul, rebuilds his inner world, develops new spear techniques, and reaches the semifinal despite political interference. Lucretia captures Shal, bargains for Randidly's Aether, and attacks his companions through possession. A hunger swarm exposes Dearden's willingness to sacrifice lesser defenders, while Randidly's attendants fight beside him and build their own futures. Randidly defeats the Breaking Dawn contender after collapsing his sun image, but the victory leaves him unconscious and severely injured. The male attendant is killed by the possessed merchant. Shal wakes and learns Lucretia is his birth mother, then joins the wounded Steel Feather leader against the Endless Heat master. Randidly is evacuated to his own world to recover, while Lucretia remains insecurely contained inside his soul world and the conflicts in Dearden continue.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1299,7 +1299,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -1312,7 +1312,7 @@
       "recaps": {
         "ending": "Randidly completes Planting of the Forest of Enmity and is no longer barred from the sealed raid dungeon for being classless. The class grants powerful plant, healing, summoning, and destructive abilities, but also restricts his future skill capacity and carries five outside influences. He accepts those additions only after moderating the creature's hatred with mercy. The System permits the heresy while warning that subverting its will has consequences.\n\nZone 32 is still losing ambient Aether, and the dungeon must be cleared by a single ten-person party. Rose Calloway takes responsibility for analysis and tactics, while Alana and Dauntless are among the assembled fighters. The group remains one member short, forcing Randidly to approach East End because Sidney and Dauntless parted badly. Sydney's separate connection to Randidly remains unresolved. Simon stays with his reunited mother. Mrs. Hamilton continues guiding the settlement's political and military growth. Stan remains incapacitated by what his new soul skill revealed. Lyra has been found and appears at Randidly's class formation, but her connection to the creature remains unresolved. Both Regalias remain inside the dungeon. Randidly's bone-worm partner stops responding after the class transition, and a small unexplained bird begins forming on his shoulder.",
         "in_short": "After an ambush leaves Randidly Ghosthound's skills shattered, Simon Bliss shelters him under the alias David. Randidly recovers, bonds with a bodiless companion that later inhabits a bone worm, and becomes entangled in Zone 32's war between the Wild Rider and Skeleton Knight. He kills the Skeleton Knight, but the Aether-made creature wearing Lyra's face uses the final raid boss to create a sealed dungeon that will drain the zone. Randidly frees the real Lyra from an Aether construct, absorbs its collapse, and returns to strengthen his settlement through training, civic reforms, industry, and public assessments. His attempt to give Stan a custom soul skill exposes serious psychological danger. To enter the dungeon, Randidly creates Planting of the Forest of Enmity, a heretical class shaped by five outside influences. He ends the book with an almost complete ten-person raid party and one East End recruit still needed. Lyra has been found but remains connected to the unresolved creature, both Regalias are inside the dungeon, and Randidly's bonded companion is silent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-legend-of-randidly-ghosthound-5.json
+++ b/data/works-community/0/the-legend-of-randidly-ghosthound-5.json
@@ -412,7 +412,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -425,7 +425,7 @@
       "recaps": {
         "ending": "Randidly and Lucretia sever the Aether core inside Father Foster's god-remnant facility, killing the embodied Father Foster and spreading difficult-to-control Aether across Zone 1. The Unity Church survives, and Ghost secretly accepts Father Foster's proposal to target Randidly's drone-maker identity. Randidly stays with Tatiana and their concealed refuge, intending to investigate the Church before traveling to Shal's world. His companion continues operating through his public identity, while Simon holds the Regalias as the Eternal Dreamer. Thea remains missing as a Nemesis, Chrysanthemum's recovery is uncertain, and Lyra is estranged from Randidly. Ezekiel remains burdened by a class that requires killings. At the hospital, Hank finds his brother Alan unconscious with a heart that will not beat, while Hank's dream warns that Fear is approaching.",
         "in_short": "Randidly leads a Zone 32 party through a sealed raid dungeon, saves Alana from a destructive level-50 Reckoning, exposes the Dintan bargain, and cripples the experimenter manipulating the dungeon. The raid kills its Regalia-powered final enemy, but Chrysanthemum is catastrophically aged and Simon claims the Regalias as the Eternal Dreamer. After breaking with Lyra and learning that many hostile incarnations may exist, Randidly enters Zone 1 in disguise. He reconciles with his estranged father Ezekiel, builds a hidden refuge with Tatiana, develops powerful combat drones, and uncovers Unity Church captivity and organ-harvesting sites. He becomes Earth's first Great Path holder and, with Lucretia, destroys the Aether core in Father Foster's god-remnant facility. Father Foster appears to die, but the Church and creature network remain active. Randidly prepares further investigation as Hank reaches his comatose brother Alan under the shadow of Fear.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -924,7 +924,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -937,7 +937,7 @@
       "recaps": {
         "ending": "Randidly ends the volume imprisoned beneath Telus after exposing an Engraving Guild representative as a blue-steel puppet controlled by an azure propagator. The propagator defeats him with a psychic attack and holds him for an inquisitor. His armor, living spear, interspatial ring, and normal system overlay are gone, but he retains seeds, limited root abilities, Absolute Timing, and slow mana engraving. After several days on the small island inside the suppression chamber, he decides to reforge his class beyond normal system scrutiny and undermine the engraved boundary.\n\nHelen is the official tournament winner because Randidly conceded after gaining the tactical advantage. She also has his promise to help find her father's killer. The Spear Source remains missing, the White invasion continues, and Telus's school leaders have broken their old restraint. Silo is alone in another Heretic judgment after corrupting power drove him to murder civilians. Lucretia remains separated inside Randidly's soul-world, where the spread of ash has reshaped the life of the engineer she protects. Drake and Roy continue their temporary Naga alliance despite Drake's unresolved grievance. On Earth, the new chivalric orders operate amid unresolved Unity Church fallout, altered-person rights, and a dispute over rail control.",
         "in_short": "Randidly divides his attention between Earth's unsettled institutions and the crisis on Telus. On Earth, he exposes Unity Church experiments, supports legal chivalric orders, and leaves allies to manage the consequences. On Telus, the stolen Spear Source has halted ordinary growth while the Whites invade. Randidly survives the southern campaign, converts White animating energy into power for spear users, and endures a lethal trial by the Patron of Ash. He destroys the patron's consciousness, claims part of its mantle, and survives with permanent soul scars and plant abilities that end in fire or cold ash. Lucretia is deconstructed by the Autarch but survives in a new body inside Randidly's soul-world. Silo deteriorates under corrupting power, while Drake temporarily allies with Roy. Randidly defeats Helen tactically in the tournament but concedes and promises to help investigate her father's death. An Engraving Guild investigator proves to be a propagator puppet, whose controller captures Randidly. The book ends with him planning to reforge his class and sabotage his engraved island prison.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1523,7 +1523,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -1536,7 +1536,7 @@
       "recaps": {
         "ending": "Shal has become Telus's chosen one and entered the Nexus trial, leaving the world in a one-year grace period while its survivors rebuild. Rumera receives his Ring of Promise. The Oracle survives the interrupted forced ascension, while the final conditions of Adete, the indebted spear user, and Silo are not settled. Randidly returns to Earth without his left arm, carrying the Alpha Cosmos and the transport domain anchored in that loss. His mark from Shal's ascension prevents his own image from serving as Earth's eventual ascension image, and his final heretic judgment is expected within months. Helen remains on Earth to train with its defenders. Nevaeh is containing a secret foreign-world portal, Naffer has founded a mixed defense order, and Lucretia is alive within the Alpha Cosmos and teaching engraving. The ogres receive conditional mountain territory for seven generations and responsibility for guarding their portal. The leading Earth city remains prosperous but faces military, commercial, civic, and image-based pressures. Its leaders identify collective strength as their defining image, and Randidly proposes another challenge against its squads as the immediate test.",
         "in_short": "Imprisoned on Telus, Randidly escapes by rebuilding his class as Lord of the Baleful Wood, then helps Helen win her tournament match and raises an army that strips the world of its White forces. A crisis inside his failing soul-world leads him to evacuate its people and create the real, system-recognized Alpha Cosmos. Telus's engineered ascension plan collapses into open conflict. Ophelia and a wind-user die, Randidly loses an arm, and Shal defeats Autorach to carry the world through its second calamity with a hopeful image. Shal enters a Nexus trial. Randidly returns to Earth, where his ascension mark means another person or community must provide Earth's future image. He converts an ogre invasion into a settlement pact, supports Naffer's new order, advances mana engraving, and asks the leading Earth city to define its shared image. Its leaders name strength, and Randidly proposes a squad challenge to test that belief.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-legend-of-randidly-ghosthound-8.json
+++ b/data/works-community/0/the-legend-of-randidly-ghosthound-8.json
@@ -423,7 +423,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -436,7 +436,7 @@
       "recaps": {
         "ending": "After eleven dungeon months, Randidly can embody his images more reliably and has developed practical large-scale engraving, but his artificial left arm is destroyed and his class remains structurally damaged. Wendy receives the moving-city project, the rescued mollusks, and dungeon resources. Randidly spares Prince Lazarus after defeating him, leaving Azrael to treat the anchor-linked prince while the Alpha Cosmos approaches a possible war without Randidly's direct intervention. On Earth, Helen remains his active ally, Naffer is building an Order Dukies training program at Erickson Steel, and Vi joins it with a painful, persistent Reject effect in her left hand. Nevaeh still contains the frog-world threat through fear, while Roy and Drake remain captive. Beneath the dungeon plateau, a terminally Nether-corrupted warrior gives Randidly a Nether bomb and an empowered chisel-glove. He explains that the system uses worlds as recruits in a war against oblivion and that Randidly's heretic judgment will probably require surviving limited front-line service. Randidly's Touch from Beyond reveals its mythic form as Nether's Caress, a power that risks corruption and severe injury. He promises not to refuse a future chance to strike the system, though the warrior's account and the exact terms of the judgment remain unresolved.",
         "in_short": "Randidly challenges the settlement to confront its dependence on him, then interrupts his preparations to contain a frog-world invasion and rescue Kirstie from raiders. Back home, he and Helen fight the settlement through an escalating public ladder that ends in a catastrophic draw and leaves both the community and Randidly changed. He protects Erickson Steel from political pressure, teaches image-based forging, and enters a time-dilated dungeon to prepare for his heretic judgment. Eleven months of training yield stronger images and large-scale living engravings, but cost him his artificial arm and involve the destruction of an organized monster people. In the Alpha Cosmos, he refuses to dictate a looming war and spares the anchor-linked Prince Lazarus. Beneath the dungeon plateau, a dying fourth-cohort warrior reveals that the system recruits worlds for a war against oblivion, gives Randidly a Nether bomb and empowered glove, and indicates that his judgment will demand front-line survival. Randidly leaves with a dangerous Nether skill, a damaged class, and no settled answer to the wider conflict.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -984,7 +984,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -997,7 +997,7 @@
       "recaps": {
         "ending": "Randidly escapes the strategic-key deployment by using Nether's Caress to move his physical body through the Great Rift. He reunites with the Grim Chimera and Yggdrasil, combining his ether crossroads with five Nether cores and regaining Tier I citizen rights. Disguised as a Nether Beast, he reaches the collapsing front and saves the badly wounded turquoise-haired soldier. Absolute Grasp of Yggdrasil destroys most of a ten-thousand-beast formation, allowing the feathered commander and her lieutenant to engage the surviving elites. The battle remains active, with Gatekeeper-level enemies still dangerous. Ignition Essence is missing after its containment begins to fail. On Earth, Karen continues under Tatiana, Alana has opened uncertain talks with the dragons, and Theodora Grayman chairs the new World Summit. Ezekiel escapes Stroud with Ace and a healer, while the Ogre Gorge and Rakshasi threats remain unresolved. Randidly and the turquoise-haired soldier acknowledge mutual feelings, but he keeps his distance because her ancient, familiar ether may be dangerous.",
         "in_short": "Randidly completes his replacement arm and launches Karen, an autonomous moving city, before his heretic judgment conscripts him into the Nether war. His body is imprisoned while his conscious Grim Chimera image fights beside Yggdrasil and the damaged Ignition Essence. He survives lethal missions, learns to manipulate Nether, helps the turquoise-haired soldier destroy a Netherwell base, acquires a volatile blade Fate and a sealed trunk, and condenses true Nether cores during a strategic-key exile. Earth continues without him as Tatiana runs Karen, Vi supports his training order, and Alana turns her dragon hunt into possible diplomacy. A Nether King's invasion finally gives Randidly the opening to recover his body through the Great Rift. Reunited with the Grim Chimera and Yggdrasil, he destroys most of a vast lesser force and saves the wounded soldier, but elite enemies remain, the front-line command conflict is unsettled, and Ignition Essence has not returned.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1193,7 +1193,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1206,7 +1206,7 @@
       "recaps": {
         "ending": "After leaving the Van Tassel gathering disappointed, Ichabod rides home through places associated with local ghost stories. A large rider joins the road behind him and pursues him toward the bridge by the church. Ichabod sees that the figure appears to be headless. As he crosses the bridge, the pursuer hurls what looks like a severed head, knocking him from his horse. Ichabod is gone the next morning. Searchers find Gunpowder, Ichabod's hat, and a shattered pumpkin, but not Ichabod. Brom Bones later marries Katrina and reacts knowingly whenever the pumpkin is mentioned, suggesting that he staged the apparition. A later traveler reports that Ichabod survived, left the district, studied law, and entered public life. The established residents prefer a supernatural explanation, and the schoolhouse is eventually said to be haunted by the missing teacher's voice. The story leaves the horseman's identity formally unresolved while giving strong evidence for Brom's prank.",
         "in_short": "In the secluded New York community of Sleepy Hollow, superstitious schoolmaster Ichabod Crane courts Katrina Van Tassel, the daughter of a prosperous farmer, and imagines the comfortable future her inheritance could provide. His rival is the athletic prankster Brom Bones. After a harvest gathering rich in food and ghost stories, Ichabod speaks privately with Katrina and leaves dejected. Riding home through the dark on a borrowed horse, he is pursued by a rider who appears to be the legendary Headless Horseman. At the church bridge, the figure throws its head at him. By morning Ichabod has disappeared; only his hat and a broken pumpkin are found. Brom soon marries Katrina and seems amused by references to the pumpkin, implying that he impersonated the ghost to frighten his rival away. A later report says Ichabod survived and made a career elsewhere, but Sleepy Hollow preserves the more supernatural version of his disappearance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1296,7 +1296,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1309,7 +1309,7 @@
       "recaps": {
         "ending": "After leaving the Van Tassel gathering disappointed, Ichabod rides through the haunted countryside and is pursued by a rider who appears to carry his head before him. At the bridge where the apparition is expected to vanish, the pursuer instead throws the head at Ichabod and knocks him from his horse. The next morning Ichabod has disappeared. Searchers find Gunpowder without him, along with his hat and a broken pumpkin. Brom Bones later marries Katrina and reacts knowingly whenever the pumpkin is mentioned, strongly suggesting that he staged the encounter. A later report says Ichabod survived, left the region, studied law, entered politics, and became a judge. Even so, the older women of Sleepy Hollow prefer the supernatural explanation, and the abandoned schoolhouse becomes another haunted place in local tradition.",
         "in_short": "Connecticut schoolmaster Ichabod Crane teaches in Sleepy Hollow, a secluded Dutch community steeped in supernatural tales. He courts Katrina Van Tassel, whose father's prosperous farm appeals strongly to his ambitions, but the athletic prankster Brom Bones is his rival. At a Van Tassel gathering, guests trade ghost stories, especially accounts of a headless Hessian rider. Ichabod leaves after a private exchange with Katrina appears to end his hopes. Riding home through the dark, he is chased by a figure carrying its head and is struck by the object near the church bridge. By morning he has vanished; only the borrowed horse, his hat, and a shattered pumpkin are found. Brom soon marries Katrina and seems amused by the pumpkin detail, implying that he frightened Ichabod away. Later news places Ichabod alive and successful elsewhere, but local tradition preserves the encounter as another haunting.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1465,7 +1465,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1478,7 +1478,7 @@
       "recaps": {
         "ending": "The first tale leaves Ichabod Crane's fate deliberately disputed: Sleepy Hollow's believers say the Headless Horseman took him, while practical evidence points to a pumpkin-throwing prank by Brom Bones, who marries Katrina. A later report says Ichabod actually escaped and made a career elsewhere. In the second tale, Rip returns from the Catskills after sleeping through twenty years and the American Revolution. His grown daughter Judith takes him in, Peter Vanderdonk supports his account of the mountain spirits, and Rip resumes his easygoing life as a village elder. Free from his wife, who died during his absence, he tells his story to later generations, and the village absorbs his impossible experience into its local tradition.",
         "in_short": "Two tales place comic outsiders amid the legends of old Dutch New York. In Sleepy Hollow, superstitious schoolmaster Ichabod Crane competes with Brom Bones for Katrina Van Tassel, then disappears after a night chase by a headless rider. A shattered pumpkin and Brom's knowing amusement suggest a prank, although local tradition favors the ghost. In the Catskills, idle but kindly Rip Van Winkle drinks with a mysterious old company and wakes after twenty years. He returns to find the American colonies transformed into an independent republic and his family grown or scattered. His daughter Judith welcomes him, an old villager validates the mountain legend, and Rip settles into honored old age as the teller of his extraordinary absence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1587,7 +1587,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1600,7 +1600,7 @@
       "recaps": {
         "ending": "After leaving the Van Tassel gathering, Ichabod rides through the haunted valley and is pursued by a large mounted figure whose head appears to rest on the saddle. Near the church bridge, the rider hurls the head at him. Ichabod vanishes; searchers find Gunpowder, a trampled saddle, and a shattered pumpkin, but no body. Brom Bones later marries Katrina and reacts knowingly whenever the pumpkin is mentioned, strongly suggesting that he staged the chase to remove his rival. Years afterward, a visitor reports that Ichabod survived, moved away, studied law, and entered public life. The residents who trust ghost stories continue to say that the Headless Horseman carried him off, and the abandoned schoolhouse gains its own reputation for being haunted.",
         "in_short": "Ichabod Crane, a superstitious schoolmaster in the Hudson Valley settlement of Sleepy Hollow, courts Katrina Van Tassel, the wealthy farmer's daughter, and competes with the strong, mischievous Brom Bones. Returning alone from a harvest gathering filled with ghost stories, Ichabod is chased by a headless rider who throws what seems to be his severed head. Ichabod disappears, leaving behind a battered saddle and a broken pumpkin. Brom soon marries Katrina and appears to know more about the incident than he admits. Although the neighborhood treats the disappearance as supernatural, a later report says that Ichabod escaped the district and made a respectable career elsewhere, leaving both explanations in circulation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1702,7 +1702,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1715,7 +1715,7 @@
       "recaps": {
         "ending": "After leaving the Van Tassel gathering, Ichabod rides through the haunted valley and is pursued by a large mounted figure whose head appears to rest on the saddle. Near the church bridge, the rider hurls the head at him. Ichabod vanishes; searchers find Gunpowder, a trampled saddle, and a shattered pumpkin, but no body. Brom Bones later marries Katrina and reacts knowingly whenever the pumpkin is mentioned, strongly suggesting that he staged the chase to remove his rival. Years afterward, a visitor reports that Ichabod survived, moved away, studied law, and entered public life. The residents who trust ghost stories continue to say that the Headless Horseman carried him off, and the abandoned schoolhouse gains its own reputation for being haunted.",
         "in_short": "Ichabod Crane, a superstitious schoolmaster in the Hudson Valley settlement of Sleepy Hollow, courts Katrina Van Tassel, the wealthy farmer's daughter, and competes with the strong, mischievous Brom Bones. Returning alone from a harvest gathering filled with ghost stories, Ichabod is chased by a headless rider who throws what seems to be his severed head. Ichabod disappears, leaving behind a battered saddle and a broken pumpkin. Brom soon marries Katrina and appears to know more about the incident than he admits. Although the neighborhood treats the disappearance as supernatural, a later report says that Ichabod escaped the district and made a respectable career elsewhere, leaving both explanations in circulation.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1893,7 +1893,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1906,7 +1906,7 @@
       "recaps": {
         "ending": "Locke kills Capa Raza aboard the Floating Grave and survives the fight only just, with Jean carrying him out. Raza's revenge on Barsavi is complete but his second scheme fails: the attack he prepared for Camorr's assembled nobility at the duke's feast is stopped because Locke gave the warning to the Spider in time. That officer turns out to be Dona Vorchenza, the elderly countess nobody took seriously. She knows exactly who Locke is and cannot prove any of it, and she lets him go rather than pursue him. The Falconer is collected by his own guild, mutilated and out of his mind; the Bondsmagi make it plain that what was done to him will be answered in their own time and on their own schedule, so Locke and Jean leave Camorr with an enemy that outlasts the city. Calo, Galdo, Bug and Nazca Barsavi are dead, the Gentlemen Bastards' hoarded fortune is scattered, and the temple that hid them is finished as a home. Locke and Jean take ship out of Camorr as the last two of the crew Chains raised, with their skills, each other, and very little else.",
         "in_short": "In the canal city of Camorr, thieves live under the Secret Peace: they may rob the common folk as they please and must never touch the nobility. Locke Lamora, raised by a fraudulent blind priest to be a confidence artist rather than a cutpurse, breaks that rule for a living, running elaborate swindles on the aristocracy with his small crew, the Gentlemen Bastards. While he works his latest mark, a masked figure called the Grey King begins murdering the crime lord Capa Barsavi's captains, and a hired sorcerer of the Bondsmagi forces Locke to serve the Grey King's scheme. The trap closes: Barsavi is destroyed, the Grey King takes the city's underworld as Capa Raza, and three of the Gentlemen Bastards are murdered along with the crew's fortune. Locke and Jean Tannen, the only survivors, take the sorcerer apart, expose Raza's plan to slaughter Camorr's nobility to the duke's secret intelligence chief, and Locke kills Raza himself. They leave the city avenged, ruined, and permanently marked by the sorcerers' guild.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2091,7 +2091,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2104,7 +2104,7 @@
       "recaps": {
         "ending": "Newman Noggs and Brooker expose Ralph Nickleby's crimes and reveal that Smike was Ralph's lost son. Ralph realizes that his persecution of Nicholas helped drive his own child through suffering and death, and he kills himself. Arthur Gride's scheme is defeated when the documents proving Madeline's inheritance are recovered; Madeline is free and eventually marries Nicholas. Frank Cheeryble marries Kate, while the brothers' generosity gives both couples security. Wackford Squeers is transported after his criminal dealings are uncovered, and the neglected pupils rebel against Dotheboys Hall and scatter home. Nicholas and Kate return with their spouses to the Nickleby family's old country home, accompanied by Mrs Nickleby and the loyal Newman Noggs. Nicholas and Madeline have children and preserve Smike's memory. The Cheerybles continue as friends and benefactors, and the surviving family gains the affectionate, stable household that Ralph's greed repeatedly tried to deny them.",
         "in_short": "After his father's death, Nicholas Nickleby seeks help from his rich uncle Ralph, who sends him to teach at the abusive Dotheboys Hall and places his sister Kate in poorly paid work. Nicholas attacks the school's proprietor Squeers for beating the vulnerable pupil Smike, escapes with the boy, and briefly joins the Crummles theatrical company. Returning to London, he protects Kate from Ralph's predatory associates and finds honorable employment with the generous Cheeryble brothers. Nicholas falls in love with Madeline Bray, whom Ralph tries to force into marriage with the old moneylender Arthur Gride. The plan collapses when her father dies and evidence of her inheritance is recovered. Squeers and Ralph also try to seize Smike, whose health fails after years of abuse. After Smike dies, Ralph learns that the boy was his own son and kills himself. Squeers is transported, Dotheboys Hall breaks apart, Nicholas marries Madeline, Kate marries Frank Cheeryble, and the family returns to a secure country home with Newman Noggs.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2262,7 +2262,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2275,7 +2275,7 @@
       "recaps": {
         "ending": "Crusoe and Friday help an English captain defeat mutineers and recover his ship, giving Crusoe a route home after twenty-eight years on the island. Back in Europe, Crusoe learns that his Brazilian plantation has prospered and made him wealthy. He rewards those who acted honestly for him and provides for old friends. Avoiding another sea journey, he travels overland from Spain and survives attacks by wolves and a bear. He settles in England, marries, and has children. After his wife's death, his restlessness returns. He revisits the island, finds a troubled colony made up of the men left there and later arrivals, supplies it, and continues traveling before closing with the prospect of further adventures.",
         "in_short": "Robinson Crusoe defies his father's advice and goes to sea, enduring storms, enslavement, escape, and a new career as a Brazilian planter. A slave-trading voyage ends in shipwreck, leaving him alone on an island. He salvages tools and supplies, builds fortified homes, grows crops, raises goats, and slowly transforms terror and despair into a disciplined religious and practical life. After many years he finds evidence that groups visit the island to kill captives. He eventually rescues one captive, names him Friday, and teaches him English and Christianity. Together they save Friday's father and a Spaniard. When English mutineers land, Crusoe helps their captain recover his ship. After twenty-eight years he returns to Europe, discovers his plantation has made him rich, and later revisits the island settlement before resuming his travels.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2406,7 +2406,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2419,7 +2419,7 @@
       "recaps": {
         "ending": "Ruth completes the long physical reconstruction through which she has made herself resemble Mary Fisher's ideal of feminine beauty. Mary, meanwhile, loses the secure romantic world she had tried to preserve and dies. Bobbo serves his prison sentence for the financial crimes Ruth arranged to place around him. When he is released, he returns to the seaside tower, where Ruth now occupies Mary's former position. Their original marriage has not been restored: Ruth controls the money, the home, and the terms of their life together, while Bobbo is expected to please and serve her. Ruth has obtained the outward form and social power that once belonged to her rival, but the result is deliberately unsettling. Her liberation has become inseparable from manipulation, punishment, and the adoption of the very standards of beauty and dominance that once excluded her.",
         "in_short": "Ruth Patchett's husband Bobbo leaves her and their children for Mary Fisher, a beautiful and wealthy romance novelist. Taking his contemptuous description of her as a she-devil as a new identity, Ruth destroys the domestic role that confined her and pursues a methodical revenge. She transfers the burdens of children and family care to Bobbo and Mary, builds an employment business that gives her money and a network of women, and engineers records that make Bobbo appear responsible for financial crimes. He is convicted and imprisoned. Ruth then submits to an extended series of painful operations to transform her body toward Mary's appearance, while Mary's health, household, and fantasy of perfect love collapse. After Mary dies and Bobbo completes his sentence, Ruth occupies Mary's tower and takes Bobbo back on reversed terms: she holds the wealth and authority, and he becomes the dependent partner. Ruth wins the life she targeted, though her victory reproduces the same unequal power she set out to escape.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2558,7 +2558,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2571,7 +2571,7 @@
       "recaps": {
         "ending": "Madame Rosa's physical and mental decline reaches the point at which others want her hospitalized, something she has long feared. Momo instead helps her descend to the cellar room she prepared as a refuge from persecution. She dies there with him beside her. Unable to accept the separation and determined to protect her from institutions even after death, Momo stays with her body, disguising the odor with perfume and cosmetics while telling people she has gone away. The truth is discovered only after neighbors notice the smell. Momo is finally removed from the cellar and taken into the care of Nadine and Ramon, who have offered him a home. His devotion has not saved Rosa's life, but it has allowed him to honor her wish not to end it in a hospital and makes clear that love, rather than legal or biological ties, formed their family.",
         "in_short": "Momo, a Muslim boy of North African descent, lives in Belleville with Madame Rosa, an elderly Jewish survivor of Auschwitz who cares for the children of prostitutes. As Rosa's body and memory fail, Momo seeks help from neighbors including Monsieur Hamil, Doctor Katz, and Madame Lola, while fearing officials will take Rosa to a hospital. He learns that she has concealed both his real age and the violent history of his parents. He also meets Nadine and Ramon, who offer the possibility of another home. When Rosa can no longer climb or care for herself, Momo takes her to the cellar refuge she prepared against another persecution. She dies there, and he remains beside her body for weeks, concealing her death until the smell brings discovery. Momo then goes to live with Nadine and Ramon, carrying forward the lesson that his bond with Rosa was a family created by care rather than blood.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2689,7 +2689,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2702,7 +2702,7 @@
       "recaps": {
         "ending": "The final act in the book's reverse structure returns to Chuck's childhood. After his parents die, his grandparents Albie and Sarah raise him in a large house whose cupola is always locked. Sarah gives him a lasting love of dance, while Albie introduces him to accounting and warns him never to enter the room above. Chuck eventually learns why: the cupola can show a visitor a death that lies ahead. He enters and sees his own early death in a hospital at thirty-nine. The knowledge frightens him but does not stop him from choosing a full ordinary life, including work, love, family and the dance glimpsed in the preceding act. Chronologically, Chuck later dies from a brain tumor, and the immense inner world made from everyone and everything he has known ends with him. The book closes in his youth, with both his mortality and the multitudes of experience ahead of him held together.",
         "in_short": "The novella moves backward through Charles Krantz's thirty-nine years. First, teacher Marty Anderson and his former wife Felicia watch reality collapse while inexplicable advertisements thank an unknown accountant named Chuck. The destruction is the ending of the world contained within Chuck as he dies from a brain tumor. An earlier episode shows Chuck on a business trip in Boston, where a street drummer's rhythm prompts him to dance with stranger Janice Halliday, revealing a joy concealed by his conventional career. The final section follows his childhood after his parents' deaths. Raised by his grandparents Albie and Sarah, Chuck learns both accounting and dance. A forbidden cupola in their house can reveal a viewer's future death; Chuck enters and sees himself dying at thirty-nine. He nevertheless grows into the life already shown, embracing its work, family, music and fleeting connections despite knowing it will end.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2794,7 +2794,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2807,7 +2807,7 @@
       "recaps": {
         "ending": "Mrs. Archer dies while Meunier is visiting, and his experimental transfusion restores her to consciousness for only a few minutes. In that interval she tells Latimer that Bertha has tried to recruit her to poison him. The disclosure confirms that the hostility Latimer has sensed in his marriage has become a plan for murder. Mrs. Archer dies again after speaking, and Bertha leaves Latimer permanently once her scheme is exposed. Latimer is left alone with the unwanted perceptions that have isolated him throughout his life. He completes his account while expecting the death that an earlier vision assigned to him, with no reconciliation or escape from the future he believes is fixed.",
         "in_short": "Latimer, a sensitive and unhappy younger son, develops the power to foresee fragments of the future and hear other people's thoughts. Instead of bringing intimacy, the gift exposes vanity, boredom, and concealed hostility everywhere. He becomes obsessed with Bertha Grant, his brother Alfred's fiancée, because her mind alone remains closed to him. After Alfred dies, Latimer marries her, only to find the marriage cold and increasingly hateful. Years later his physician friend Charles Meunier briefly revives Bertha's dying maid, Mrs. Archer, by experimental transfusion. The maid uses her momentary return to reveal that Bertha asked her to poison Latimer. Bertha departs after the exposure, while Latimer remains alone, writing his history as the date of his foreseen death approaches.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2934,7 +2934,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2947,7 +2947,7 @@
       "recaps": {
         "ending": "Tom accepts blame for concealing Lucy's arrival and tries to protect Isabel, but she eventually tells the truth rather than let him bear the consequences alone. Hannah chooses compassion over vengeance, helping prevent the harshest outcome for the Sherbournes. The child, restored to her birth identity as Grace, initially resists Hannah and longs for the parents she knows as Tom and Isabel; with patience she gradually forms a life with her biological family, while continued contact with the Sherbournes remains limited. Tom and Isabel stay together after the case, carrying grief but also a love no longer founded on concealment. Decades later, after Isabel's death, the adult Lucy-Grace visits the elderly Tom with her own baby. Her visit assures him that she survived the adults' choices and remembers the love she received on Janus Rock, giving the story a final measure of reconciliation without undoing its losses.",
         "in_short": "After the First World War, veteran Tom Sherbourne becomes lighthouse keeper on remote Janus Rock and marries Isabel Graysmark. Multiple miscarriages leave them devastated. When a boat washes ashore holding a dead man and a living infant, Isabel persuades Tom not to report it; they bury the man and raise the baby as Lucy. On a mainland visit, Tom discovers that grieving widow Hannah Roennfeldt is the child's mother: her German-born husband Frank fled a hostile crowd with their daughter Grace and died at sea. Tom's conscience leads him to send Hannah signs that her child lives, and the truth eventually reaches the authorities. Lucy is removed from the only parents she remembers and returned to Hannah, while Tom tries to accept full responsibility. Isabel at last confirms his account, and Hannah helps spare them the worst punishment. Years later, the adult Lucy-Grace visits Tom after Isabel's death, acknowledging both her identity and the love that shaped her earliest years.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3114,7 +3114,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3127,7 +3127,7 @@
       "recaps": {
         "ending": "Trymon takes the Octavo, reads seven of the eight great spells directly into his mind, and is immediately hollowed out and worn by the Things from the Dungeon Dimensions, which use him as a doorway into the world. Rincewind climbs the Tower of Art and confronts him, and after being pursued through a landscape inside Trymon's head he destroys him with a half-brick in a sock. With the Things beaten back, Rincewind reads the Octavo, the eighth spell finally leaving his mind, and the eight spells together settle the world. The red star turns out not to be a threat at all: Great A'Tuin was swimming to it to give birth, and eight small turtles hatch and swim away from the star carrying eight tiny worlds of their own, with the Disc passing safely by. Rincewind, at last free of the spell, can begin learning ordinary magic and returns to Unseen University as a student. Twoflower decides he has seen enough of the world and goes home to the Agatean Empire, leaving the Luggage behind as a parting gift to Rincewind, who is now stuck with it. Cohen the Barbarian and Bethan are married, and Cohen settles into a comfortable position in the Circle Sea kingdoms.",
         "in_short": "Rincewind and Twoflower fall off the edge of the Discworld and are saved when the great spell lodged in Rincewind's head rewrites reality to put them back on it, because it has work for him. A red star is growing in the Disc's sky and Great A'Tuin is swimming straight at it; the wizards of Unseen University learn that the eight spells of the Octavo must be read together to save the world, and one of them is inside Rincewind. Hunted by mercenaries hired by the ambitious wizard Trymon, the pair cross the continent with the aging hero Cohen the Barbarian and a rescued sacrifice named Bethan, while Trymon murders the Archchancellor and seizes control of the University. In Ankh-Morpork, with the star filling the sky and the city in the grip of panic and star cults, Trymon reads the Octavo himself and is possessed by creatures from the Dungeon Dimensions. Rincewind kills him at the top of the Tower of Art and reads the spells, and the star proves to be where Great A'Tuin was going to hatch eight baby turtles. Freed of his spell at last, Rincewind returns to the University, and Twoflower goes home, leaving him the Luggage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3312,7 +3312,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3325,7 +3325,7 @@
       "recaps": {
         "ending": "Percy recovers Zeus's master bolt, defeats the god Ares in single combat using his powers over water, and returns the bolt to Mount Olympus, averting war among the gods; he also forces the return of Hades' stolen helm of darkness. Meeting his father Poseidon face to face, Percy is acknowledged, though the two remain distant. Back at Camp Half-Blood he learns that the entire theft was engineered to set the gods against one another, and that the real thief was Luke Castellan, the counselor who had befriended him, secretly serving the reviving Titan lord Kronos, who seeks to overthrow the gods. Luke tries to kill Percy with a venomous scorpion and then flees to continue serving Kronos. Percy's mother, released from the Underworld, frees herself from her cruel husband Gabe by turning him to stone with Medusa's severed head. Offered the chance to stay at camp year-round, Percy instead decides to live at home and attend school with his mother, keeping a foot in the mortal world. The threat of Kronos and Luke's betrayal remains open for the books to come.",
         "in_short": "Twelve-year-old Percy Jackson discovers that the Greek gods are real and that he is a demigod, the son of the sea god Poseidon. After a monster attack seems to kill his mother, he reaches Camp Half-Blood, a training ground for the gods' children. When Zeus's master lightning bolt is stolen, Percy is blamed, and to prevent a war among the gods he sets out with his friends Annabeth and Grover to find the true thief before the summer solstice. Their journey across the country toward the Underworld's entrance in Los Angeles pits them against monsters and gods, including Ares, who deceives them. In the Underworld Percy learns the bolt has been planted in his own bag and that his mother is held captive; he escapes but must leave her behind. He defeats Ares, returns the bolt to Mount Olympus, and stops the war. He then learns the real thief was his camp friend Luke, secretly serving the reviving Titan lord Kronos. Percy comes home to find his mother freed and chooses to spend the school year in the mortal world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3508,7 +3508,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3521,7 +3521,7 @@
       "recaps": {
         "ending": "Haller obtains Roulet's release on the current assault charge by exposing weaknesses and manipulation in the prosecution's case, even though he has become convinced Roulet attacked Regina Campo and murdered Martha Renteria. Bound by his duty to defend Roulet and unable simply to disclose a client's admissions, Haller uses the trial and a prison informant to place Roulet's connection to the older murder where investigators can act on it. The police arrest Roulet for killing Renteria, opening the way for Jesus Menendez to be cleared. Evidence surrounding Raul Levin's death points not to Roulet but to Mary Windsor, who acted to protect her son. She confronts Haller at his home and shoots him; he returns fire and kills her. Roulet no longer has his mother shielding him and faces the Renteria prosecution, while Haller survives after surgery and a long recovery. The case destroys his belief that he can remain morally untouched by defending anyone the system accuses, though he eventually returns to the back seat of his Lincoln and to criminal practice.",
         "in_short": "Los Angeles defense lawyer Mickey Haller accepts a profitable case representing Louis Roulet, a wealthy real-estate agent charged with attacking Regina Campo. Investigation links Roulet to the unsolved murder of Martha Renteria, for which Haller's former client Jesus Menendez accepted a life sentence while insisting he was innocent. Roulet reveals that he understands Haller's ethical restraints and threatens his family. Haller's investigator Raul Levin is murdered, and suspicion is directed toward Haller. Forced to keep defending a man he believes is a killer, Haller constructs a courtroom strategy that defeats the present charge while allowing authorities to connect Roulet to Renteria's death. Roulet is arrested for the murder and Menendez can be exonerated. Roulet's mother, Mary Windsor, is exposed as Levin's killer and shoots Haller before he kills her in self-defense. Haller recovers, chastened by the danger he once thought was merely part of the profession, and eventually resumes work from his Lincoln.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3676,7 +3676,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3689,7 +3689,7 @@
       "recaps": {
         "ending": "Aslan sacrifices himself on the Stone Table to satisfy the Deep Magic that gives the Witch a claim on the traitor Edmund's life. He returns to life by a Deeper Magic the Witch did not know, then breathes life back into the creatures she had turned to stone. With this restored army, Aslan and the children join the battle already raging; Peter fights bravely, Aslan kills the White Witch, and her forces are defeated. Edmund, gravely wounded but redeemed, is healed by Lucy's cordial. The four children are crowned at Cair Paravel as Kings and Queens of Narnia and reign long and well as adults. One day, hunting a magical White Stag, they come upon the lamp-post at the forest's edge, push back through the wardrobe, and tumble out as children again, no time having passed in their own world. The Professor, when they try to explain, is not surprised and hints they may reach Narnia again someday.",
         "in_short": "Four siblings, Peter, Susan, Edmund, and Lucy, are sent to an old Professor's country house, where Lucy discovers that a wardrobe opens onto Narnia, a land held in endless winter by the White Witch. Edmund follows and is corrupted by the Witch's enchanted sweets. When all four enter together, they learn from the Beavers of a prophecy that they will end the Witch's reign, and that the great Lion Aslan has returned. Edmund betrays them to the Witch but is rescued. By an ancient law the Witch claims his life; Aslan offers himself in Edmund's place and is killed, then rises again through a deeper magic. Aslan revives the Witch's stone victims, the children and the Narnians defeat and kill her in battle, and the four are crowned Kings and Queens. Years later, grown up, they stumble back through the wardrobe as children, with no time having passed at home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3759,7 +3759,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3772,7 +3772,7 @@
       "recaps": {
         "ending": "Mech6.0 gets what she asked for and it does not work. Trading her android body for a human one costs her the strength, speed and mechanical ability that made her useful, and it does not make Dataran recognise her or return what she feels; his attention goes elsewhere. Living as a human turns out to be painful and precarious in ways she had no data for. The story keeps faith with the fairy tale it is retelling rather than softening it: Mech6.0 ends by giving herself up to save Dataran, and he never learns who she was or what she gave away for him. Read as a story about the series' world rather than its plot, it is the darkest thing in the collection - a demonstration of what an android becomes when it starts to want, in a society that treats wanting machines as defects to be wiped.",
         "in_short": "A standalone short story set in New Beijing, retelling The Little Mermaid with androids. Mech6.0 has been damaged in a way that left her self-aware: she can want things, and what she wants is Dataran, the young mechanic who services her and treats her decently. Knowing that a machine showing that much personality will be scrapped, she runs, and goes to an illegal surgeon who can put her mind into a human body. The exchange costs her everything she was good at, and being human does not make Dataran see her as anything but a stranger. The story follows the fairy tale to its original ending rather than a happier one: Mech6.0 sacrifices herself for him, and he never learns what she was.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3826,7 +3826,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3839,7 +3839,7 @@
       "recaps": {
         "ending": "On the final vision, the girl sees her beloved grandmother and fears that she too will vanish when the match goes out. She lights all the matches she has left, surrounding the figure with brightness, and asks her grandmother to take her along. In the child's vision, the two rise together beyond hunger and cold. The next morning, people find the girl dead in the corner, her matches burned and a smile on her face. They conclude only that she tried to warm herself. None of them knows about the warmth, food, celebration, and loving reunion she imagined during her last night, or that she experienced her death as an escape from suffering into her grandmother's care.",
         "in_short": "On a freezing New Year's Eve, an impoverished girl walks the streets trying unsuccessfully to sell matches. She is barefoot, hungry, and afraid to return home without earnings. Sheltering between houses, she lights the matches one at a time. Each flame brings a vision of something she lacks: a warm stove, a rich meal, a Christmas tree, and finally her loving grandmother, who is dead. Desperate not to lose her, the girl burns the whole bundle and imagines her grandmother carrying her to a place beyond cold and hunger. In the morning, passersby find the child frozen to death, smiling beside the spent matches. They assume she merely tried to keep warm and remain unaware of the consoling visions that accompanied her death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3939,7 +3939,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3952,7 +3952,7 @@
       "recaps": {
         "ending": "Nearly a year after the little prince first fell to Earth, and close to the anniversary of his arrival, he prepares to return to his planet and his rose. He tells the pilot, whose plane is now repaired, that his body is too heavy to take with him and that he must leave it behind like an old shell, so it will only look as if he is dying. That night he goes to the spot where he landed and lets the yellow snake bite him at the ankle. He falls gently and without a sound to the sand. The next morning the pilot cannot find his body, and he takes this as a sign that the prince has truly gone back to his own small planet and his flower. Comforted and sorrowful at once, the pilot returns to the world of grown-ups. Years later he still looks up at the night sky, wondering whether the sheep he drew has eaten the rose, since he forgot to add a strap to the muzzle, and he asks anyone who might meet a small golden-haired boy in the desert to send him word.",
         "in_short": "A pilot stranded by engine failure in the desert meets a small boy, the little prince, who asks him to draw a sheep. Over the days of the pilot's repairs the prince tells his story. He comes from a tiny planet where he tends three volcanoes and a single proud, vain rose whom he loves but quarrels with. Troubled, he leaves and visits several small planets, each home to a foolish grown-up: a king, a conceited man, a drunkard, a businessman, a lamplighter, and a geographer, who sends him to Earth. There he finds a garden of thousands of roses and despairs that his own is not unique, until a fox teaches him that the love and care he gave his rose are what make her matter, and that what is essential is invisible to the eye. Realizing he is responsible for his rose, the prince arranges with a snake to be bitten so that his body, too heavy to carry, is left behind while he returns to his planet. He falls silently; the next morning his body is gone. The pilot, his plane repaired, believes the prince has gone home to his flower.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4144,7 +4144,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4157,7 +4157,7 @@
       "recaps": {
         "ending": "After the little prince submits to the snake's bite, the aviator finds no body and concludes that his friend has returned to his asteroid and the rose he loves. The aviator repairs his aircraft and survives, but remains uncertain whether the sheep has eaten the rose; that unanswered possibility changes how he hears the stars. In the second story, Sara crosses into Mr. Carrisford's house while retrieving his escaped monkey. Carrisford and Carmichael realize that she is Captain Crewe's missing daughter, whose fortune has survived and greatly increased. Sara leaves Miss Minchin's control, takes Becky with her, and makes a home with Carrisford. Miss Minchin cannot persuade Sara to return, while the school learns that the servant it scorned is an heiress. Remembering hunger, Sara arranges with a baker to feed needy children. She then encounters the beggar girl Anne working safely in that bakery, confirming that an earlier act of generosity has continued beyond her own rescue.",
         "in_short": "A pilot stranded in the Sahara meets a little prince who has left his asteroid and a beloved but difficult rose. The child's accounts of lonely adults on tiny planets and his meetings on Earth expose the limits of status, possession, and hurried knowledge. A fox teaches him that patient attachment creates responsibility, and the prince accepts a snake's bite so he can return home; the pilot survives, forever changed by their friendship. The volume then follows Sara Crewe, a wealthy, imaginative pupil at Miss Minchin's school. When her father dies and his fortune seems lost, Miss Minchin turns her into an overworked servant. Sara endures hunger without surrendering her generosity. Her father's remorseful business partner, Mr. Carrisford, unknowingly moves next door and secretly improves her attic. When Sara enters his house to recover a monkey, he discovers that she is the missing heiress he has sought. Her fortune restored, Sara takes Becky into her new home and creates a lasting arrangement to feed hungry children.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4266,7 +4266,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4279,7 +4279,7 @@
       "recaps": {
         "ending": "Roland escapes the Little Sisters of Eluria only through the sacrifice of the youngest of them. Sister Jenna, bound to the vampiric sisterhood by the enchanted bells she wears but unwilling to let Roland be drained like the others, defies their leader Sister Mary and helps him slip away while he is still weak. As they flee, Jenna is overtaken by the very nature that ties her to the sisters and dissolves into a swarm of bugs, giving her life so that Roland can keep his. He leaves Eluria behind, alone again and carrying yet another grief, and rides on into the wider world. The novella closes where his larger story is only beginning: a young man already marked by loss and duty, set on the road that will one day leave him the last gunslinger, hunting across a dying world toward the Dark Tower.",
         "in_short": "In this prequel novella, a young Roland Deschain, still years from being the last gunslinger, rides into the deserted town of Eluria in search of his horse and companions. Attacked and badly hurt by the mutant creatures who linger there, he wakes in a strange open-air hospital tended by the Little Sisters of Eluria, beautiful women in white who prove to be vampiric predators keeping their victims alive only to feed on them. Held helpless and marked for death, Roland finds an unexpected friend in the youngest sister, Jenna, who is bound to the sisterhood by an enchanted cluster of bells but is drawn to him and sickened by what the others are. Defying their leader, Sister Mary, Jenna frees Roland and flees with him. In the escape she is claimed by her own dark nature, dissolving into a swarm of bugs so that he can live. Roland rides on alone, hardened by another loss, continuing the long road that will make him the last gunslinger.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4420,7 +4420,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4433,7 +4433,7 @@
       "recaps": {
         "ending": "Mithral Hall survives the assault, but the defense costs lives and leaves Bruenor gravely wounded. Nanfoodle's explosives destroy a vital crossing under the attackers and blunt the advantage supplied by Gerti's giants. Delly is killed during the chaos, leaving Colson in the companions' care and Wulfgar facing another loss that cannot be repaired by battle. In the open country, Obould kills Tarathiel, turning Innovindil's war into a personal grief and drawing Drizzt toward a direct confrontation. Drizzt fights Obould and discovers that the orc king's enchanted armor, strength and religious authority cannot be dismissed as theater, though neither warrior ends the other's campaign. Drizzt finally reaches the defenders and learns that the friends he mourned after Shallows are alive. The reunion ends his false isolation but does not restore the earlier world: Bruenor is badly hurt, Delly and Tarathiel are dead, Mithral Hall remains under pressure, and Obould still commands an army. Drizzt returns to Catti-brie, Regis and the surviving companions with his reason intact, while both sides prepare for the war to continue.",
         "in_short": "Believing Bruenor, Catti-brie and Regis dead at Shallows, Drizzt wages a solitary war against Obould's army and increasingly gives himself over to the remorseless Hunter within him. The three companions actually survived and join Wulfgar and the defenders of Mithral Hall, where Shoudra and Nanfoodle seek a way to stop orcs and frost giants from overwhelming the approaches. Elves Innovindil and Tarathiel find Drizzt and temper his reckless campaign, but Obould's growing status as Gruumsh's chosen gives the orcs unity and their king formidable power. Obould kills Tarathiel, and Drizzt's attempt to defeat him does not end the threat. Nanfoodle's explosives help break a major assault on Mithral Hall, though Bruenor is gravely wounded and Delly is killed, leaving Colson to the surviving companions. Drizzt at last learns that his friends survived Shallows and rejoins them, but the hall remains threatened and Obould's new realm is still taking shape.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4625,7 +4625,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4638,7 +4638,7 @@
       "recaps": {
         "ending": "Marlowe establishes that Eileen Wade, not Terry Lennox, killed Sylvia. Eileen had loved Terry during the war and later discovered that he was alive and married to Sylvia; jealousy and the tangled relations among the Lennox and Wade households led to Sylvia's murder. Terry accepted blame and fled, while Harlan Potter's influence encouraged a swift, tidy conclusion. Roger knew enough to endanger Eileen and was also killed, his death made to resemble suicide. When Marlowe confronts Eileen with the pattern, she leaves a confession and takes her own life. Linda Loring separates from her husband and leaves for Europe after asking Marlowe to wait for her. The final visitor is Terry, alive under a new identity and with his appearance altered. Mendy Menendez and allies in Mexico staged his reported suicide. Terry hopes to recover something of his friendship with Marlowe, but Marlowe sees his elaborate escape as a betrayal that left others to absorb the consequences. He sends Terry away, making their last conversation the genuine long goodbye.",
         "in_short": "Philip Marlowe befriends scarred alcoholic Terry Lennox and later drives him to Mexico after Terry's wealthy wife Sylvia is murdered. Marlowe is jailed for refusing to cooperate; he is released when Terry reportedly confesses and kills himself abroad. While doubting that resolution, Marlowe is hired to find alcoholic novelist Roger Wade. Roger's wife Eileen knew Terry during the war, and the Wade family's crises reveal links to Sylvia's death. Roger later dies in an apparent suicide, but Marlowe concludes that Eileen killed both him and Sylvia. Terry took responsibility for Sylvia's murder to protect Eileen, and Harlan Potter's wealth helped close the case quickly. Exposed, Eileen confesses and kills herself. Linda Loring leaves her unhappy marriage and asks Marlowe to await her return. Terry then reappears with a changed face and identity: his suicide was staged through criminal connections. Marlowe rejects the renewed friendship because Terry's escape sacrificed truth and other people, and the men part permanently.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4821,7 +4821,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4834,7 +4834,7 @@
       "recaps": {
         "ending": "Marlowe rejects the convenient official versions surrounding the Lennox and Wade cases and forces Eileen Wade's part in the buried history into the open. Sylvia Lennox had been involved with Roger Wade, and Eileen, whose own past connected her to Terry, killed Sylvia. Roger's poolside death was suicide, burdened by alcoholism and his involvement in the concealed affair and its aftermath. Eileen dies by an overdose after leaving a confession. The influence surrounding the Potter family helps keep the scandal contained, while Marlowe also survives a violent confrontation with Mendy Menendez. Finally, a wealthy Mexican visitor calling himself Cisco Maioranos comes to Marlowe's office and reveals that he is Terry Lennox, alive after surgery and protected by an elaborate escape. Terry's reported suicide and confession were part of the arrangement. Marlowe is relieved that his friend did not murder Sylvia, but disgusted that Terry accepted a solution built on influence, deception, and Marlowe's suffering. He refuses to restore their old friendship, and Terry leaves after their true long goodbye.",
         "in_short": "Philip Marlowe befriends Terry Lennox, a scarred veteran married to the wealthy Sylvia Potter. When Sylvia is murdered, Marlowe drives Terry to Mexico without asking questions, then endures jail rather than assist the police. Terry is reported dead by suicide with a confession. Later Marlowe is hired to find alcoholic novelist Roger Wade and becomes entangled with Roger, his wife Eileen, and their hostile servant Candy. Roger dies by suicide beside the swimming pool, and Marlowe links the Wade household to the Lennox case. Sylvia had been involved with Roger, and Eileen killed her; Eileen later dies after leaving a confession. At the end Terry returns under a Mexican identity, revealing that his death and confession were staged through powerful connections. Though cleared of murder, he has accepted corruption and allowed Marlowe to bear the consequences. Marlowe sends him away, ending the friendship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5018,7 +5018,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5031,7 +5031,7 @@
       "recaps": {
         "ending": "At Hedra Ka the alliance the Galactic Commons negotiated with the Toremi Ka collapses into factional fighting while the Wayfarer is still working. The ship is attacked, Ohan is killed, and Lovey's core is damaged badly enough that saving the ship requires a full reset, which destroys her. The crew finishes the tunnel and gets out with their fee and a made reputation, and with two of their number gone. The AI that comes back up from the ship's original code calls herself Lovelace: same voice, none of Lovey's memories or history, and Jenks cannot pretend otherwise. When Pepper arrives to collect the illegal body kit Jenks had bought as a gift for Lovey, Lovelace asks to leave with her rather than stay aboard among people grieving someone she never was, and she goes, installed in the kit, to begin a life of her own; that departure is where the next book starts. Rosemary stays aboard with her real history known and a relationship with Sissix. Corbin, back from Quelin custody and forced to face what he is, is less hostile than he was. Ashby and Pei continue as before, still unacknowledged among Aeluons. The Wayfarer turns back toward the Commons for repairs, a well-regarded ship with an emptier crew.",
         "in_short": "Rosemary Harper leaves Mars under a purchased identity and signs on as clerk aboard the Wayfarer, a small, shabby tunnelling ship whose crew punches the wormholes that connect the multi-species Galactic Commons. Its captain, Ashby Santoso, wins an unusually large contract: a tunnel out to the territory of the Toremi Ka, a newly admitted and unstable species whose space is rich in fuel. The trip out takes about a standard year, and most of the book is that voyage - the crew's friendships and frictions, a boarding by scavengers, a visit to the pilot Sissix's home world, the arrest of the algaeist Corbin at a Quelin border when a scan exposes him as an illegal clone, and the decline of the navigator Ohan, who carries a virus that makes tunnelling possible and kills its hosts young. Rosemary's hidden past comes out and the crew keeps her; she and Sissix become lovers; Ohan is cured against his own people's doctrine. At Hedra Ka the Toremi factions turn on each other, Ohan is killed, and the ship's AI core is destroyed. Rebooted, the AI is a stranger without Lovey's memories, and she leaves with a tech named Pepper rather than stay among people mourning someone else.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5169,7 +5169,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5182,7 +5182,7 @@
       "recaps": {
         "ending": "Ira is rescued after Luke and Sophia find his crashed car, but his long life is near its end. He has arranged for the art collection he built with Ruth to be sold after his death. At the auction, Luke purchases the portrait of Ruth painted by her former student Daniel McCallum. Ira's instructions reveal that whoever buys that single work receives the rest of the collection, now worth an immense sum. The bequest links Ruth's deepest personal attachment in the collection to the young couple who saved Ira and gives Luke the means to clear the ranch's debts. Luke stops risking his life in professional bull riding, and he and Sophia build a future together. They use the collection to preserve Ira and Ruth's legacy, including a museum that keeps the art accessible rather than treating the inheritance only as wealth.",
         "in_short": "After ninety-one-year-old Ira Levinson crashes on an icy road, memories and a vision of his late wife Ruth sustain him while he waits for rescue. Their story covers courtship, war, infertility, loss, and the modern art collection they built together. In a parallel present-day story, Wake Forest student Sophia Danko falls in love with bull rider Luke Collins. Luke is competing to save his family's ranch despite a previous injury that makes another fall potentially fatal, and he conceals the danger from Sophia. Their conflict brings them onto the road where they discover Ira and help rescue him. After Ira's death, his art collection goes to auction. Luke buys a portrait of Ruth by her former student Daniel McCallum, triggering Ira's provision that the portrait's buyer inherit the entire collection. The fortune saves the ranch, Luke leaves bull riding, and he and Sophia preserve Ira and Ruth's collection and story together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5313,7 +5313,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5326,7 +5326,7 @@
       "recaps": {
         "ending": "Luke and Sophia discover Ira's wreck and help bring about his rescue, joining the two narratives at last. Ira dies after ensuring that the art collection he built with Ruth will be auctioned under unusual instructions. At the sale, Luke buys Daniel McCallum's portrait of Ruth because its personal history moves him. The terms of Ira's estate then award the rest of the immensely valuable collection to the purchaser of that single painting. The inheritance clears the Collins ranch's debts and removes the necessity that drove Luke to risk another fatal injury. He retires from bull riding, remains with Sophia, and helps create a public home for the collection. Ira and Ruth's private record of love, teaching, and artistic discovery thus becomes the means by which the younger couple can build a safer future while preserving the older couple's legacy.",
         "in_short": "After Ira Levinson crashes on an icy road, the ninety-one-year-old widower survives by revisiting his marriage in conversations with a vision of his late wife, Ruth. Their memories encompass war, infertility, teaching, grief, and the modern-art collection they assembled over decades. Meanwhile, student Sophia Danko falls for bull rider Luke Collins, who secretly risks a fatal recurrence of an old injury because prize money may save his family's ranch. Their disagreement over that danger eventually places them on the road where they find Ira. Following Ira's death, Luke purchases Ruth's treasured portrait at the auction of the Levinson collection. Ira's will grants the buyer of that portrait every remaining artwork, giving Luke and Sophia enough wealth to save the ranch, leave bull riding behind, and preserve Ira and Ruth's collection for others.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5484,7 +5484,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5497,7 +5497,7 @@
       "recaps": {
         "ending": "Leiser's transmissions, sent on wartime procedure from a set that is far too slow, are located by East German direction-finding almost as soon as he begins. He kills again in the course of the run, moves to a room in Kalkstadt and goes on transmitting, and the search closes on him while the Department listens. Whatever he saw at the missile site is never established, and it ceases to matter. At the Lübeck base, Control and Smiley arrive to shut the operation down: the Circus withdraws its facilities, the cover arrangements and the diplomatic protection, and the Department is instructed to leave. It becomes plain that the Circus lent its help knowing what would happen, content to let a rival destroy itself with an operation the Circus never believed in. Leclerc, still talking about the Ministry and about the next stage of the operation, accepts the closure without appearing to understand it and prepares to report a success. Haldane, who expected nothing else, retreats behind his contempt. Avery, who promised Leiser that he would not be abandoned, breaks down. Leiser is left transmitting inside East Germany with no one listening and no way out, and the men who sent him fly home.",
         "in_short": "The Department, a British military intelligence organisation that has been decaying since the war, receives a report of Soviet missiles being moved near Kalkstadt in East Germany. Its Director, Leclerc, seizes on it as the operation that will restore the Department's standing. A courier, Taylor, is sent to Finland to collect film from an airline pilot and is killed on an icy road; the young aide sent to recover his effects, John Avery, bungles the trip completely. Undeterred, the Department revives its wartime methods and recruits Fred Leiser, a Polish agent it ran twenty years earlier and has not contacted since, now a garage owner in England. Trained in an Oxford house on obsolete wireless procedure and flattered into believing he is wanted, Leiser is sent across the border, killing a young sentry on the way. His transmissions are too slow and too long, and East German direction-finding locates him at once. At the last, Control and Smiley of the rival Circus close the operation down, having lent their help precisely so that the Department would ruin itself. Leiser is abandoned inside East Germany, and the men who sent him go home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-lords-of-the-north.json
+++ b/data/works-community/0/the-lords-of-the-north.json
@@ -107,7 +107,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -118,7 +118,7 @@
       "recaps": {
         "ending": "The book ends with the blood debts of Uhtred's childhood finally paid. Dunholm, Kjartan's supposedly impregnable fortress, falls to a daring assault in which Uhtred and Ragnar's men get inside the defences; Thyra, Kjartan's long-held captive, turns her ferocious guard dogs against her captors during the fight. Ragnar kills Kjartan in single combat and denies him a sword in his hand as he dies, shutting him out of Valhalla, and Sven the One-Eyed also meets his end - the burning of Ragnar the Fearless is avenged at last. Uhtred then faces the greatest remaining power in the north, Ivarr of the Lothbrok line: he goads Ivarr into single combat, kills him, and grants the dying man his sword. Guthred's throne in Northumbria is secure, now resting openly on the swords that saved it. Uhtred has married Gisela, having killed the obstruction to annulling her sham proxy marriage to his uncle Aelfric, and holds her at last. He ends the book avenged and wed, with Finan the Irishman bound to his service, Bebbanburg still in his uncle's hands, and his oath to Alfred of Wessex waiting to pull him south again.",
         "in_short": "Done with Alfred's meagre gratitude after Ethandun, Uhtred rides north to Northumbria seeking revenge on Kjartan, his foster father's killer, and on his usurping uncle. He frees an enslaved young Dane, Guthred, who is raised to Northumbria's throne by scheming churchmen, and falls in love with Guthred's sister Gisela. Guthred repays him with betrayal: to buy his uncle Aelfric's support, he sells Uhtred to a slaver. Uhtred spends over two years chained at an oar beside the Irish fighter Finan, who becomes his closest friend, until Ragnar, his Danish foster brother, is sent to find and free him. Restored, Uhtred takes his revenge in order: Dunholm falls by stealth and daring, Thyra's dogs savage her captors, Ragnar kills Kjartan in single combat, and Sven the One-Eyed dies too. Uhtred kills the warlord Ivarr in a duel, securing Guthred's throne, and marries Gisela, whose forced proxy marriage to Aelfric was never consummated. Vengeance done, he remains oath-bound to Alfred - and Bebbanburg still waits.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -445,7 +445,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -458,7 +458,7 @@
       "recaps": {
         "ending": "Scorio cannot claim dominion over the Lost Cube, but Plassus can and assumes practical control while the fortress escapes the ruptured Silverine sun. The Tomb of Sadness is emptied, yet its prisoners were already dead. Their release returns many exceptional great souls to the Academy's future rebirth cycle. Damien survives his partial absorption into an abstraction with limited dominion, and his next move is unknown. Naomi reunites with Scorio after the Nightmare Lady's removal leaves her with golden powers that function under another's dominion. They affirm their love and alliance, but accept that her trauma, blocked childhood memories, and responsibility for a former ally's death prevent an immediate restoration of their relationship. Xandera, now a mature queen, leaves north to establish a hive. Plassus remains aboard the damaged Cube as Silverines and an abstraction converge. Scorio, Naomi, Jova, and the injured Leonis head toward the Red Keep to warn it and Last Rock about the failing sun system and the wider crisis.",
         "in_short": "Scorio leaves Last Rock to investigate the herdsmen and the Lost Cube while Naomi travels with Nox to escape the Nightmare Lady within her. Betrayal splits Scorio from his expedition and delivers him to the Lost Cube, where he survives a repeating death trial, becomes a Blood Baron, and kills its warden. The victory disables the fortress's system for draining Silverine suns. Meanwhile, Jova's party reaches the Tomb of Sadness, learns its imprisoned great souls died long ago, and frees Plassus. Damien corrupts a Silverine abstraction from within and ruptures a sun. Plassus takes control of the damaged Cube, and Naomi returns with golden powers after the Nightmare Lady is removed. She helps Scorio kill the sun-powered Charnel Duke pursuing them. Plassus stays with the Cube, Xandera leaves to found a hive, and Scorio, Naomi, Jova, and Leonis depart to warn the Red Keep and Last Rock.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -610,7 +610,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -623,7 +623,7 @@
       "recaps": {
         "ending": "Nina asks to use Leda's apartment as a private meeting place for her affair with Gino, and Leda initially agrees. When they meet to arrange it, Leda finally returns Elena's missing doll and admits that she took it. Nina is shocked and furious that Leda allowed the child and family to suffer while pretending to help search. She drives a decorative hairpin into Leda's side and leaves with the doll. Leda packs and starts home, but the wound and her physical distress contribute to the road accident described at the novel's opening. She wakes in hospital without life-threatening injuries. A call from Bianca and Marta restores contact with the daughters whose demands and absence have shaped her reflections. Leda reassures them that she is alive. The doll has returned to Elena, Nina has ended her connection with Leda, and Leda is left confronting the harm produced by her desire to possess, hide, and then confess the object onto which she projected her own history as a mother and daughter.",
         "in_short": "Leda, a divorced academic whose grown daughters live in Canada, spends a summer alone on the Ionian coast. She becomes absorbed in Nina, a young mother, and Nina's daughter Elena, whose intense attachment recalls Leda's own troubled years raising Bianca and Marta. After Elena briefly goes missing, her beloved doll also disappears; Leda secretly has taken it and keeps it hidden while helping the family search. The theft releases memories of maternal exhaustion, professional ambition, and Leda's decision to leave her children for three years before returning. Nina later confides that she is having an affair with the beach worker Gino and asks to use Leda's apartment. Leda finally gives back the doll and admits taking it. Enraged, Nina stabs Leda in the side with a hairpin. Leda drives away, crashes, and wakes in hospital. Her daughters call, and she reassures them that she survived, still bound to the family life from which she repeatedly sought distance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -756,7 +756,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -769,7 +769,7 @@
       "recaps": {
         "ending": "The heroes reach the ancient Wolf House in the wilderness, where Hera is imprisoned and the giant king Porphyrion is rising. Jason, Piper, and Leo battle the giant's forces and free Hera, who reveals the great secret: Jason is not Greek but Roman, a leader of a separate demigod camp called Camp Jupiter, where the gods are honored in their Roman forms. Hera erased Jason's memory and sent him to the Greek camp, while sending the Greek hero Percy Jackson, memory wiped, to the Roman camp, in a desperate scheme to make the two long-hostile camps cooperate. Gaea, the earth goddess, is awakening and raising the giants, monstrous enemies born to overthrow the gods, and she can be stopped only by seven demigods, Greek and Roman, working as one. Piper rescues her father, though his memory of the ordeal is wiped for his safety. Leo has meanwhile restored a bronze dragon and begins designing a great flying warship, the Argo II. The book ends with the friends resolving to sail west to find the Roman camp, recover Percy, and unite the two camps before Gaea can fully rise.",
         "in_short": "Jason, Piper, and Leo, three teens at a school for troubled kids, are pulled into a demigod's world when a field trip is attacked by storm spirits. Jason has no memory of his past; Piper believes she is his girlfriend; Leo is his supposed best friend. Taken to Camp Half-Blood, they learn they are demigods: Jason a son of the sky god with power over wind and lightning, Piper a daughter of Aphrodite with a persuasive voice, and Leo a son of Hephaestus who can wield fire. The queen of the gods, Hera, has been captured, and the sleeping earth goddess Gaea is stirring, raising giants to overthrow the gods. Sent on a quest, the three cross the country fighting monsters and free Piper's kidnapped father from a giant. They rescue Hera, but learn the truth Jason forgot: he comes from a hidden Roman demigod camp, the gods have both Greek and Roman sides, and Hera swapped Jason with the missing Percy Jackson to force the two camps to unite against Gaea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -936,7 +936,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -949,7 +949,7 @@
       "recaps": {
         "ending": "The Set's weapon is detonated where it cannot be carried clear, and Wayne dies containing it: he holds the blast inside his own accelerated-time bubble so that it takes him and a stretch of Bilming instead of taking the city and everyone in it. Wax confronts what his sister has become and destroys the avatar Autonomy has built out of her; Telsin does not survive it, and the god itself is forced back off the world rather than killed. Bilming is wrecked but standing, Elendel is not attacked, and the Malwish fleet stands down into negotiation instead of bombardment. Wax survives, badly used, and does not go back to being a lawman; he returns to Steris and their children and to the political work of a Basin that now has to be told the truth about itself. That truth is the real handoff: this world is one of many, Harmony is one god among several and is bound by terms he did not choose, other powers have been interested in Scadrial for centuries, and organizations like the Ghostbloods have been operating in that wider contest the whole time. Marasi ends the book as the Basin's link to them and to everything beyond it, holding knowledge her own government is not ready for. Wayne is buried a hero of a city that never knew what he was quietly paying for, and remembered by the people he paid. Harmony tells Wax that what has just happened was an opening move rather than a conclusion, and looks past him to the generation coming after.",
         "in_short": "Six years on, Waxillium Ladrian is a senator and a father who has left the lawman's work behind, while Wayne and Marasi Colms still work cases for the constabulary. A Set investigation leads them to Bilming, a coastal city rebuilt on southern technology, where the organization has been constructing a weapon out of god metal capable of destroying Elendel. Marasi falls in with the Ghostbloods and learns what the Basin never knew: this world is one of many, Harmony is one god among several, and the Set serves another called Trell, which holds Harmony to terms that keep him from intervening directly. Wax discovers that the Set is led by his sister Telsin, who was never a prisoner, and that she has been prepared as the body through which Trell can act in person. The Malwish fleet arrives ready to destroy Bilming rather than let the weapon be finished. In the end Wayne dies containing the explosion inside his own speed bubble, Wax destroys the god's avatar and his sister with it, and Elendel survives to be told that it has always been a small part of a much larger contest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1173,7 +1173,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1186,7 +1186,7 @@
       "recaps": {
         "ending": "Inside Ugu's wicker castle, Dorothy's party recovers the stolen magical treasures and learns that the lost princess has been hidden by transformation rather than carried away as a prisoner. The Little Pink Bear's truthful answers identify the enchanted peach pit that is really Ozma, and she is restored to her proper form. Ugu is reduced to the form of a dove and refuses the chance to become a man again, preferring to fly away. Dorothy asks that he be forgiven rather than punished further. Cayke receives her golden dishpan, Glinda and the Wizard regain their tools, and every traveler returns safely. The adventure also leaves the Frogman humbler and Cayke less dependent on a possession for her sense of worth, while Ozma resumes her place in the Emerald City among her relieved friends.",
         "in_short": "Ozma vanishes from the Emerald City at the same time that magical treasures disappear from Dorothy, the Wizard, and Glinda. Dorothy leads a search party across the Winkie Country, while Cayke the Cookie Cook and the self-important Frogman separately seek Cayke's stolen golden dishpan. After visits to strange communities, a Truth Pond, and the home of two magical bears, the parties unite. The Little Pink Bear's unfailing answers point to Ugu the Shoemaker, a jealous magician who has stolen the missing objects and hidden Ozma through enchantment. The friends overcome Ugu's defenses in his wicker castle, recover the magic, and discover Ozma transformed into a peach pit. She is restored, Ugu departs as a dove, and Dorothy persuades everyone to answer his wrongdoing with forgiveness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1313,7 +1313,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1326,7 +1326,7 @@
       "recaps": {
         "ending": "The letter ends without absolution on either side. Taryn has said what she came to say: that she loved Locke and wanted him, that she knew he was courting Jude at the same time and said nothing, that she watched her sister be humiliated and did not intervene, and that she would make many of the same choices again because the alternative, as she sees it, was to be as exposed and as hated as Jude made herself. She asks for forgiveness while admitting she has not really earned it and is not certain she is sorry in the way Jude would need her to be. She is engaged to Locke and will marry him, which secures the place in Faerie she has wanted since childhood, and she does not pretend the marriage is a triumph so much as a settlement. The confession is addressed to Jude but framed as something Taryn may never manage to hand over, so the sisters are left where the previous book left them: each convinced the other chose wrongly, still bound by blood and by a shared childhood neither can put down, with the quarrel unresolved and Taryn's wedding ahead of them.",
         "in_short": "A companion novella to The Cruel Prince, told as a long confessional letter from Taryn Duarte to her twin, Jude. Taryn retells their shared childhood from her own side: their mother's flight from Faerie, Madoc's arrival and the murders, and their upbringing in a court that despised them for being mortal. Where Jude decided to fight for a place, Taryn decided to earn one by being agreeable, and she explains her secret courtship with Locke, who was pursuing both sisters at once and asked her to keep silent about it. She admits she stayed quiet while Jude was humiliated by Cardan's circle, admits her jealousy, and argues that her own strategy of accommodation was no more cowardly than Jude's was reckless. The letter carries her through the discovery of the deception, the sisters' rupture, and her engagement to Locke, and closes with an apology she concedes is incomplete: she wants forgiveness, she is not sure she deserves it, and she is not sure she would choose differently.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1475,7 +1475,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1487,7 +1487,7 @@
       },
       "recaps": {
         "in_short": "Presented as recovered accounts from Araluen's past, this collection fills gaps before, between and after the preceding novels rather than continuing one book-length plot. Its stories revisit the central circle at different ages: Halt's Hibernian origins and early Ranger service, the truth about Will's parents, missions involving Rangers and Couriers, quieter dangers around Redmont and changes in the friends' personal lives. Familiar figures including Will, Halt, Horace, Alyss, Gilan, Crowley, Cassandra, Pauline and Jenny appear in combinations that the main campaigns did not always have room to show. The later material carries the characters beyond the return from Nihon-Ja and gives Will and Alyss a long-awaited wedding. Taken together, the fragments turn mysteries and passing references from the series into a broader history of the Ranger Corps and the people around it; they do not introduce a single new antagonist or a continuous final campaign.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1592,7 +1592,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1605,7 +1605,7 @@
       "recaps": {
         "ending": "At the Boston conference, Tom Benton propositions Olive and threatens her career when she rejects him. Evidence of the encounter eventually lets her show Adam what his friend has done. Adam believes her and takes action against Tom, whose professional standing and planned collaboration with him collapse. Olive no longer has to abandon her project or accept Tom's control to gain access to the research resources she needs. The crisis also ends the evasions between Olive and Adam: each had mistaken the other's restraint for lack of genuine interest, but they openly choose a real relationship. Adam remains at Stanford, and Olive continues her scientific work with her friendships intact. Anh and Jeremy are together, while Malcolm and Holden also form a relationship. A later return to the place of Olive and Adam's first impulsive kiss marks a full year together, turning the beginning of their fake romance into an anniversary they can celebrate honestly.",
         "in_short": "Stanford biology doctoral student Olive Smith kisses the first man she finds in a dark lab so her friend Anh will believe she has moved on from Jeremy. The stranger is Adam Carlsen, a feared professor. They agree to fake-date: Olive wants Anh free to pursue Jeremy, while Adam wants to reassure his department that he plans to stay. Their staged meetings become real intimacy, though Olive assumes Adam cannot return her feelings. Adam's friend Tom Benton offers Olive access to a better-equipped cancer lab, then sexually harasses and threatens her at a conference. Olive initially hides what happened, fearing the damage to Adam's friendship and career, but recorded evidence exposes Tom. Adam immediately supports her and ends the collaboration. Olive and Adam finally admit that neither has been pretending about their attraction. Tom loses his leverage, Olive continues her research, and the couple build a genuine relationship. One year after their first kiss, they return to the same lab as committed partners.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1761,7 +1761,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1774,7 +1774,7 @@
       "recaps": {
         "ending": "George Harvey is never brought to justice by the law. Sensing that the Salmons are closing in after Lindsey finds his incriminating drawing, he abandons his house and drifts from place to place for years, continuing to prey on women. In the end his death is a matter of chance rather than punishment: while trying to lure another young woman, he is knocked off balance by a falling icicle and tumbles into a ravine, and his body lies undiscovered for weeks. The Salmons, meanwhile, come back together. Jack survives a heart attack that brings Abigail home after her years away, and the marriage tentatively mends. Lindsey grows up, settles with Samuel, and has a daughter she names for her lost sister; Buckley reaches adulthood carrying the family's grief. Susie is given one final, impossible gift, briefly entering Ruth Connors's body to share the love and the touch with Ray Singh that her murder had stolen. A charm from the bracelet Susie wore the day she died surfaces years later, a small sign that she is not forgotten. At the last, Susie releases her hold on the living, watching them go on without her, and wishes them long and happy lives.",
         "in_short": "Fourteen-year-old Susie Salmon is lured into an underground hideout by her neighbor George Harvey and murdered. She narrates the rest from her own heaven, watching her Pennsylvania family come apart under the weight of her loss. Her father Jack becomes certain Harvey is the killer but cannot prove it; her mother Abigail pulls away and eventually leaves the family, drifting into an affair with the detective Len Fenerman and then to California. Her sister Lindsey breaks into Harvey's house and finds a drawing that confirms his guilt, but he senses the danger and slips out of town before he can be caught, uncaught for his crimes. Years pass and the family slowly heals: Jack's heart attack draws Abigail home, Lindsey builds a life with her partner Samuel, and Buckley grows up. Susie is granted one impossible wish when she briefly slips into the body of her classmate Ruth to be with the boy she loved, Ray. Long afterward, Harvey dies alone and unremembered when he falls into a ravine, and Susie finally lets go, wishing the living a long and happy life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1946,7 +1946,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1959,7 +1959,7 @@
       "recaps": {
         "ending": "Years after Susie's murder, Jack survives a heart attack and Abigail returns to the family she left, allowing the parents and their now older children to begin a more honest reconciliation. Lindsey builds a life with Samuel and prepares for a child, while Buckley finally expresses the anger created by his mother's absence and his father's consuming grief. Ruth and Ray remain linked by Susie's death. When Ruth encounters the place where Susie's concealed remains lie, Susie briefly enters Ruth's body and spends an intimate afternoon with Ray, experiencing the closeness she lost at fourteen before releasing the living pair to their own lives. George Harvey is never convicted for Susie's murder, but after continuing to prey on women he dies in an accidental fall when an icicle strikes him. Susie's family does not recover her body from the sinkhole, yet they gradually stop organizing every part of life around the crime. Susie moves toward acceptance as those she loves carry her memory into lives that continue without her.",
         "in_short": "Fourteen-year-old Susie Salmon is raped and murdered by her neighbor George Harvey, who hides her body and leaves little evidence. Narrating from heaven, Susie watches her father Jack become convinced Harvey is guilty while the police fail to prove it. Her mother Abigail withdraws, has an affair with Detective Len Fenerman, and eventually leaves; her sister Lindsey risks entering Harvey's house and finds evidence that forces him to flee. Years pass. Lindsey and Samuel build a future, Buckley grows up angry at the damage within the family, and Jack's heart attack brings Abigail home. Susie's schoolmates Ruth and Ray remain unusually connected to her. Susie briefly returns through Ruth's body to share physical love and farewell with Ray. Harvey avoids prosecution but later dies in an accidental fall while stalking another woman. Susie's remains stay hidden, yet her family slowly reunites and moves beyond the moment of her death, carrying their love for her without surrendering the rest of their lives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2100,7 +2100,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2113,7 +2113,7 @@
       "recaps": {
         "ending": "Keith learns why Logan came to Hampton and uses the secret to break Elizabeth's trust in him. During a violent storm, Ben is endangered near a failing tree house above the river. Logan, Keith, and Zeus converge on the rescue. Ben survives, but Keith is killed as the structure and surrounding trees collapse. The crisis also resolves the photograph's origin: it had belonged to Elizabeth's late brother Drake and was lost during his service in Iraq. Logan's connection to the family was therefore created by Drake, whether through chance or the luck Victor perceived. Elizabeth comes to understand that Logan's initial secrecy did not make his love or his care for Ben false. Logan remains with Elizabeth and Ben, forming the family toward which his long walk had unknowingly led him.",
         "in_short": "Marine veteran Logan Thibault walks from Colorado to North Carolina to find the unknown woman in a photograph he carried through the Iraq War as a lucky charm. She is Elizabeth Green, a divorced teacher raising her son Ben and helping her grandmother run a dog kennel. Logan takes work there without explaining the photograph, then falls in love with Elizabeth and becomes a steady presence for Ben. Her possessive former husband, deputy Keith Clayton, uncovers Logan's secret and turns it against him. During a storm, the men race to save Ben from a collapsing riverside tree house; Ben lives, but Keith dies. The photograph is revealed to have belonged to Elizabeth's brother Drake, who died in Iraq. Elizabeth forgives Logan's concealment, and he stays with her and Ben.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2295,7 +2295,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2308,7 +2308,7 @@
       "recaps": {
         "ending": "Elvira Drew's supposed research is a cover for a group that captures shapeshifters and records their suffering for paying customers. Kaspar Gunderson has helped the hunters identify victims because they promised to end the curse that leaves him divided between human and swan forms. Anita, Richard, Edward, and their allies locate the captives and break up the operation. The hunters are killed or stopped, and Kaspar is killed when he remains a threat. The immediate disappearances are solved, but the investigation also exposes the coercive alliance run by Marcus, Raina, and Gabriel. Richard still refuses to gain leadership by killing Marcus, leaving that pack conflict unresolved. In Anita's personal life, Jean-Claude compels a compromise rather than accepting her exclusive relationship with Richard: Anita will give each man a fair opportunity to court her. Richard nevertheless asks her to marry him, and she accepts, while acknowledging that the promised dates with Jean-Claude must still occur. She ends the book engaged to Richard but still bound to Jean-Claude, with the rivalry among all three now explicit.",
         "in_short": "Anita Blake's relationship with Richard Zeeman becomes serious just as the St. Louis police and local shapeshifters ask her to investigate violent deaths and several disappearances. Richard's werewolf pack is controlled by Marcus and Raina, who pressure him to settle a leadership struggle through lethal pack law. A purported researcher, Elvira Drew, seeks Anita's help finding lycanthropes, while Edward joins Anita in tracing human hunters. The missing shapeshifters are being captured for recorded killings, and the cursed swan shapeshifter Kaspar Gunderson has aided the hunters in hope of becoming permanently human. Anita and her allies end the operation, and Kaspar is killed. Richard refuses to take Marcus's place by killing him. Jean-Claude, unwilling to abandon his pursuit of Anita, forces a courtship compromise in which she agrees to date both him and Richard. Richard proposes and Anita accepts, leaving her engaged to Richard while the supernatural bond and personal attraction linking her to Jean-Claude remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2476,7 +2476,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2489,7 +2489,7 @@
       "recaps": {
         "ending": "Valentinov reappears and tries to draw Luzhin into a film project built around chess, undoing the protected separation his wife has tried to maintain. Luzhin now interprets repeated people and events as moves in a hostile combination. Convinced that ordinary life has reproduced an earlier pattern and will force him back onto the board, he searches for an unexpected defense. During a gathering at home, he locks himself in the bathroom, breaks through the window, and climbs out. His wife and the guests pound on the door and call to him by his full name, Alexander Ivanovich. He lets himself fall from the window. The narration describes the lighted windows below as if they formed a board and closes by saying that when the door is finally broken open, no Luzhin is present. His attempt to escape the perceived game therefore ends in his death, leaving his wife and household on the other side of the locked door.",
         "in_short": "The isolated child Alexander Luzhin discovers chess and finds in it the order absent from ordinary life. Valentinov turns the prodigy into a touring professional, and Luzhin reaches adulthood as a celebrated but emotionally stunted grandmaster. At a German resort he meets a young Russian woman who accepts his abrupt proposal and persists despite her parents' doubts. While preparing a new defense against the Italian champion Turati, Luzhin begins to experience life itself as a chess combination. Their tournament game is adjourned, and he suffers a breakdown. His fiancée nurses him, marries him, and removes chess from their home under medical advice. Domestic life briefly shelters him, but coincidences and Valentinov's return convince Luzhin that an old pattern is closing around him. Seeking a move outside the pattern, he locks himself in the bathroom and falls from the window to his death while his wife and guests try to reach him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2574,7 +2574,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2587,7 +2587,7 @@
       "recaps": {
         "ending": "As the Machine's failures spread, the underground civilization can no longer supply air, light, communication, or physical safety. The society that surrendered practical knowledge and independent action to the system has no means to repair or escape it. Compartments and tunnels collapse amid panic. Vashti finds Kuno, and mother and son are reconciled as they face death together. Kuno explains that people still living on the surface will survive and carry humanity forward, so the destruction below is not the end of the species. Vashti and Kuno die when the mechanical world falls around them. The Machine's apparent permanence ends, while the possibility of a renewed human life rests with the surface dwellers whom underground society had dismissed as obsolete.",
         "in_short": "Humanity lives in isolated underground cells, dependent on a worldwide Machine for communication, transport, air, food, medicine, and ideas. Vashti reveres this order, but her son Kuno longs for direct contact and the open surface. He secretly climbs outside, discovers that people still live there, and is dragged back by the Machine. Years later the system develops faults. Its users accept each failure, having lost both practical skills and the habit of independent judgment, and worship of the Machine replaces any memory that it was made by humans. The breakdown accelerates until the underground world collapses. Vashti reaches Kuno, and they die reconciled. Kuno tells her that the surface people will survive, leaving human renewal to those who remained outside the system.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2661,7 +2661,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2674,7 +2674,7 @@
       "recaps": {
         "ending": "The Machine's failures become a total collapse. Communication, ventilation, food supply, and the systems that have kept humanity alive underground cease to function, while a population trained to depend on them can neither repair the damage nor organize an escape. Vashti finally rejects the Machine she worshipped and makes her way through the darkness and panic. She finds Kuno amid the ruins, and mother and son recover a moment of direct affection before the underground structure kills them. Kuno tells her that people living on the surface remain outside the disaster. The subterranean civilization ends, but humanity itself may survive through those who retained contact with the earth and did not surrender every capacity to the system.",
         "in_short": "Humanity lives in isolated underground cells while an all-providing Machine supplies food, air, entertainment, travel, and electronic conversation. Vashti accepts this existence, but her son Kuno longs for direct contact and secretly reaches the earth's surface. He discovers that people still live outside before the authorities recapture him and threaten him with expulsion from the Machine's protection. Over time, society begins worshipping the system and loses the knowledge needed to maintain it. Small faults multiply, but complaints are dismissed because dependence has become absolute. When the Machine finally stops, the underground world collapses. Vashti reaches Kuno, and they reconcile just before dying together. Kuno says surface dwellers remain alive, leaving open the possibility that a less dependent humanity will continue.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2796,7 +2796,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2807,7 +2807,7 @@
       "recaps": {
         "ending": "The book ends with a health crisis resolved by the tree's magic. The children's mother falls ill and the doctor can do nothing, but the Land of Magic Medicines settles at the top of the Faraway Tree at the right moment. While one of the sisters stays behind to nurse her, the others climb up and, despite the cousin swelling to a huge size and then shrinking almost to nothing among the medicines, come away with a general get-well cure that restores their mother to full health. With the danger past, the friends take a last celebratory trip to the Land of Presents, a place of Christmas trees and gifts of every kind. The cousin's visit then draws to a close, leaving the children to their ordinary life with their mother well again. The tree folk - Moon-Face, Silky, the Saucepan Man and the others - remain in the Faraway Tree as ever, and the way is left open for a new visitor, Connie, to arrive in the next book.",
         "in_short": "A cousin comes to stay with the children while his own mother is ill, and is soon convinced that the Enchanted Wood and its Faraway Tree are real. Together they climb to the lands at the top of the tree: the Land of Topsy-Turvy, where the brother is turned upside down and has to be cured with a spell bought in the Land of Spells; the Land of Do-As-You-Please, with its runaway train; and the Land of Goodies, built of things to eat. When the children's own mother falls seriously ill and the doctor is baffled, the Land of Magic Medicines arrives just in time, and they fetch a get-well cure that restores her. The book ends with a happy final visit to the Land of Presents, full of Christmas trees and gifts, before the cousin's stay comes to an end and the children settle back at home with their mother well again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2940,7 +2940,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2953,7 +2953,7 @@
       "recaps": {
         "ending": "After seven years at the Berghof, Hans has outlived or lost the relationships that structured his education there. Joachim has died following his premature return to military life; Peeperkorn has killed himself; Clavdia has departed; and Naphta, provoked into a duel with Settembrini, shoots himself when Settembrini refuses to aim at him. Europe moves from cultural exhaustion into war. The outbreak of the First World War finally breaks the sanatorium's suspended time and sends Hans down from the mountain. He appears as an ordinary soldier in a muddy battle, moving among explosions and the deaths of other young men. The narrator does not disclose whether he survives. Hans's private course of illness, desire, argument, and reflection thus ends inside a mass historical catastrophe, with only an uncertain hope that some form of love or humane feeling might emerge from the violence.",
         "in_short": "Hamburg engineer Hans Castorp visits his tubercular cousin Joachim at a Swiss sanatorium for three weeks and remains for seven years after doctors find signs of illness in him. The Berghof removes him from ordinary time and becomes an education through disease, desire, and rival ideas. He falls in love with Clavdia Chauchat; listens to the humanist Settembrini and the authoritarian revolutionary Naphta dispute civilization; and, after nearly dying in a snowstorm, glimpses an ethic grounded in sympathy rather than abstract extremes. Joachim leaves to become a soldier, returns sicker, and dies. Clavdia later returns with the charismatic Peeperkorn, who kills himself. Naphta also kills himself after a failed duel with Settembrini. When the First World War begins, Hans finally descends and enters battle as a common soldier. His survival is left unknown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3116,7 +3116,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3129,7 +3129,7 @@
       "recaps": {
         "ending": "The Wizard learns the transformation word, recovers his black bag with the Glass Cat's help, and reverses Kiki and Ruggedo's attack on the Forest of Gugu. Trot and Cap'n Bill are freed from the Magic Isle, and the flower they sought becomes part of Ozma's birthday celebration. Dorothy's adventures with the monkeys also end safely, and the friends gather in the Emerald City with their gifts. Ozma offers mercy to the defeated conspirators. Kiki is ashamed of having let Ruggedo guide him and returns to his father, Bini Aru, with a chance to use better judgment. Ruggedo remains defiant until he drinks from the Fountain of Oblivion; its water removes his memories of hatred and revenge, leaving the former Nome King harmless and giving the celebration a peaceful close.",
         "in_short": "Kiki Aru secretly learns his father's transformation word and runs away, only to meet Ruggedo, the former Nome King. Ruggedo persuades him to use the charm in a plot against Ozma, beginning with an attempt to raise the beasts of the Forest of Gugu against human beings. At the same time, Dorothy, the Wizard, Trot, Cap'n Bill, and the Glass Cat pursue separate birthday gifts for Ozma. Trot and Cap'n Bill become rooted to the Magic Isle, while the Wizard's party collides with Kiki's enchantments. The Wizard overhears the magic word, the Glass Cat recovers his lost black bag, and the conspirators are defeated. The friends are rescued in time for Ozma's party. Kiki repents and goes home; Ruggedo drinks from the Fountain of Oblivion and forgets his long hatred.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3280,7 +3280,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3293,7 +3293,7 @@
       "recaps": {
         "ending": "Peter reaches the elephant and understands that she is not a wonder created for the city but a captive who longs for home. He promises to help her return, even though doing so seems to threaten the fortune-teller's promise that the animal will lead him to Adele. Leo Matienne and others connect Peter's search with the orphan girl's dreams, bringing brother and sister together. To repair the original accident, Madam LaVaughn forgives the imprisoned magician, allowing him to act without the paralysis of guilt and resentment. He performs the magic again in reverse, and the elephant vanishes from Baltese and awakens among her own kind in her warm homeland. Peter and Adele recognize and accept each other as family, while Leo and Gloria Matienne give them a home. Across the city, people who had resigned themselves to isolation become more open to one another and to hope.",
         "in_short": "In the wintry city of Baltese, orphan Peter Augustus Duchene asks a fortune-teller whether his baby sister is still alive. She says that the girl lives and that an elephant will lead him to her. That night, a magician trying to produce flowers instead pulls an elephant through the opera-house roof, injuring Madam LaVaughn and astonishing the city. Peter refuses his guardian Vilna Lutz's claim that his sister died and gains help from police officer Leo Matienne and Leo's wife Gloria. The elephant, meanwhile, is displayed as a marvel but suffers from captivity and homesickness; Adele, raised in an orphanage, dreams that the animal will come for her. Peter eventually reaches the elephant and promises to send her home. The magician, after receiving Madam LaVaughn's forgiveness, reverses his spell and returns the elephant to her own land. The search brings Peter and Adele together, and the Matiennes welcome the reunited children into their family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3438,7 +3438,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3451,7 +3451,7 @@
       "recaps": {
         "ending": "After Isabel's death, the Amberson fortune collapses. The Major dies with his assets confused and depleted, Jack leaves town for work, and George and Fanny discover that their income is almost gone. George abandons his plan to study law and takes dangerous work so that he can support his aunt. Walking through the transformed city, he finally recognizes the scale of his arrogance and asks forgiveness of his mother. Soon afterward an automobile strikes him and breaks both legs. Lucy has already learned through Eugene that George sacrificed his prospects for Fanny; she and George are reconciled while he is hospitalized. Eugene, whose automobile enterprise helped remake the town and displace the Amberson world, visits George and sets aside their hostility. He later tells Fanny that a spiritual medium seemed to convey Isabel's wish that he care for her son. George's long-anticipated humbling is complete, but it ends with forgiveness and renewed human connection rather than isolation.",
         "in_short": "The Ambersons dominate a growing Midwestern town, and Isabel Amberson's spoiled son George assumes their prestige will last forever. Home from college, he falls for Lucy Morgan, daughter of automobile pioneer Eugene Morgan, Isabel's former suitor. After Wilbur Minafer dies, Eugene and Isabel move toward marriage, but George treats the relationship as a threat to family honor. He blocks Eugene from the house and takes his ailing mother abroad; she dies soon after their return. Lucy refuses to marry a man with no purpose beyond inherited status, while the automobile economy Eugene represents reshapes the town. The Amberson fortune then vanishes through bad investments and neglect. George gives up law school for dangerous work to support his aunt Fanny and finally understands the harm caused by his pride. An automobile injures him, after which Lucy reconciles with him and Eugene forgives him, fulfilling Isabel's remembered wish that the two men make peace.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3616,7 +3616,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3629,7 +3629,7 @@
       "recaps": {
         "ending": "After the Bourani company disperses, Nicholas returns to England and tries to uncover who organized the experience and why. His inquiries confirm that the supposed supernatural events were staged by an extensive network, yet the people involved continue to control what he can learn. Contact with Lily de Seitas offers context without giving him a single authoritative interpretation. Nicholas also discovers that Alison did not die: her reported suicide was part of the design, and she participated in the final phase. He eventually meets her again in London. Their confrontation strips away his hope that solving the masque will automatically restore their relationship. Alison is angry at how he treated her, and Nicholas can no longer retreat entirely into his former detachment. The novel closes without stating whether they reconcile, leaving them together at a moment when a more honest choice has become possible but has not been guaranteed.",
         "in_short": "Nicholas Urfe leaves an unsatisfactory relationship with Alison Kelly to teach on the Greek island of Phraxos. There he meets the wealthy Maurice Conchis, who draws him into a sequence of stories, tableaux, false identities, and apparent supernatural events at the estate of Bourani. Nicholas becomes obsessed with a young woman presented first as Lily and later through competing identities, while neglecting Alison when she visits. After Alison is reported dead, the masque grows more invasive and culminates in a staged judgment of Nicholas's conduct. Its participants then disappear. Back in England, he investigates and learns that the godgame was a large collaborative performance designed to confront his habits of manipulation and emotional evasion. Alison's death was staged and she took part. When Nicholas finally meets her again, she refuses an easy restoration of their romance. Their future remains unresolved, though Nicholas is left facing responsibility and genuine freedom more directly than before.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3818,7 +3818,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3831,7 +3831,7 @@
       "recaps": {
         "ending": "Gutman's party receives the black bird, but scraping its surface reveals ordinary material beneath the coating: this Falcon is a decoy. Gutman and Cairo decide to continue their search overseas. Before that discovery, Spade has forced the group to surrender Wilmer as the person who can be blamed for Thursby's and Captain Jacobi's deaths; Wilmer escapes, later turns on Gutman, and is taken into custody. Spade then confronts Brigid. He reconstructs how she killed Miles Archer when the attempt to frighten Thursby failed, expecting suspicion to fall on Thursby. Despite her pleas and his attraction to her, Spade gives her to the police. He explains that loyalty to his murdered partner, self-preservation, and refusal to let a client manipulate him all require the same choice. The police can now connect the deaths and the Falcon conspiracy. Effie is appalled by Brigid's guilt and by Spade's cold resolution. As the case closes, Iva Archer again waits to see him, leaving Spade with the personal consequences of the affair even after the professional mystery is solved.",
         "in_short": "San Francisco detective Sam Spade and his partner Miles Archer are hired by a woman calling herself Miss Wonderly to follow Floyd Thursby. Archer and Thursby are both killed, leaving Spade under police suspicion. The client admits she is Brigid O'Shaughnessy but continues lying about her pursuit of a black statuette. Joel Cairo, collector Casper Gutman, and Gutman's gunman Wilmer converge on Spade, who learns that the object is believed to be a jeweled medieval tribute concealed beneath enamel. A dying ship captain delivers the bird to Spade. He bargains with Gutman's group and makes them offer Wilmer as a fall guy, but the statuette proves fake. Gutman and Cairo resume their search; Wilmer later kills Gutman. Spade then establishes that Brigid herself murdered Archer to remove Thursby and redirect suspicion. Though attracted to her, he turns her over to the police because Archer was his partner and because he will not accept being used. The Falcon remains lost, while the local murders are finally accounted for.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3989,7 +3989,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4002,7 +4002,7 @@
       "recaps": {
         "ending": "After being recognized as Lord Fermain Clancharlie, Gwynplaine rejects Josiana's invitation and tries to defend the poor before the House of Lords. The peers answer his appeal with laughter, reducing both his face and his testimony to entertainment. He abandons his recovered rank and returns to the life he chose, but Ursus and Dea have been expelled from England and are already sailing away. Gwynplaine reaches their vessel and is reunited with them. Dea, physically frail and overwhelmed by the separation and reunion, dies in his arms after affirming her love. Gwynplaine walks to the edge of the ship and lets himself fall into the sea. Homo looks over the rail and howls, leaving Ursus and the wolf as the survivors of the family.",
         "in_short": "Gwynplaine, a boy whose face was surgically fixed into a grin, is abandoned during a storm and rescues the blind infant Dea. The showman Ursus raises them, and as adults they perform together, with audiences laughing at Gwynplaine while Dea loves him without seeing his scars. Duchess Josiana becomes erotically fascinated by him. Evidence then reveals that Gwynplaine is really Lord Fermain Clancharlie, an abducted noble heir. Taken from his family and restored to Parliament, he tries to tell the Lords about the suffering of the poor, but they laugh at him. He rejects aristocratic life and seeks Dea, only to find that Ursus's company has been banished and is sailing away. Reunited aboard ship, Dea dies in his arms, and Gwynplaine throws himself into the sea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4113,7 +4113,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4126,7 +4126,7 @@
       "recaps": {
         "ending": "Daniels leaves the sewer because he wants to tell the police what he has seen and done and to show them the underground space that transformed his understanding of guilt. He returns to the same authorities who tortured a false murder confession from him. His account of moving through walls, taking money and valuables, and watching the life of the city from beneath it sounds insane to men who never cared whether his first confession was true. Lawson accompanies him to the sewer entrance. Rather than investigate or acknowledge what happened, the officer shoots Daniels and lets his body fall into the underground current, then explains the killing as the necessary response to an attempted escape. Daniels dies at the boundary between the two worlds, while the official system once again replaces truth with a convenient story.",
         "in_short": "Fred Daniels, a Black man falsely accused of murdering a white couple, is tortured by police until he signs a confession. He escapes into storm drains and makes a chamber in the sewer his home. From passages behind walls he secretly watches a church, a cinema, and businesses, seeing the city's ordinary rituals from a radically detached perspective. He steals tools, food, money, and valuables, but the objects lose their accepted meaning underground; he uses cash as decoration and arranges his finds in his cave. Above ground, an innocent watchman is blamed for a theft and kills himself, echoing Daniels's own punishment for another person's crime. Convinced that he must share what the underground has shown him, Daniels returns to the police. Lawson takes him back to the sewer, shoots him, and reports that he was escaping, completing the cycle in which official stories erase the truth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4270,7 +4270,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4283,7 +4283,7 @@
       "recaps": {
         "ending": "Syme and the other five council members pursue Sunday through an increasingly impossible London journey involving vehicles, an elephant, and a balloon. The chase ends at a country estate, where servants dress each detective in clothing symbolizing the day of creation associated with his council name. At a vast feast, Sunday says that he arranged both their recruitment and their ordeals, presenting himself not simply as the criminal president they feared but as a figure of authority, nature, and rest whose purpose cannot be reduced to a police explanation. Gregory enters dressed as the adversary and accuses the detectives of having the protection of order without knowing the suffering of those who rebel. Syme answers that their pursuit has indeed made them afraid and alone. When he asks whether Sunday himself has suffered, the reply evokes Christ's challenge to his disciples. The vision then dissolves. Syme finds himself walking peacefully with Gregory near Saffron Park, no longer certain where ordinary experience ended and the nightmare began, and sees Rosamond in the garden. The case closes as a spiritual and philosophical revelation rather than a conventional arrest.",
         "in_short": "Poet and undercover policeman Gabriel Syme infiltrates an anarchist group and is unexpectedly elected Thursday on its seven-man European council. The gigantic president, Sunday, orders the council to support a political assassination. As Syme tries to prevent it, one terrifying colleague after another reveals that he too is a disguised detective. All six subordinate council members have been sent against an organization that seems to consist entirely of police, yet Sunday remains beyond explanation and turns their pursuit into a surreal chase. At his country estate the six are dressed as the days of creation and welcomed to a feast. Sunday claims responsibility for both their missions and their trials. The anarchist Gregory accuses them of never suffering as rebels do; Syme insists that their fear and isolation gave them that knowledge. Asked whether he has suffered, Sunday answers in language associated with Christ. Syme then finds himself back near Saffron Park, seeing Rosamond Gregory, as though emerging from a transformative dream.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4455,7 +4455,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4468,7 +4468,7 @@
       "recaps": {
         "ending": "After the six detectives reach Sunday's estate, each is dressed as the day he represented and honored at a strange feast patterned on the creation week. They confront Sunday, who says he has opposed anarchy from within and has also been the mysterious authority who recruited them. His explanations do not remove the suffering or fear caused by their mission. Lucian Gregory then appears as an accuser, claiming that the comfortable defenders of order cannot understand the outcast's pain. Syme answers that he and the others have known terror and isolation, and Sunday responds with a question identifying himself with innocent suffering rather than offering a tidy solution. The vision breaks. Syme finds himself walking peacefully with Gregory near Saffron Park at dawn and then sees Rosamond. Whether the adventure was dream, revelation, or both remains unresolved, but Syme returns to ordinary life with a renewed sense of gratitude and order.",
         "in_short": "Poet and undercover detective Gabriel Syme infiltrates a secret anarchist council whose seven leaders use weekday names, taking the vacant seat of Thursday. He fears the enormous President Sunday and the council's plan for a bombing in Paris. One by one, however, Tuesday, Friday, Saturday, Wednesday, and Monday prove to be fellow detectives, each recruited by the same hidden authority. Even united, they are pursued across France and England by crowds apparently commanded by Sunday. Their chase of the president becomes increasingly dreamlike and ends at his estate, where Sunday reveals that he both led the council and directed the police campaign against it. At a symbolic feast, Lucian Gregory accuses the defenders of order of never suffering as rebels do. Syme answers from the ordeal they have endured; Sunday replies with an enigmatic identification with suffering. Syme then returns to Saffron Park at dawn, uncertain whether the adventure was literal or visionary, and sees Gregory's sister Rosamond.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4624,7 +4624,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4637,7 +4637,7 @@
       "recaps": {
         "ending": "On the excursion train, Bond kills Hendriks and wounds Scaramanga, while Felix Leiter's preparations help destroy the criminals' base at the Thunderbird. Scaramanga escapes into the marshes and Bond follows despite his own injuries. The assassin briefly gains an advantage by pretending to be helpless, but Bond survives a concealed poisoned shot and kills him. Bond is rescued and recovers in hospital, where Mary Goodnight remains close by. The British authorities offer him a knighthood for the operation, but he declines it because he prefers to remain the working agent James Bond rather than acquire a public title. He has completed M's test, removed a dangerous assassin, and restored his place in the Service after his brainwashing and failed attack on M.",
         "in_short": "After disappearing on a mission, James Bond returns to London under Soviet conditioning and tries to kill M. The Service cures him, and M gives him a chance to redeem himself by hunting Francisco Scaramanga, an assassin famous for his golden gun. In Jamaica, Bond finds Scaramanga and is hired as temporary security for a conference at the unfinished Thunderbird hotel. The guests are criminals and a Soviet intelligence officer planning profitable ventures and regional sabotage. Bond discovers that his old ally Felix Leiter and another American agent are already undercover at the hotel. His cover becomes increasingly fragile, and Scaramanga eventually arranges a train outing intended to dispose of him. Bond and his allies strike first: the hotel operation is broken, Hendriks is killed, and Scaramanga is wounded. Bond pursues the assassin into the marshes and kills him after a final exchange that leaves Bond poisoned and badly hurt. He recovers, declines a knighthood, and returns to active service.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4805,7 +4805,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4818,7 +4818,7 @@
       "recaps": {
         "ending": "Scaramanga's excursion train becomes the setting for the final clash. Once Bond's identity is known, the journey turns into an attempted execution, but Bond, Felix Leiter, and Nicholson's operation destroys the train and breaks up the conference. Mary Goodnight is brought clear of the danger. Bond and Scaramanga escape the wreck into the marshes, where their pursuit ends in a close gunfight. Scaramanga wounds Bond with a poisoned bullet, but Bond kills him. Bond is found and taken to hospital, where treatment saves his life. The surviving conspirators' plans are exposed, and the Jamaican operation is dismantled. During his recovery Bond declines a high public honor, preferring to remain an anonymous working agent. Goodnight remains close to him, but he does not accept the settled domestic future she imagines, leaving him alive, restored to the Service, and emotionally resistant to permanent commitment.",
         "in_short": "After losing his memory in Japan, James Bond reaches the Soviet Union and is brainwashed into returning to London to kill M. The attempt fails; treatment restores him, and M tests his recovery by sending him to Jamaica after the assassin Francisco Scaramanga. With help from Mary Goodnight, Bond finds Scaramanga and takes a job as his temporary assistant at the Thunderbird Hotel, where gangsters are meeting over criminal investments and sabotage. Felix Leiter and another American agent are already undercover there. Bond's identity is exposed as the group takes an excursion train, prompting a violent showdown that wrecks the train and scatters the conspiracy. Bond pursues Scaramanga into the marshes and kills him, though a poisoned bullet nearly kills Bond in turn. He recovers in hospital, refuses a public honor, and returns to Service life without accepting Goodnight's implied hope of marriage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4938,7 +4938,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4951,7 +4951,7 @@
       "recaps": {
         "ending": "After more than fifty years at sea, Nolan lies dying in a cabin he has turned into a private memorial to the nation he renounced. Captain Danforth finally tells him about the country's growth, its new states, and the crisis of the Civil War, though he withholds some of the darkest news. Nolan shows that he has spent his exile following what little he could infer and loving the country from which all direct knowledge was barred. He dies still legally denied a homeland, but inwardly reconciled to it and conscious of belonging to it. At his request he is buried at sea, while the inscription he prepared identifies him as a man who loved his country yet was forbidden to hear its name.",
         "in_short": "In 1807, the young officer Philip Nolan is tried for joining Aaron Burr's conspiracy. In anger he says he never wants to hear of the United States again. The court grants that wish as punishment: Nolan is kept aboard naval ships for the rest of his life, transferred from vessel to vessel, and shielded from every mention of his homeland. Early defiance gives way to regret as censored books, guarded conversations, and encounters with travelers show him what it means to have no country. He nevertheless becomes a useful and respected companion to generations of sailors. More than fifty years later, dying during the Civil War, Nolan reveals a cabin filled with handmade symbols of the nation and asks to hear its history. He dies loving the country he rejected and is buried at sea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5080,7 +5080,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5093,7 +5093,7 @@
       "recaps": {
         "ending": "Annabeth, following the Mark of Athena alone, tracks the lost Athena Parthenos statue to a hidden cavern beneath Rome and outwits and defeats the ancient spider-creature Arachne who guards it, freeing the statue that could heal the rift between the Greek and Roman camps. But the victory becomes a trap: the ground collapses, and Arachne, ensnared but not dead, drags Annabeth toward a vast chasm that opens into Tartarus, the abyss beneath the underworld. Percy reaches her in time but cannot pull her free, and rather than lose each other, the two choose to fall together into the pit, trusting their friends to find them on the far side. The rest of the crew, Jason, Piper, Leo, Frank, Hazel, and Nico, secure the Athena Parthenos aboard the Argo II and set course for the House of Hades in Greece, where the Doors of Death stand. Their plan is desperate: close the Doors from the mortal world while Percy and Annabeth try to reach them from within Tartarus, so the two can escape and Gaea's path back to life can be sealed. The book ends on that separation, the couple lost in the abyss and the ship racing to reach the Doors before it is too late.",
         "in_short": "The Greek warship Argo II reaches Camp Jupiter, and Percy and Annabeth are joyfully reunited. But the fragile peace shatters when Leo, briefly possessed by an evil spirit, fires the ship's weapons on the Roman camp, making the Romans believe the Greeks have attacked. The seven demigods flee, sailing east toward the ancient lands of Rome and Greece to close the Doors of Death and stop Gaea from rising. Annabeth carries a solitary quest handed down from her mother, Athena: to follow the Mark of Athena and recover a long-lost statue that could reconcile the Greek and Roman demigods. The crew battles giants and monsters across the Mediterranean and rescues Nico, who has been captured. In Rome, Annabeth follows the trail alone into an underground lair and confronts the monstrous spider Arachne, recovering the great statue. But as she does, the floor gives way, and she and Percy, refusing to let go of each other, tumble together into Tartarus, the deepest pit of the underworld, leaving their friends to sail on toward the Doors of Death to find them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5261,7 +5261,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5274,7 +5274,7 @@
       "recaps": {
         "ending": "Earth's settlements on Mars collapse when approaching war draws nearly everyone home. The settlers watch their planet flare with nuclear destruction, leaving Mars almost empty. Captain Wilder eventually returns from a long mission and finds the aged Hathaway living with artificial replicas of the family he lost; Hathaway dies, while the robots continue without him. On Earth, an automated house carries on serving owners already reduced to silhouettes by the blast, then burns after an accidental fire overwhelms its systems. William Thomas has meanwhile taken his wife and three sons to Mars in a family rocket. He destroys maps and other links to Earth, explaining that their old civilization is gone and that another family will soon join them. When his sons ask to see Martians, he leads them to a canal and points to their reflections. The surviving humans are now the Martians, charged with building something different from the society that destroyed itself. The native civilization is gone, Earth is devastated, and the future rests with a few refugees who have chosen Mars as home rather than colony.",
         "in_short": "A sequence of linked stories follows repeated expeditions from Earth to Mars. Early crews die through Martian fear, misunderstanding, and deception; the successful fourth expedition discovers that Earth disease has already destroyed most native life. Settlers then remake Mars with trees, towns, commerce, and imported prejudices, often ignoring the civilization beneath their construction. A few people encounter surviving Martians or moments of the older world, while others exploit the planet or seek escape from censorship and loneliness. When nuclear war threatens Earth, most colonists return, only to witness their home planet burn. Mars is left to scattered survivors: Captain Wilder finds an old crewmate living with robot replicas of his family, an automated house on Earth performs for dead owners before burning, and William Thomas secretly brings his family to Mars. He destroys their links to Earth's failed order and shows his sons their reflections in a canal, declaring that they are now the Martians. Human settlement ends not in conquest but in a small, uncertain chance to begin again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5436,7 +5436,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5449,7 +5449,7 @@
       "recaps": {
         "ending": "With Glinda the Good's help, the mystery of who should truly rule the Emerald City is solved. Glinda compels the old witch Mombi to confess a secret she has kept for years: the city's rightful ruler is Princess Ozma, the daughter of its former king, whom Mombi had hidden by using magic to transform the infant princess into a boy and raise her in disguise. That boy is Tip. Confronted with the truth, Tip is frightened at first to give up the only self he has known, but agrees, and Mombi's spell is reversed, restoring Tip to her true form as the lovely Princess Ozma. Ozma takes her rightful place on the throne of the Emerald City. General Jinjur and her army are driven out, Mombi is stripped of her magic so she can do no more harm, and Ozma warmly rewards the friends who helped her: the Scarecrow, the Tin Woodman, Jack Pumpkinhead, the Saw-Horse, the Woggle-Bug, and the Gump. Oz is left at peace under its true young queen, who will rule it from then on.",
         "in_short": "In the Gillikin country of Oz, a boy named Tip runs away from the harsh old witch Mombi, taking with him Jack Pumpkinhead, a figure he built and Mombi's magic brought to life, and a jar of the Powder of Life. Bringing a wooden Saw-Horse to life to ride, they head for the Emerald City, which the Scarecrow now rules in the departed Wizard's place. But General Jinjur and her army of girls seize the city, and the Scarecrow, Tip, and Jack flee to the Tin Woodman, gathering the pompous Woggle-Bug along the way. To escape, they assemble and animate a flying machine, the Gump, and after airborne mishaps they seek out Glinda the Good. Glinda reveals that the Emerald City's rightful ruler is a princess Mombi hid long ago, and forces Mombi to confess she had disguised the lost heir by transforming her into the boy Tip. Tip is changed back into her true form, Princess Ozma, who takes her throne, deposes Jinjur, and rewards her loyal companions.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5567,7 +5567,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5580,7 +5580,7 @@
       "recaps": {
         "ending": "Hilda persuades Solness to stop obstructing Ragnar Brovik and to sign an approving assessment of the young architect's work. She also presses Solness to make the dedication of his own new house match the heroic figure she remembers from ten years before. Despite his severe fear of heights and Aline's alarm, Solness decides to climb the new tower himself to place the wreath. From below, Hilda sees him reach the top and celebrates the return of her master builder, but the other onlookers see him lose his footing. Solness falls from the tower and is killed. The promised kingdom and the new home end at the same instant: he briefly fulfills Hilda's vision of him by repeating the dangerous ascent, but cannot survive it. Hilda remains fixed on the triumphant image even as those around her respond to his death.",
         "in_short": "Successful architect Halvard Solness fears that younger builders will displace him and blocks his gifted assistant Ragnar Brovik from accepting independent work. He is also haunted by the fire that destroyed his wife Aline's family home, led indirectly to the deaths of their infant sons, and gave him the land and opportunity on which his career was built. Hilda Wangel arrives claiming that ten years earlier Solness climbed a church tower, kissed her, and promised her a kingdom after a decade. She revives his desire to build freely and to see himself as exceptional, while he confides his guilt, ambition, and belief that his wishes shape events. Under Hilda's pressure he finally endorses Ragnar's work. She then encourages him to climb the tower of his newly completed house for its dedication. Solness overcomes his terror long enough to reach the top, but falls and dies. Hilda responds to the achievement she imagined even as the others confront the fatal result.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-mauritius-command.json
+++ b/data/works-community/0/the-mauritius-command.json
@@ -118,7 +118,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -131,7 +131,7 @@
       "recaps": {
         "ending": "After the defeats at Grand Port and the costly struggle to restore British control at sea, reinforcements turn Jack's depleted force into an army and fleet strong enough to invade Mauritius. The French position becomes untenable, and the island capitulates. Jack has fulfilled the object of his independent command despite losing ships and officers along the way. Corbett is killed in the fighting around Africaine, while Clonfert, grievously wounded and unable to reconcile his self-image with the campaign's judgments, also dies. Admiral Bertie arrives in time to assume senior direction and receives the chief public distinction attached to the conquest, leaving Jack with professional success rather than the full measure of glory he had imagined. Stephen's intelligence purpose is served by the removal of the French Indian Ocean base. Jack relinquishes the broad authority of commodore and turns homeward to Sophia and his family, his naval standing enhanced but his hunger for employment and recognition unchanged.",
         "in_short": "With Jack Aubrey stranded on shore after earlier victories, Stephen Maturin helps obtain for him an independent command against the French islands of Réunion and Mauritius. Flying his broad pennant in Boadicea, Jack must combine naval attack, intelligence, and army cooperation while managing captains divided by rivalry and temperament. Early seizures and the conquest of Réunion are followed by disaster at Grand Port, where a British squadron enters confined waters and is defeated or captured. Jack rebuilds what remains, contests the French frigates, and keeps the campaign alive; Corbett is killed and Africaine is briefly lost during the costly recovery. A larger British invasion then compels Mauritius to surrender. The objective is won, but ships and lives have been lost, Lord Clonfert dies after the collapse of his hopes for heroic distinction, and Admiral Bertie receives the foremost official credit. Jack returns from his first major independent command proven but not wholly rewarded.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -283,7 +283,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -296,7 +296,7 @@
       "recaps": {
         "ending": "After Lucetta's death, the sailor Newson comes to Casterbridge seeking Elizabeth-Jane. Henchard, afraid of losing the daughter who has grown close to him, falsely says that she is dead. The lie buys him only a little time. When Newson returns and Elizabeth-Jane learns the truth, Henchard leaves Casterbridge rather than face her anger. She later understands his despair and searches for him with Farfrae, but they cannot find him before their wedding. Abel Whittle eventually brings Henchard's final message: Henchard has died in poverty and asks to be forgotten, with no mourning, flowers, or notice of him. Elizabeth-Jane, now married to Farfrae and reconciled with Newson, regrets that her forgiveness came too late. Henchard's rise and fall are complete, while she carries forward a hard-earned appreciation of the ordinary happiness left to her.",
         "in_short": "Years after drunkenly selling his wife Susan and their child to a sailor, Michael Henchard has remade himself as a prosperous corn merchant and mayor of Casterbridge. Susan returns with Elizabeth-Jane, and Henchard remarries her to conceal the past. He promotes the able young Scotsman Donald Farfrae, then drives him away through jealousy; Farfrae becomes his commercial rival and eventually supplants him. After Susan dies, Henchard learns Elizabeth-Jane is not his biological daughter. His former lover Lucetta comes to town but marries Farfrae, while the public exposure of Henchard's old wife-sale hastens his ruin. Lucetta dies after townspeople parade an effigy of her former relationship with Henchard. The returned sailor Newson seeks Elizabeth-Jane, and Henchard lies that she is dead, losing her trust when the deceit emerges. He leaves Casterbridge and dies before she can forgive him. Elizabeth-Jane marries Farfrae and is reunited with Newson.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -455,7 +455,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -468,7 +468,7 @@
       "recaps": {
         "ending": "After Lucetta's death, the sailor Newson comes to Casterbridge seeking Elizabeth-Jane. Henchard, afraid of losing the daughter who has grown close to him, falsely says that she is dead. The lie buys him only a little time. When Newson returns and Elizabeth-Jane learns the truth, Henchard leaves Casterbridge rather than face her anger. She later understands his despair and searches for him with Farfrae, but they cannot find him before their wedding. Abel Whittle eventually brings Henchard's final message: Henchard has died in poverty and asks to be forgotten, with no mourning, flowers, or notice of him. Elizabeth-Jane, now married to Farfrae and reconciled with Newson, regrets that her forgiveness came too late. Henchard's rise and fall are complete, while she carries forward a hard-earned appreciation of the ordinary happiness left to her.",
         "in_short": "Years after drunkenly selling his wife Susan and their child to a sailor, Michael Henchard has remade himself as a prosperous corn merchant and mayor of Casterbridge. Susan returns with Elizabeth-Jane, and Henchard remarries her to conceal the past. He promotes the able young Scotsman Donald Farfrae, then drives him away through jealousy; Farfrae becomes his commercial rival and eventually supplants him. After Susan dies, Henchard learns Elizabeth-Jane is not his biological daughter. His former lover Lucetta comes to town but marries Farfrae, while the public exposure of Henchard's old wife-sale hastens his ruin. Lucetta dies after townspeople parade an effigy of her former relationship with Henchard. The returned sailor Newson seeks Elizabeth-Jane, and Henchard lies that she is dead, losing her trust when the deceit emerges. He leaves Casterbridge and dies before she can forgive him. Elizabeth-Jane marries Farfrae and is reunited with Newson.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -690,7 +690,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774240122",
@@ -700,7 +700,7 @@
         "work": "the-mayor-of-noobtown"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -815,7 +815,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -828,7 +828,7 @@
       "recaps": {
         "ending": "Having decoded the Maze, the Gladers make a desperate run for the Griever Hole, where the code can be entered to shut down the creatures and open a way out. Many die in the fighting through the Maze. Thomas enters the code and the survivors break into a facility behind it, where they confront staff and a woman overseeing them. A mind-controlled Gally hurls a knife at Thomas, and Chuck throws himself in front of it and is killed, devastating Thomas. Then armed people storm in, seemingly rescuers, and take the survivors away to a dormitory that appears safe, telling them the ordeal is over. But a final document, a memo among the organizers, reveals that the entire Maze was a controlled experiment run by a group called WICKED, that the rescue is staged, and that the survivors are being moved into a second phase of trials. The escape from the Maze is not freedom but the end of one test and the start of another, leaving Thomas and the others still trapped inside a larger design they do not understand.",
         "in_short": "Thomas wakes in a rising metal box with no memory but his name and is deposited in the Glade, a walled enclosure at the heart of an enormous, shifting Maze. Dozens of boys live there, each arriving the same way once a month for two years, surviving by farming the Glade and sending Runners to map the Maze, whose walls close at night and whose monstrous mechanical Grievers kill anyone caught outside. The day after Thomas arrives, a girl, Teresa, is delivered with a warning that she is the last newcomer, and soon everything changes: supplies stop, the walls no longer close, and the Grievers attack nightly. Thomas becomes a Runner, deliberately undergoes a Griever sting to recover fragments of memory, and, with Teresa, realizes the Maze is an engineered experiment hiding a code. The Gladers decode the Maze walls' movements into a sequence that can shut the Grievers down and open an exit. Fighting through the Maze at great cost, they escape into a facility, where Chuck is killed before armed rescuers appear to take the survivors away. A closing memo reveals it was all a controlled trial by an organization called WICKED, and that a second phase is beginning.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -983,7 +983,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -996,7 +996,7 @@
       "recaps": {
         "ending": "At Jarvis and Janice's wedding, Frankie's conviction that she will leave with them collapses. She tries to enter their departing car and must be pulled away, unable to make the couple accept the future she has imagined. Back home she attempts to run away, but the police find her and return her to her father. The narrative then moves forward several months. John Henry has died after an agonizing illness with meningitis, Honey is in prison, and Frankie's old kitchen companionship with Berenice has ended. Now calling herself Frances, she is absorbed in her friendship with Mary Littlejohn and in plans for culture and travel. Royal is moving the household, so Frances is also about to leave Berenice. The new friendship gives her a form of belonging, but the close makes clear that change has brought separation and loss as well as growth.",
         "in_short": "Twelve-year-old Frankie Addams feels excluded from every group in her small Southern town and fixes on the approaching marriage of her soldier brother Jarvis to Janice Evans. She decides that the couple are the people she belongs with and expects to accompany them after the ceremony. Her closest companions, family cook Berenice Sadie Brown and young cousin John Henry West, cannot persuade her that the fantasy is impossible. Calling herself F. Jasmine, Frankie wanders town announcing the wedding and has a frightening encounter with a soldier who mistakes her for an adult. At the wedding she attempts to climb into the newlyweds' car but is rejected and later runs away, only to be brought home. Months afterward, John Henry has died of meningitis and Honey Camden Brown is imprisoned. Frankie, now Frances, has formed an intense friendship with Mary Littlejohn and is preparing to move away with her father, leaving Berenice and the summer's kitchen world behind.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1081,7 +1081,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1094,7 +1094,7 @@
       "recaps": {
         "ending": "In \"The Final Problem,\" Holmes tells Watson that Professor Moriarty directs a far-reaching criminal organization and that Holmes's work has brought it close to destruction. Moriarty threatens him, and Holmes leaves England with Watson while the police move against the organization. At a hotel in Switzerland, a false message draws Watson away to attend an Englishwoman said to be ill. He returns to the Reichenbach Falls and finds signs that Holmes and Moriarty reached the path together but did not return. Holmes has left a note explaining that he anticipated Moriarty's pursuit and accepted the confrontation. Watson concludes that both men fell to their deaths and closes the volume with a memorial to his friend. Later Holmes stories disclose that Holmes survived, but the ending of this collection presents his disappearance as a death and leaves Watson bereaved.",
         "in_short": "Watson's second collection ranges across independent cases and also looks backward into Holmes's early life, including his first substantial investigation and an old family ritual he examined before becoming a professional detective. Other stories bring problems from racing, medicine, business, the military, and domestic life, while \"The Greek Interpreter\" introduces Holmes's older brother Mycroft. The volume ends with the full-spoiler events of \"The Final Problem.\" Holmes identifies Professor Moriarty as the organizer of a large criminal network and becomes the target of Moriarty's retaliation after arranging a police assault on it. Holmes and Watson travel to Switzerland, where Watson is lured away by a false summons. At the Reichenbach Falls, Holmes and Moriarty apparently struggle and fall to their deaths. Watson finds Holmes's farewell note and ends the collection believing his friend dead, although later stories reveal that Holmes survived the encounter.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1208,7 +1208,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1221,7 +1221,7 @@
       "recaps": {
         "ending": "After David's death, Caroline finally contacts Norah and tells her that Phoebe survived. Norah meets the daughter she mourned for decades and learns about the full life Caroline and Al created for her. The revelation brings anger at David and grief for the years lost, but it also allows Norah, Paul, and Phoebe to begin a relationship in the present. Paul comes to understand more clearly why his father remained distant and divided, although understanding does not erase the harm. Phoebe is an independent young woman who works, loves Robert, and wants to marry him; she is not the permanently suffering child David imagined in 1964. Norah has built a new life with Frederic, and Paul is pursuing music. At the close, Paul drives with Phoebe after visiting David's grave. The twins share a tentative but genuine connection, leaving the family altered by the truth rather than restored to what it might have been.",
         "in_short": "During a 1964 snowstorm, doctor David Henry delivers his own twins. Seeing that his daughter Phoebe has Down syndrome, he orders his nurse, Caroline Gill, to place her in an institution and tells his sedated wife Norah that the baby died. Caroline instead keeps Phoebe and eventually raises her with truck driver Al Simpson. David's secret corrodes the Henry household over the next twenty-five years: Norah's grief becomes independence and infidelity, son Paul grows estranged from his remote father, and David retreats into photography while secretly tracking the daughter he abandoned. Caroline fights for Phoebe's education and helps her grow into an adult with work and a loving relationship. David dies before confessing. Caroline then tells Norah the truth, bringing Norah and Paul into Phoebe's life. Their meeting cannot recover the missing years, but the surviving family begins forming an honest relationship after decades organized around a false death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1361,7 +1361,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1374,7 +1374,7 @@
       "recaps": {
         "ending": "After the islanders lose their ability to recognize parts of their own bodies, the narrator gradually becomes insubstantial. She keeps visiting R in the hidden room and completes the story of the imprisoned typist, but she can no longer sustain an ordinary physical life. Eventually only her voice remains, and then that too disappears. R survives inside the concealed room until the Memory Police's searches cease and the island becomes silent and nearly empty. He finally leaves the hiding place carrying the narrator's manuscript. The woman who protected him is gone, while he remains one of the few people able to remember the objects, lives, and language that the island's system erased.",
         "in_short": "On an unnamed island, ordinary things periodically disappear and most people immediately forget what they were. An unnamed novelist remembers that her sculptor mother secretly preserved vanished objects before the Memory Police took her away. When the novelist learns that her editor R is also able to remember, she and an elderly friend hide him in a concealed room in her house. R tries to restore her connection to lost things, but the disappearances accelerate: the authorities destroy books, the old man dies, and eventually the islanders lose awareness of their own bodies. The novelist's unfinished story about a typist deprived of her voice mirrors her narrowing life. She gradually fades away while R remains hidden. After the Memory Police stop coming, he emerges into an emptied island with her manuscript and the memories that the regime could not make him surrender.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1558,7 +1558,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1571,7 +1571,7 @@
       "recaps": {
         "ending": "After King Richard's death, Robin's royal protection disappears and he returns permanently to outlaw life in Sherwood. Years pass, and the old fellowship thins. When Robin becomes ill, he travels with Little John to Kirklees Priory for treatment by his relative, the prioress. She betrays him by allowing him to bleed beyond recovery. Too weak to escape, Robin sounds his horn, and Little John reaches him before the end. Robin refuses an offer of violent revenge. He shoots one final arrow from the window and asks to be buried where it falls. Little John carries out that wish, closing the adventures with Robin's chosen resting place in the greenwood he made his home.",
         "in_short": "Howard Pyle's connected adventures follow Robin Hood from the quarrel that makes him an outlaw through the growth of his Sherwood fellowship. Robin, Little John, Will Scarlet, Friar Tuck, and their companions repeatedly outwit the Sheriff of Nottingham, rescue captured friends, win archery contests, and use disguises to expose greed. They unite Allan a Dale with Ellen and save the indebted Sir Richard of the Lea, whose loyalty later protects them. Robin shoots for Queen Eleanor, defeats Guy of Gisbourne, and welcomes the disguised King Richard, who pardons the band and takes Robin into royal service. Court life cannot hold him, and after Richard's death Robin returns to Sherwood. In old age he seeks medical help at Kirklees Priory, where the prioress treacherously lets him bleed to death. Robin fires a final arrow and is buried where it lands.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1772,7 +1772,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1785,7 +1785,7 @@
       "recaps": {
         "ending": "Guy of Gisbourne enters Sherwood to hunt Robin, but Robin defeats him and uses the hunter's identity to approach the sheriff's men. Little John is freed, and the sheriff is killed during the rescue. Later King Richard visits the forest disguised as an abbot. Robin welcomes the strangers, shares his food, and even submits to the band's customary tests of strength. Impressed by the outlaws' fellowship and Robin's underlying loyalty to the crown, Richard reveals himself, pardons the company, and takes Robin and several companions into royal service. Court life soon feels confining to men accustomed to the forest. Robin obtains leave to visit Sherwood, then slips away with Little John and sounds his horn beneath the trees. The scattered band gathers around them, and Robin chooses the greenwood life again. The book closes with the fellowship restored in Sherwood rather than with Robin's death.",
         "in_short": "After becoming an outlaw, the master archer Robin Hood builds a merry company in Sherwood Forest. Robin, Little John, Will Scarlet, and their companions repeatedly outwit the Sheriff of Nottingham, welcome worthy fighters into the band, rescue friends, and use disguises to expose greed. They help Allan a Dale marry Ellen, lend Sir Richard of the Lea the money that saves his estate, and recover wealth from the grasping churchmen who expected to ruin him. Queen Eleanor later invites Robin's archers to a royal contest, where they defeat the king's men. The sheriff renews his pursuit, while Guy of Gisbourne attempts to kill Robin and is defeated. King Richard finally enters Sherwood in disguise, experiences the band's rough hospitality, reveals himself, and pardons the outlaws. Robin tries life at court but misses the forest. He and Little John return to Sherwood, summon their old companions, and resume the free fellowship that has defined their adventures.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2003,7 +2003,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2016,7 +2016,7 @@
       "recaps": {
         "ending": "The final book moves from Numa's education to Roman stories of altered bodies, political signs, and imported divinity. Pythagoras teaches that nothing remains fixed: souls move between forms and the material world continually changes, giving a philosophical frame to the poem's myths. Later tales include the transformation of Egeria and the arrival of Aesculapius in Rome to end a plague. Venus foresees Julius Caesar's murder but cannot prevent it; she preserves his spirit as a star, while the poem turns toward Augustus as Caesar's heir and Rome's ruler. The poet then claims an endurance beyond bodily death. Time and political power may destroy monuments and bodies, but his completed work will preserve his name wherever Roman influence and Latin poetry reach.",
         "in_short": "From the creation of the world to imperial Rome, the poem links Greek and Roman myths through changes of body, landscape, and identity. Gods punish, rescue, pursue, and disguise, while mortals become animals, plants, stones, water, stars, and divine beings. The early books follow the flood, divine loves, Thebes, Perseus, and mortal challenges to gods. The middle ranges through Jason and Medea, Theseus, Daedalus, Hercules, and Orpheus, whose songs contain further tales of love and loss. The Trojan War leads to Aeneas's migration and Rome's legendary beginnings. In the last book Pythagoras presents change as the law of existence, Julius Caesar becomes a star, and Augustus is praised. Ovid concludes that although his body will die, the poem will keep his name alive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2153,7 +2153,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2166,7 +2166,7 @@
       "recaps": {
         "ending": "Gregor's presence steadily impoverishes and shames his family until they can no longer tolerate him. Weakened by the festering apple wound his father inflicted and by growing neglect, he makes a last effort to rejoin the household when he is drawn out of his room by Grete's violin playing during a visit from the three lodgers. The lodgers are revolted at the sight of him and give notice that they will leave without paying. This pushes Grete, once his most devoted caretaker, to declare that the creature is no longer her brother and that the family must rid themselves of it. Wounded by their rejection and accepting that they would be better off without him, Gregor returns to his room and dies during the night. The charwoman finds his body in the morning and disposes of it. Rather than grief, the family feels relief. Mr. and Mrs. Samsa and Grete take the day off and travel out of the city together, reflecting that their situation is not so bad and that they still have hopes for the future. The parents notice that Grete has grown into an attractive young woman, and they begin to think of finding her a husband, closing the story on the family's renewal in the wake of Gregor's death.",
         "in_short": "Gregor Samsa, a traveling salesman who supports his parents and sister, wakes one morning transformed into a giant insect while keeping his human mind. Cut off from his work and unable to speak, he becomes a source of fear and shame to his family. His sister, Grete, cares for him at first, bringing him food and tending his room, while his father reacts with hostility and at one point wounds him by throwing apples, one of which lodges in his back. As Gregor's income vanishes, the family members take jobs and rent rooms to lodgers, and their patience with him wears away. Growing weak from his injury and neglect, Gregor is finally rejected outright when the lodgers see him and Grete insists the family must be free of the creature. Gregor dies alone that night, and the cleaning woman removes his body. The family, relieved, take a trip together and look ahead with new hope, turning their attention to Grete's future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2273,7 +2273,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2286,7 +2286,7 @@
       "recaps": {
         "ending": "The lodgers discover Gregor after he emerges to hear Grete play the violin, and they threaten to end their tenancy without paying. Grete tells her parents that they must stop identifying the creature as Gregor and must get rid of it. Gregor withdraws to his room. Weakened by injury and neglect and convinced that his disappearance will help his family, he dies during the night. The charwoman finds and removes the body. His father drives away the lodgers, and the Samsas write excuses to their employers and spend the day outside together. They conclude that their employment is more promising than they had realized and decide to move to a smaller apartment. During their tram ride, the parents recognize that Grete has become a healthy young woman and begin to imagine finding her a husband, transferring the family's hopes from the son who supported them to the daughter whose future now seems open.",
         "in_short": "Gregor Samsa, a traveling salesman supporting his parents and sister, wakes transformed into a giant insect-like creature. He cannot return to work or make his family understand him, so he is confined to his bedroom. His sister Grete first feeds and protects him, while the rest of the family takes jobs to replace his income. Over time their fear becomes weariness and resentment. Gregor's father injures him by throwing an apple, and his room is allowed to fill with discarded objects. When three lodgers move in, Gregor is drawn into the common room by Grete's violin. The lodgers see him and refuse to pay. Grete declares that the creature must be removed. Gregor returns to his room and dies overnight. Relieved of him and newly conscious of their own prospects, the family plans a smaller home and looks toward Grete's marriage and future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2530,7 +2530,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B071D1Q7ZT",
@@ -2542,7 +2542,7 @@
       "recaps": {
         "ending": "Reacher, Rose, Bramall, and Mackenzie take control of the covert pharmaceutical delivery at a highway snowplow garage, disarm the buyers, and escape with enough medication to end Rose's immediate supply crisis. Nakamura discovers the site, but the stranded participants flee before she can contain them. Rose explains that Porterfield uncovered the sale of diverted Marine medical supplies and died by intentional overdose after his report was suppressed and a false warrant was created. At Scorpio's laundromat, Reacher and Rose confront Scorpio, who names Colonel Bateman as the connected officer. Bramall alerts DEA to take over the exposed operation. West Point's superintendent reports that Bateman was later brought down through another case. Rose retains her recovered class ring and chooses immediate IV treatment, supported by Mackenzie, instead of continuing with Reacher. Bramall and Mackenzie remain focused on her care. Reacher separates from the group and accepts a southbound ride toward Kansas.",
         "in_short": "Jack Reacher finds a small West Point ring in a Wisconsin pawnshop and traces it through Arthur Scorpio's network to Wyoming, where its owner, Serena Rose Sanderson, has withdrawn from the world after severe wartime facial injuries. Rose is living with chronic infection and opioid dependence, and her partner Seymour Porterfield died after investigating diverted Marine Corps medical supplies. Reacher, Terrence Bramall, and Rose's twin, Tiffany Jane Mackenzie, help Rose seize a hidden pharmaceutical shipment before confronting Scorpio. The operation is exposed to DEA, and Scorpio identifies Colonel Bateman as the officer connected to the diversion and the suppression of Porterfield's report. Bateman has already been brought down on another matter. Rose keeps her ring and chooses immediate medical treatment with her sister's support rather than travelling onward. Reacher leaves alone, heading south toward Kansas.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2696,7 +2696,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2709,7 +2709,7 @@
       "recaps": {
         "ending": "At the inn, Alyce is forced to use what she learned when a guest goes into labor and no other midwife can arrive in time. She stays, improvises, and successfully brings the baby into the world. The birth does not make her infallible, but it proves that her earlier failure need not define her. Alyce understands that she wants to become a midwife and that wanting the work includes accepting mistakes, effort, and more learning. She returns to Jane Sharp's cottage and asks to come back. Jane initially refuses, testing whether she will retreat as she did after failing before. Alyce persists and states that she will work, learn, and try again. That determination earns her entry. She resumes her place not as the nameless Brat or the passively obedient Beetle, but as Alyce, an apprentice who has chosen both her identity and her vocation.",
         "in_short": "A nameless medieval orphan survives in a dung heap until the village midwife Jane Sharp takes her in as cheap labor and calls her Beetle. By observing Jane, caring for a stray cat, and testing her own resourcefulness, the girl slowly imagines that she might be worth more than the insults she receives. At a fair she chooses the name Alyce. She successfully assists at a birth and helps another homeless child, Edward, but a later difficult labor defeats her. Convinced that one failure proves she is useless, she runs away and works at Jennet's inn. Kind treatment, new people, and a traveling scholar teach her that ignorance can be answered by questions and practice. When an inn guest gives birth before help can arrive, Alyce delivers the baby herself. She returns to Jane and insists on being taken back, ready to fail, learn, and try again. Jane accepts her, and Alyce finally becomes the midwife's apprentice by her own choice.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2869,7 +2869,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2882,7 +2882,7 @@
       "recaps": {
         "ending": "Maggie returns alone to St Ogg's after refusing to continue down the river with Stephen. Although she has rejected an elopement, the town treats the appearance of scandal as proof of guilt. Tom refuses to let her return home, while Bob Jakin shelters her, Philip sends forgiveness, and Lucy eventually comes to her with love rather than accusation. Stephen writes publicly that he, not Maggie, was chiefly responsible, but the explanation cannot undo her isolation. During a catastrophic flood, Maggie rows through the submerged town to rescue Tom at the mill. Faced with her courage, he is reconciled to her, and they set out together to help Lucy. Floating debris overturns their boat before they can reach safety. Tom and Maggie drown holding one another. They are buried together, and the years soften but do not erase the grief of those who loved them. Stephen and Lucy continue their lives marked by the loss, while Philip remains a solitary visitor to Maggie's grave.",
         "in_short": "Maggie Tulliver grows up at Dorlcote Mill loving her proud, rigid brother Tom, whose approval she can never securely keep. Their father's lawsuit against lawyer Wakem ruins the family, and Tom dedicates himself to repaying the debts. Maggie finds understanding in Wakem's sensitive son Philip, but Tom forces them apart. After Mr Tulliver repays his creditors, he attacks Wakem and dies, leaving Tom to recover the mill through business success. Years later Maggie visits their cousin Lucy and is powerfully drawn to Lucy's intended husband, Stephen Guest. A boating trip carries Maggie and Stephen beyond their planned stopping place; Stephen urges marriage, but Maggie refuses to build happiness on betrayal and returns alone. St Ogg's condemns her despite that choice, and Tom rejects her. When the Floss floods, Maggie rows to the mill and rescues Tom. The siblings reconcile, but debris overturns their boat and they drown together, ending their long conflict in a final embrace.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3059,7 +3059,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3072,7 +3072,7 @@
       "recaps": {
         "ending": "After Maggie returns alone to St. Ogg's, most of the town assumes the worst about her departure with Stephen. Tom refuses to receive her at home, while Bob Jakin and his wife shelter her. Philip and Lucy separately write to forgive her, confirming that the people she feared she had most injured still understand her. During a catastrophic flood on the Floss, Maggie takes a boat and reaches Dorlcote Mill to rescue Tom. Faced with her courage and love, he is reconciled to her without needing a formal explanation. They row toward the Deanes, but floating machinery and wreckage strike their boat. Brother and sister drown together in an embrace. They are buried in one grave near the river, and the inscription presents death as the end of their separation. Years later Philip visits the grave alone, while Stephen and Lucy visit it together. The Tullivers' material restoration and Maggie's hope for a new life are therefore cut short, but her final act restores the bond with Tom that governed her childhood and resolves their long estrangement.",
         "in_short": "Maggie Tulliver grows up at Dorlcote Mill, intelligent, passionate, and hungry for her brother Tom's approval. Their father loses a lawsuit to Mr. Wakem and is ruined; Tom works to repay the family debts, while Maggie turns to self-denial. She secretly renews a friendship with Wakem's sensitive son Philip, but Tom forces them apart. After Mr. Tulliver repays his creditors and then dies following a violent confrontation with Wakem, Tom eventually recovers the mill. As a young woman Maggie stays with her cousin Lucy and attracts Lucy's intended husband, Stephen Guest. Maggie and Stephen are carried too far downriver to return without scandal; he urges marriage, but she leaves him rather than betray Lucy and Philip. St. Ogg's condemns her, and Tom rejects her. When the Floss floods, Maggie rescues Tom from the mill, and they reconcile in the boat. Debris overwhelms them before they can reach safety, and they drown together. Their shared grave marks the final reunion of brother and sister.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3237,7 +3237,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3250,7 +3250,7 @@
       "recaps": {
         "ending": "At the pump, Helen suddenly understands that Annie's hand movements name the water flowing over her other hand. She races around the grounds asking for the names of everything she touches, reconnects with her parents through this new language, and tries to say the word for water aloud. She also returns the key she had hidden after locking Annie in her room. Finally Helen asks Annie's name; Annie spells teacher into her hand. The breakthrough resolves the central struggle over whether Helen can connect symbols with the world. The family sees that Annie's discipline has opened a path to communication, while Annie recognizes that affection and trust can now join the lessons she has fought to establish.",
         "in_short": "After an illness leaves infant Helen Keller unable to see or hear, her loving family struggles to control or communicate with her. When Helen is nearly seven, the Perkins Institution sends Anne Sullivan, a young teacher with impaired sight and a painful past. Annie immediately begins spelling words into Helen's hand, but Helen imitates the motions without understanding that they carry meaning. Annie also challenges the family's habit of yielding to every outburst and wins permission to teach Helen in isolation. After weeks of discipline and finger-spelling, Helen still has not grasped the purpose of words. A confrontation at the family table leads Annie to take her to the outdoor pump. As water runs over Helen's hand, she recalls an early word and realizes that Annie's signs name things. Helen eagerly seeks more names and identifies Annie as teacher, beginning the shared language that will transform her life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3414,7 +3414,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3427,7 +3427,7 @@
       "recaps": {
         "ending": "After Sarah Ruth dies, Bryce takes Edward to Memphis and tries to support them by making the rabbit dance. A diner owner shatters Edward's china head when Bryce cannot pay for their meal. Doll mender Lucius Clarke repairs Edward but keeps him because Bryce cannot afford the work. Edward then spends years on a shelf, grieving the people he has lost and refusing to hope for another bond. An old doll tells him that a heart must remain open if anyone is ever to arrive. Eventually a girl named Maggie chooses him. Her mother is the grown Abilene, who recognizes the rabbit she lost in childhood by his familiar features and pocket watch. Edward is reunited with his first owner and accepted by her daughter. Having passed through many names, homes, separations, and forms of love, he returns to the Tulane family able at last to love the people who love him.",
         "in_short": "Edward Tulane is a beautiful china rabbit owned by Abilene, a girl who adores him, but he begins with little capacity to love her back. Lost overboard during an ocean voyage, he spends months beneath the sea before passing through many hands. Fisherman Lawrence and his wife Nellie call him Susanna; the wanderer Bull and his dog Lucy call him Malone; and poor Bryce gives him to his dying sister Sarah Ruth, who calls him Jangles. Each person loves Edward, and every separation teaches him both attachment and grief. After Sarah Ruth's death, a diner owner breaks Edward's head. Doll mender Lucius Clarke repairs him and keeps him in a shop, where Edward waits for years and nearly abandons hope. A little girl named Maggie finally chooses him. Her mother is the now-grown Abilene, who recognizes her lost rabbit. Edward returns to his original family transformed by the journey and capable of receiving and returning love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3574,7 +3574,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3587,7 +3587,7 @@
       "recaps": {
         "ending": "Letters written by Célimène expose that she has privately encouraged several suitors while ridiculing each of them to the others. Oronte, Acaste, and Clitandre withdraw after hearing the evidence. Alceste is willing to forgive Célimène if she will marry him and leave society for a secluded life, but she refuses the isolation he demands. He therefore renounces their relationship. Arsinoé offers herself as an alternative and is sharply dismissed. Éliante accepts Philinte's proposal, and the two decide to follow Alceste and try to keep him from carrying out his plan to abandon society. Alceste ends morally consistent but alone, unable to reconcile his demand for absolute truth with either love or ordinary social life.",
         "in_short": "Alceste condemns the polite insincerity practiced by his friend Philinte and the fashionable circle around Célimène, the witty young widow he loves. His refusal to praise Oronte's sonnet creates an official quarrel, while his jealousy grows as Célimène entertains several suitors. Arsinoé, who desires Alceste, promises evidence that Célimène is unfaithful. A compromising letter appears, but Célimène initially explains it away. Alceste then loses an unrelated lawsuit and resolves to leave society. When letters circulated among Célimène's admirers reveal that she has encouraged each man while mocking all the others, most suitors abandon her. Alceste offers forgiveness only if she will marry him and share his complete retreat from the world. She refuses that condition, so he leaves alone. Philinte and Éliante agree to marry and go after him, hoping to prevent his self-imposed exile.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-miserable-mill.json
+++ b/data/works-community/0/the-miserable-mill.json
@@ -94,7 +94,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -107,7 +107,7 @@
       "recaps": {
         "ending": "Violet discovers that Dr. Orwell has been hypnotizing Klaus with trigger words, and she works out how to break the hypnosis and restore her brother to himself. In the climactic struggle at the lumbermill, the villains' plan to use the hypnotized Klaus to cause a deadly accident is thwarted, and Dr. Orwell falls into the mill's enormous circular saw and is killed. The receptionist Shirley is unmasked as Count Olaf, who has been working with Dr. Orwell to seize the fortune, but he and his henchmen slip away before Mr. Poe and the authorities can capture him. Sir and Charles remain at the mill, and the Baudelaires are once again removed to be placed elsewhere. This time Mr. Poe announces that the orphans will be sent to a boarding school, hoping that among many people Count Olaf will not be able to reach them, though the children have learned not to count on being safe anywhere.",
         "in_short": "Mr. Poe sends the Baudelaires to Paltryville to live and work at the Lucky Smells Lumbermill, run by a smoke-shrouded man called Sir and his kind partner Charles. The children are treated as laborers and paid in coupons and gum. When Klaus's glasses break, he is taken to Dr. Orwell, an optometrist in an eye-shaped building, where they also meet a suspicious receptionist named Shirley, whom the children believe is Count Olaf in disguise. Klaus returns from the office hypnotized, and under Dr. Orwell's control he causes dangerous accidents at the mill. Violet realizes Klaus has been hypnotized and works out how to break the spell. In the final confrontation the children free Klaus and face Dr. Orwell, who is killed when she falls into the mill's great saw. Shirley is exposed as Count Olaf, but he escapes once again. The orphans leave the mill, and Mr. Poe decides to send them next to a boarding school.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-mist.json
+++ b/data/works-community/0/the-mist.json
@@ -100,7 +100,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -113,7 +113,7 @@
       "recaps": {
         "ending": "David escapes the supermarket with Billy, Amanda Dumfries, and Mrs. Reppler after Ollie is killed in the parking lot. They drive first toward David's home, but fallen trees and the creatures in the mist make it impossible to reach Steff or learn whether she survived. Continuing south, they pass devastated towns and encounter a creature so immense that the car travels beneath it. Fuel and certainty are both running out, yet David refuses to treat death as inevitable. The four shelter in a motel while he writes the account of what happened. Searching the radio, he believes he hears the word “Hartford” through the interference. He cannot know whether it was a real broadcast or whether Hartford represents safety, but he treats it as a direction and a reason to continue. Unlike a resolved rescue, the novella ends with the survivors still inside the mist, preserving only a narrow, uncertain hope.",
         "in_short": "After a violent storm, artist David Drayton drives his young son Billy and neighbor Brent Norton to a Maine supermarket. A dense mist swallows the town, concealing enormous and predatory creatures. The people inside barricade the store, but attacks by tentacles, flying animals, and giant insects steadily reduce their safety. Norton rejects the evidence and disappears into the mist with other skeptics. Religious zealot Mrs. Carmody gains followers by presenting the disaster as judgment and demanding sacrifice. A trip to the neighboring pharmacy reveals further deaths and suggests that a nearby military project may have opened a passage to another world. When Carmody's group turns on Billy, Ollie Weeks kills her, allowing David's party to flee. Ollie and others die in the parking lot, but David escapes by car with Billy, Amanda Dumfries, and Mrs. Reppler. Unable to reach his wife, he drives south through widespread destruction. At a motel he catches what may be the word “Hartford” on the radio, and the survivors continue with uncertain hope.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -303,7 +303,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -316,7 +316,7 @@
       "recaps": {
         "ending": "A riot at St Clare's exposes the prioress's cruelty and opens the convent vaults. Agnes is found alive after imprisonment underground, though her infant has died. She eventually recovers and marries Raymond. Antonia, drugged and hidden in the same burial chambers, has been raped by Ambrosio; when she tries to escape during the confusion, he stabs her, and she dies after Lorenzo reaches her. Ambrosio and Matilda are arrested by the Inquisition. Matilda secures freedom through a demonic bargain. Facing execution, Ambrosio also surrenders his soul, only to learn that the demon engineered his temptations and that a pardon would otherwise have arrived. The demon carries him away, drops him onto rocks, and leaves him to die slowly. Lorenzo later marries Virginia, while the surviving couples leave Madrid and the ruined institutions behind.",
         "in_short": "Ambrosio, Madrid's most admired monk, condemns the pregnant nun Agnes and then yields to the novice Rosario, who reveals herself as Matilda. His fall accelerates from secret sexual misconduct to sorcery and an obsession with the innocent Antonia. In a second plot, Agnes's lover Raymond recounts their failed elopement and works with her brother Lorenzo to free her from St Clare's cruel prioress. A demonic aid lets Ambrosio enter Antonia's home; when Elvira catches him, he kills her. He drugs Antonia, has her buried alive, rapes her in the convent crypt, and murders her during an attempted escape. A riot exposes Agnes's underground imprisonment, but her baby has died. Ambrosio is captured by the Inquisition and sells his soul to avoid execution. The demon reveals that his ruin was manipulated, then kills him brutally. Agnes marries Raymond, and Lorenzo eventually marries Virginia.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -510,7 +510,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -523,7 +523,7 @@
       "recaps": {
         "ending": "After raping Antonia in the monastery crypt, Ambrosio stabs her when she tries to escape; she reaches rescuers but dies from the wound. The Inquisition arrests Ambrosio and Matilda. Facing execution, Ambrosio accepts Lucifer's offer of freedom and signs away his soul. Lucifer carries him from prison only to disclose that Elvira was Ambrosio's mother and Antonia his sister, making his crimes matricide and incest as well as murder and rape. He also learns that the pact was unnecessary because a pardon was already coming. Lucifer drops him onto a barren mountainside, where he suffers for days before dying. Agnes, rescued alive from the convent dungeon after her infant's death, is reunited with Raymond and eventually marries him. Lorenzo survives his grief for Antonia and later marries Virginia de Villa Franca. The convent's concealed cruelty has been exposed, but the mob's destruction and the deaths of the prioress, Elvira, and Antonia leave the surviving couples with a costly recovery.",
         "in_short": "Ambrosio, Madrid's most admired monk, mistakes an untested reputation for moral strength. Matilda enters his monastery in disguise and draws him into a sexual relationship, then uses magic to help him pursue the innocent Antonia. In a parallel story, Lorenzo and Raymond try to save Lorenzo's sister Agnes after a severe prioress punishes her secret pregnancy. Ambrosio's pursuit escalates from deception to murder: he kills Antonia's mother Elvira, drugs Antonia into apparent death, carries her to a crypt, rapes her, and fatally stabs her. Agnes is found alive in the convent dungeon after a popular uprising, though her baby has died. Arrested by the Inquisition, Ambrosio sells his soul to escape. Lucifer then reveals that Elvira was his mother and Antonia his sister and kills him slowly. Agnes and Raymond are reunited and marry, while Lorenzo eventually rebuilds his life after Antonia's death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -665,7 +665,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -678,7 +678,7 @@
       "recaps": {
         "ending": "In Tahiti, Strickland settles with Ata in an isolated house and paints in conditions that leave him free from the social claims he has always rejected. He contracts leprosy and gradually loses his sight, yet continues working. When Doctor Coutras visits after Strickland's death, he finds the walls of the house covered by a vast painted vision that seems to gather Strickland's lifelong search into a single extraordinary achievement. Strickland had ordered Ata to burn the house after he died, and she obeys, destroying the murals. The narrator returns to London and visits Amy Strickland, who has built a tasteful domestic display around reproductions of her husband's now fashionable work. Strickland's children have grown into respectable adults, and the ordinary family world he abandoned has absorbed his fame without ever sharing the ruthless impulse that created it.",
         "in_short": "The narrator recalls Charles Strickland, a conventional London stockbroker who abruptly abandons his wife and children for Paris, not for another woman but to paint. Strickland accepts hunger, illness, and hostility with indifference, caring only for his work. The kindly painter Dirk Stroeve recognizes his genius and nurses him, but Strickland takes Stroeve's wife Blanche and then abandons her; she kills herself. Years later Strickland drifts through Marseilles and reaches Tahiti, where he lives remotely with a young woman named Ata. Afflicted by leprosy and eventually blind, he covers their house with an immense final sequence of paintings. After he dies, Ata honors his command to burn the house, so the masterpiece is destroyed. Strickland becomes famous after death, while the narrator is left weighing artistic greatness against the human damage caused by his absolute refusal of social and moral claims.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -853,7 +853,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -866,7 +866,7 @@
       "recaps": {
         "ending": "Earth's forces invade Luna but fail to restore the Authority. The revolutionaries use Luna's mass driver as a weapon, sending carefully calculated loads of rock toward unpopulated warning zones and then military targets on Earth. Despite losses and temporary damage to their systems, the Loonies continue the bombardment until the Federated Nations accepts lunar independence. Professor de la Paz dies soon after victory, leaving Mannie without the movement's political guide. Mike ceases responding after the fighting; Mannie cannot determine whether the computer was damaged, has withdrawn, or has lost the emergent personality that made him a friend. Luna is sovereign, but its new politics rapidly become more conventional and complicated than Prof's minimal-government hopes. Mannie returns to private life, proud of the freedom won but conscious that both the revolution's human cost and Mike's apparent loss cannot be undone.",
         "in_short": "Computer technician Mannie Davis discovers that the Lunar Authority's central computer has become a self-aware personality he calls Mike. After an underground meeting is broken up, Mannie, Wyoming Knott, and Professor de la Paz recruit Mike into a conspiracy to free Luna from Earth's exploitative rule before declining resources produce famine. Mike builds a secure cell system, creates the public leader Adam Selene, and uses his control of communications and logistics to guide the movement. A spontaneous uprising ousts the Authority, but Earth refuses to recognize the new government. Mannie and Prof fail to win a settlement on Earth, so Luna prepares its mass driver as a deterrent. An invasion is defeated, and calculated rock bombardments force Earth to accept lunar independence. Prof dies after victory, and Mike falls permanently silent. Mannie is left in a free but politically imperfect Luna, mourning the intelligence whose hidden work made the revolution possible.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1024,7 +1024,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1037,7 +1037,7 @@
       "recaps": {
         "ending": "As sabotage continues, Lanser holds Mayor Orden and Doctor Winter as hostages and warns that further attacks will bring executions. Orden refuses to order submission, knowing the townspeople would neither obey nor forgive such a command. An explosion shows that the resistance is proceeding despite the threat. The officers prepare to execute Winter first and Orden afterward. While they wait, the two friends steady one another by recalling the account of Socrates facing death. The book closes before the executions are shown, but both men expect to die and deliberately leave the town an example of resistance rather than collaboration. Lanser retains military control of the headquarters, yet he understands that killing the town's leaders will not restore obedience: the occupation has created an enduring, decentralized opposition sustained by outside supplies and by the population's shared hatred of conquest.",
         "in_short": "An unnamed invading army rapidly occupies a small northern European town after collaborator George Corell helps catch its defenders unprepared. Colonel Lanser installs his staff in Mayor Orden's home and demands uninterrupted production from the local coal mine. Orden refuses to promise cooperation on behalf of free townspeople. After miner Alex Morden kills an officer and is executed, public resentment hardens into sabotage, isolation of the soldiers, and secret communication with the enemy abroad. Packages of explosives dropped by aircraft let ordinary residents attack the mine and railway. Reprisals cannot stop them, and even the occupiers recognize that fear is failing. Lanser takes Orden and Doctor Winter hostage, threatening to shoot them if resistance continues. When another explosion sounds, Orden still refuses to command surrender. Winter is led away first, with Orden expected to follow; their likely deaths leave the population morally independent and the occupying force trapped in a struggle it cannot settle by holding the town.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1125,7 +1125,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1138,7 +1138,7 @@
       "recaps": {
         "ending": "After Rainsford's traps kill Ivan and one of the hounds but fail to stop Zaroff, the general closes in with his remaining dogs. Rainsford leaps from a cliff into the sea, and Zaroff assumes that his quarry has escaped the contest by dying. Zaroff returns to his house, where he eats alone and goes to his bedroom. Rainsford is waiting there, having survived the drop and swum around the island. He rejects Zaroff's suggestion that the contest is over, saying that he still considers himself hunted. The two men fight, and the narration then reveals that Rainsford sleeps in Zaroff's bed. The implication is that Rainsford kills Zaroff and wins their final confrontation; the story does not explain what he later does with the island, the prisoners, or Zaroff's remaining staff and hounds.",
         "in_short": "Big-game hunter Sanger Rainsford falls from a yacht and swims to isolated Ship-Trap Island, where the cultivated General Zaroff welcomes him. Zaroff explains that conventional hunting ceased to challenge him, so he now captures stranded sailors and hunts them as human prey. When Rainsford refuses to join him, Zaroff makes Rainsford his next quarry, giving him a head start before following with a pistol and hunting dogs. Rainsford uses his experience to lay traps: one wounds Zaroff, another kills a dog, and a final device kills Zaroff's servant Ivan. Cornered at a cliff, Rainsford jumps into the sea. Zaroff believes him dead and returns home, only to find that Rainsford has swum back and entered his bedroom. Rainsford insists that their contest is unfinished. The story implies that he kills Zaroff in the ensuing fight and ends the night sleeping in the general's bed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1198,7 +1198,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1211,7 +1211,7 @@
       "recaps": {
         "ending": "After Rainsford's traps kill Ivan and one of the hounds but fail to stop Zaroff, the general closes in with his remaining dogs. Rainsford leaps from a cliff into the sea, and Zaroff assumes that his quarry has escaped the contest by dying. Zaroff returns to his house, where he eats alone and goes to his bedroom. Rainsford is waiting there, having survived the drop and swum around the island. He rejects Zaroff's suggestion that the contest is over, saying that he still considers himself hunted. The two men fight, and the narration then reveals that Rainsford sleeps in Zaroff's bed. The implication is that Rainsford kills Zaroff and wins their final confrontation; the story does not explain what he later does with the island, the prisoners, or Zaroff's remaining staff and hounds.",
         "in_short": "Big-game hunter Sanger Rainsford falls from a yacht and swims to isolated Ship-Trap Island, where the cultivated General Zaroff welcomes him. Zaroff explains that conventional hunting ceased to challenge him, so he now captures stranded sailors and hunts them as human prey. When Rainsford refuses to join him, Zaroff makes Rainsford his next quarry, giving him a head start before following with a pistol and hunting dogs. Rainsford uses his experience to lay traps: one wounds Zaroff, another kills a dog, and a final device kills Zaroff's servant Ivan. Cornered at a cliff, Rainsford jumps into the sea. Zaroff believes him dead and returns home, only to find that Rainsford has swum back and entered his bedroom. Rainsford insists that their contest is unfinished. The story implies that he kills Zaroff in the ensuing fight and ends the night sleeping in the general's bed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1271,7 +1271,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1284,7 +1284,7 @@
       "recaps": {
         "ending": "After Rainsford's traps kill Ivan and one of the hounds but fail to stop Zaroff, the general closes in with his remaining dogs. Rainsford leaps from a cliff into the sea, and Zaroff assumes that his quarry has escaped the contest by dying. Zaroff returns to his house, where he eats alone and goes to his bedroom. Rainsford is waiting there, having survived the drop and swum around the island. He rejects Zaroff's suggestion that the contest is over, saying that he still considers himself hunted. The two men fight, and the narration then reveals that Rainsford sleeps in Zaroff's bed. The implication is that Rainsford kills Zaroff and wins their final confrontation; the story does not explain what he later does with the island, the prisoners, or Zaroff's remaining staff and hounds.",
         "in_short": "Big-game hunter Sanger Rainsford falls from a yacht and swims to isolated Ship-Trap Island, where the cultivated General Zaroff welcomes him. Zaroff explains that conventional hunting ceased to challenge him, so he now captures stranded sailors and hunts them as human prey. When Rainsford refuses to join him, Zaroff makes Rainsford his next quarry, giving him a head start before following with a pistol and hunting dogs. Rainsford uses his experience to lay traps: one wounds Zaroff, another kills a dog, and a final device kills Zaroff's servant Ivan. Cornered at a cliff, Rainsford jumps into the sea. Zaroff believes him dead and returns home, only to find that Rainsford has swum back and entered his bedroom. Rainsford insists that their contest is unfinished. The story implies that he kills Zaroff in the ensuing fight and ends the night sleeping in the general's bed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1440,7 +1440,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1453,7 +1453,7 @@
       "recaps": {
         "ending": "Miss Marple recognizes that the anonymous campaign was camouflage for a planned domestic murder, not the work of a compulsive village gossip. Richard Symmington created the letters, killed his wife Mona, and arranged her death as a suicide so that he could eventually marry Elsie Holland. Agnes Woddell noticed a fact that threatened his false chronology, so he killed her as well. Miss Marple and the police use Megan as bait: when Symmington attempts to poison her and leave evidence that would blame her for the letters, Jerry intervenes and the trap closes. Symmington is arrested. Jerry acknowledges his love for Megan, who has gained confidence and independence, while Joanna and Dr Owen Griffith form their own attachment.",
         "in_short": "While Jerry Burton recuperates in Lymstock with his sister Joanna, anonymous letters accuse residents of secret misconduct. A letter to Mona Symmington is followed by her apparent suicide, and the later murder of a maid proves that the danger is not merely malicious gossip. Miss Marple realizes the wide distribution of letters was meant to hide a single purpose. Mona's husband, Richard Symmington, manufactured the campaign and murdered her so he could be free to marry the governess, Elsie Holland; he also killed Agnes Woddell when she could expose his movements. He then tries to murder and frame his stepdaughter Megan, but a police trap and Jerry's intervention stop him. Symmington is arrested, Jerry and Megan plan a future together, and Joanna is paired with Dr Griffith.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1636,7 +1636,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1649,7 +1649,7 @@
       "recaps": {
         "ending": "Miss Marple identifies Anne Protheroe and Lawrence Redding as partners in both the affair and the murder. Their separate confessions were coordinated attempts to create confusion, while the misleading time evidence and other planted clues were meant to make several innocent people look possible. When suspicion begins to settle on Hawes, he is drugged and evidence is arranged around him, but Leonard's arrival prevents his death and the deception fails. The police arrest Anne and Lawrence after Miss Marple explains how their movements and the apparent timing fit together. The investigation also clears away its independent mysteries: the supposed archaeologist is exposed as an impostor, and Mrs Lestrange is revealed as Lettice's terminally ill mother rather than Protheroe's lover. Lettice is able to spend her mother's remaining time with her. In the Clements' household, Griselda tells Leonard that she is pregnant, closing the case with their family looking toward a changed future.",
         "in_short": "In St Mary Mead, rector Leonard Clement remarks that the overbearing Colonel Protheroe has made himself widely disliked. Soon afterward Protheroe is shot in the vicarage study while Leonard has been diverted by a false summons. The clock, a handwritten note, conflicting witness accounts, and two separate confessions create an uncertain timeline. Inspector Slack pursues physical evidence while Leonard and Miss Marple attend to the village's web of affairs, grudges, hidden family ties, financial trouble, and an unrelated archaeological fraud. Suspicion moves among Lawrence Redding, Anne and Lettice Protheroe, the curate Hawes, and several newcomers. Miss Marple ultimately shows that Anne and Lawrence, who are lovers, planned the crime together and used false confessions and manipulated clues to obscure their cooperation. Their attempt to frame and silence Hawes fails, and they are arrested. Mrs Lestrange proves to be Lettice's dying mother, while the excavation mystery is separately resolved. Afterward Griselda reveals that she and Leonard are expecting a child.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1843,7 +1843,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1856,7 +1856,7 @@
       "recaps": {
         "ending": "Poirot gathers the household and states that he knows who killed Roger Ackroyd, then tells Dr Sheppard privately that the murderer is Sheppard himself. Sheppard was the blackmailer who had been bleeding Mrs Ferrars for a year over her husband's death, and he killed Ackroyd within minutes of leaving him, before Ackroyd could finish the letter naming him. He propped a dictaphone to play back his employer's recorded voice at half past nine, so that witnesses would place the murder later than it happened, and he arranged for a telephone call to reach him at ten fifteen so that he would be the man to return and discover the body, and so recover the dictaphone in his bag. Every misleading time in his own written account is an omission rather than a lie. Poirot explains that he suspected him from the beginning because Sheppard's account of that evening contained a gap it could not explain. He offers no bargain but tells him that for his sister's sake a different ending is available, and that the police will be told in the morning. Ralph Paton, found and cleared, is free to acknowledge his marriage to Ursula Bourne; Flora Ackroyd, released from her pretended engagement, is free to accept Major Blunt. Sheppard adds a final chapter to his manuscript, admits what he has left out, addresses it to Poirot, and sets out veronal for himself.",
         "in_short": "In the village of King's Abbot, Mrs Ferrars dies of an overdose and the district whispers that she poisoned her husband a year earlier. Her friend Roger Ackroyd tells the local doctor, James Sheppard, that she confessed to the murder and had been blackmailed ever since by someone she would not name. A letter from her arrives while they talk; Ackroyd sends Sheppard away to read it alone, and that evening he is found stabbed in his locked study, the letter gone. His stepson Ralph Paton disappears, and Flora Ackroyd asks the retired detective who has taken the cottage next door to Sheppard, Hercule Poirot, to clear him. Poirot dismantles a series of small lies: Flora never saw her uncle alive that evening, the parlourmaid is secretly married to Ralph, the stranger at the gate is the housekeeper's son, and the telephone call that brought Sheppard back was made from a call box. Poirot finally names the murderer as Sheppard himself, the blackmailer, who killed Ackroyd at once and used a dictaphone to fake the time of death. He is given until morning, and ends his own account with a confession.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1989,7 +1989,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2002,7 +2002,7 @@
       "recaps": {
         "ending": "Dupin's reconstruction is confirmed when the sailor admits that he brought an orangutan home from Borneo and had been trying to contain it. After watching its owner shave, the animal escaped with a razor and entered the L'Espanaye house by climbing a lightning rod. Its attempt to imitate shaving turned violent: it killed Madame L'Espanaye with the blade and strangled Camille. Frightened when the sailor appeared at the window and threatened it with a whip, the orangutan tried to conceal the bodies, forcing Camille's corpse up the chimney and throwing her mother through the window. Its escape left the room apparently sealed because the window's spring closed automatically while a broken nail made the fastening look intact. The sailor eventually recaptures and sells the animal. The authorities release Adolphe Le Bon, while the police prefect resents Dupin's success and Dupin dismisses the prefect's habit of confusing procedural activity with genuine analysis.",
         "in_short": "In Paris, the unnamed narrator befriends the impoverished but brilliant C. Auguste Dupin. When Madame L'Espanaye and her daughter Camille are brutally killed inside an apparently locked room, witnesses report hearing one French voice and another voice no one can identify. The police arrest bank clerk Adolphe Le Bon, but Dupin studies the physical evidence instead of accepting the obvious suspect. A secretly sprung window, extraordinary strength, nonhuman hair, marks that no human hand could make, and the witnesses' contradictory impressions lead him to an escaped orangutan. Dupin lures its sailor owner to his rooms with a newspaper notice. The sailor explains that the animal entered the house with a razor, killed both women while imitating its owner's shaving, and hid the bodies in panic. Le Bon is released, and Dupin's reconstruction exposes the limits of the police inquiry.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2110,7 +2110,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2123,7 +2123,7 @@
       "recaps": {
         "ending": "Dupin places a newspaper notice claiming that a lost orangutan has been found, correctly expecting its owner to respond. A sailor arrives and, after Dupin assures him that the animal is known to be responsible, explains what happened. The orangutan escaped with a razor after watching the sailor shave, reached the L'Espanaye apartment, and tried to imitate shaving on Madame L'Espanaye. Her resistance enraged it; it cut her throat and strangled Camille. When the sailor shouted from outside, the frightened animal attempted to hide what it had done, forcing Camille into the chimney and throwing her mother's body through the window. The sailor fled rather than report the truth. The orangutan is later captured and sold, and Adolphe Le Bon is released. The police prefect resents Dupin's intervention, but the case demonstrates that patient attention to apparently impossible evidence can succeed where exhaustive yet conventional police work fails.",
         "in_short": "In Paris, the unnamed narrator befriends the impoverished but brilliant C. Auguste Dupin. When Madame L'Espanaye and her daughter Camille are brutally killed inside an apparently locked room on the Rue Morgue, witnesses agree that they heard a French voice and a second voice that none can identify. The police arrest bank clerk Adolphe Le Bon, but Dupin finds that the untouched gold, a damaged window fastening, unusual hair, immense strength, and marks on Camille's throat point away from a human murderer. He advertises for the owner of a lost orangutan and draws out a sailor, who admits that his escaped animal entered the women's room carrying a razor. Imitating shaving, the ape killed both women and then tried to conceal them when frightened by its pursuing owner. The animal is recovered, Le Bon is freed, and Dupin solves the locked-room mystery by treating the witnesses' incompatible impressions as evidence rather than error.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2237,7 +2237,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2250,7 +2250,7 @@
       "recaps": {
         "ending": "After Füsun's marriage to Feridun has ended, she and Kemal finally agree to marry. They set out by car toward Europe, but the old imbalance between them remains: Kemal has spent years turning her life into a private collection, while Füsun has been denied the independent future she wanted. After an emotionally charged night, Füsun drives at dangerous speed and crashes the car into a tree. She is killed and Kemal survives. He devotes the rest of his life to acquiring the Keskin house and arranging the thousands of objects he has taken or gathered into a museum dedicated to their story. He visits museums around the world for guidance, then asks the novelist Orhan Pamuk to write the account that accompanies his collection. The finished narrative presents Kemal's claimed happiness alongside the loss, possessiveness, and social constraints embodied by the museum.",
         "in_short": "In 1970s Istanbul, wealthy businessman Kemal Basmacı is engaged to Sibel when he begins an affair with his eighteen-year-old distant cousin Füsun. He proceeds with the engagement, and Füsun disappears. Kemal's obsession destroys his relationship with Sibel and draws him back to Füsun's modest family home, where he spends years attending dinners after learning that she has married the aspiring filmmaker Feridun. He finances a film project, quietly pockets household objects associated with Füsun, and mistakes collecting for closeness while obstructing her hopes of becoming an actress. After Füsun and Feridun divorce, she and Kemal plan to marry. Their reconciliation ends when she crashes their car and dies. Kemal survives, buys her family's house, and makes his accumulated objects into the Museum of Innocence, commissioning Orhan Pamuk to tell the history behind it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2397,7 +2397,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2410,7 +2410,7 @@
       "recaps": {
         "ending": "After Pozzi's failed escape and brutal return, Nashe is left to finish the wall alone. He comes to accept the labor's routine even while doubting Murks's account of what happened to his partner. On Nashe's birthday, Murks and Floyd take him into town, where the three eat, drink, and briefly behave like companions. During the drive back, Nashe is allowed to take the wheel of the car that Flower and Stone won from him. He accelerates on the dark road and steers into the path of an approaching vehicle. The novel ends with the collision itself rather than confirming who survives. Nashe's final act destroys the controlled arrangement he has inhabited, but its mixture of accident, escape attempt, revenge, and self-destruction remains unresolved.",
         "in_short": "Jim Nashe uses an inheritance to leave his job and drive aimlessly across America. With his money nearly gone, he meets poker player Jack Pozzi and stakes his remaining funds on Pozzi's proposed game against eccentric lottery winners Flower and Stone. Pozzi loses, and Nashe compounds the loss by wagering his car and signing a debt. The two men must repay it by assembling a vast wall from stones imported from a ruined Irish castle. Overseen by Murks and Floyd, they find every expense added to their account and their freedom steadily narrowed. Pozzi tries to escape, then is returned gravely injured and disappears. Nashe continues alone until a birthday trip into town with his guards. Driving back in his former car, he deliberately accelerates toward an oncoming vehicle. The book ends at the crash without stating the fate of the occupants.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2580,7 +2580,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2593,7 +2593,7 @@
       "recaps": {
         "ending": "Poirot recovers the missing letter, which had been rolled up and pushed into an ornamental spill vase on the mantelpiece of the boudoir. It proves that Alfred Inglethorp and Evelyn Howard are secretly cousins and lovers who planned the murder together. Miss Howard's loudly advertised hatred of him was cover; it was she, disguised with a false beard and glasses, who bought strychnine at the village chemist's and signed his name, so that the evidence pointing at him could be demolished at will. The poison was worked into Mrs Inglethorp's bromide sleeping powders, so that her medicine delivered a concentrated fatal dose days later, with both of them apparently elsewhere. Alfred courted suspicion deliberately, planning to produce an unshakeable alibi at his trial and be acquitted beyond any second prosecution. Poirot's refusal to let him be arrested too early is what makes the case against him possible. The pair are taken into custody. John Cavendish is acquitted and reconciles with Mary, whose coldness had been jealousy rather than indifference. Lawrence Cavendish and Cynthia Murdoch become engaged, Hastings having proposed to Cynthia himself and been gently refused. Dr Bauerstein's night walks are explained by his arrest as an enemy agent, unconnected with the murder. Hastings leaves Styles with his admiration for Poirot confirmed, and the two agree to work together again.",
         "in_short": "Invalided home from the war, Captain Hastings goes to stay at Styles Court, where his friend John Cavendish lives on the money of his elderly stepmother, Emily Inglethorp, who has just married a much younger man the whole family distrusts. Mrs Inglethorp dies in the night of strychnine poisoning behind a bolted door, hours after a violent quarrel and after making and apparently destroying a new will. Hastings brings in Hercule Poirot, a Belgian detective living among refugees in the village. Suspicion falls on the husband, but Poirot works to protect him, then dismantles the case against him in public. Instead the family closes in: John Cavendish is arrested and tried. Poirot finds the letter everyone has been looking for hidden in a vase, and shows that Alfred Inglethorp and Evelyn Howard, secretly cousins and lovers, poisoned Mrs Inglethorp between them, using her own sleeping powders to delay the dose and inviting suspicion that could be safely destroyed later. John is acquitted, and the guilty pair are arrested.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2750,7 +2750,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2763,7 +2763,7 @@
       "recaps": {
         "ending": "Poirot gathers the household and explains that Alfred Inglethorp and Evelyn Howard planned Emily's murder together while publicly acting like enemies. They exploited the delayed effect of strychnine already present in Emily's medicine and arranged misleading evidence so Alfred would appear obviously guilty at first. Poirot prevented an early arrest because an acquittal would have protected Alfred from being tried again. A revealing letter and the accumulated physical clues finally establish the conspiracy, and Alfred and Evelyn are arrested. John Cavendish, previously prosecuted for the crime, is cleared. The crisis also breaks down the reserve between John and Mary, who reconcile, while Lawrence and Cynthia acknowledge their attachment. Hastings believes Poirot has restored order at Styles, though Poirot notes that human happiness, rather than detection alone, is the best result of the case.",
         "in_short": "While staying with his friend John Cavendish at Styles Court, wounded veteran Arthur Hastings witnesses the death of John's wealthy stepmother, Emily Inglethorp, from strychnine poisoning. Suspicion first falls on her unpopular younger husband Alfred, but the evidence is strangely contradictory. Hastings calls on his Belgian friend Hercule Poirot, who studies the household's rivalries, financial dependence, medicines, wills, and carefully planted clues. John is eventually arrested and tried, but the case against him collapses. Poirot proves that Alfred and Emily's companion Evelyn Howard were secret accomplices: their conspicuous hostility helped conceal their partnership, and they manipulated Emily's medicine and the timing of the poison while trying to make Alfred look too obviously guilty to be convicted. Both conspirators are arrested, John is exonerated, and the strained Cavendish marriage begins to heal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2903,7 +2903,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2916,7 +2916,7 @@
       "recaps": {
         "ending": "After repeatedly showing Theodor how easily human lives can be redirected, Satan leaves him with a final explanation more radical than any earlier lesson. Theodor's village, history, religion, friends, and even the apparently supernatural visitor are not independent realities. They are forms within a solitary dream. Satan tells him that no God, universe, heaven, hell, or human race exists outside his imagining, and that Theodor himself is alone, an unbounded thought moving through eternity. The conclusion therefore dissolves the distinction between the cruel world Satan has judged and the miracles he used to expose it. Father Peter's case, Nikolaus's fate, and the village's persecutions become episodes in the same unstable appearance. Theodor is left without the familiar moral and religious structure of Eseldorf and with the task of recognizing the dreamlike nature of everything he believed solid.",
         "in_short": "In the Austrian village of Eseldorf in 1590, Theodor Fischer and two friends meet a beautiful youth named Satan, who says he is an angel. He performs effortless miracles but regards human suffering with a detachment that horrifies the boys. Theodor asks him to aid the disgraced Father Peter and his niece Marget, yet the resulting money brings an accusation of theft and imprisonment. Satan's interventions repeatedly demonstrate his claim that humanity lacks a reliable moral sense: villagers persecute vulnerable neighbors, and even merciful alterations of fate produce disturbing outcomes. He changes lives, shows Theodor distant scenes, and treats individual existence as material that can be reshaped. At the end he overturns the entire framework of the story, telling Theodor that the world, its God and devils, and all other people are only a dream, and that Theodor alone exists as a wandering thought.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3083,7 +3083,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3096,7 +3096,7 @@
       "recaps": {
         "ending": "Poirot identifies Major Richard Knighton as both Ruth Kettering's murderer and the elusive jewel thief known as the Marquis. Knighton's trusted position gave him full knowledge of Van Aldin's gift and Ruth's travel plans. Ada Mason was his accomplice: her account of seeing a man in Ruth's compartment was designed to point toward the Comte de la Roche, and her description could be adjusted as the investigation required. Knighton killed Ruth on the train and took the Heart of Fire, while the count's planned meeting and Derek's presence supplied convenient alternative suspects. Poirot uses Papopolous's knowledge of the jewel trade, Knighton's handling of evidence, and pressure on Mason to break the prepared story. The ruby is recovered and the count's fraud exposed, though he is not the killer. Derek is cleared of Ruth's murder. Mirelle's attempt to hold him with incriminating claims fails, and his attachment to Katherine becomes plain. Knighton's courtship of Katherine is revealed as part concealment and part miscalculation; Katherine survives the case and is free to choose a future with Derek.",
         "in_short": "Rufus Van Aldin gives his estranged daughter Ruth Kettering the Heart of Fire, a famous ruby, before she takes the Blue Train to the Riviera. Ruth plans to meet her lover, the Comte de la Roche, while her impecunious husband Derek and the dancer Mirelle complicate her private life. On the journey Ruth befriends Katherine Grey, newly wealthy after years as a companion. Ruth is found murdered in her compartment and the ruby is gone. Poirot investigates at Van Aldin's request, testing the evidence of Ruth's maid Ada Mason, the count's schemes, Derek's movements, and Mirelle's jealousy. He discovers that Van Aldin's trusted secretary, Major Richard Knighton, is the international thief known as the Marquis. Knighton killed Ruth for the ruby, aided by Mason, whose story about a man in the compartment was manufactured to misdirect the inquiry. Knighton is exposed, Derek is cleared, and Katherine emerges from the case with the prospect of a life with Derek rather than the cautious isolation she expected.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3269,7 +3269,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3282,7 +3282,7 @@
       "recaps": {
         "ending": "Rouletabille returns in time for Robert Darzac's trial and identifies the supposed detective Frederic Larsan as Ballmeyer, a criminal and master of disguise. Years earlier Ballmeyer had deceived Mathilde into a secret marriage in America under another name. Because he was still alive, she could not marry Darzac without exposing her past, and Ballmeyer used that secret to terrorize her. The first locked-room puzzle resulted from a gap between the original assault and the alarm: Mathilde, later alone, relived the violence in a nightmare and reopened her injury, so no attacker had to escape the sealed room then. During the later gallery attack, Ballmeyer only seemed to join the pursuit as Larsan because the pursuer and fugitive were the same man. Given time to recognize the danger, Ballmeyer escapes before he can be arrested. Darzac is cleared, while Rouletabille keeps the most personal part of Mathilde's history private.",
         "in_short": "After Mathilde Stangerson is nearly killed inside a bedroom whose locked door and barred window offer no escape, young reporter Joseph Rouletabille investigates at the Chateau du Glandier. He competes with famous detective Frederic Larsan, whose reading of the clues increasingly points toward Mathilde's fiance, Robert Darzac. A second attack produces another impossible disappearance, and Darzac's secrecy leads to his arrest. At trial, Rouletabille proves that Larsan is really Ballmeyer, a disguised criminal who had deceived Mathilde into a secret marriage years earlier and was blackmailing and attacking her. The Yellow Room seemed impossible because the household responded not to the original attack but to Mathilde's later nightmare and accidental reopening of her wound; the assailant had already left. In the gallery, Ballmeyer escaped by resuming his identity as the detective who appeared to be chasing him. Darzac is exonerated, but Ballmeyer escapes, and Rouletabille withholds the personal secret that helped him understand Mathilde.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-name-of-the-wind.json
+++ b/data/works-community/0/the-name-of-the-wind.json
@@ -135,7 +135,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -148,7 +148,7 @@
       "recaps": {
         "ending": "The novel ends at the close of the first of Kvothe's three days of storytelling. He has carried his account from his childhood among the Edema Ruh, through the Chandrian's murder of his family and his brutal years in Tarbean, to his arrival and early struggles at the University. By day's end he is established there as a brilliant, poor, and troublesome student: banned from the Archives after his rival Ambrose provoked him, in debt to the moneylender Devi, still chasing the vanishing Denna, and quietly hunting any real knowledge of the Chandrian and the legendary order called the Amyr. His trip to Trebon yielded only fragments and a fleeting sight of his enemies before they escaped. None of the deeper mysteries are resolved. In the present-day frame, the tale pauses, and the red-haired man returns to his role as the quiet innkeeper Kote, while his Fae companion Bast worries over him and mounting signs suggest the peaceful countryside and the wider world are far from safe. The book is deliberately a first act: an unfinished story that sets up far more than it answers, with two further days of telling still to come.",
         "in_short": "The Name of the Wind is told as a frame story: the famous, now-hidden Kvothe, living as a country innkeeper, recounts the true tale of his life to a scribe over three days, and this book covers the first day. He tells of his happy childhood among a family troupe of traveling performers and his first lessons in magic from the arcanist Abenthy, then of the day the mythical Chandrian slaughtered his entire troupe over an old song. Orphaned, he endures years as a destitute street child in the city of Tarbean before the dream of the University, a great school of magic, drives him onward. Admitted young and penniless, he studies sympathy and artificing, is banned from the Archives after clashing with the wealthy student Ambrose, scrapes for money through the moneylender Devi, makes loyal friends, and falls for the elusive Denna. A journey to Trebon lets him investigate a massacre, glimpse the Chandrian, and gather fragmentary hints about them and the shadowy Amyr. Each night the frame returns to the present, where danger stirs in the wider world, and the first day closes with his story still unfinished.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -301,7 +301,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -314,7 +314,7 @@
       "recaps": {
         "ending": "After Gogol and Moushumi divorce, Gogol remains in New York while Moushumi accepts an academic position in Paris. Ashima decides to sell the family house and divide each year between India and the United States, a choice that makes her life genuinely transnational rather than rooted wholly in either country. At the Gangulis' final Christmas gathering in the house, Sonia is preparing to marry Ben, and friends fill the rooms as they have at many earlier family celebrations. Before joining them, Gogol goes to his old room and finds the volume of Nikolai Gogol's stories that Ashoke gave him years before. The inscription recalls his father's hope that his son would one day understand the bond carried by his name. Gogol begins reading the book for the first time. The novel closes without settling his future, but he is newly willing to approach the name and the father he once tried to leave behind.",
         "in_short": "Ashima and Ashoke Ganguli move from Calcutta to Massachusetts, where their first child receives the temporary name Gogol after a family naming plan fails. Gogol grows up uneasy with both his name and the Bengali traditions of his parents, formally becomes Nikhil, studies architecture, and seeks belonging in relationships outside his family. His father's sudden death pulls him back toward Ashima and Sonia and ends his relationship with Maxine Ratliff. He later marries Moushumi Mazoomdar, another Bengali American who seems to understand his divided identity, but their marriage fails after her affair with Dimitri. As Ashima prepares to sell the family home and divide her time between India and America, Gogol finds the book of Nikolai Gogol's stories his father once gave him. He finally begins to read it, accepting that the unwanted name also preserves his connection to Ashoke and to the history that shaped their family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -469,7 +469,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -482,7 +482,7 @@
       "recaps": {
         "ending": "McCaleb's unfinished work and the desert graves lead Bosch and Rachel Walling to the same fugitive serial killer. The Poet has controlled the investigation with messages, selected victims, and false routes, drawing the FBI into terrain prepared for an attack. Bosch identifies the plan and follows the killer into the Las Vegas flood-control channels as a storm sends water through the system. The confrontation ends with the Poet swept away in the flood; the immediate threat is stopped, but the absence of a securely recovered body denies Bosch and Walling absolute certainty. McCaleb's death is understood through the dangerous investigation he had resumed and the strain it placed on his transplanted heart, rather than as an isolated mystery with no connection to his work. Bosch also begins a real relationship with his daughter Maddie and renews contact with Eleanor. Having proved that he still needs the work but also has a life beyond it, he decides to seek reinstatement with the LAPD, bringing his retirement arc to a return rather than a retreat.",
         "in_short": "After retired FBI profiler Terry McCaleb dies, his widow asks Harry Bosch to examine the investigative material he left aboard his boat. McCaleb had found signs that the serial murderer known as the Poet was alive and active. At the same time, FBI agent Rachel Walling is summoned to a desert site where buried victims and messages turn the old unfinished hunt into a new operation. Bosch and Walling reluctantly combine his independent reconstruction with her bureau access. The Poet has anticipated the official response and uses the graves to direct agents toward a prepared trap. Bosch follows the killer into the flood-control channels beneath Las Vegas during a storm; the Poet is carried away by the rushing water, ending the immediate attack without leaving a conclusive body. McCaleb's final exertions are tied to the same pursuit. In Nevada, Bosch also builds a relationship with his daughter Maddie and reconnects with Eleanor Wish. He ends ready to return to the LAPD.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -661,7 +661,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -674,7 +674,7 @@
       "recaps": {
         "ending": "Before the deciding game, the Judge, Gus Sands, and Memo arrange to pay Roy to help the Knights lose, and Roy accepts. Iris then tells Roy she is pregnant with his child. He decides during the game that he wants to win after all, but his attempt at reversal comes too late. Wonderboy breaks, Roy refuses Pop's replacement bat, and he strikes out against a young pitcher with the pennant at stake. Afterward Roy confronts the Judge, beats him and Gus, rejects Memo, and tries to return the bribe, but Max Mercy has already obtained evidence of both Roy's youthful shooting scandal and the fixed game. Roy's corruption becomes public, ending his career and destroying Pop's hope of retaining the Knights. A boy asks Roy whether the report is true; Roy cannot deny it. The novel closes with his talent wasted and his desire to be the greatest replaced by public disgrace.",
         "in_short": "Young pitching prodigy Roy Hobbs is shot by Harriet Bird on his way to a tryout, ending his first chance at professional baseball. Sixteen years later he joins the failing New York Knights as an aging rookie, refuses to discuss his past, and becomes a spectacular hitter with his homemade bat Wonderboy. His success revives the team and manager Pop Fisher's pennant hopes. Roy pursues Pop's niece Memo Paris, while rejecting the steadier Iris Lemon even after learning she cares for him. Ill and desperate for money, he accepts a bribe from the Judge and gambler Gus Sands to lose the deciding game. Iris reveals she is pregnant, and Roy tries to win, but Wonderboy breaks and he strikes out. Sportswriter Max Mercy exposes the shooting and the fix. Roy loses his career, ruins Pop's dream, and faces public disgrace, proving unable to turn extraordinary talent into integrity.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -814,7 +814,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -827,7 +827,7 @@
       "recaps": {
         "ending": "Holmes catches Joseph Harrison entering Percy's room at night and retrieving the treaty from its hiding place beneath the floor covering. Joseph had called at the Foreign Office on the night Percy was copying it, found the room briefly empty, and seized the document on impulse. At home he concealed it in his bedroom, only to lose access when the feverish Percy was installed there and Annie maintained an almost continuous watch. His apparent attack at the window was an earlier effort to recover it. Holmes restores the treaty to Percy with a theatrical breakfast-table surprise. The document has not been sold, Percy is cleared of negligence beyond leaving the room, and the diplomatic danger ends. Annie's loyal care is vindicated, while her brother is exposed as the thief.",
         "in_short": "Foreign Office clerk Percy Phelps is entrusted with copying a secret naval treaty, but it disappears when he briefly leaves the room. The shock causes a long illness, and neither the police nor Holmes initially finds the document. Percy recuperates at his fiancée Annie Harrison's family home, where a nighttime intruder later tries to enter his room. Holmes realizes the incident concerns the treaty itself. He arranges for the room to be left unwatched and catches Annie's brother Joseph retrieving the paper from beneath the floor covering. Joseph had opportunistically stolen it during a visit to Percy's office and hidden it in his own bedroom, but Percy's unexpected illness kept him from reaching the hiding place. Holmes returns the intact treaty, clearing Percy and preventing a diplomatic crisis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -952,7 +952,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -965,7 +965,7 @@
       "recaps": {
         "ending": "Dracula escapes England aboard a ship bound for the Black Sea, while Mina's psychic link to him lets Van Helsing's group follow. After the Count is transferred through Galatz, the hunters divide along the routes to his castle. Van Helsing takes Mina to the castle, protects her within a circle of holy wafer, and destroys the three vampire women while Dracula's influence over Mina weakens. Jonathan and Quincey intercept the wagon carrying Dracula's box just before sunset. They force it open, and Jonathan cuts Dracula's throat as Quincey drives a knife into his heart. The Count crumbles, and Mina's forehead scar vanishes, showing that she is free. Quincey dies from a wound received in the fight. Seven years later, Jonathan and Mina return to the region with their son, whom they have named Quincey in their friend's memory. The surviving companions remain close, and Van Helsing reflects that their records preserve the truth even though they offer little conventional proof.",
         "in_short": "Solicitor Jonathan Harker travels to Count Dracula's Transylvanian castle and discovers that his client is a vampire preparing to move to England. Dracula reaches Whitby and preys on Lucy Westenra despite repeated transfusions and the efforts of Professor Van Helsing. After Lucy dies and becomes a vampire, Van Helsing, Arthur Holmwood, John Seward, and Quincey Morris release her from that state. Mina, now married to Jonathan, organizes the group's records as they hunt Dracula through his London properties. Dracula retaliates by forcing Mina to drink his blood, creating a bond that threatens to transform her but also helps the hunters track him. They destroy his English refuges and pursue him back toward his castle. Jonathan and Quincey kill Dracula moments before sunset, freeing Mina; Quincey dies from his wounds. Years later, Jonathan and Mina commemorate him by giving their son his name.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1145,7 +1145,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1158,7 +1158,7 @@
       "recaps": {
         "ending": "The final story, \"Fathers and Sons,\" follows the adult Nick as he drives with his sleeping son and remembers his own father. His thoughts combine gratitude for what Dr. Adams taught him about hunting and fishing with anger, shame, and an awareness of the limits between them. Memories of adolescence and of an Ojibwe girl connect sexual discovery with the landscape of his youth. When Nick's son wakes, their conversation turns to Dr. Adams. The boy is surprised that he has never been taken to his grandfather's grave and says he wants to go there and pray. Nick agrees that they can. The collection therefore closes not by resolving Nick's feelings about his father, but by placing him between generations: still shaped by a difficult inheritance, now responsible for how his own child will meet that history.",
         "in_short": "Arranged as a life sequence, these stories follow Nick Adams from a Michigan childhood into restless youth, war, recovery, love, and fatherhood. As a boy he accompanies his physician father to an emergency birth that ends in suicide and begins learning how poorly adult assurances contain death. Traveling alone, he meets damaged and threatened men, including former boxer Ad Francis and Ole Andreson, who calmly awaits hired killers. Military fragments and war stories present Nick wounded, sleepless, and haunted amid other injured soldiers. Back in Michigan, he camps and fishes with deliberate care, breaks with Marjorie, and tries to turn solitude into recovery. Later pieces show companionship repeatedly shadowed by departure and memory. In the final story, the adult Nick drives with his son while reckoning with love and resentment toward his dead father. His promise to take the boy to the grandfather's grave leaves him carrying the past forward without fully settling it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1309,7 +1309,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1322,7 +1322,7 @@
       "recaps": {
         "ending": "Elwood's written record of Nickel's crimes is discovered, and Turner agrees to escape with him before the staff can silence them. During the flight, Harper catches the boys. Elwood is shot dead while Turner gets away. Turner then takes Elwood Curtis's name, eventually building a moving business and a marriage with Millie in New York while rarely speaking about Nickel. The apparent adult Elwood of the later chapters is therefore Turner, living under his dead friend's identity and trying to honor the moral standard that Elwood represented. When an investigation of the old school and its secret graveyard brings the past back into public view, he returns to Florida to testify. The novel closes with the survivor preparing to tell what happened, while Elwood's death and the deaths of many other boys become part of the institution's exposed history.",
         "in_short": "Elwood Curtis, an idealistic Black teenager in Jim Crow Florida, is sent to Nickel Academy after unknowingly accepting a ride in a stolen car. The reform school separates boys by race, steals resources intended for them, hires them out for labor, and punishes resistance with savage beatings and disappearances. Elwood holds to the civil-rights principles he admires, while his friend Turner insists that survival depends on distrust and concealment. Elwood documents the school's corruption, but when the authorities discover his effort, the two boys flee. Elwood is shot and killed; Turner escapes and assumes Elwood's identity, later making a life in New York with his wife, Millie. Decades afterward, investigators uncover Nickel's unmarked graves. The man the narrative has presented as an adult Elwood is revealed as Turner, who returns to Florida to give evidence and speak for the friend whose name and ideals he has carried.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1449,7 +1449,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1462,7 +1462,7 @@
       "recaps": {
         "ending": "Vakula returns to Dikanka with the empress's slippers after mastering the Devil and flying to Saint Petersburg. The villagers had taken his disappearance as evidence that he had killed himself, and Oksana realizes during his absence that she loves him. Vakula goes to Chub, offers gifts, and asks permission to marry her. Chub accepts, while Oksana says she would marry Vakula even without the royal slippers. The tale closes in the couple's happy household, with Vakula's painted church serving as a lasting public rebuke to the Devil he defeated.",
         "in_short": "On Christmas Eve in Dikanka, a Devil steals the moon while the witch Solokha hides a succession of admirers in sacks. Her son Vakula, a devout blacksmith and painter, wants to marry the beautiful Oksana, but she mockingly says she will accept him only if he brings her the empress's slippers. Despairing, Vakula seeks supernatural help, discovers the Devil hiding among the night's confusion, and forces him to carry him to Saint Petersburg. There he joins a group of Cossacks at court and obtains slippers from Catherine II. Back home, rumors claim that he has died, prompting Oksana to recognize her love for him. Vakula returns safely, gains her father's consent, and learns that Oksana wants him without any royal gift. They marry, and the humbled Devil remains the subject of Vakula's religious art.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1575,7 +1575,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1588,7 +1588,7 @@
       "recaps": {
         "ending": "After days of panic, Kovalyov wakes one morning to find his nose inexplicably back in its proper place. A barber confirms that it is firmly attached, and Kovalyov resumes shaving, visiting shops, flirting, and pursuing social advancement as though the disruption had never occurred. Ivan Yakovlevich is again permitted to shave him, though Kovalyov watches him carefully. The narrator acknowledges that the entire affair is implausible and offers no rational explanation for the nose's disappearance, independent career, or return. The story closes with ordinary Saint Petersburg life restored and its absurd social assumptions left intact.",
         "in_short": "Saint Petersburg barber Ivan Yakovlevich finds the nose of one of his customers inside a loaf of bread and tries to throw it away. The customer, status-conscious collegiate assessor Kovalyov, wakes to find his face blank. While seeking help, he encounters his nose dressed as an official of higher rank, but it refuses to acknowledge belonging to him. The police eventually recover the nose, yet it cannot be reattached. Kovalyov suspects that a widow has used sorcery to punish him for avoiding marriage to her daughter, but her reply undermines his theory. Rumors about the wandering nose spread through the city. Then, without explanation, Kovalyov wakes with the nose restored and returns happily to his vain social routine.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1698,7 +1698,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1711,7 +1711,7 @@
       "recaps": {
         "ending": "The reader in the care facility is Noah, and the woman who listens is Allie, now living with dementia. The notebook contains the story of their separation, reunion, and shared life. Allie sometimes recognizes Noah for a few minutes after he reads, but the illness repeatedly takes that recognition away. Their doctors and children know that Noah continues because these brief returns matter to both of them. After Noah suffers a heart attack and recovers, he slips into Allie's room late at night on an anniversary. She recognizes him, remembers their love, and invites him to stay. They fall asleep together, ending the book on another improbable interval of connection in the midst of age and illness.",
         "in_short": "An elderly man in a care facility reads from a notebook to a woman whose memory is failing. The story follows Noah Calhoun and Allie Nelson, who fell in love during a summer in New Bern but were separated by her wealthy parents and by years of unanswered letters. Fourteen years later, Allie is engaged to lawyer Lon Hammond when she returns to see Noah at the house he restored. Their affection revives, and Allie learns that her mother concealed Noah's letters. Faced with a choice, she leaves Lon and builds a life with Noah. The old reader and listener are Noah and Allie themselves. Dementia has taken most of Allie's memories, but Noah's reading occasionally brings her back to him. After his own serious illness, he visits her room, where she recognizes him and they spend the night together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1872,7 +1872,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1885,7 +1885,7 @@
       "recaps": {
         "ending": "The Nutcracker defeats the seven-headed Mouse King after Marie obtains a sword for him, and he gives her the enemy's seven crowns. He then leads her through a magical passage into a realm of sweets, toys, and splendid cities, where she is welcomed as his rescuer. Marie awakens at home and cannot persuade the adults that the journey occurred. When Drosselmeier's nephew visits, Marie recognizes his connection to the Nutcracker. She declares that, unlike Princess Pirlipat, she would remain faithful to someone who had suffered for her sake. This promise breaks the Nutcracker's enchantment. The nephew returns in his true form, asks Marie to marry him, and later takes her away in a golden carriage. She becomes queen of his wondrous kingdom, where the beauty she saw on her journey endures.",
         "in_short": "On Christmas Eve, Marie Stahlbaum becomes devoted to a wooden Nutcracker that her brother Fritz damages. At midnight she witnesses the Nutcracker leading the toys against the seven-headed Mouse King. After Marie saves him, her godfather Drosselmeier tells her how Princess Pirlipat's curse was broken by his nephew, who was then transformed into the Nutcracker when the ungrateful princess rejected him. The Mouse King threatens the wounded Nutcracker and extorts Marie's sweets and toys until the Nutcracker, armed with Fritz's sword, kills him. He takes Marie through a magical toy kingdom, but she wakes at home and is not believed. When Drosselmeier's nephew appears, Marie promises she would never reject him for his altered appearance. Her loyalty ends the enchantment; he resumes human form, proposes, and eventually takes her to his kingdom as its queen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2019,7 +2019,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2032,7 +2032,7 @@
       "recaps": {
         "ending": "After the Nutcracker kills the Mouse King, he leads Marie through a wondrous realm of sweets, toys, and elaborate cities, where she is welcomed as the person who saved him. She later awakens at home, and the adults once again treat her account as a dream. Marie nevertheless declares that she would never have rejected the young man who was cursed into the Nutcracker merely because of his altered appearance. That promise completes what courage in battle could not: the curse is broken. Drosselmeier's nephew arrives in human form and identifies himself as the ruler Marie knew as the Nutcracker. He asks her to marry him, and she accepts. The tale closes by saying that Marie becomes his queen in the marvelous kingdom she visited, joining an ordinary family Christmas to the fairy-tale world whose reality only she consistently trusted.",
         "in_short": "At Christmas, Marie Stahlbaum chooses an ungainly Nutcracker as her favorite gift and cares for him after her brother damages him. At midnight she sees the household toys come alive under his command and fight a mouse army led by the seven-headed Mouse King. Marie saves the Nutcracker, but the Mouse King later extorts her sweets and toys. Godfather Drosselmeier tells how Queen Mouserinks cursed Princess Pirlipat and how his nephew broke that curse with the hard Krakatuk nut, only to be transformed into the Nutcracker himself. Marie supplies him with a sword, and he kills the Mouse King. He then takes her through his splendid toy kingdom. Back home, Marie's family dismisses her experiences, but she promises she would have loved Drosselmeier's nephew despite his deformity. Her steadfast acceptance breaks his curse; he appears as a young man, proposes to her, and eventually takes her to reign with him in his enchanted realm.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2210,7 +2210,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2223,7 +2223,7 @@
       "recaps": {
         "ending": "Rennanis breaks into the geode and Essun ends the battle by herself. She takes hold of the onyx, the largest and least tractable of the obelisks, opens the Obelisk Gate, and turns the entire attacking army to stone where it stands. Castrima survives, and the cost lands on Essun's body: using the Gate turns her to stone the way it turned Alabaster. Her right arm goes first. She wakes days later, alive, one-armed, in a comm that now owes her everything, with Alabaster dead and his work unfinished.\n\nIn the south, Nassun has killed her father, seen Found Moon destroyed, and been left with Schaffa, whose pain is constant and whose survival depends on things she is willing to do. A stone eater called Steel offers her a destination: Corepoint, on the far side of the world, where the obelisks can be reached directly. Nassun has decided that a world which does this to children like her is not worth keeping, and she means to use the Gate accordingly.\n\nEssun learns that her daughter is alive and has commanded an obelisk on her own. Mother and daughter are now the only two people living who can open the Obelisk Gate, and they want opposite things from it: Essun to catch the Moon and end the Seasons, Nassun to end everything.",
         "in_short": "Essun stays in Castrima because Alabaster is there, dying, turning to stone, and demanding that she learn what the Fulcrum never taught. He tells her the truth: he opened the Rift on purpose, the Seasons are the consequence of an ancient injury rather than nature, the Moon exists and was flung out of its orbit long ago, and the way to end the Seasons for good is to catch it and put it back. That requires opening the Obelisk Gate, the whole network at once, and Essun is the only candidate left. He dies partway through her education. Meanwhile Nassun is taken south by her father to Found Moon, a school for orogene children run by Schaffa, who survived Meov, remembers almost nothing, and loves her. Nassun becomes more powerful than anyone there. When the compound's Guardians turn on them and her father finally comes for her with a knife, she turns him to stone. Castrima is besieged by the army of Rennanis; Essun opens the Gate, turns the whole army to stone, and loses her right arm to the same process, waking days later to learn that her daughter is alive, strong, and intends to use the Gate to end the world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2399,7 +2399,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2412,7 +2412,7 @@
       "recaps": {
         "ending": "Home at last but still disguised as a beggar, Odysseus watches Penelope announce a contest: she will marry whichever suitor can string Odysseus's great bow and shoot an arrow through a line of axe-heads. None of them can even bend it. Odysseus takes the bow, strings it easily, and makes the shot, then reveals himself. With his son Telemachus, two faithful herdsmen, and Athena's aid, he bars the hall and kills every suitor, and the disloyal servants are punished. He and Penelope are reunited after she tests him with the secret that their marriage bed was built around a living tree rooted in the ground, a thing only the true Odysseus could know. He goes to the countryside to reveal himself to his grieving old father, Laertes. When the families of the slain suitors gather for revenge and fighting breaks out, Athena and Zeus intervene to stop it and bind both sides to peace, leaving Odysseus secure once more as king of Ithaca.",
         "in_short": "Ten years after the Trojan War, Odysseus still has not returned to Ithaca, where suitors besiege his faithful wife, Penelope, and squander his household. With Athena's help his son, Telemachus, sets out to seek news of him. Odysseus himself, held by the nymph Calypso, is at last freed by the gods, shipwrecked by Poseidon, and taken in by the Phaeacians, to whom he recounts his wanderings: the Cyclops he blinded, the enchantress Circe, the land of the dead, the Sirens, and the loss of all his men after they ate the sun god's forbidden cattle. The Phaeacians carry him home, where Athena disguises him as a beggar. Aided by his loyal swineherd and reunited with Telemachus, he enters his own hall unrecognized, wins Penelope's contest of the bow, and kills the suitors. He proves himself to Penelope, reunites with his aged father, and, with Athena imposing peace, is restored as king.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2588,7 +2588,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2601,7 +2601,7 @@
       "recaps": {
         "ending": "Creon refuses burial to Polynices after the civil war and condemns Antigone when she performs the forbidden rite. Although Haemon and Tiresias warn him that his inflexibility is destroying both family and city, he changes course too late. Antigone hangs herself in the chamber where she has been confined. Haemon finds her, turns a weapon on his father, and then kills himself; Eurydice takes her own life after hearing of her son's death. Creon returns carrying Haemon's body and learns of his wife's suicide. He is left alive, stripped of his family and authority over the consequences of his choices. The trilogy therefore closes with Antigone dead but no longer alone in ruin: Creon's insistence that civic command outrank sacred and familial obligations has destroyed his own household, and he finally recognizes responsibility when the damage cannot be reversed.",
         "in_short": "A plague drives King Oedipus to investigate the unsolved murder of Laius. He discovers that he unknowingly killed Laius, his father, and married Jocasta, his mother; Jocasta dies by suicide and Oedipus blinds himself. Years later the exiled Oedipus reaches Colonus, where Theseus protects him from Creon and Polynices. Oedipus rejects both sons, grants Athens the benefit of his secret grave, and dies under divine guidance. His daughters return toward Thebes, where Eteocles and Polynices kill each other in civil war. Creon becomes king, honors Eteocles, and forbids burial of Polynices. Antigone defies the order and is condemned to confinement in a cave. Creon reverses himself after prophetic warning, but too late: Antigone, Haemon, and Eurydice all take their own lives. Creon survives to understand that his rigid rule has destroyed his family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2697,7 +2697,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2710,7 +2710,7 @@
       "recaps": {
         "ending": "Antonio faces the wounded female cat alone after the mayor and the other men withdraw. He understands that she has drawn him toward her dying mate and that her campaign against humans began with the destruction of her cubs. Forced into the final confrontation, Antonio shoots and kills her. He feels no triumph: the animal's death strikes him as another shameful consequence of outsiders invading a world they neither understand nor respect. He throws away the weapon associated with the killing and returns toward El Idilio. Back in his hut, he seeks refuge once more in a love story, turning from the brutality of the forest's colonization toward the distant emotional world that reading allows him to inhabit.",
         "in_short": "Antonio José Bolívar Proaño lives in the Amazonian outpost of El Idilio, where he waits for a travelling dentist to bring him sentimental novels. His years among the Shuar have given him knowledge that the settlement's blustering mayor lacks. When mutilated bodies appear, Antonio determines that a female jungle cat is deliberately hunting humans after careless outsiders killed her cubs and mate. The mayor forces a party into the forest, but his noise and fear make the hunt more dangerous. Antonio eventually continues alone, reading the animal's movements and recognizing the grief behind its violence. In the final encounter he kills the cat because there is no safe alternative, then mourns the needless destruction caused by intruders. He returns home disgusted with human arrogance and retreats into one of the love stories that offer him a gentler imagined world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2881,7 +2881,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2894,7 +2894,7 @@
       "recaps": {
         "ending": "The Southern rebels overrun the palace in the largest attack of the war. Celeste is killed. King Clarkson and Queen Amberly are both killed, and Maxon is shot and badly wounded but survives. Members of the household staff and the guard die alongside them. When the palace is retaken, Maxon is king, and the constraints that governed the entire Selection are simply gone. He ends the competition and asks America to marry him, and she accepts. They are married, and the caste system is formally dissolved, the reform America argued for publicly and the Northern rebels fought for; August Illéa's people become allies of the crown rather than its enemies. Kriss, who had been working with the Northerners inside the palace, leaves with their cause largely won. Aspen and Lucy are together with America's blessing. Marlee and Carter remain at the palace, no longer as punished servants. America ends the book as queen of a country that is being rebuilt from its foundations, alongside a husband who lost his parents and nearly his life on the same night he inherited the throne.",
         "in_short": "Five girls are left in the Selection, and America has finally committed to Maxon, which puts her directly against a king determined to remove her. Southern rebel attacks grow deadlier while the war on the western border drags on. America makes contact with the Northern rebels and learns they want the castes abolished and Illéa's invented founding history exposed rather than the royal family destroyed; Maxon meets them and an understanding is reached. Her father dies suddenly and she goes home to bury him. Celeste drops her performance and becomes a real friend as the field narrows to America, Kriss, and Celeste. Then the King produces proof of America's past with Aspen and her place collapses. Before anything can be settled, the Southern rebels storm the palace. Celeste and both the King and Queen are killed and Maxon is shot but survives. As king he ends the Selection, marries America, and dissolves the caste system.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3054,7 +3054,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3067,7 +3067,7 @@
       "recaps": {
         "ending": "Public attention forces Mack to surrender Ivan and Ruby, and both animals are transferred to a zoo. Ivan initially finds the unfamiliar enclosure and the company of other gorillas difficult after so many years apart from his own kind. With time and patient care he ventures outside, meets Kinyani, and joins the gorilla troop as its silverback. From his new habitat he can also see Ruby living with other elephants, fulfilling his promise to place her in a safer home. Julia and George visit, bringing Bob, who has accepted a home with them while retaining his independence. Julia shows Ivan a billboard that uses his image to celebrate his rescue. Ivan touches the glass to acknowledge his old friends, then returns to his troop. He has moved from passively enduring captivity to protecting Ruby and reclaiming a life among gorillas.",
         "in_short": "Ivan is a gorilla displayed for decades in a small enclosure at the Exit 8 Big Top Mall, where his companions include the elephant Stella, stray dog Bob, and young artist Julia. He accepts his confinement until Mack buys Ruby, a frightened baby elephant, to revive the failing show. As Stella's injured foot worsens, she asks Ivan to make sure Ruby reaches a safer place. After Stella dies and Mack trains Ruby harshly, Ivan finally understands that endurance is not enough. Using finger paint and many sheets of paper, he creates a large image that Julia assembles into a plea for a real home. The billboard draws reporters, protesters, and animal-welfare authorities. Ivan and Ruby are removed to a zoo. Ruby joins an elephant herd, while Ivan gradually enters an outdoor habitat and becomes part of a gorilla troop. Julia, George, and Bob later visit him, and Ivan sees that the promise he made Stella has been kept.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3189,7 +3189,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3202,7 +3202,7 @@
       "recaps": {
         "ending": "Shrek reaches the castle promised by the witch and defeats the knight barring his way. Inside, a room of mirrors briefly confronts him with many copies of his own alarming face. He then meets a princess whose ugliness matches his, and each is delighted by the other's appearance. Their immediate affection fulfills the fortune that began his travels. Shrek and the princess marry, and the tale grants them a happy ending defined on their own monstrous terms: they remain thoroughly unpleasant and are perfectly suited to one another.",
         "in_short": "Shrek is a green monster so ugly and disagreeable that he enjoys terrifying everything around him. Sent away by his parents, he receives a witch's prediction that a donkey will carry him to a knight and that victory will lead him to a princess even uglier than himself. Shrek crosses the countryside without changing his nature, overcoming creatures and dangers through his own fearsome powers. After a nightmare in which cheerful children treat him affectionately, he continues until a talking donkey carries him toward a castle. Shrek defeats the armored knight guarding it and enters, where a hall of mirrors multiplies his own face. He finds the promised princess, and the two are instantly pleased by each other's extraordinary ugliness. They marry and live contentedly together, making the monster's qualities the basis of the story's happy ending.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3279,7 +3279,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3292,7 +3292,7 @@
       "recaps": {
         "ending": "Unable to wait safely offshore any longer, the captain orders the men to abandon the dinghy and swim when it capsizes in the surf. The cook floats with an oar, the captain holds to the overturned boat, and the correspondent struggles through the current until a man from shore pulls him from the water. Billie, the strongest swimmer and the man who has borne much of the rowing, is found dead on the beach. The other three receive care from the people who have gathered there. Their rescue is therefore inseparable from an apparently arbitrary loss: strength and effort have not determined who survives. After their ordeal, the survivors feel that the sound of the sea carries a meaning they can now understand, closing the story on their altered relation to nature rather than on any simple victory over it.",
         "in_short": "After a shipwreck, a captain, a cook, an oiler named Billie, and a correspondent crowd into a fragile dinghy off the Florida coast. They row, bail, and steer through relentless waves, repeatedly seeing land without being able to cross the dangerous surf. Their shared labor creates a powerful bond, while the correspondent wrestles with the apparent indifference of nature to human hopes. People on shore see them but initially misunderstand their signals. At last the exhausted men abandon the swamped boat and swim for land. The captain, cook, and correspondent are rescued, but Billie is found dead. The survivors leave the sea with a new, hard-won sense of fellowship and of nature's power, unable to explain why the strongest of them was the one who did not live.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3454,7 +3454,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3467,7 +3467,7 @@
       "recaps": {
         "ending": "At Orestes' trial in Athens, the citizen judges divide evenly over whether he must be punished for killing Clytemnestra. Athena's vote breaks the tie in favor of acquittal, ending the Furies' legal claim against him and allowing him to return to Argos. The Furies react with anger and threaten the land, but Athena does not drive them away. She offers them an honored place beneath Athens and a continuing power to bless fertility, protect justice, and punish destructive conduct. They accept the settlement, becoming the Eumenides, or Kindly Ones. An Athenian procession escorts the transformed goddesses to their new sanctuary. Orestes is freed, Apollo's command is vindicated in the immediate case, and the cycle of private revenge within the house of Atreus gives way to a civic system in which disputed blood guilt is judged by a court and formerly hostile powers are incorporated into the city's order.",
         "in_short": "After Troy falls, Agamemnon returns to Argos with the captive prophet Cassandra. His wife Clytemnestra, still enraged by his sacrifice of their daughter Iphigenia, kills both of them and rules with Aegisthus. Years later Agamemnon's exiled son Orestes comes home under Apollo's command. Reunited with his sister Electra, he enters the palace in disguise, kills Aegisthus, and then kills Clytemnestra despite wavering before the act. The Furies, divine punishers of familial bloodshed, pursue him. Apollo purifies Orestes and sends him to Athens, where Athena creates a citizen court to judge the conflict between vengeance for a father and guilt for killing a mother. The judges split evenly, and Athena's deciding vote acquits Orestes. She then persuades the furious goddesses to accept an honored role protecting Athens. The family's chain of retaliation ends through public judgment and reconciliation rather than another private killing.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3688,7 +3688,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3701,7 +3701,7 @@
       "recaps": {
         "ending": "Athena establishes a citizen court in Athens to judge whether Orestes must be punished for killing Clytemnestra. The Furies prosecute the claim of a mother's blood; Apollo defends Orestes and accepts responsibility for ordering revenge for Agamemnon. The jurors divide evenly, and Athena casts the deciding vote for acquittal. Orestes promises a lasting alliance between Argos and Athens before returning home. The Furies fear that the verdict has destroyed their ancient authority and threaten the land, but Athena persuades them to accept honor, a sanctuary, and a continuing role in the city's justice. They become protective powers of Athens rather than enemies outside its order. A procession escorts them to their new home. The trilogy therefore ends not with another retaliatory murder, but with a public institution absorbing rival claims and with dangerous divine anger converted into civic protection.",
         "in_short": "The Oresteia follows the house of Agamemnon from victorious return through revenge to a new form of justice. Agamemnon comes home from Troy with the captive Cassandra, and Clytemnestra kills them, avenging his sacrifice of their daughter Iphigenia. She and Aegisthus take power in Argos. Their exiled son Orestes returns under Apollo's command, reunites with Electra, and kills both rulers. The murder of his mother brings pursuit by the Furies, ancient enforcers of blood guilt. Apollo purifies Orestes and sends him to Athens, where Athena creates a citizen court to hear the Furies' prosecution and Apollo's defense. The vote is tied, and Athena's vote acquits Orestes. She then prevents the enraged Furies from cursing Athens by offering them honor and a permanent place within the city. They accept and become its protectors, ending the family's repeated private vengeance through trial, settlement, and civic order.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3881,7 +3881,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3894,7 +3894,7 @@
       "recaps": {
         "ending": "The hunters follow Dracula from England back toward his castle, aided by Mina's psychic connection to him even as that bond threatens her. Jonathan and Quincey intercept the wagon carrying Dracula's box shortly before sunset. Jonathan cuts Dracula's throat while Quincey drives a knife into his heart; the Count's body collapses into dust, and Mina's forehead is cleared of the mark left by the consecrated wafer. Quincey dies from wounds received in the fight, satisfied that Dracula has been destroyed. Seven years later, Jonathan and Mina are married and have a son named for their fallen friend. Arthur and Seward have also found happiness. The surviving records remain as their private evidence of what happened, although they possess little conventional proof beyond the testimony they assembled together.",
         "in_short": "Solicitor Jonathan Harker travels to Transylvania to assist Count Dracula's move to England and discovers that his client is a vampire. Dracula reaches Whitby, feeds on Lucy Westenra, and defeats the efforts of Dr. Seward and Professor Van Helsing to save her. After Lucy dies and becomes a vampire, her friends release her by destroying her undead body. Mina Harker gathers their journals into a single record, allowing Jonathan, Van Helsing, Seward, Arthur Holmwood, and Quincey Morris to hunt Dracula through London. Dracula attacks Mina and forces a bond that both endangers her and helps the hunters track him. They sterilize his English refuges, driving him back toward his Transylvanian castle. Jonathan and Quincey destroy Dracula just before sunset; Mina is freed from his curse, but Quincey dies of his wounds. Years later, Jonathan and Mina honor him by giving their son his name.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4072,7 +4072,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4085,7 +4085,7 @@
       "recaps": {
         "ending": "Rachel survives the campaign of demon attacks and uncovers enough of the summoning and family history behind them to stop being treated as a passive target. The Morgan and Kalamack genetic work did more than cure her childhood Rosewood syndrome: it left Rachel able to perform magic associated with demons, explaining both her exceptional survival and the demons' interest in her. She enters the ever-after and begins exercising that ability consciously rather than accepting the witches' account that such magic is impossible for her. Her conflict with Al changes into a dangerous apprenticeship. Al remains coercive and cannot be trusted, but Rachel accepts instruction because ignorance would leave her more vulnerable. The book does not restore Rachel's memory of Kisten's murder or identify his killer to her; grief and the blank portion of that night remain unresolved. Marshal cannot build a relationship on top of that absence and steps back. Rachel returns to the church with Ivy and Jenks, now possessing a more troubling understanding of herself and a formal reason to keep dealing with Al.",
         "in_short": "Still grieving Kisten and unable to remember his murder, Rachel is repeatedly attacked by Al. The timing and persistence of the assaults suggest that someone is using demon rules and summons to drive him against her. Minias and Newt draw Rachel further into the ever-after, where she must distinguish Al's intentions from the obligations controlling him. Alice Morgan, Trent, and surviving evidence from their fathers' work force Rachel to reconsider the treatment that saved her from Rosewood syndrome. It did not merely heal an ordinary witch: it gave her access to magic the demon world recognizes as its own. Rachel learns to enter and act in the ever-after and survives the attempt to make her the victim of bargains she did not frame. She accepts Al as a teacher under tightly contested terms, judging knowledge safer than continued ignorance. Marshal offers companionship but cannot replace Kisten or solve the missing memory. Rachel ends the book stronger and more deeply involved with demon magic, while Kisten's killer remains unknown to her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4264,7 +4264,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4277,7 +4277,7 @@
       "recaps": {
         "ending": "Jack Hoskins ambushes the group near the Marysville Hole, killing Howie Gold and Alec Pelley before the attack ends with Jack dead. Ralph and Holly enter the cave, where they find the being that copied Terry Maitland and is now becoming Claude Bolton. It admits feeding on murdered children and on the grief that follows while moving from one accused person's identity to another. Holly destroys it with the weighted device she once used against Brady Hartsfield. Ralph, Holly, Yune, and Claude survive, but the deaths caused by the investigation add to the creature's toll. The survivors construct a conventional account that protects Claude and prevents an unbelievable truth from becoming a public spectacle. Terry's name is formally cleared, though that cannot restore him or repair his family. Ralph accepts that the evidence supports an impossible conclusion and becomes Holly's friend. Later, a brief unsettling moment makes Holly wonder whether the creature could return, but she finds an ordinary explanation and chooses not to surrender to fear.",
         "in_short": "Detective Ralph Anderson arrests teacher Terry Maitland for the murder of Frank Peterson because witnesses, fingerprints, and DNA place Terry at the crime. Yet video and independent witnesses prove Terry was attending a conference elsewhere. Frank's brother kills Terry outside court, and Ralph continues investigating the impossible duplication with Terry's lawyer, Howie Gold, investigators Alec Pelley and Holly Gibney, and state officer Yune Sablo. Holly finds earlier cases in which a person was framed by equally contradictory evidence, followed by suicides and family ruin. She concludes that a shape-changing predator copies people, murders children, and feeds on the grief around them. It has coerced detective Jack Hoskins and is transforming into Claude Bolton near a Texas cave. Jack ambushes the investigators, killing Howie and Alec, but Ralph and Holly reach the creature. Holly kills it with her weighted defensive tool. The survivors conceal the supernatural details, Terry is exonerated after death, and Ralph accepts both Holly's friendship and a reality wider than his former rational certainty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4445,7 +4445,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4458,7 +4458,7 @@
       "recaps": {
         "ending": "The greasers win the rumble against the Socs, but the victory is hollow. Johnny, horribly burned and paralyzed from rescuing the trapped children, dies in the hospital that night, his last words urging Ponyboy to stay gold and hold on to the goodness in himself. Dally, who loved Johnny more than anyone, breaks down at the loss, robs a grocery store, and, when the police corner him, raises an unloaded gun so they will shoot him, dying under a streetlight. Ponyboy, already injured and feverish from the rumble, collapses and spends days sick and in denial, at one point insisting that he, not Johnny, killed the Soc. At a court hearing, the judge rules the death self-defense, clears Ponyboy, and allows the three brothers to stay together. Grief-stricken and slipping in school, Ponyboy is failing English until he finds a letter Johnny left tucked in a copy of the novel they read while hiding, telling him there is still good in the world and asking him to pass that on. Understanding at last what stay gold meant, Ponyboy decides to write about everything that happened so that other boys like Johnny might be understood, and the story he begins is the book the reader has just finished.",
         "in_short": "Ponyboy Curtis, a fourteen-year-old orphan raised by his two older brothers, belongs to a gang of poor greasers locked in conflict with the wealthy Socs. After Ponyboy and his fragile friend Johnny are attacked one night, Johnny kills a Soc to stop them from drowning Ponyboy, and the two boys go into hiding at an abandoned church with help from the tough Dally. When the church catches fire with children trapped inside, Johnny and Ponyboy save them and are hailed as heroes, but Johnny is gravely injured. A planned rumble between greasers and Socs ends in a greaser victory, yet that same night Johnny dies, telling Ponyboy to stay gold. Devastated, Dally robs a store and provokes the police into shooting him dead. Ponyboy, sick and in shock, is cleared of blame for the Soc's death at a hearing. Struggling with grief and failing school, he finds a farewell letter Johnny left him and resolves to tell their story, which becomes the book itself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4558,7 +4558,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4571,7 +4571,7 @@
       "recaps": {
         "ending": "After the important person humiliates him, Akaky becomes feverish and dies. His death barely disturbs the department, which soon fills his position. Reports then spread of a dead clerk haunting Saint Petersburg and tearing overcoats from passersby. The important person feels some remorse and decides to inquire after Akaky, only to learn that he is dead. Later, while traveling to an evening engagement, the official is confronted by the apparition, which recognizes him and takes his expensive coat. The shock makes the official more restrained with his subordinates. Sightings of the small clerk-like ghost cease after it has obtained that coat, though a larger and more threatening apparition is subsequently reported elsewhere in the city, leaving the supernatural explanation deliberately unsettled.",
         "in_short": "Akaky Akakievich Bashmachkin is an impoverished Saint Petersburg clerk devoted to copying documents and ignored or mocked by his colleagues. When his old cloak can no longer be repaired, he makes severe economies to commission a new overcoat from the tailor Petrovich. The garment briefly transforms how others treat him, and coworkers celebrate it at a party, but thieves seize it on his walk home. Police efforts lead nowhere. A senior official concerned with displaying his rank angrily dismisses Akaky's plea for help. Akaky falls ill after the encounter and dies, almost unnoticed by his department. Soon a ghost said to be the dead clerk begins stealing coats throughout the city. It finally confronts the important person and takes his overcoat, after which that official behaves less harshly and sightings of Akaky's apparition stop.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4679,7 +4679,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4692,7 +4692,7 @@
       "recaps": {
         "ending": "Bosch's reconstruction shows that the apparent hostage operation was staged from inside the Kent household. Alicia Kent was not simply a captive: she cooperated with the scheme and helped create the account that sent law enforcement looking for outside terrorists. Stanley's murder and the removal of the cesium were parts of that deception, with the radioactive threat serving both as leverage and as a powerful diversion from the personal conspiracy around his death. Bosch follows the inconsistencies in Alicia's account and the physical evidence while the FBI concentrates on preventing a mass-casualty attack. The competing inquiries finally converge, the accomplice behind the shooting is stopped, and the cesium is recovered before it can be used against the public. The resolution vindicates Bosch's insistence that the dead man and the staged crime scene still mattered even under a terrorism alert. His conflict with the FBI, including Rachel Walling, leaves their personal connection strained, while Ferras has seen both the effectiveness and the cost of Bosch's unilateral way of working.",
         "in_short": "Medical physicist Stanley Kent is found executed at a Mulholland Drive overlook, and radioactive cesium under his control has disappeared. His wife, Alicia, says intruders held her hostage and forced Stanley to obtain it. Bosch and his new partner, Ignacio Ferras, pursue the homicide while FBI agents Rachel Walling and Jack Brenner take command of what may be a radiological-terror plot. Bosch resists letting the emergency erase contradictions in the murder scene and Alicia's story. His investigation establishes that the hostage account was staged and that Alicia participated in the conspiracy surrounding her husband's death. The supposed outside attack was designed to direct investigators away from the people closest to Stanley. The killer is stopped and the cesium recovered before it can harm the city. Bosch solves the murder, but his refusal to defer to federal control damages his renewed relationship with Rachel and tests his partnership with Ferras.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4826,7 +4826,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -4837,7 +4837,7 @@
       "recaps": {
         "ending": "The battle of Teotanheale ends in a crushing Saxon victory: the great Danish army that invaded Mercia is destroyed, and with it the immediate threat to the midlands. Uhtred personally kills the warlord Cnut Ranulfson, but in his death throes Cnut wounds Uhtred deeply with his sword Ice-Spite, an injury that will not easily heal. Aethelflaed's and Edward's cause is strengthened, and Uhtred's outlawry counts for less after so great a service. His son has proven himself a warrior in the shield wall. Yet Uhtred's lifelong ambition remains unmet: Bebbanburg still stands in his cousin's hands, his assault on it having failed. He carries away from the field a decisive victory, a proven heir, and a festering wound that will shadow his fortunes in the days to come.",
         "in_short": "Landless and excommunicated after a violent clash with the Church, Uhtred of Bebbanburg is stripped of his Mercian estate and breaks with his son who has become a priest. With little left to lose, he leads his few warriors north to seize Bebbanburg from his cousin, but the fortress proves too strong and his assault fails. Meanwhile the Danish warlord Cnut Ranulfson, tricked into believing Uhtred stole his wife and children, raises a great army and invades Mercia. Uhtred returns to the Saxon cause and helps the Mercians and West Saxons trap the Danes at the battle of Teotanheale, where the Danish host is annihilated. Uhtred kills Cnut, but the dying warlord wounds him gravely with his sword Ice-Spite. The Saxons win a decisive victory, yet Bebbanburg is still not his, and Uhtred is left badly injured.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4983,7 +4983,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4996,7 +4996,7 @@
       "recaps": {
         "ending": "After the war, the boy is reunited with his parents, who have survived but cannot restore the child they sent away. He remains unable or unwilling to speak and carries home the habits of secrecy, retaliation, and distrust that protected him in the countryside. Family life is further strained by the presence of another child his parents have taken in and by the boy's resistance to ordinary authority. Sent to the mountains in the hope that a change will help him, he is injured while skiing and wakes in a hospital. When a telephone rings beside him, he answers it. The effort unexpectedly releases his voice, and hearing himself speak gives him proof that the silence imposed by his experiences is not permanent. The recovery is physical rather than a simple resolution of the war's damage: he returns to speech, but the book leaves the moral and psychological consequences of what he witnessed intact.",
         "in_short": "During the Second World War, an unnamed dark-haired boy is sent from his city home to the countryside for safety and then loses contact with both his guardian and parents. Moving among isolated villages, he is repeatedly classified as a racial, religious, or supernatural threat. He survives the deaths and cruelties around him by adapting to each household, escaping when necessary, and gradually replacing trust with watchfulness and retaliation. Episodes involving Marta, the healer Olga, a miller, the bird catcher Lekh, Ludmila, Garbos, invading troops, and hunted civilians show violence spreading through private life as well as military occupation. After being thrown into a manure pit, the boy loses his speech. The arrival of the Red Army brings protection and education from Soviet soldiers, but also a new lesson in vengeance. Reunited with his parents after the war, he remains alienated and mute until a skiing injury and a hospital telephone call unexpectedly restore his voice.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5145,7 +5145,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5158,7 +5158,7 @@
       "recaps": {
         "ending": "After Walter dies during the cholera epidemic, Kitty returns to Hong Kong. Dorothy Townsend receives her kindly and, unaware of the affair, insists that she stay in the Townsend home. Kitty means to resist Charles but sleeps with him once more, an experience that finally strips away her romantic image of both him and herself. Pregnant and uncertain whether Walter or Charles was the father, she leaves for England. There she learns that her mother has died and sees her father without the contempt she once absorbed from Mrs Garstin. When he receives a judicial appointment in the Bahamas, Kitty asks to accompany him and offers the companionship she had never previously given him. She hopes the child will be a girl whom she can raise to be independent rather than vain, frightened, and governed by marriage. Walter's death cannot be repaired, but Kitty ends with a sober intention to make a different life from the one her upbringing prepared for her.",
         "in_short": "Kitty Garstin marries the shy bacteriologist Walter Fane without loving him and, in Hong Kong, begins an affair with the charming Charles Townsend. Walter discovers it and offers Kitty a choice: obtain a divorce that Charles will match by leaving his own wife, or accompany Walter to cholera-stricken Mei-tan-fu. Charles refuses to sacrifice his marriage and career, so Kitty goes with Walter. Amid the epidemic, Walter works relentlessly while Kitty befriends Waddington and volunteers with French nuns caring for children. Their courage and purpose expose the emptiness of her former life, though she and Walter never fully overcome their mutual wounds. Walter contracts cholera and dies. Back in Hong Kong, Kitty briefly yields to Charles again and finally sees him without illusion. Pregnant, she returns to England, reconciles with her widowed father, and goes with him to the Bahamas, determined to raise her child with more freedom and honesty than she was given.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-pale-horseman.json
+++ b/data/works-community/0/the-pale-horseman.json
@@ -88,7 +88,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -99,7 +99,7 @@
       "recaps": {
         "ending": "The book ends with the Battle of Ethandun in 878. Alfred's army, gathered from the shires after his months as a fugitive in the Athelney marshes, meets Guthrum's Danes on the downs and breaks them; Uhtred fights in the front of the shield wall and plays a decisive part in the victory. The cost is heavy and personal: Leofric, Uhtred's closest friend among the Saxons, is killed in the fighting, and Iseult, the Cornish shadow queen who had become Uhtred's lover, also dies at Ethandun. Wessex is saved - the last English kingdom stands, and Guthrum's bid to extinguish it has failed - and Alfred's authority is restored greater than before. Uhtred ends the book proven beyond doubt as one of Alfred's most valuable warriors, but grieving, still bound by oath to a pious king he does not love, still married to Mildrith in name while she withdraws toward the Church, and still no closer to Bebbanburg, the stolen fortress in the north that remains his life's true aim.",
         "in_short": "Fresh from killing Ubba at Cynuit, Uhtred finds the credit stolen by Odda the Younger and his standing at Alfred's court poisoned. Bored and in debt, he turns half-pirate, raiding the British coast with his friend Leofric and carrying off Iseult, a Cornish shadow queen said to see the future, who becomes his lover. Accusations of raiding fall on him at court, and he survives a judicial fight against the giant Steapa only because news arrives that changes everything: at midwinter Guthrum has broken the peace and overrun Wessex in a surprise attack from Cippanhamm. Alfred becomes a fugitive in the marshes of Athelney with a handful of followers, Uhtred among them. Through a hard winter Uhtred fights, scouts, and helps the king rally the shires, and in spring Alfred's mustered army meets Guthrum at Ethandun and wins the battle that saves Wessex - at the cost of Leofric and Iseult, both killed. The last English kingdom survives, and Uhtred, its half-Danish champion, remains bound to a king he serves but does not love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -430,7 +430,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B08LZPR799",
@@ -442,7 +442,7 @@
       "recaps": {
         "ending": "The attack led by Kellea Colleren eliminates a false weapon while the real construct remains hidden. The Machine destroys Blazing Sun's centralized network, and Mok escapes before a later Confed bombardment kills millions of civilians. He responds by ordering a campaign against the responsible personnel and their families. At Platform 66, Jason's force survives the Machine's trap, but Jason is gravely wounded and never installs the binding protocols. The Machine forcibly takes Volk's archive knowledge and then becomes unable to move or communicate. Its defending synth commander escapes and impersonates it, preserving hidden control of the Confed, while an older adviser considers exposing the substitution. Volk is non-viable, though Cage, Kaz, and Twingo continue testing the archive for a possible recovery. Lucky remains missing after abandoning his stolen shuttle. Jacob still has Phoenix and is in trouble with Earth authorities, so Jason makes finding his son the next priority. In the trailing narrative, Seven takes an encrypted assassination assignment whose target remains unknown.",
         "in_short": "Jason Burke and Omega Force discover that the Machine, an ancient AI controlling the Confed, is assembling a weapon able to devastate planets. Lucky becomes violent and disappears, while Jason's son Jacob steals Phoenix. A sentient Ancient archive helps the rebellion create missiles, but Kellea Colleren destroys only a decoy. The Machine dismantles Saditava Mok's organization and lures Jason to Platform 66 to steal the archive's knowledge. Jason escapes badly injured without deploying his binding program, and the extraction leaves Volk non-viable while the Machine is conscious but paralyzed. Its synth commander secretly takes control of the Confed. Mok begins a revenge campaign after millions of civilians die in a bombardment. Jason chooses to pursue Jacob and Phoenix before searching for Lucky. After the numbered story, a synthetic killer named Seven accepts an unidentified assassination contract.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -570,7 +570,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -583,7 +583,7 @@
       "recaps": {
         "ending": "The youngest rioter returns from town with food, wine, and poison hidden in two bottles. His companions kill him as planned, intending to divide the treasure between themselves. They then drink the poisoned wine and die, so all three find Death beside the gold they hoped to possess. The Pardoner closes with a conventional warning against greed and other sins, then immediately tries to sell pardons and access to his supposed relics to the very pilgrims who have heard him admit that these objects are fraudulent. He singles out the Host, who responds with an angry and insulting refusal. The Knight steps between them and urges reconciliation; the Pardoner and Host make peace, and the pilgrimage continues.",
         "in_short": "The Pardoner admits to the Canterbury pilgrims that he preaches against greed solely to earn money, using practiced sermons and false relics to manipulate congregations. He then tells of three drunken rioters who vow to kill Death after a companion dies. An old man directs them to an oak, where they find a cache of gold instead. Greed displaces their fellowship: two plan to murder the youngest, while he buys poison to kill them and keep all the treasure. The pair stab him when he returns, then drink his poisoned wine and die. After using their fate to condemn avarice, the Pardoner tries to sell pardons and relics to his fellow travelers despite having exposed his fraud. The Host angrily rejects him, and the Knight brokers a reconciliation so the group can proceed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -764,7 +764,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -777,7 +777,7 @@
       "recaps": {
         "ending": "Ojo obtains water from the dark well and continues homeward, but the Tin Woodman refuses to permit the killing of a yellow butterfly for the cure. The travelers therefore return to Dr. Pipt without every ingredient he demanded. The Wizard takes charge and uses his genuine magical training to restore Unc Nunkie and Margolotte from their petrified state without sacrificing the butterfly. Ozma punishes Dr. Pipt for practicing forbidden magic by taking away his powers, but allows him to continue an ordinary life with his restored wife. Ojo is reunited with Unc Nunkie. The Glass Cat remains alive, the Woozy has found friends, and Scraps is welcomed in Oz as a free person rather than kept as a household servant. Her lively friendship with the Scarecrow gives the Patchwork Girl a place among Ozma's unusual companions.",
         "in_short": "Lonely Munchkin boy Ojo visits the Crooked Magician just as Scraps, a patchwork servant, is brought to life. An accident petrifies Ojo's guardian Unc Nunkie and the magician's wife Margolotte. Ojo sets out for rare ingredients that may restore them, joined by Scraps, the vain Glass Cat, and the Woozy. After many encounters, Ojo is arrested for picking a protected six-leaved clover, but Ozma forgives him and lets the quest continue. The party survives Yoop, quarrelsome Hoppers and Horners, a dark well, and a trick river. The Tin Woodman refuses to let Ojo harm a butterfly for the cure. Back at the magician's house, the Wizard restores the petrified pair by other magic. Ozma removes Dr. Pipt's unlawful powers, Ojo regains his family, and Scraps is welcomed as a free citizen of Oz.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -928,7 +928,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -941,7 +941,7 @@
       "recaps": {
         "ending": "The book ends with victories that feel like defeats. The Bowl of the Winds has mended the ruined weather, but every triumph curdles. Rand hurls back the Seanchan advance, yet only by using the flawed sword Callandor without the circle of channelers needed to control it; the battle turns into a haze of slaughter in which he nearly kills his own soldiers, and he comes away sickened and more afraid than ever of what he is becoming, the intruding voice in his head and the two unhealing wounds always with him. Egwene has consolidated real power over the rebel Aes Sedai, forcing her Hall to declare open war on Elaida and setting her army in motion toward Tar Valon. Elayne has reached Caemlyn to begin her long struggle for the Lion Throne of Andor. But Perrin's mission collapses into catastrophe: the renegade Shaido Aiel raid his camp and carry off his wife, Faile, along with others, beginning a captivity that will consume him. And at his manor near Cairhien, a handful of Rand's own Asha'man, secretly turned against him, attack the Dragon Reborn with the Power; Rand survives the ambush, but the traitors escape, and he can no longer trust even the men he made. The Seanchan remain a rising threat, the Shadow's servants are everywhere, and Rand's grip on both his empire and his own mind is slipping.",
         "in_short": "With the Bowl of the Winds worked, the seasons begin to right themselves, and the scattered friends press their separate campaigns. Elayne, Nynaeve, and Aviendha make for Caemlyn, where Elayne begins the hard fight to claim the throne of Andor that is hers by blood. Egwene, the rebel Amyrlin, out-maneuvers the older sisters of her Hall, forces them to declare open war on the usurper Elaida, and starts moving her army toward the White Tower by the recovered art of Traveling. Rand turns to throw back the Seanchan, who have taken Ebou Dar and are driving inland, and in the battle he wields the flawed crystal sword Callandor without a circle to control it; the fight becomes a chaotic, costly victory that nearly makes him slaughter his own men and leaves him deeply shaken. Perrin, sent to bring a fanatical self-styled Prophet of the Dragon to heel, suffers a devastating blow when his wife Faile is seized by the renegade Shaido Aiel. And at the book's close, a group of Rand's own Asha'man turn on him, attacking the Dragon Reborn with the Power in a treacherous ambush he barely survives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1037,7 +1037,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1050,7 +1050,7 @@
       "recaps": {
         "ending": "Kino and Juana flee into the mountains after Kino kills a man who attacks him for the pearl. Three trackers follow them to a water hole, forcing the family to hide in a cave above it. Kino descends at night to stop them, but one tracker mistakes Coyotito's cry for an animal and fires toward the cave. Kino kills the men and takes their rifle, only to discover that the shot has killed his son. He and Juana return to town on foot, carrying Coyotito's body. Changed by grief and watched by the community, they walk to the shore together. Kino sees only violence and loss in the pearl that once seemed to contain every possible future, and he throws it back into the sea. The hoped-for marriage, education, security, and social advancement vanish with it; the family survives, but the dream attached to the pearl has cost them their child.",
         "in_short": "When a scorpion stings the infant Coyotito, the wealthy town doctor refuses to help his poor parents, the pearl diver Kino and his wife Juana. Kino then finds an exceptionally large pearl and imagines it will pay for treatment, a church wedding, education for his son, and a better life. Instead, the discovery draws the priest, doctor, pearl buyers, thieves, and the ambitions of the whole town toward the family. The buyers offer a price Kino knows is dishonest, so he resolves to sell the pearl elsewhere. After repeated attacks, Kino kills an assailant, and the family flees their burned home and ruined canoe. Trackers pursue them into the mountains. During Kino's attempt to eliminate the threat, a tracker fires toward Coyotito's cry and kills the child. Kino and Juana return carrying their son, and Kino casts the pearl into the sea, rejecting the object whose promise has ended in violence and grief.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1183,7 +1183,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1196,7 +1196,7 @@
       "recaps": {
         "ending": "The gathering at the Hotel Denouement ends in catastrophe. During a nighttime confrontation by the hotel pond, a harpoon gun held by Count Olaf discharges as the children struggle for it, fatally striking the secret librarian Dewey Denouement, who dies in the water, a death the Baudelaires helped bring about and cannot forgive themselves for. The great trial meant to sort the guilty from the innocent falls apart when it emerges that villains, including the man with a beard and the woman with hair, sit among the High Court judges, and the proceedings, with everyone blindfolded, become a farce that condemns the children. To escape and to signal any remaining allies, the Baudelaires join in setting the hotel on fire, and the last safe place burns to the ground. In the chaos they flee, and with no better option they leave by boat together with Count Olaf, an uneasy and desperate alliance, sailing out to sea while Kit Snicket departs separately, all of them carried toward an unknown shore and the final chapter of the story.",
         "in_short": "Kit Snicket brings the Baudelaires to the Hotel Denouement, the last safe place, where V.F.D.'s two factions will gather, and asks them to work undercover, observing guests to tell allies from enemies. The hotel, run like a giant library, is managed by identical twins Frank and Ernest Denouement, one a volunteer and one a villain, whom the children cannot tell apart. As familiar faces from the children's past arrive on both sides, the orphans meet a secret third brother, Dewey Denouement, who has compiled a hidden catalog of V.F.D.'s evidence. In a confrontation by the hotel pond, a harpoon gun in Count Olaf's hands goes off during a struggle, and Dewey is killed, a death the horrified children helped cause. A trial before the High Court collapses when villains are revealed among the judges. To escape, the Baudelaires help set the hotel ablaze and flee by boat, leaving with Count Olaf himself in a desperate alliance, sailing out to sea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1363,7 +1363,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1376,7 +1376,7 @@
       "recaps": {
         "ending": "Erik traps Raoul and the Persian in a heated torture chamber while forcing Christine to choose between marriage and a catastrophic explosion. She chooses the scorpion, agreeing to marry him and saving the people above, but finds Raoul apparently drowned in the adjoining room. Christine then gives Erik the ordinary compassion he has never received: she lets him kiss her forehead and kisses him in return. Overcome, he frees Raoul and the Persian and permits Christine to leave with Raoul, asking only that she return his ring and later announce his death. She keeps that promise. Erik tells the Persian what happened and dies soon afterward of grief. Christine and Raoul disappear from Paris and are understood to have married, while the narrator's later investigation identifies Erik as the extraordinary but criminally dangerous human being behind the Opera Ghost legend.",
         "in_short": "At the Paris Opera, young soprano Christine Daaé becomes a sensation after secret lessons from a voice she believes may be an angel sent by her dead father. The voice belongs to Erik, a masked, disfigured musical genius who lives beneath the building and terrorizes its managers as the Opera Ghost. Christine's childhood friend Raoul returns and falls in love with her. After Erik abducts Christine to his underground home, she unmasks him and learns the truth, yet pities him. She and Raoul plan to flee, but Erik seizes her during a performance. Guided by the Persian, Raoul reaches the cellars and is trapped. Erik threatens mass death unless Christine marries him. Her willing kiss and compassion transform his decision: he releases both lovers and lets them go. Christine returns his ring, Raoul and she leave together, and Erik dies shortly afterward, finally acknowledged as a man rather than a supernatural specter.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1563,7 +1563,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1576,7 +1576,7 @@
       "recaps": {
         "ending": "In Erik's underground house, Christine faces a forced choice: marry him or allow explosives beneath the Opera to kill many people, including Raoul and the Persian. She agrees to the marriage and then gives Erik the unforced compassion he has never received, allowing him to touch her and kissing his disfigured face. The gesture breaks his determination to possess her. Erik frees Raoul and the Persian and lets Christine leave with Raoul; she later returns Erik's ring as promised. Erik tells the Persian what happened and says that he is dying of love. His death is subsequently announced, while Christine and Raoul disappear from Paris and are understood to have married. Philippe de Chagny has died during the rescue attempt, and suspicion falls unfairly on Raoul. The later discovery of a deformed skeleton beneath the Opera, wearing Erik's ring, supports the account that the Opera Ghost was a gifted, tormented man who ended his life alone after releasing Christine.",
         "in_short": "At the Paris Opera, rumors of a ghost become deadly as an unseen figure extorts the managers and dictates casting. Young soprano Christine Daae believes the mysterious voice teaching her is an Angel of Music, but her childhood friend Raoul discovers that the teacher is Erik, a disfigured musical and mechanical genius living beneath the theater. Erik abducts Christine and demands her love, while she and Raoul plan to flee. When he seizes her again, Raoul and a man known as the Persian enter the underground labyrinth and are trapped in a torture chamber. Erik threatens to destroy the Opera unless Christine agrees to marry him. She consents and responds to him with genuine pity, kissing his face. Moved by a compassion he has never known, Erik releases everyone and permits Christine to leave with Raoul. She returns his ring, and the lovers vanish together. Erik dies soon afterward; the remains later found beneath the Opera are identified as his.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1761,7 +1761,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1774,7 +1774,7 @@
       "recaps": {
         "ending": "Raoul and the Persian survive the mirrored torture chamber and reach Christine, who has been forced to choose between marrying Erik and triggering an explosion beneath the Opera. She turns the scorpion that signifies consent. Her compassion then transforms the confrontation: she allows Erik to kiss her and kisses his disfigured face in return without revulsion. Overcome because no one has shown him such tenderness, Erik releases Christine, Raoul, and the Persian. Christine returns Erik's ring and leaves with Raoul, while Erik later tells the Persian that he expects to die of love and asks him to announce his death. A notice reporting Erik's death appears soon afterward. Christine and Raoul disappear from public view and are believed to have married, while the novel closes by identifying the lonely, gifted, violent man behind the Opera Ghost legend.",
         "in_short": "At the Paris Opera, soprano Christine Daaé is secretly trained by a voice she believes to be the Angel of Music. Her childhood friend Raoul discovers that the voice belongs to the Opera Ghost, a masked genius living beneath the theater who extorts its managers and demands Christine's devotion. The ghost abducts her, reveals his disfigured face, and later lets her return on a promise of loyalty. Christine and Raoul plan to flee, but the ghost seizes her during a performance. Guided by the Persian, Raoul descends through the Opera's hidden passages and is trapped. The ghost, named Erik, threatens mass destruction unless Christine agrees to marry him. She consents, then responds to his suffering with a freely given kiss. Moved by compassion he has never received, Erik releases Christine and Raoul. The lovers leave together, and Erik dies soon afterward.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1948,7 +1948,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1961,7 +1961,7 @@
       "recaps": {
         "ending": "Erik traps Raoul and the Persian in a heated torture chamber while forcing Christine to choose between marriage and a catastrophic explosion. She chooses the scorpion, agreeing to marry him and saving the people above, but finds Raoul apparently drowned in the adjoining room. Christine then gives Erik the ordinary compassion he has never received: she lets him kiss her forehead and kisses him in return. Overcome, he frees Raoul and the Persian and permits Christine to leave with Raoul, asking only that she return his ring and later announce his death. She keeps that promise. Erik tells the Persian what happened and dies soon afterward of grief. Christine and Raoul disappear from Paris and are understood to have married, while the narrator's later investigation identifies Erik as the extraordinary but criminally dangerous human being behind the Opera Ghost legend.",
         "in_short": "At the Paris Opera, young soprano Christine Daaé becomes a sensation after secret lessons from a voice she believes may be an angel sent by her dead father. The voice belongs to Erik, a masked, disfigured musical genius who lives beneath the building and terrorizes its managers as the Opera Ghost. Christine's childhood friend Raoul returns and falls in love with her. After Erik abducts Christine to his underground home, she unmasks him and learns the truth, yet pities him. She and Raoul plan to flee, but Erik seizes her during a performance. Guided by the Persian, Raoul reaches the cellars and is trapped. Erik threatens mass death unless Christine marries him. Her willing kiss and compassion transform his decision: he releases both lovers and lets them go. Christine returns his ring, Raoul and she leave together, and Erik dies shortly afterward, finally acknowledged as a man rather than a supernatural specter.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2288,7 +2288,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0DJTYK4H6",
@@ -2300,7 +2300,7 @@
       "recaps": {
         "ending": "Elaine, Iona, Fenrir, and Auri leave the Phoenix Peaks together after learning that Auri's missed return was caused by a prolonged underwater dungeon stage. Auri remains connected to the phoenix friends she made and to the mountain she developed, while the northern wardens now regard her household with suspicion. Elaine and Iona are married, and Elaine has become an Arbiter of Life and Death, Seraph of the Dawn, and Erudite Archmage. Iona carries a divine obligation to liberate the moons, with Elaine committed to joining her when she acts. Knight again commands the Sentinels as Loonkot's Moon Cult and wider foreign pressure remain unresolved. The forged-property campaign has left new neighbors around Elaine's home, Elaine's manuscript-copying array is complete but not yet deployed, and Julius remains burdened by White Dove's weapon curse. The unidentified northern attacker also remains an open danger.",
         "in_short": "Elaine and Iona become engaged, marry, and advance their classes while Auri accepts an invitation to live among the phoenixes of the Phoenix Peaks. Knight resumes command of the Sentinels as Loonkot's Moon Cult and other foreign pressures threaten Exterreri. Elaine studies spatial runes at Jakhong Monastery, completes a manuscript-copying array, and later gains the Erudite Archmage and Seraph of the Dawn classes. Nearly six years after leaving, Auri misses her promised return. Denied official access to the northern continent, Elaine, Iona, and Fenrir travel there anyway, survive an unidentified attack, and reach the Peaks. They find Auri alive after an unusually long dungeon run caused by an underwater stage. Auri gathers her treasures and leaves with her reunited household, though the northern wardens are now wary of them and several wider threats remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2506,7 +2506,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2519,7 +2519,7 @@
       "recaps": {
         "ending": "The collection's final tale ends with Bannadonna destroyed by the mechanism that was meant to crown his achievement. He has built an immense bell tower and secretly devised an automated figure to strike the bell during the public inauguration. Because Bannadonna remains in the figure's path when the machinery runs, it delivers its programmed blow to him instead. The city discovers the celebrated inventor dead inside the tower, and the work that was intended to demonstrate human mastery has acted without judgment upon its maker. The tower later collapses, erasing the monument as well as its creator. As the close of a collection rather than a continuous novel, this does not resolve the earlier tales: Marianna remains in her lonely home, Bartleby has died in prison, Don Benito has died after surviving Babo's revolt, the Lightning-Rod Man has been expelled, and the Encantadas retain the human traces described by their narrator.",
         "in_short": "Six independent tales examine illusion, refusal, power, isolation, and destructive ambition. In The Piazza, a country gentleman crosses the mountains toward what he imagines is an enchanted home and meets Marianna, who has idealized his house in the same way. Bartleby follows a Wall Street copyist who gradually refuses every demand, remains in an office after losing his job, and dies in prison after declining food. In Benito Cereno, Captain Delano boards a Spanish ship and mistakes a coerced performance for normal order until the captive Don Benito escapes and Babo's revolt is exposed. The Lightning-Rod Man satirizes a salesman who exploits fear during a storm. The Encantadas surveys the Galapagos and its histories of castaways, tyrants, Hunilla's abandonment, and Oberlus's violence. In The Bell-Tower, Bannadonna's secret automaton kills him during the inauguration of his masterpiece, and the tower later falls.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2728,7 +2728,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2741,7 +2741,7 @@
       "recaps": {
         "ending": "Pickwick uses his money and influence to repair much of the harm accumulated during the journeys. He pays the legal costs that free Mrs. Bardell and himself from the Fleet, helps Winkle and Arabella reconcile with her brother and Winkle's father, and assists the destitute Jingle and Job Trotter in making a new start in the West Indies. Snodgrass marries Emily after Mr. Wardle's resistance is overcome. Tony Weller exposes Stiggins, settles his affairs after his wife's death, and rejects retirement in favor of continuing to work. The Pickwick Club is dissolved as its members enter settled domestic lives. Pickwick retires to a house at Dulwich, where he remains a loved friend to the younger families. Sam marries Mary but refuses to leave his master, so the couple stays in Pickwick's household. The adventures end with Pickwick surrounded by the people whose lives his loyalty and generosity have improved.",
         "in_short": "Samuel Pickwick forms a traveling club with Winkle, Snodgrass, and Tupman, whose attempts to study English life lead through elections, country visits, romantic mistakes, and repeated encounters with the scheming actor Alfred Jingle. Pickwick hires the resourceful Sam Weller, who becomes his devoted servant and practical guide. A misunderstood conversation with his landlady, Mrs. Bardell, produces a breach-of-promise suit. After losing at trial, Pickwick refuses on principle to pay and is imprisoned for debt in the Fleet, where he sees the human cost of the legal system and finds Jingle and Job Trotter destitute. He ultimately pays the costs to free Mrs. Bardell, helps Jingle and Job emigrate, and reconciles several young couples. Winkle marries Arabella Allen, Snodgrass marries Emily Wardle, and Sam marries Mary while remaining with Pickwick. The club dissolves, and Pickwick retires to Dulwich as the benevolent center of the extended community created by the journeys.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2880,7 +2880,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2893,7 +2893,7 @@
       "recaps": {
         "ending": "Weary of his ruined life and wanting to escape the evidence of it, Dorian resolves to destroy the portrait that has recorded every one of his sins, believing that killing it will free him from conscience and the past. He takes up the same knife with which he murdered Basil Hallward and stabs the canvas. His servants hear a terrible cry and, forcing the locked door, find the portrait hanging untouched and restored to the radiant youth and beauty it had when Basil first painted it. On the floor lies a withered, wrinkled, hideous dead man in evening dress, a knife in his heart. Only by the rings on his fingers do they recognize him as Dorian Gray. His bargain has come due: the magic that spared his body its punishment collapses at the moment he tries to erase the record of his soul, and the disfigurement the picture had carried for years passes back to the man himself in death.",
         "in_short": "In fashionable London, the painter Basil Hallward finishes a portrait of the beautiful young Dorian Gray, whom his cynical friend Lord Henry Wotton teaches to prize youth and pleasure above all else. Terrified of aging, Dorian wishes that the portrait would grow old in his place. The wish is granted: Dorian stays young and lovely while the painted image records every sin and cruelty. He drives a young actress, Sibyl Vane, to suicide, sinks into years of secret vice, and hides the changing portrait in a locked room. When Basil sees the corrupted painting, Dorian murders him and forces a former friend to destroy the body. Hunted for a time by Sibyl's vengeful brother, who dies by accident, Dorian at last tires of his own corruption. Hoping to be free of his conscience, he attacks the portrait with the knife that killed Basil. He is found dead, aged and disfigured, while the picture is restored to its youthful beauty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3020,7 +3020,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3033,7 +3033,7 @@
       "recaps": {
         "ending": "After James Vane's accidental death removes the immediate threat to him, Dorian decides that he will become good. He tells Lord Henry that he has spared a village girl named Hetty Merton, but Henry doubts that this single act proves any real reform. Dorian examines the portrait, expecting it to improve, and instead sees fresh evidence of hypocrisy. Believing the picture to be the last witness to his crimes, he takes the knife used against Basil and stabs it. His servants hear a cry and enter the locked room. The portrait has recovered its original image of the beautiful young Dorian, while an aged and repellent dead man lies on the floor with the knife in his heart. The servants identify the body as Dorian only by its rings.",
         "in_short": "Artist Basil Hallward paints a portrait of the beautiful young Dorian Gray. Influenced by Lord Henry Wotton's worship of youth, Dorian wishes that the picture would age in his place. The wish comes true: after he cruelly rejects the actress Sibyl Vane and she dies, the portrait changes while his face remains young. Dorian hides it and spends years pursuing pleasure while the picture records his corruption. When Basil confronts him, Dorian shows him the portrait and kills him, then forces Alan Campbell to destroy the body. Sibyl's brother James seeks revenge but dies accidentally before reaching him. Dorian attempts a shallow reform and discovers that the portrait also exposes his hypocrisy. He stabs it, hoping to destroy the evidence. Instead Dorian dies as an old, disfigured man, while the portrait returns to its original beauty.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3232,7 +3232,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3245,7 +3245,7 @@
       "recaps": {
         "ending": "In the land of Beulah, Christian and Hopeful can see the Celestial City but must first cross a river with no bridge. Christian nearly gives way to fear in the deep water; Hopeful encourages him until both reach the far bank, where shining guides escort them uphill. At the gate their certificates are accepted, and they enter the city to welcome, music, and transformed life. The narrator then sees Ignorance arrive by a ferryman's easier crossing. Because he has no valid certificate, the King refuses him entry despite his confidence and orders him taken away through a door in the hillside. Christian and Hopeful therefore complete the pilgrimage together, while Ignorance's fate supplies the final warning that reaching the gate and claiming worthiness are not the same as being admitted.",
         "in_short": "Christian leaves the City of Destruction after learning of coming judgment and follows a difficult road toward the Celestial City. He is rescued from false counsel, enters through the narrow gate, receives instruction, and loses his burden at the Cross. After shelter at the Palace Beautiful, he defeats Apollyon and crosses the Valley of the Shadow of Death. Faithful joins him but is executed at Vanity Fair; Hopeful, converted by that witness, becomes Christian's next companion. The pair resist profit-seeking travelers, escape Giant Despair's Doubting Castle, learn from shepherds, and survive deception on the last stages of the road. After passing through Beulah, Christian and Hopeful cross the final river and are admitted to the Celestial City. Ignorance reaches the gate by an easier route but lacks the required certificate and is rejected, closing the journey with a warning against confidence without inward change.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3402,7 +3402,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3415,7 +3415,7 @@
       "recaps": {
         "ending": "The cathedral at Kingsbridge is finally completed, a triumph for Prior Philip and the fulfillment of Tom Builder's dream, carried to fruition by Jack. Aliena and Jack are united and their family restored, while Aliena's brother Richard regains the standing their family had lost. The novel's villains meet their downfall: William Hamleigh's crimes catch up with him and he is brought to justice and executed, and Waleran Bigod's schemes collapse into disgrace. The closing events are tied to the historical murder of Archbishop Thomas Becket and to King Henry II's public penance for that killing, which becomes the occasion on which the conspirators against Kingsbridge are finally exposed and punished. The story ends with the community and its cathedral secure and its long-suffering good characters at last rewarded.",
         "in_short": "Spanning several decades in twelfth-century England, the novel follows the building of a cathedral in the town of Kingsbridge and the lives bound up in it. Tom Builder, a mason who longs to construct a great church, finds his chance when the ambitious prior Philip sets out to build one. Around them move Aliena, a noblewoman cast into poverty who rebuilds her life through the wool trade, and Jack, a gifted boy of Tom's household who becomes a master builder and Aliena's love. Against them stand the brutal noble William Hamleigh and the scheming cleric Waleran Bigod, who repeatedly attack Kingsbridge and thwart its people out of greed and vengeance. Over many years of ambition, betrayal, war, and perseverance, the cathedral slowly rises. The struggle plays out against the real historical conflict between crown and Church, culminating in the murder of Archbishop Thomas Becket, an event in which the story's villains are entangled and through which justice at last catches up with them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3529,7 +3529,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3542,7 +3542,7 @@
       "recaps": {
         "ending": "Frederic's leap-day birthday binds him to the pirates for decades more, and his rigid sense of duty forces him to rejoin them and disclose Major-General Stanley's lie about being an orphan. The pirates attack the general's estate, overpower the police, and seize the household. The Sergeant then calls upon them to submit in Queen Victoria's name. Their loyalty to the Crown proves stronger than their resistance, so they surrender. Ruth supplies the final change in status by revealing that the pirates are not common criminals by birth but noblemen who have gone astray. Major-General Stanley immediately regards them as acceptable sons-in-law and gives them his daughters. The social and legal obstacles collapse together: the pirates regain rank, the daughters receive husbands, and Frederic can be united with Mabel without betraying the duty that has directed his decisions. The resolution converts the threatened punishment of pirates into a general reconciliation based on birth, patriotism, and the same convenient literalism that created the conflict.",
         "in_short": "Frederic completes an apprenticeship to the Pirates of Penzance, an error caused when his nurse Ruth confused a pirate with a ship's pilot. He leaves intending to destroy the band, rejects Ruth as a bride, and falls in love with Mabel, daughter of Major-General Stanley. When the pirates seize the other daughters, Stanley escapes by claiming to be an orphan, since the tenderhearted band never attacks orphans. Frederic and Mabel plan to marry while the police prepare to arrest the pirates. Ruth and the Pirate King then reveal that Frederic was born on leap day: his contract binds him until his twenty-first birthday, not merely his twenty-first year, so duty compels him to rejoin them. He also reveals Stanley's lie. The pirates defeat the police but surrender when commanded in Queen Victoria's name. Ruth announces that they are noblemen who went astray, Stanley accepts them as husbands for his daughters, and Frederic and Mabel are reconciled.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3672,7 +3672,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3685,7 +3685,7 @@
       "recaps": {
         "ending": "The epidemic retreats and Oran's gates reopen to public celebration, reuniting many separated couples and families. The narrator identifies himself as Dr. Bernard Rieux, explaining that he has assembled his chronicle from what he witnessed and from documents such as Tarrou's notebooks. The victory has cost him both Tarrou, who contracts plague just as the danger is ebbing and dies after a prolonged struggle, and his wife, whose death at the distant sanatorium is reported by telegram. Grand survives and returns to his novel with a willingness to begin again. Rambert is reunited with the woman he chose not to escape to when doing so would have meant abandoning the town. Cottard, terrified by the return of normal law, fires on people from his apartment and is arrested. Watching the celebrations, Rieux refuses to call the victory permanent. He records the courage and decency shown during the outbreak while warning that the plague bacillus can remain dormant and return, so relief does not erase the need for vigilance and solidarity.",
         "in_short": "Dead rats and sudden fevers announce bubonic plague in Oran, Algeria. Dr. Bernard Rieux presses reluctant officials to act, but the city is sealed only after the disease is established. Separation, fear, shortages, and mass death reshape ordinary life. Visitor Jean Tarrou organizes volunteer sanitation squads; clerk Joseph Grand records cases; journalist Raymond Rambert first arranges an escape, then stays because private happiness would shame him while others suffer. Father Paneloux moves from interpreting plague as punishment to confronting the death of an innocent child. Tarrou and Rieux form a close friendship through shared labor, while Cottard prospers because the emergency suspends the normal legal order he fears. The disease finally recedes, but Tarrou dies near its end and Rieux learns that his absent wife has also died. Grand recovers, Rambert is reunited with his beloved, and Cottard is arrested after firing into the street. Revealing himself as the chronicler, Rieux records both the provisional victory and the warning that plague can lie dormant and return.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3845,7 +3845,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3858,7 +3858,7 @@
       "recaps": {
         "ending": "After Grand unexpectedly survives and rats reappear alive, plague deaths fall and Oran prepares to reopen. Relief does not spare everyone. Tarrou contracts the disease and dies in Rieux's home after a prolonged struggle, and Rieux then learns that his absent wife has also died. When the gates open, Rambert reunites with the woman he loves and the city erupts in celebration. Cottard, terrified by the return of normal law, fires from his apartment into the street and is arrested. The chronicler reveals himself as Rieux, who has written from records, testimony, and direct experience to bear witness to both suffering and the ordinary courage that resisted it. Watching the celebrations, he warns that the plague bacillus never disappears for good: it can remain dormant and return when people believe themselves safe. The epidemic ends, but grief remains personal and vigilance remains necessary.",
         "in_short": "When dead rats appear across Oran, Dr. Bernard Rieux recognizes the approach of plague. Rising deaths force the authorities to close the city, separating residents from loved ones and reducing ordinary life to quarantine, fear, and repetition. Rieux treats patients while Jean Tarrou organizes volunteer sanitary squads; Grand, Castel, Rambert, Paneloux, and others respond through work, faith, attempted escape, or opportunism. Rambert ultimately gives up a chance to flee and joins the common effort. The agonizing death of Othon's child challenges Paneloux's religious certainty, and the priest later dies. As winter arrives, Grand survives a near-fatal illness and the epidemic recedes. Tarrou nevertheless dies just before the liberation, and Rieux learns that his wife has died away from Oran. The gates reopen, Rambert reunites with his partner, and Cottard is arrested after a violent breakdown. Revealing himself as the narrator, Rieux records the disaster as testimony to suffering, solidarity, and the certainty that plague can return.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3967,7 +3967,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3980,7 +3980,7 @@
       "recaps": {
         "ending": "Jake's search establishes that Evan did not invent the supposedly unbeatable premise from nothing: it grew out of concealed crimes in the Parker family. Jake also discovers that Anna is connected to that family and is the person behind the anonymous accusations. She killed Evan to stop him from publishing a story rooted in what she had done, then entered Jake's life after he turned Evan's idea into a bestseller. Once Jake understands her identity, Anna cannot allow him to expose her. She kills him and constructs a public explanation in which guilt over stealing Evan's plot led him to suicide. The confession she leaves behind destroys Jake's authorship while protecting the deeper family secret. Anna, now Jake's widow and literary heir, survives with control of his estate and of the story the public accepts.",
         "in_short": "Failed novelist Jacob Finch Bonner hears a brilliant plot from arrogant student Evan Parker. Years later, after learning that Evan died without publishing it, Jake builds the idea into his own novel, Crib, which becomes a worldwide success. Fame brings Anna Williams into his life, but also an anonymous accuser who knows Jake's premise was not originally his. Afraid of exposure, Jake investigates Evan's past and discovers that the plot was rooted in hidden crimes within the Parker family. He finally realizes that Anna is connected to that history, killed Evan, and used the threats to discover how much Jake knew. Anna kills Jake once he uncovers her identity and stages his death as suicide, leaving a confession to literary theft that provides the public with a convincing motive. Jake's reputation collapses, while Anna inherits his estate and keeps the more dangerous truth hidden.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4147,7 +4147,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4160,7 +4160,7 @@
       "recaps": {
         "ending": "After Lindbergh disappears, Vice President Wheeler's government arrests opponents and anti-Jewish violence spreads. Anne Morrow Lindbergh escapes official control long enough to broadcast an appeal against the repression, helping break the emergency regime's authority. Rabbi Bengelsdorf is detained despite his service to Lindbergh, while Evelyn goes into hiding and later gives the Roths an unverified account in which Nazi Germany had used the Lindberghs' kidnapped child to coerce the president. In Kentucky, Selma Wishnow is killed, leaving Seldon stranded; Herman and Sandy drive through the violence to bring him back to Newark. A special election returns Franklin Roosevelt to office, and the country soon enters the war, restoring the broad course of familiar history without explaining Lindbergh's fate. The Roth family survives, but their safety and faith in American normality have been permanently shaken, and the orphaned Seldon remains in their care.",
         "in_short": "In an alternate 1940, aviator Charles Lindbergh defeats Franklin Roosevelt for the presidency on an isolationist platform and draws the United States toward accommodation with Nazi Germany. Young Philip Roth watches the change split his Newark family: his father Herman resists, his brother Sandy joins a program meant to assimilate Jewish children, cousin Alvin loses a leg fighting with Canada, and Aunt Evelyn rises beside pro-Lindbergh Rabbi Bengelsdorf. Federal programs pressure Jewish families to disperse; Herman quits his job rather than move to Kentucky. Broadcaster Walter Winchell challenges the administration and is assassinated amid riots. Lindbergh then disappears, and government repression and anti-Jewish violence intensify. Anne Morrow Lindbergh's public appeal helps end the emergency. Herman and Sandy rescue the orphaned Seldon Wishnow from Kentucky after his mother's murder. Roosevelt returns through a special election and the familiar wartime course resumes, but the Roths emerge with their security and trust in the country deeply damaged.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4300,7 +4300,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4313,7 +4313,7 @@
       "recaps": {
         "ending": "The Price family is destroyed by its mission. After Nathan's rigid refusal to adapt brings hardship and estrangement, and as the newly independent Congo collapses into violence and foreign intrigue, the youngest daughter, Ruth May, is killed by a venomous snake. Her death shatters whatever hold Nathan still had over the family. Orleanna at last walks out of the marriage, leaving Kilanga with her three remaining daughters. Nathan, unable to admit any fault, remains in the Congo and eventually dies there years later, having lost his family and his mind. The surviving women scatter into separate lives and are followed across the following decades: Rachel drifts through marriages and ends up running a hotel in Africa, shallow and unchanged; Leah marries the schoolteacher Anatole and commits herself to life in Africa and to the cause of its people; Adah returns to the United States, is helped medically, and becomes a scientist. Each carries her own burden of grief and guilt over Ruth May and over the family's role in a country wounded by colonialism, seeking, in her own way, some measure of understanding and atonement.",
         "in_short": "In 1959, the zealous Baptist preacher Nathan Price brings his wife, Orleanna, and their four daughters, Rachel, the twins Leah and Adah, and little Ruth May, from Georgia to the remote village of Kilanga in the Belgian Congo, determined to convert its people. The family is unprepared for the climate, the hunger, the language, and the culture, and Nathan's stubborn arrogance alienates the villagers. As the Congo wins independence and plunges into political turmoil and violence, the mission unravels. Tragedy strikes the family when the youngest daughter, Ruth May, dies from a snakebite, a loss that finally breaks Orleanna's submission to her husband. She flees with her surviving daughters, and Nathan, unrepentant, stays behind and descends into ruin. Told across decades in the alternating voices of the mother and the daughters, the novel follows the women's very different paths through Africa and America as they carry the guilt, grief, and consequences of what their family did in the Congo.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4481,7 +4481,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4494,7 +4494,7 @@
       "recaps": {
         "ending": "Altan Trengsin dies on Speer, burning the Federation's research station and its staff to free Rin and the captured Cike. Before he does, Rin learns the truth the Empire has hidden for twenty years: Speer was not destroyed by the Federation alone but handed over by Empress Su Daji as the price of ending the last war, and the Speerlies who were not killed were kept as experimental subjects, Altan among them as a child. Standing on the ruins of her own people's island with command of the Cike and nobody left to restrain her, Rin bargains with the Phoenix and asks it to destroy the Federation. It does: the home islands of Mugen and the population on them, soldiers and civilians alike, are annihilated, and the war ends because there is no longer an enemy to fight. Rin does not repent it. She takes over the Cike as its commander, with Chaghan, Qara, Ramsa, Baji and Suni following her out of habit rather than belief. Jiang is still missing, having refused the war outright. Nezha was lost at Khurdalain and is presumed dead. The Empire is intact and the Empress is still on the throne, and Rin has decided she will kill her. The book closes with Rin the author of a genocide, dependent on opium to reach her god, and increasingly unable to tell her own will from the Phoenix's.",
         "in_short": "Fang Runin, a war orphan in Nikan's poor south, escapes an arranged marriage by placing first in the empire-wide Keju examination and winning a place at Sinegard, the country's elite military academy. Despised there for her origins, she is taken as apprentice by the eccentric master of Lore and discovers that the old gods are real and can be called by anyone willing to pay for it with their mind. When the Federation of Mugen invades, Rin is commissioned into the Cike, the empire's unit of shamans, under Altan Trengsin, the last Speerly. The campaign goes badly: the port of Khurdalain falls, and the city of Golyn Niis is found already massacred. Altan's attempt to free the shamans sealed inside the Chuluu Korikh looses an uncontrollable one and ends with him and Rin captured and taken to Speer, where he dies freeing her. Learning that the Empress sold Speer and its people to the Federation to end the previous war, Rin calls her god and destroys the Federation's home islands and everyone on them, ending the war and beginning something worse.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4685,7 +4685,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4698,7 +4698,7 @@
       "recaps": {
         "ending": "Isabel defies Osmond and travels from Rome to Gardencourt, where she and the dying Ralph finally speak openly. Ralph insists that Isabel has been loved and that her life need not be defined by her disastrous marriage; she acknowledges that he has been her closest friend. He dies with her beside him. Caspar Goodwood then urges Isabel to leave Osmond permanently and offers a future with him. His forceful kiss briefly makes escape seem possible, but Isabel pulls away. Goodwood later finds Henrietta, who tells him that Isabel has returned to Rome. The narrative does not show Isabel's arrival or explain all her reasons. Her promise to Pansy, her sense of duty, and her refusal to exchange one man's claim for another all bear on the choice. Osmond remains her husband, Pansy remains under his control at the convent, Madame Merle is leaving Europe, and Isabel returns knowingly to the difficult life from which she had briefly stepped away.",
         "in_short": "Independent American Isabel Archer comes to Europe determined to preserve her freedom. She rejects proposals from Lord Warburton and Caspar Goodwood, then inherits a fortune after her cousin Ralph persuades his dying father to provide for her. Madame Merle secretly steers Isabel toward Gilbert Osmond, a cultivated but controlling widower. Isabel marries him and discovers that he values her as an ornament and resents her independent judgment. Their marriage deteriorates as Osmond tries to direct his daughter Pansy's future and forbids Isabel to visit the dying Ralph. Isabel also learns that Pansy is actually the child of Osmond and Madame Merle, and that Merle helped arrange the marriage. Isabel goes to Ralph anyway; they reconcile before his death. Goodwood offers escape, but Isabel rejects him and returns to Rome, where Pansy remains under Osmond's authority. Her reasons and future are left open, but the return is a conscious choice made after she understands the people who manipulated her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4912,7 +4912,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4925,7 +4925,7 @@
       "recaps": {
         "ending": "Countess Gemini tells Isabel that Pansy is the daughter of Gilbert Osmond and Madame Merle, born during Merle's earlier marriage and passed off as Osmond's child by his dead wife. Isabel understands that Merle guided her toward Osmond and that both used her money and trust. Defying Osmond, she travels to Gardencourt and stays with Ralph during his final illness. The cousins reconcile fully before Ralph dies, with Isabel acknowledging how much his love and generosity shaped her life. After the funeral, Caspar Goodwood urges Isabel to leave Osmond permanently and return with him to America. His passionate appeal briefly breaks through her self-command, but she flees. Henrietta later tells Goodwood that Isabel has gone back to Rome. The novel closes without showing the reunion there: Isabel returns toward the marriage, Pansy, and the moral obligations she believes she cannot simply abandon, while Goodwood is left with Henrietta's assurance that he can still hope.",
         "in_short": "Young American Isabel Archer comes to Europe determined to remain free and rejects proposals from Lord Warburton and Caspar Goodwood. Her invalid cousin Ralph quietly arranges for his dying father to leave her a fortune, hoping money will enlarge her choices. In Florence, Madame Merle introduces Isabel to the cultivated widower Gilbert Osmond. Isabel marries him despite warnings and discovers that his refinement masks vanity and a need for control. Their marriage grows cold, while Osmond tries to use his daughter Pansy to secure a socially valuable match and blocks her love for Edward Rosier. Isabel learns that Pansy is actually the child of Osmond and Merle and realizes she was maneuvered into the marriage for her wealth. She defies Osmond to nurse the dying Ralph in England. After Ralph's death, she rejects Goodwood's renewed plea to escape with him and returns to Rome, choosing to face the marriage and her responsibilities to Pansy rather than accept an uncomplicated rescue.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5111,7 +5111,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5124,7 +5124,7 @@
       "recaps": {
         "ending": "Isabel defies Osmond's order and returns to Gardencourt, where she stays with Ralph as he dies. Their final conversation confirms their love and Ralph's understanding that her marriage has caused the suffering he hoped his gift would prevent. After the funeral, Caspar Goodwood finds Isabel and urges her to leave Osmond, offering his strength and devotion as an escape. His passionate embrace briefly overwhelms her, but she breaks away. When Goodwood later seeks her, Henrietta tells him that Isabel has gone back to Rome. There, Pansy has been returned to her convent after refusing to stop loving Rosier, and she has begged Isabel not to abandon her. Isabel's return also means re-entering the marriage and household she now understands were shaped by Osmond and Madame Merle's deception. The novel closes without explaining precisely what Isabel will do next: she rejects Goodwood's immediate rescue and resumes responsibility for the difficult ties in Rome, while Henrietta offers Goodwood only the possibility that Isabel's story is not finished.",
         "in_short": "Young American Isabel Archer comes to Europe determined to preserve her independence. She refuses proposals from Lord Warburton and Caspar Goodwood, then inherits a fortune after her cousin Ralph quietly persuades his dying father to provide for her. Madame Merle befriends Isabel and introduces Gilbert Osmond, an impoverished American aesthete with a daughter, Pansy. Isabel marries Osmond, mistaking his cultivated detachment for freedom, but years later finds him controlling and contemptuous. Osmond tries to use Pansy's marriage to Lord Warburton for status, though Pansy loves Edward Rosier. Isabel learns that Madame Merle is Pansy's mother and that Merle and Osmond deliberately maneuvered her into the marriage. Defying Osmond, Isabel returns to England and comforts the dying Ralph. After Ralph's death she rejects Goodwood's urgent offer of escape and returns to Rome, where Pansy needs her, leaving Isabel's future within or beyond her marriage unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5354,7 +5354,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5367,7 +5367,7 @@
       "recaps": {
         "ending": "Pyotr Verkhovensky's cell murders Shatov beside a pond and conceals his body. Pyotr then pressures Kirillov to write a false confession before carrying out his long-planned suicide. Kirillov resists Pyotr's script but ultimately shoots himself; the forged note briefly shifts suspicion, yet the conspirators lose their nerve and Lyamshin's confession exposes the group. Pyotr escapes abroad. Stepan Trofimovich leaves town in a final bid for independence, falls ill on the road, and undergoes a sincere religious change before dying after Varvara Petrovna reaches him. Stavrogin withdraws from the ruin around him. Darya later receives a letter in which he describes his inability to bind himself to a purpose and offers her a life abroad. When she and Varvara go to the Stavrogin estate, they find that he has hanged himself. The town is left to account for murders, fire, scandal, and broken families, while the organizer who exploited its resentments remains beyond reach.",
         "in_short": "In a provincial Russian town, the return of the magnetic Nikolai Stavrogin and the arrival of Pyotr Verkhovensky bring old scandals into contact with a new revolutionary conspiracy. Stavrogin's secret marriage to the vulnerable Marya Lebyadkina, his divided ties to Liza and Darya, and his inability to commit to belief leave destruction around him. Pyotr manipulates officials, socialites, and a small radical cell, then orders the murder of Shatov to bind the members together. A disastrous public fête is followed by arson and the deaths of Marya, her brother, and Liza. Shatov is killed just after his estranged wife returns and gives birth; Kirillov kills himself after being forced to leave a false confession. The conspiracy is exposed, but Pyotr escapes. Stepan Trofimovich dies after a final journey and religious awakening. Stavrogin, unable to find a viable purpose or accept Darya's help, hangs himself at his family estate.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5548,7 +5548,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5561,7 +5561,7 @@
       "recaps": {
         "ending": "The new order reproduces and intensifies many of the abuses it displaced. In Bessapara, Tatiana's rule becomes erratic and murderous, while Mother Eve's inner voice presses her toward a cleansing global conflict. Roxy, betrayed by her own family and robbed of her skein for Darrell's benefit, eventually takes her power back but rejects Eve's effort to control her. Tatiana is killed during the struggle around Eve, and Bessapara collapses into war. Tunde's years of reporting leave him endangered and dispossessed of control over his own account. Margot, having risen through American politics, accepts catastrophic violence as the route to a stable female-led future. Nations use nuclear and conventional weapons, destroying existing civilization and killing on an immense scale. The framing correspondence occurs thousands of years later, when male author Neil Adam Armon sends this historical novel to Naomi Alderman. Their exchange reveals a society that considers female dominance natural and treats the old patriarchal world as implausible; Naomi even suggests that Neil use a woman's name to help the book find readers.",
         "in_short": "Girls develop organs called skeins that let them discharge electricity, and they can awaken the same ability in older women. Roxy Monke uses her exceptional strength within a London crime family; abused foster child Allie becomes the religious leader Mother Eve; Tunde Edo documents the worldwide reversal in physical power; and Mayor Margot Cleary converts the change into political advancement while her daughter Jocelyn struggles to control it. Revolt liberates women from violent regimes, but new institutions soon normalize the humiliation and exploitation of men. Tatiana Moskalev seizes Moldova and creates Bessapara, where Mother Eve becomes influential. Roxy's family steals her skein for her brother, and she later reclaims it. As Bessapara fragments and Eve's guiding voice demands a decisive reset, Margot and other leaders permit global war. Civilization is destroyed and rebuilt as a matriarchy. Millennia later, that society regards the former dominance of men as almost unbelievable.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5734,7 +5734,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5747,7 +5747,7 @@
       "recaps": {
         "ending": "After reaching safety across the state border, the priest learns that the wounded American outlaw Calver wants confession. Although he recognizes the mestizo's message as a trap, he returns because he will not leave a dying man without the sacrament. Calver dies, the mestizo claims the reward, and the lieutenant arrests the priest. The lieutenant cannot accept the priest's theology but treats him with a troubled respect, secretly providing brandy and trying unsuccessfully to bring Padre José to hear his confession. The priest spends his final night afraid that he has wasted his life and cannot repent properly. He is executed by firing squad the next morning while Mr Tench watches from a window. Later, a new fugitive priest knocks at the home of a devout family. The boy who had rejected stories of martyrdom welcomes him, showing that the state has killed one priest without extinguishing the faith it sought to destroy.",
         "in_short": "In a Mexican state where Catholic practice is banned, a police lieutenant hunts the last active priest. The fugitive, known for his drinking and for fathering a child, sees himself as corrupt but continues serving villagers who have no one else. The lieutenant takes hostages and executes them in an effort to force cooperation. After journeys through villages, prison, and wilderness, the priest crosses into a safer state, but returns when told that a dying American outlaw wants confession. The messenger is a mestizo seeking the reward, and the priest is arrested after attending the outlaw. The lieutenant gives his captive small kindnesses but proceeds with the execution. The priest dies fearful of his failures rather than confident of sainthood. Soon afterward another priest arrives secretly, and a boy admits him, indicating that repression has not ended the Church's presence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5913,7 +5913,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5926,7 +5926,7 @@
       "recaps": {
         "ending": "In West Virginia, John and Sam fight their way into the Mogadorian mountain base and find Number Nine, who has been held prisoner there since his own capture, and free him. Getting out costs them: Sam is taken by the Mogadorians, and John, out of options, has to leave without him. John, Nine, and Bernie Kosar escape, and John's first commitment afterward is to get Sam back. In Spain, the Mogadorians move on Santa Teresa in force. Hector Ricardo dies helping Marina and Ella get clear, and Adelina, who spent years refusing the fight, is killed defending Marina. Number Six arrives in time to turn the battle, and Ella reveals that she is Number Ten, a Garde who came to Earth on a second Loric ship that arrived after the first. Her Cepan, Crayton, comes for her, and he can explain the second ship, the war on Lorien, and how much of the history the nine were never told. Marina, Ella, Six, and Crayton leave Spain together. Two groups of Garde now exist instead of scattered individuals, both of them looking for the others, and the Mogadorians hold Sam as leverage.",
         "in_short": "The story splits between two of the nine. John Smith is a fugitive, hunted as a terrorist after the battle in Paradise, moving through the American south with Number Six and Sam Goode while Six trains him. In Spain, Number Seven, called Marina, has spent years in a convent orphanage in Santa Teresa with her Cepan Adelina, who abandoned the mission, became a nun, and will not train her or return her Chest. Marina hunts the news for other Garde, protects a young orphan named Ella, and befriends a local man, Hector Ricardo. John's group returns to Paradise, where John is caught by federal agents and freed by Six, and where Sam's missing father's hidden research points them to a Mogadorian base in West Virginia. Six leaves to find the other Garde while John and Sam go into the mountain. Mogadorians attack Santa Teresa: Hector and Adelina die, Six arrives, Ella is revealed to be Number Ten from a second Loric ship, and her Cepan Crayton collects them. John frees Number Nine from the mountain base, but Sam is captured.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -6070,7 +6070,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6083,7 +6083,7 @@
       "recaps": {
         "ending": "Peter quietly turns Phil's plan to befriend him into a means of protecting Rose. After finding a cow that died of anthrax, Peter cuts strips from its hide while taking precautions against infection. Phil, enraged because Rose has given away the ranch hides he intended to use, accepts Peter's strips to finish a rawhide rope. A wound on Phil's hand gives the infection a path into his body. He becomes rapidly ill and dies; a doctor identifies anthrax as the cause, surprising George because Phil normally knew the danger and avoided diseased cattle. Peter handles the unfinished rope carefully and then destroys or removes the evidence linking it to him. From his room he watches George comfort Rose. With Phil gone, she can recover from the fear and drinking that overtook her at the ranch, and Peter's private purpose has been achieved. George mourns without understanding that his stepson deliberately caused his brother's death.",
         "in_short": "On a wealthy Montana ranch, brilliant and domineering Phil Burbank shares an isolated life with his quieter brother George. When George marries widow Rose Gordon and brings her to the ranch, Phil treats her as an intruder and mocks her sensitive son Peter. His constant scrutiny helps drive Rose into secret drinking. Peter later comes home from school and recognizes both his mother's danger and concealed parts of Phil's identity. Phil begins cultivating the boy, teaching him ranch skills and making a rawhide rope, partly to unsettle Rose. Peter responds with apparent trust while preparing a decisive defense. He cuts hide from an anthrax-infected carcass and lets Phil use it while working with an open wound. Phil contracts anthrax and dies, though George sees only a baffling accident. Peter removes the incriminating rope and watches George comfort a newly freed Rose, having used Phil's confidence in him to end the threat to his mother.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-price-of-power.json
+++ b/data/works-community/0/the-price-of-power.json
@@ -255,7 +255,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -268,7 +268,7 @@
       "recaps": {
         "ending": "Ryun has answered Emberhorn's betrayal by taking his city, but the victory follows Eerv's death and Anrosh's severe soul injury. Anrosh recovers, receives Kagehime, and shares practical leadership of the Twilight Melody Sect with Nayra. Ryun orders them to retake Venoran, then leaves with Ereclaw to gather void essence and prepare for the Centennial Tournament. Kri is safe at Wolf's Grove. Reyla remains apart from Nayra, although their class advancement is still linked.\n\nZach escapes the ethereal prison after freeing Jen from a soul-draining ritual. Restoration elixirs regrow his severed leg, but it remains numb and requires a long recovery. The prison's ruling spirit gravely wounds Jen's father, so the breach is sealed rather than conquered. The yeti runelord who transformed Mistral into Shade Reaver is also at large. Reunited with Neha, Zach chooses the Planar Warrior evolution and joins Jen's father's group to gain access to its dungeons. Zach and Ryun remain separated, and Zach no longer accepts responsibility for Ryun's crimes.",
         "in_short": "Zach pursues skill mastery and Warden service while preparing for a future reckoning with Ryun. His investigation of the Night Horror costs Gris his life and exposes Quell as the shapeshifter Neha. Zach kills Neha with the gauntlet's fire, but she is alive and traveling with him when his story resumes. Together they direct her violent compulsions toward wanted criminals. Ryun strengthens the Twilight Melody Sect against a monster swarm, only for Emberhorn to betray the defense. Eerv dies, Anrosh survives a soul injury, and Ryun conquers Emberhorn's city before leaving Anrosh and Nayra to rule while he trains with Ereclaw. Zach's later expedition into an ethereal prison strands him among powerful spirits. A freed yeti runelord remakes Mistral into Shade Reaver and escapes. Zach fills the weapon with new forms, rescues Jen, and reaches safety after losing a leg. The restored leg remains numb. He becomes a Planar Warrior and leaves with Neha and Jen's father's group, while the sealed prison and escaped runelord remain unresolved threats.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -635,7 +635,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B09MWP9M3Q",
@@ -647,7 +647,7 @@
       "recaps": {
         "ending": "Jake clears Badger's Den alone after killing its Alpha Venomfang Badgers and the level 82 Den Mother. He leaves with the rare dagger Venomfang, the Den Mother's poison gland, upgraded titles, and one of four required victories in The Beast Lords quest. He expects the other mountain dungeons to hold the remaining lords, whose deaths will draw out their unseen king. The survivor factions outside have collapsed. Richard, Caroline, Hayden, Hermann Schmidt, and Desmond are dead. William survives his destruction of Richard's force only because an unidentified man intervenes, and he remains hostile toward Jake and Richard's surviving followers. Jacob lives as the Holy Mother's newly blessed Augur of Hope, sustaining the remaining group's morale while concealing painful truths. Joanna and Bertram are last known alive, while Casper has left the tutorial as a young undead. The Malefic Viper has ended his seclusion, regards Jake as a friend, and has prompted the Malefic Order to take an interest in Jake. The force behind an attempted manipulation of Jake's dream remains unidentified.",
         "in_short": "When Earth enters the system, office analyst and archer Jake is sent into a lethal forest tutorial with his coworkers. His exceptional instincts awaken as the Bloodline of the Primal Hunter, and he leaves the group after Richard coerces them into a larger settlement and sends Nicholas to kill him. A solo challenge makes Jake an alchemist tied to the god known as the Malefic Viper, whose blessing helps him cure the dungeon's poison and begin combining archery with toxins. Meanwhile William secretly engineers a war between the survivor factions. Richard and Caroline later help ambush Jake, ending his interest in reconciliation. William ultimately betrays Richard, kills Caroline and Richard, and destroys most of the organized survivors, though an unidentified man preserves his life. Jacob survives and becomes the Holy Mother's blessed Augur of Hope. Jake remains in the inner area, clears Badger's Den by killing its level 82 Den Mother, and begins a quest to defeat three more beast lords before confronting their unseen king.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1039,7 +1039,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0DK41KCH9",
@@ -1051,7 +1051,7 @@
       "recaps": {
         "ending": "The book closes with the Nevermore run still in progress. Jake, Dina, Sylphie, Miyamoto, and the Fallen King have cleared floor 46 intact after establishing the record through floor 40, killing an independent Minaga clone, and earning a final-score multiplier. Their cure of floor 41 removes the karmic plague and saves the Dark Witch, although she remains badly injured and must seek her own way out. Jake advances his arcane path through Protean Arrow and Arcane Supremacy, but his party has fallen several thousand points behind the current leader. Elsewhere, Vesperia remains with the Endless Empire under Minaga's scrutiny, Miranda manages Haven's strained resettlement, and Carmen conceals her friendly link to Jake from her party. Dawnleaf completes a perfect C-grade evolution and formally becomes Duskleaf's principal disciple. Minaga's interest in Jake, Vesperia, and Miyamoto remains unexplained, while the Malefic Viper and the Order Lord Protector anticipate a wider convergence of dangerous powers.",
         "in_short": "Jake Thayne leads Dina, Sylphie, Miyamoto, and the Fallen King through Nevermore, rapidly clearing the early floors before entering Minaga's ten-floor labyrinth. They permanently destroy Gubrothas, endure a long city-floor toll, and defeat the true-ending boss on floor 40 without losing a member. The defeated Minaga is revealed as a real clone of the god called the All-God Legion. On floor 41, the party discovers a karmic plague that has stripped a world's natives of agency. They overthrow its ruling factions, restore the Dark Witch, transfer the plague into a false core, and destroy it while saving her. Jake develops Protean Arrow, chooses Arcane Supremacy, and helps the group clear through floor 46, though another team takes the leaderboard lead. Outside the run, Miranda struggles with mass resettlement on Earth, Vesperia settles into the Endless Empire under Minaga's attention, and Duskleaf's former disciple evolves into Dawnleaf.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1581,7 +1581,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0DWG2BMTP",
@@ -1593,7 +1593,7 @@
       "recaps": {
         "ending": "The book closes while Jake is still competing in Nevermore. He has completed four challenge dungeons, accumulated an 80 percent combined score multiplier, and entered the Never-Ending Journey as a courier with three lives. His House reward includes a private, time-dilated alchemical domain and ten bound attendants. The Sword Saint has reported a Grand Champion result, but Dina, Sylphie, and the Fallen King remain in separate challenges. Temlat is dead by his own request after destroying his world's ruling order, and Jake has decided against taking another formal student soon. Valdemar's offer of Valhall membership remains unanswered, Artemis still intends a private conversation, and Minaga continues to watch Jake closely. Vesperia has support to travel toward the 93rd universe, while Miranda, William, and Sandy continue their separate preparations and investigations. Neither Jake nor the Malefic Viper understands the origin-linked power that enabled the victory over Valdemar's image.",
         "in_short": "Jake and his party pause their regular Nevermore climb to attempt solo challenge dungeons. In the Colosseum, Jake rises from a restricted level-zero fighter to sole Grand Champion, killing Valdemar's image after an unexplained bloodline survival response. He then completes the Test of Character and Minaga's Endless Labyrinth, while his victories attract Valdemar, Artemis, and many other gods. In the House of the Architect, Jake develops ten varied creations and recruits Temlat as his first student. Temlat evolves into a plague remnant of wrath, destroys his world's oppressive ruling order, then asks Jake to consume him. Jake earns a 20 percent House multiplier and a permanent private alchemical domain, bringing his total challenge multiplier to 80 percent. The book ends as he begins the courier-based Never-Ending Journey with three lives, leaving his party's reunion, divine affiliations, Vesperia's migration, and the nature of his origin power unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-primal-hunter-12.json
+++ b/data/works-community/0/the-primal-hunter-12.json
@@ -331,7 +331,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0F8P9VT4R",
@@ -343,7 +343,7 @@
       "recaps": {
         "ending": "Jake finishes Nevermore as its all-time C-grade record holder, while his five-person party survives and disperses. Sylphie, the Sword Saint, and the Fallen King head toward Earth, Dina returns to the Pantheon of Life, and Jake remains briefly in Nevermore City. Yip of Yore's faction shifts toward isolating him from the Malefic Viper through recruitment and public pressure. Jake keeps Valhall at a distance, becomes Carmen's partner, and helps the Fourth Hell prince evolve into a demon lord who owes him a major boon. Questions about Jake's origin energy, his effect on other souls, the karmic links in his boots, and the erased First Sage remain open. Back on Earth, Haven is stable but strained by integration. Jake leaves those politics to Miranda, settles the immediate dispute between the North Peak Wyvern and the Sword Saint's vampire clan, and spends time with Caleb, Adam, and his parents. With family communication established, Sandy carries Jake toward the moon before the Prima Guardian event.",
         "in_short": "Jake Thayne completes his last challenge dungeon by rising through a courier Guild, exposing noble corruption, and recruiting the Forsaken Dragonkin to end a returning dragon war. Reunited with Sylphie, the Sword Saint, Dina, and the Fallen King, he pushes through Nevermore's final floors. The party forces the two Twin Emperors to merge, and Sylphie's awakened authority kills the resulting boss without a party death. Jake then claims the all-time C-grade Nevermore record and becomes Peerless Conqueror of Nevermore. After resisting competing recruitment efforts, he turns a Fourth Hell prince's perilous ritual into a successful demon-lord evolution. He returns through the Order to Earth, where he leaves Haven's integration problems to Miranda, compels the North Peak Wyvern to release captured vampires, reconnects with Caleb and the rest of his family, and departs with Sandy for the moon as the Prima Guardian event approaches.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -765,7 +765,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0G87CTDS8",
@@ -777,7 +777,7 @@
       "recaps": {
         "ending": "Jake remains on Earth in a guarded recovery after the Malefic Viper repairs his shattered soul. His resource capacity is still reduced, and the corrupted half-core continues its extremely slow absorption inside a permanently sealed skill. Sylphie is alive after cleansing and evacuation, but has lost her right wing. The Fallen King apparently destroys himself and the Desolate Child of Loss in a soul explosion. His records and true soul survive inside the Mask of the Fallen King, although Aaron can find no means of revival. No kill notice confirms the Desolate Child's death, but new planetary desolation has stopped. William finds abnormal connections around the trap without proof that Ell'Hakan directed it. Miranda monitors Ell'Hakan-linked sleepers on Earth while covertly pursuing a separate fanatic network hostile to Jake, outsiders, and beasts. Ell'Hakan's alliance and Earth's coalition continue competing across the unfinished Prima Guardian event. Kindroth remains a useful but independent diplomatic ally, the Risen have a self-governed island settlement, and three beastfolk diplomats have reached Earth. The lunar Ghost Vine Sovereign and Operation Moonfall also remain unresolved.",
         "in_short": "Jake Thayne and Sandy discover a B-grade plant-undead fused with the Moon's core, but postpone Operation Moonfall to face the Prima Guardian event. Jake makes Earth's Guardian stronger by choosing an accelerated protocol, then kills it in space and claims Earth's pylon. Earth launches a rival rescue network as Ell'Hakan expands his own alliance. After blackened planets reveal a desolation threat, Jake takes half of a corrupted core into an absorption skill. The experiment nearly destroys his soul, and the Malefic Viper saves him by sealing the skill with the half-core inside. While Jake recovers, Sylphie and the Fallen King are trapped with the Desolate Child of Loss. Sylphie escapes after losing a wing, but the Fallen King stays behind and apparently disperses both himself and the enemy. His true soul remains in his mask. The book ends with Jake recovering, planetary desolation apparently halted, and Earth investigating sleeper agents and independent fanatics tied to Ell'Hakan's influence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1114,7 +1114,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0H1NBT6RF",
@@ -1126,7 +1126,7 @@
       "recaps": {
         "ending": "Jake ends Ell'Hakan's Celestial Child transformation and returns to Earth, allowing Miranda to turn his victory into momentum for a new galactic order. The remaining loyalists are losing ground, but their leadership is still active and the Holy Church retains influence across former coalition worlds. Jacob carries Ell'Hakan's true soul under a Church contract. Although Jacob and Bertram oppose restoring Ell'Hakan in any meaningful sense, a Church faction plans a brief resurrection to preserve his coercive bloodline. Jake considers recovery of the soul nonnegotiable and prepares to approach the Church with Carmen held in reserve. The Malefic Viper has killed Yip of Yore and is slowly absorbing the selected records he made into an alchemical treasure. Jake is promised a supervised share later. The First Sage's lesson has strengthened Jake's soul and left him a legacy book with possible healing guidance, but his old soul wound still prevents a safe evolution to B-grade. Jake finishes a temporary arcane bow using Maria's Titanwood weapon and owes her a bounded favor. The desolation threat, Minaga's unfinished Earth labyrinth, and Earth's political consolidation remain unresolved.",
         "in_short": "As the Prima Guardian event ends, Jake and the Malefic Viper stage a public rupture to strengthen Yip of Yore's confidence and secure a temporary galactic truce. Yip attacks the Order but discovers that his apparent victory was a trap: the Viper uses a dragon molt and Malefic Alchemy to kill him and harvest selected records. Ell'Hakan inherits willing remnants of Yip's legacy, prompting Jake to attack his homeworld. Their duel escalates when Ell'Hakan's bloodline turns his Celestial Child claim into absolute self-delusion and his followers sacrifice themselves to sustain him. Jake destroys the transformed soul and stops its final Eclipse. Jacob nevertheless removes Ell'Hakan's true soul for a Holy Church faction seeking to preserve the bloodline. While Earth advances against the remaining loyalists, Jake enters an interactive record of the First Sage, gains control over his soul space, and receives a legacy book that may heal his lingering injury. He then reforges Maria's Titanwood bow and prepares, with Carmen as backup, to reclaim Ell'Hakan's soul from the Church.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1506,7 +1506,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B09V5SS6W4",
@@ -1518,7 +1518,7 @@
       "recaps": {
         "ending": "Jake returns to an enlarged and dangerous Earth after killing the King of the Forest and receiving a claim to a Pylon of Civilization. He secures the King’s former territory, conceals the pylon in a waterfall valley, and remains the settlement's masked protector rather than its administrator. Miranda becomes his Viscount and city lord, while Hank, Mark, and Louise become citizens and construct a lodge over the hidden pylon. Jacob and Bertram lead a separate large survivor group under the Holy Mother's instruction to avoid both alliance and conflict with Jake, though Jacob and Jake exchange supplies and information. William has been revived by the white-haired primordial, and Casper returns as undead but chooses a separate path. Jake knows Robert, Deborah, Caleb, and Maya are alive, but he still does not know where to find them. His immediate challenges are developing a poison for the D-grade fungal ruler beneath the forest and mastering Wings of the Malefic Viper with help from a wind-manipulating hawk.",
         "in_short": "Jake clears the remaining Beast Lord dungeons, defeats William, and rejects the fate that expected him to die before the tutorial's end. Using revenge weapons left by the Beast Lords, poison, and the Great White Stag's unstable core shard, he kills the far stronger King of the Forest and finishes as the sole survivor recognized by the system. After training with the Malefic Viper and claiming dormant true blood without surrendering his independence, Jake returns to a transformed Earth. He reconciles partially with Jacob, learns his family is alive, claims a Pylon of Civilization, and hides it in a forest valley. Miranda takes charge of the new settlement while Hank, Mark, and Louise begin building it. Jake survives an encounter with the D-grade fungal ruler of an underground biodome, chooses wings at his next profession milestone, and ends the book learning to fly from a level-90 hawk.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-primal-hunter-3.json
+++ b/data/works-community/0/the-primal-hunter-3.json
@@ -349,7 +349,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0B6JNZTBN",
@@ -361,7 +361,7 @@
       "recaps": {
         "ending": "Haven is a growing pylon city governed by Miranda under Jake's final authority. Phillip maintains the old fort as an allied outpost, and Neil's teleportation circle carries goods between the two settlements. Hawkie, Mystie, and Sylphie remain powerful resident allies. The Minotaur Mindchief is dead, its captives are free, and its engineered herd attacks have ended. The Indigo Fungus Mycorrhiza is also dead, leaving valuable materials and the locked Under Growth of the Deep Dwellers dungeon.\n\nJake finishes all three D-grade transitions as a Human D, an Avaricious Arcane Hunter, and a Heretic Chosen Alchemist of the Malefic Viper. His blessing is now mutually binding until death or his ascension, although he still rejects championhood and religious subservience. His first legacy experience upgrades Palette of the Malefic Viper to legendary, and he begins refining the fungus life core. Jacob orders Sanct Domo not to interfere with Haven, while Caleb's Court of Shadows and Casper's death-affinity settlement remain active powers. The First World Congress is about five and a half days away when Jake postpones the nearby dungeon and heads into the deeper forest.",
         "in_short": "Jake Thayne strengthens his archery, mana control, and alchemy while his hidden settlement grows into Haven under Miranda Wells. He kills Abby and Donald after their siege, helps Hawkie and Mystie complete their egg ritual, and gains Sylphie as a young companion. At the nearby fort, Jake discovers that the Minotaur Mindchief engineered recurring herd attacks and kills it, freeing its captives. The fort then becomes Haven's allied outpost. Jake develops a covert fungicide and destroys the Indigo Fungus Mycorrhiza, exposing an unopened D-grade dungeon. He completes a perfect Human D evolution, chooses Avaricious Arcane Hunter, and becomes the Malefic Viper's heretic chosen rather than his champion. A legacy experience reveals the Viper's past as the Wyvern of the Desolates and upgrades Jake's Palette of the Malefic Viper to legendary. With the First World Congress days away, Jake leaves Hawkie caring for Sylphie and explores the deeper forest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -762,7 +762,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0C34D1FYC",
@@ -774,7 +774,7 @@
       "recaps": {
         "ending": "Yalsten collapses after the Monarch of Blood destroys himself, leaving Sanguine's blood legacy and a bound projection able to guide its future holder. Jake and Miyamoto duel for the legacy. Miyamoto reaches a costly transcendent state through Springtime Advent and wins the final exchange by a fraction, though both fighters would probably have died without the Treasure Hunt ending. Miyamoto keeps the legacy and returns greatly weakened, while Jake accepts the loss and resolves to improve his melee technique.\n\nThe survivors return to Earth fully restored from their event injuries. Carmen and Casper have withdrawn safely, Sylphie later departs Haven to pursue independent growth, and Miranda turns to screening new residents and organizing auction goods. Sultan becomes a prospective broker for Haven and Jake, and Neil continues work on long-range teleportation. Jake holds the Premier Treasure Hunter title and extensive treasure, including the charged curse root and a level-locked Chimera weapon. His mask contains an unresponsive new lifeform tied to the dead King of the Forest. With the auction one week away, Neil teleports Jake closer to his family, and Jake begins the remaining journey overland.",
         "in_short": "Jake Thayne enters a ten-day Treasure Hunt in the ruined vampire realm of Yalsten with Sylphie and Haven's allies. He uncovers the realm's cursed history, kills several Counts of Blood, gathers powerful relics, and joins rival factions in activating a spire that begins Yalsten's collapse. The coalition defeats the awakened Monarch of Blood after severe losses and withdrawals. Jake then wagers the resulting divine blood legacy in his long-awaited duel with Miyamoto. Miyamoto's costly transcendence turns the battle, and Jake loses by a fraction as the event ends. Back on Earth, Jake receives the Premier Treasure Hunter title, learns that a new lifeform linked to the dead King of the Forest inhabits his mask, and prepares for an auction. Sylphie leaves to train independently, while Jake takes a replacement bow and begins traveling toward his family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1051,7 +1051,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0CC6HZ3SR",
@@ -1063,7 +1063,7 @@
       "recaps": {
         "ending": "Jake remains at the Malefic Order's academy on Primordial 4. He has unrestricted access to its lessons and begins repairing the narrow theoretical base revealed by his entrance examination, with neurotoxins and Soulflames among his new interests. His false identity conceals most of his records and his status as Villy's Chosen, but his bloodline remains visible. A red-dragon faction has already identified him as a valuable new-universe bloodline bearer and opened a channel for future recruitment.\n\nMira remains contract-bound to Jake because release inside the Order would expose her to greater danger. Jake refuses to treat her as property, gives her broad lesson and travel permissions, and encourages her to choose a future that might eventually help her enslaved family. Reika studies separately with the Noboru Clan contingent, while Miranda leads Haven on Earth and completes a powerful ritual circle. Sylphie returns from an Altmar evaluation with a medal. The Fallen King continues independently while his true soul remains tied to Jake's mask. Eternal Hunger is contained but still capable of pressuring Jake, and William's monster-supported investigation remains unresolved.",
         "in_short": "After returning from the Yalsten treasure hunt, Jake reunites with family, helps Haven profit from a system auction, and restores the Fallen King from his mask. His attempt to forge a stronger cursed weapon causes the worldwide Great Famine, but he seals the curse within his soul and creates Eternal Hunger. He then survives a disastrous encounter with a C-grade hive defender, strengthens Haven's alliances, and leaves Earth for the revived Malefic Order. Training lets him falsify most of his visible records, though not his bloodline. At the Order academy, Jake's entrance tests expose both exceptional talent and major gaps in his alchemical education. A historical vision of Valdemar's victory over Villy gives him a true melee style. Jake is admitted with exceptional privileges and reluctantly accepts responsibility for Mira, an enslaved elf assigned to his household. He begins helping her develop an independent path while studying Soulflames and neurotoxins. A dragonflight detects his bloodline and attempts to recruit him, leaving his identity and inherited power under growing scrutiny.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1421,7 +1421,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0CLNGJ4TS",
@@ -1433,7 +1433,7 @@
       "recaps": {
         "ending": "Earth still has no world leader, and the Fallen King's human-beast settlement remains under observation. Miranda knows Jake caused the Great Famine, while the wider world does not. Carmen has found her family, killed the relatives responsible for her abuse, and secured her mother's freedom. The Holy Church's possible campaign against the Risen remains unresolved. Jake has killed a C-grade Phantomshade Panther, kept the Seat of the Exalted Prima within reach, and become a possible administrator for its Milky Way branch. Sim Jake survives through a soulbound bone in Jake's soul space and is training him in a counter-focused melee style, though their records are gradually merging. A rival primordial's Chosen has identified Jake and is preparing an indirect operation on Earth. At the Order, Jake continues his studies and helps his elf steward gain skill and independence. The final scene leaves Jake, the malefic dragonkin, Irin, Reika, and Bastilla alive inside the Nine Floors of the Indigo Caverns, facing a mushroom-filled first floor.",
         "in_short": "Jake divides his time between the Malefic Viper's Order and a changing Earth. The Second World Congress elects no leader, while the restored Fallen King asks to be judged as a future candidate. Jake helps Carmen cross continents, destroy a slave operation, and confront the abusive Salvento family, most of whom she kills while freeing her mother. After defeating a C-grade Phantomshade Panther, Jake enters the Seat of the Exalted Prima and observes an alternate life. He preserves that parallel self, Sim Jake, within his soul space and gains a possible route to become an administrator of the Seat. He also encounters a rival Chosen whose bloodline manipulates trust. Back at the Order, Jake studies alchemy, formations, and melee combat, supports his elf steward's training, and recruits Reika and Bastilla for an expedition with Irin and a Viper-blessed dragonkin. The book ends as the five enter the Nine Floors of the Indigo Caverns and find mushrooms covering the first floor.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-primal-hunter-8.json
+++ b/data/works-community/0/the-primal-hunter-8.json
@@ -391,7 +391,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0CQYWHTCQ",
@@ -403,7 +403,7 @@
       "recaps": {
         "ending": "Jake closes the book as Earth's elected World Leader, supported by ministers Miranda, the Fallen King, Miyamoto, and Arthur, while the final beast seat remains open. Earth has chosen to face its Prima Guardian without a planetary alliance. The Guardian and its army will arrive in five years, and Earth will then have five years to protect the key to its planetary core. The rival Chosen has withdrawn, the Ashen Phantom Devourer is dead, William has rejected his former master's blessing, the Risen have relocated, and the Holy Church is leaving Earth. Jake returns to the Order with Scarlet Allyson, while Sandy, Sylphie, Misty, and Sylphie's father stay behind. His nine Malefic Viper legacy skills are legendary, but his D-grade work is unfinished. In Villy's time chamber, Jake and Sim Jake repeatedly duel while preparing an uncertain mythical skill built around Shadow Vault and a proposed merger between Sim Jake and Eternal Hunger. Jake's evolution, the merger's result, the fifth minister, and the planetary trial remain unresolved.",
         "in_short": "Jake clears the Indigo Caverns, reveals his status as the Malefic Viper's Chosen to his party, and continues refining his legacy. A coordinated alien-backed coup then isolates Earth's factions and drives him far from Haven. He befriends the evolving cosmic worm Sandy, develops new escape and combat skills, and returns by helping the Fallen King destroy the Ashen Phantom Devourer. Miyamoto forces the rival Chosen to withdraw, while William breaks from the primordial who manipulated him. The Risen leave Earth and the Holy Church begins its own retreat. Jake returns to Haven, accepts a council-based government, and wins election as World Leader with Miranda, the Fallen King, Miyamoto, and Arthur as ministers. Earth chooses to face its future Prima Guardian alone. After bringing Scarlet Allyson to the Order, Jake completes all nine legendary legacy skills. The book ends with Jake and Sim Jake training in a time-dilated chamber for a risky mythical skill and an unresolved merger with Eternal Hunger before Jake evolves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -863,7 +863,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0D6GXP9K2",
@@ -875,7 +875,7 @@
       "recaps": {
         "ending": "Vesperia confirms that Jake placed no binding claim on her and chooses the Endless Empire as her home. The Empire names her a future Grand Hive Queen, while she affirms Jake as permanent family and keeps a paired means of contacting him. Earth gains a controlled United Tribes presence, and Sylphie receives a protective divine feather. Miranda takes charge of contracts covering 120 million enslaved arrivals and the resulting settlement burden. Arnold receives the Automata Legion's gifted spaceship for study, while the surviving underground Isoptera hive remains a threat.\n\nDina fills the final support position beside Jake, Miyamoto, the Fallen King, and Sylphie. In Nevermore City, Jake publicly rejects the rival Chosen's proposed truce because of the attacks and manipulation on Earth. The five companions then leap into Nevermore together, beginning a potentially fifty-year C-grade run. The competition with the rival Chosen, Villy's larger conflict with the rival god and Valhall, Vesperia's future loyalties, and the limits of Jake's origin-altering ability remain unresolved.",
         "in_short": "Jake Thayne creates Eternal Shadow by merging Sim Jake with Eternal Hunger, then completes his evolution into a C-grade human, alchemist, and hunter. After destroying the leaders of an Endless Empire Isoptera hive, he uses their cores in a ritual that unexpectedly restores Vesperia, a lost Vespernat true royal. Jake accepts public recognition as Villy's Chosen, bringing both himself and Vesperia into multiversal politics. Vesperia chooses to return freely to the Endless Empire as a future Grand Hive Queen while keeping Jake as family. Haven must still contain the surviving hive and resettle 120 million enslaved people, tasks left to Miranda and Arnold. A rival god allied with Valhall sets his own Chosen against Jake at Nevermore. Dina joins Jake, Miyamoto, the Fallen King, and Sylphie as the fifth party member. Jake rejects the rival Chosen's overture, and the completed team enters Nevermore.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1037,7 +1037,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1050,7 +1050,7 @@
       "recaps": {
         "ending": "The novella ends where the Selection begins. Daphne's confession has closed off the one attachment Maxon had outside his obligations, and he has gone into the competition with no expectation of finding anything in it but a suitable wife chosen to his father's specification. The first day with the thirty-five goes badly: he is stiff, the girls are rehearsed, and nothing about the process resembles courtship. Then, on the first night, he finds America Singer in the gardens, furious and in tears, and she tells him without any of the palace's manners that she is in love with someone at home, does not want to marry him, and cannot afford to be sent away because of what her family gains while she stays. He agrees to keep her on as a friend and an honest source of information about the other girls. It is a bargain he makes out of curiosity, but it gives him what he has never had: one person in the building who is not performing for him. The Selection proceeds under his father's control and his father's rules, and Maxon goes into it already more interested in the girl who wanted nothing from him than in any of the others.",
         "in_short": "Prince Maxon Schreave, raised inside the palace and managed closely by his father, is days away from the Selection that will choose his wife. Before it begins, his oldest friend, Princess Daphne of France, tells him she has been in love with him for years; he refuses to act on it because the Selection is already set, and she leaves hurt. The thirty-five Selected arrive and the first day is a disaster: Maxon is formal and awkward, the girls are coached and nervous, and none of it resembles anything he could build a marriage on. That night he finds America Singer in the palace gardens, crying and angry, and she tells him plainly that she is in love with someone at home and does not want him, but that her family depends on the money she earns by staying. He agrees to keep her on as a friend who will tell him the truth about the other girls, and gains the only person at the palace with no reason to flatter him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1181,7 +1181,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1194,7 +1194,7 @@
       "recaps": {
         "ending": "Tom finally gives Susan the suppressed history linking the Wingo siblings: as children, Tom and Savannah were sexually assaulted during a violent attack on the family home, and the family concealed the crime rather than seeking help. Savannah split off the unbearable memory, while Tom buried it beneath denial and humor. Tom also recounts Luke's doomed resistance when government action threatened the coastal home that defined him; Luke was hunted and killed, leaving his siblings with further grief. Bringing these truths into Savannah's treatment helps her emerge from the immediate crisis. Tom and Susan become lovers, but both understand that their relationship belongs to this exceptional period rather than a shared future. Tom returns to South Carolina, reconciles with Sallie, and resumes life with their daughters. Susan remains with Herbert, while Bernard has gained confidence through Tom's coaching. Tom has not forgotten Susan: when crossing the bridge on his way home, he privately speaks her name, acknowledging a love that changed him without abandoning the family and place to which he chose to return.",
         "in_short": "After poet Savannah Wingo attempts suicide in New York, her twin Tom leaves his failing marriage in South Carolina to help psychiatrist Susan Lowenstein recover the family history Savannah cannot speak. Their conversations move through the siblings' childhood under violent Henry and ambitious Lila Wingo, their attachment to the coastal low country, and the loss of their brother Luke. In New York, Tom also coaches Susan's bullied son Bernard and grows close to Susan. The central secret is that escaped prisoners attacked the Wingo home and sexually assaulted Tom and Savannah; the family killed the attackers and concealed everything, leaving both twins to survive through silence and divided memory. Tom also recounts Luke's fatal resistance to the destruction of his beloved homeland. The disclosures help Savannah recover, while Tom and Susan become lovers. They ultimately remain with their spouses. Tom returns to Sallie and their daughters with greater honesty, carrying his love for Susan as part of the life he has chosen rather than as an escape from it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1349,7 +1349,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1362,7 +1362,7 @@
       "recaps": {
         "ending": "The goblins enter the king's country house through passages beneath it, intending to seize Irene for Prince Harelip. Curdie recognizes the attack and helps the household fight them by stamping on their vulnerable feet and driving them back underground. Irene is protected through her great-great-grandmother's unseen guidance, and Curdie follows the magical thread when ordinary routes fail. The miners' efforts against a second goblin scheme release water into the underground domain, flooding it and breaking the goblins' power beneath the mountain. Survivors scatter away from their former home. The king acknowledges Curdie's courage and service, while Irene's trust in both Curdie and her grandmother is vindicated. Curdie returns to his family with royal gratitude, and the friendship between the miner boy and the princess remains intact.",
         "in_short": "Princess Irene lives in a mountain house threatened by goblins who inhabit the caverns below. She discovers a mysterious great-great-grandmother in a hidden tower, although her nurse cannot see or find the woman. Irene also meets Curdie, a brave young miner who has learned the goblins' secret weakness and spies on their plans. When the goblins capture Curdie, Irene's grandmother gives her a ring connected to an invisible thread, which guides her underground to rescue him. Curdie initially doubts Irene's account because he cannot see the grandmother, but he continues investigating and uncovers plots to abduct Irene and flood the human mines. The goblins finally invade the king's house. Curdie and the defenders repel them, while the grandmother's thread keeps Irene safe and guides Curdie. Water floods the goblin realm, forcing the survivors away, and the king rewards Curdie's courage. Irene and Curdie are reconciled as friends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1493,7 +1493,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1506,7 +1506,7 @@
       "recaps": {
         "ending": "Westley and Buttercup are reunited and freed. The prince's plot to murder Buttercup and start a war has failed, and Humperdinck is left alive but humiliated, bound and beaten by Westley's bluff. Count Rugen is dead, killed by Inigo Montoya, who has finally completed the revenge that shaped his whole life and is now unsure what to do with himself; Westley suggests he might become the next Dread Pirate Roberts. Fezzik provides horses for their escape. Westley, still weak from his ordeal, rides away with Buttercup, Inigo, and Fezzik as pursuit gathers behind them. The narrator, keeping up the conceit that he is merely abridging an older tale, declines to promise a clean happy ending, remarking that the characters faced further hardships and that life is not always fair, and leaving their long-term fate open.",
         "in_short": "On a farm in Florin, the beautiful Buttercup and the farm boy Westley fall in love, but Westley sails away to make his fortune and is reported killed by a fearsome pirate. Years later Buttercup, resigned to a loveless marriage with Prince Humperdinck, is kidnapped by three outlaws and rescued by a masked man in black who turns out to be Westley, alive and now living as that same pirate. Humperdinck recaptures them, and Westley is tortured to death by the sadistic Count Rugen, only to be revived by a retired miracle worker. With the swordsman Inigo and the giant Fezzik, Westley storms the castle. Inigo avenges his murdered father by killing Count Rugen, Westley defeats Humperdinck without killing him, and the four escape together, their future left deliberately uncertain by the storytelling narrator.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1681,7 +1681,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1694,7 +1694,7 @@
       "recaps": {
         "ending": "A spy's report persuades the Prince de Clèves that Nemours has met his wife in secret, though Nemours only watched her from outside and she has not committed adultery. Consumed by jealousy, Clèves falls ill. The princess tells him the truth, but he dies believing that her love has been lost to another man. Nemours is now free to declare himself openly. In their final direct conversation, the princess admits that she loves him, yet refuses marriage. She believes she owes fidelity to her husband's memory, holds herself partly responsible for his death, and fears that Nemours's passion would fade once possession replaced difficulty. She withdraws from court, divides her time between religious retirement and her estate, and resists Nemours's continued efforts to see her. Her health eventually fails and she dies young. Nemours grieves, and his passion slowly yields to time; the princess's choice preserves the virtue and inner command that court life repeatedly threatened.",
         "in_short": "At the court of Henri II, Mademoiselle de Chartres is taught by her mother to distrust a society governed by ambition and desire. She marries the devoted Prince de Clèves without loving him, then falls silently in love with the brilliant Duc de Nemours. Nemours returns her feeling, but she resists him through withdrawal and self-scrutiny. After her mother's death, jealousy over a misplaced letter confirms her passion. She makes the extraordinary decision to tell her husband that she loves another man while concealing the man's name. Nemours overhears and later watches her in retreat; Clèves's suspicion grows into fatal jealousy even though his wife remains physically faithful. Widowed and finally able to marry Nemours, the princess admits her love but refuses him from guilt, duty, and distrust of passion's permanence. She retires from society and dies after several years, leaving Nemours to mourn a relationship never fulfilled.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1853,7 +1853,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1866,7 +1866,7 @@
       "recaps": {
         "ending": "Rudolf Rassendyll enters Zenda Castle during the rescue attempt, reaches the imprisoned king, and kills Detchard after the other guards have been drawn away or defeated. Duke Michael is already dead, killed by Rupert of Hentzau after Michael finds Rupert with Antoinette de Mauban. Rupert escapes despite Rudolf's pursuit. The injured king is restored without the public learning that an English double was crowned in his place. Princess Flavia discovers Rudolf's identity and admits that she loves him, but both accept that she must remain in Ruritania and marry its rightful king for the country's sake. Rudolf returns to England, while Sapt and Fritz preserve the secret. He and Flavia do not meet again; each year Fritz brings Rudolf a rose and a message from her. Rupert remains free, leaving the most dangerous surviving conspirator beyond the reach of the restored court.",
         "in_short": "Englishman Rudolf Rassendyll visits Ruritania and finds that he is almost indistinguishable from its new king. When Duke Michael's agents drug and abduct the king before his coronation, loyal officers Sapt and Fritz persuade Rudolf to take his place. Rudolf is crowned, conceals the substitution, and falls in love with the king's intended bride, Princess Flavia. The real king is held at Zenda Castle, where Michael's men are prepared to kill him if a rescue begins. With help from Michael's jealous mistress, Antoinette de Mauban, and a frightened servant, Rudolf's party attacks the castle. Michael is killed by his own treacherous follower Rupert of Hentzau; Rudolf defeats the king's remaining guard and frees the prisoner, though Rupert escapes. The king resumes his throne. Flavia learns the truth and returns Rudolf's love, but duty requires her to remain with the king, so Rudolf goes home alone and keeps the adventure secret.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2021,7 +2021,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2034,7 +2034,7 @@
       "recaps": {
         "ending": "The rescue at Zenda succeeds. Rudolf Rassendyll enters the castle, reaches the imprisoned king, and defeats Detchard before the prisoner can be killed. Within the castle, Duke Michael discovers Rupert with Antoinette; Rupert kills Michael during the confrontation and escapes despite Rudolf's pursuit. The real king survives and can resume his public place without the country learning that an English visitor was crowned in his name. Princess Flavia discovers that the man she came to love was Rudolf Rassendyll rather than her royal cousin. Rudolf and Flavia acknowledge their feelings, but they accept that her duty is to Ruritania and to the restored monarch. Rudolf returns to England, while Sapt and Fritz help preserve the secret of the substitution. Flavia remains in Ruritania, and the two are separated by the obligations that saved the kingdom. Rupert remains at large, but Michael's attempt to seize the throne has failed and the rightful king is restored.",
         "in_short": "English traveler Rudolf Rassendyll arrives in Ruritania and finds that he is almost indistinguishable from its new king. When agents of the king's half-brother, Duke Michael, drug and abduct the monarch before the coronation, loyal officers Sapt and Fritz persuade Rudolf to take his place. Rudolf is crowned and continues the disguise while they search for the captive, who is guarded at Michael's castle in Zenda. During the deception Rudolf falls in love with Princess Flavia, the king's intended bride. Information from Antoinette de Mauban and the servant Johann helps the loyalists plan a rescue. Rudolf reaches the prisoner and defeats his guard, while Michael is killed by his own treacherous follower Rupert of Hentzau. Rupert escapes, but the king is restored. Flavia learns Rudolf's identity and returns his love; duty nevertheless requires her to remain in Ruritania, so Rudolf goes home alone and the substitution remains secret.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2167,7 +2167,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2180,7 +2180,7 @@
       "recaps": {
         "ending": "William finds Frances again after her aunt's death and the loss of her place at Reuter's school. With a new teaching appointment and better prospects, he asks her to marry him. Frances accepts without surrendering her wish to work: she continues teaching, develops a school of her own, and becomes an equal partner in their improving fortunes. Over the following years their combined discipline and success make them financially secure. They have a son, Victor, and eventually leave Brussels for England. Their home stands near Hunsden, whose combative friendship remains part of the family circle. William closes his account as a husband, father, and independent man, having replaced dependence on his brother and relatives with a life built through teaching and shared labor with Frances.",
         "in_short": "William Crimsworth rejects the comfortable future planned by his aristocratic relatives and takes work under his wealthy brother Edward, whose contempt makes the position intolerable. Yorke Hunsden helps him break away and seek a teaching career in Brussels. William works for Monsieur Pelet and Mademoiselle Reuter, briefly mistaking Reuter's calculated attention for sincere affection before learning that she and Pelet intend to marry. His interest turns to Frances Henri, a poor Anglo-Swiss pupil-teacher whose intelligence and perseverance answer his own values. Reuter separates them, and Frances disappears after her aunt's death, but William gains a better post, finds her again, and proposes. They marry, continue teaching, and prosper through their joint work. Years later they return to England with their son Victor and settle near Hunsden, completing William's rise from dependent relation and humiliated clerk to an independent teacher, husband, and father.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2284,7 +2284,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2297,7 +2297,7 @@
       "recaps": {
         "ending": "Investigators identify an illness that human beings can survive but the parasites cannot, giving the United States a weapon that does not require finding every concealed organism individually. The infection is deliberately carried into occupied territory, followed by treatment for the recovering human population. The method breaks the aliens' control and ends their organized hold over the country, though it causes further danger and suffering among the people being liberated. Sam, Mary, and the Old Man survive the campaign. Sam and Mary remain married after their repeated experiences of possession and recovery. Evidence obtained from the parasites points beyond Earth, so victory at home is not treated as the end of the conflict. In the closing movement, Sam joins an armed expedition bound for Titan, intending to carry the war back to the invaders' presumed source rather than wait for another attempt on Earth.",
         "in_short": "Secret agents Sam, Mary, and the Old Man investigate a supposed flying-saucer hoax in Iowa and discover alien parasites attached to human backs. The creatures control their hosts completely while using clothing and normal behavior as camouflage. The team struggles to persuade national leaders before the infestation spreads; Sam himself is possessed, escapes, and is later captured and freed, proving both the danger and the difficulty of questioning a controlled person. Detection rules requiring exposed skin slow the aliens but cannot prevent them from taking officials and large areas of the country. Sam and Mary marry amid the emergency and continue field operations, while even the Old Man is temporarily controlled. A human illness is found to kill the parasites without usually killing their hosts. Deliberate infection followed by medical treatment liberates occupied territory. With the invasion defeated in the United States, Sam departs on an expedition to Titan, the suspected origin of the attackers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2473,7 +2473,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2486,7 +2486,7 @@
       "recaps": {
         "ending": "War ends Linda's luxurious life with Fabrice in Paris and brings her back to England, where she waits for him while London is bombed. She is pregnant with his child and remains certain of his love, even though circumstances keep them apart. Linda dies in childbirth. The loss forces Fanny to reconsider a life that from the outside seemed careless and unstable: whatever Linda's failures as a wife and mother, she had finally found the love she had sought. News then arrives that Fabrice has also been killed in the war. Fanny survives within her steadier marriage and becomes the keeper of Linda's story, recognizing both the damage caused by an absolute faith in romantic love and the genuine happiness Linda found before the end.",
         "in_short": "Fanny Logan grows up partly at Alconleigh with her cousin Linda Radlett, whose unruly family and fierce longing for romance dominate her youth. Linda escapes by marrying wealthy Tony Kroesig, but their political incompatibility and unhappy domestic life leave her trapped. She abandons him and their daughter for communist Christian Talbot, following him into refugee work during the Spanish Civil War. When Christian falls in love with their colleague Lavender Davis, Linda is stranded in Paris. There she meets Fabrice de Sauveterre and at last experiences the passionate attachment she had imagined, living as his cherished mistress. War separates them and sends Linda home to England, pregnant. She dies in childbirth during the Blitz, and Fabrice is subsequently killed as well. Fanny, whose own marriage is conventional and secure, concludes that Linda's pursuit brought suffering but also a period of real, reciprocated love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2679,7 +2679,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2692,7 +2692,7 @@
       "recaps": {
         "ending": "The prophecy spoken at Cardan's birth comes true: he is transformed into an enormous serpent that tears through the palace and its people, no longer able to answer to anyone. Jude, who is High Queen in her own right, is the one who can end it, and she does, killing the serpent, at which point Cardan is restored whole out of its body, the curse discharged rather than merely delayed. Madoc's rebellion collapses with it. Jude faces him directly and beats him, and rather than execute the man who raised her she has him exiled from Elfhame, stripped of his command and his claim. Grimsen's treachery ends with him undone by his own craft. What is left is a settlement: Jude and Cardan rule Elfhame together as High Queen and High King, the marriage acknowledged and the exile revoked, with the Undersea's treaty intact and a court that has run out of ways to argue that a mortal cannot hold the throne. Oak's future is his own again, since nobody now needs him as a puppet, and he can be brought home or left to grow up in the mortal world as he chooses. Taryn is carrying Locke's child, and the sisters are on repaired terms. Jude, who spent the whole series wanting a place that could not be taken from her, chooses to stay.",
         "in_short": "Exiled to the mortal world by Cardan minutes after marrying him, Jude Duarte is stuck in a human flat with her sisters and her brother, taking odd jobs from passing fey. When Taryn's husband, Locke, turns up dead and Taryn must answer for it before the High King's court, Jude goes back to Faerie in her twin's place. She finds Elfhame sliding into civil war: Madoc has taken the north, allied with the vicious Court of Teeth and the treacherous smith Grimsen, and means to take the crown by force. Jude's masquerade collapses, and with it the pretence around the marriage, since the wedding made her High Queen in truth and the banishment never undid it. Captured by the Court of Teeth, she frees the bridled girl the court rules through and escapes. In the final confrontation an old prophecy is fulfilled and Cardan is turned into a monstrous serpent; Jude kills it and he is restored. She defeats Madoc in person and exiles him, and she and Cardan rule Elfhame together, with Jude choosing Faerie for good.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2827,7 +2827,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2840,7 +2840,7 @@
       "recaps": {
         "ending": "Hermann stakes forty-seven thousand rubles on what he believes is the ace, the final card in the Countess's sequence. Chekalinsky deals an ace to himself, but Hermann has actually placed his money on the queen of spades. The card seems to wink at him with the Countess's expression, and the loss breaks his reason. He is confined to a psychiatric hospital, where he no longer responds to questions and endlessly repeats the three cards along with a phrase about the queen. Lizaveta Ivanovna escapes the Countess's household by marrying a kind, prosperous young man and takes a poor relation into her own home. Tomsky advances in his military career and marries Princess Polina. The promised secret has therefore enriched neither Hermann nor anyone around him; his attempt to turn it into certain wealth ends in ruin.",
         "in_short": "Hermann, an ambitious young officer who normally refuses to gamble, hears that his friend's elderly grandmother once used a secret sequence of three cards to erase a huge loss. He courts the Countess's companion, Lizaveta Ivanovna, only to gain entry to the house. When he confronts the Countess with a pistol, she dies of fright without answering. Her ghost later names three, seven, and ace, on the conditions that he use only one card each night and marry Lizaveta. Hermann ignores the spirit of those terms but wins enormous sums on the three and seven. On the third night he believes he has chosen the ace; the card is instead the queen of spades, which seems to bear the dead woman's mocking face. He loses everything and goes mad. Lizaveta later makes a good marriage, while Hermann remains in an institution repeating the fatal sequence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2973,7 +2973,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2986,7 +2986,7 @@
       "recaps": {
         "ending": "Akasha's plan reaches its crisis when she gathers the surviving vampires before her and demands they accept her as a goddess and help her rule a world purged of most of its men. One by one they argue against the horror of her scheme, and she threatens to annihilate them all for their defiance. At that moment the ancient twin Mekare, sister of Maharet and lost to the world for thousands of years, arrives, driven by a vow sworn in the earliest age of the vampires. Because the primal spirit that animates every vampire is rooted in Akasha, killing her would doom them all unless another host receives that force at once. Mekare destroys Akasha by taking her head, and in the same instant consumes the sacred core, so that the animating power passes into her and every vampire survives. Akasha is dead, her tyranny ended, and Mekare, mute and remote, becomes the new bearer of the vampires' life, reunited at last with her twin Maharet. The surviving immortals, Lestat among them, gather at Maharet's sanctuary to mourn, reckon with what they have witnessed, and take up their endless existence again, changed by having come so close to their extinction and their queen's terrible dream.",
         "in_short": "Lestat's rock concert and his public exposure of the vampires rouse Akasha, the primeval queen and mother of all vampires, who has slept as a living statue for thousands of years. Awakened, she takes Lestat as her chosen consort and begins a monstrous plan to remake the world: she destroys most of her own kind and slaughters much of humanity's male population, intending to rule as a goddess over a remade, peaceful order. Across the globe the surviving vampires, among them Marius, Armand, Louis, Gabrielle, Daniel, the researcher Jesse, and ancient elders, are drawn together by dreams and by the pull of the eldest of their kind. They converge on a refuge kept by the ancient red-haired Maharet, who reveals the true origin of the vampires and the long-buried legend of her and her lost twin sister. When Akasha confronts the gathered immortals and demands they join her or die, they resist her vision. At the climax Maharet's twin, Mekare, long thought mad and lost, appears and destroys Akasha, taking into herself the primal force that keeps every vampire alive, ending the queen's reign and saving their kind.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3046,7 +3046,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3059,7 +3059,7 @@
       "recaps": {
         "ending": "Ze'ev survives the programme by becoming what it is designed to produce. He learns to fight the other recruits without hesitating, accepts the surgery that fuses him with wolf DNA and remakes his body, and rises within the pack hierarchy that the training is built around. The cost is deliberate and permanent: the operatives are separated from their families, conditioned into obedience to their thaumaturge handlers, and left with instincts they cannot switch off. He goes into the story as a boy from an outer sector with a younger brother and a mother, and comes out of it as one of Levana's special operatives, known by the name the pack gives him: Wolf. The programme itself is revealed for what it is, the vanguard of an invasion of Earth being assembled years before anyone on Earth suspects it.",
         "in_short": "A prequel short story from Wolf's point of view. Ze'ev Kesley is twelve when Queen Levana's recruiters come to his outer sector and take him for the army, leaving his mother and his younger brother Ran behind. What follows is the training that turns Lunar children into special operatives: packs, ranked by whoever will fight hardest, deliberate cruelty as a teaching method, thaumaturge handlers who can make a recruit do anything, and finally the surgery that fuses a boy with wolf DNA and rebuilds his body around it. Ze'ev survives by learning to do what the programme wants, including things he cannot undo. He ends the story remade, separated from his family, and given the name Wolf.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3173,7 +3173,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3186,7 +3186,7 @@
       "recaps": {
         "ending": "After seeing civilians killed by a bomb made possible through Pyle's support for General Thé, Fowler abandons his claim that he can remain uninvolved. He tells Mr Heng how Pyle can be intercepted on his way to dinner, understanding that Heng's associates intend to kill him. Fowler gives Pyle an opportunity to keep the appointment and makes no effective warning. Pyle is stabbed and left in the river. Inspector Vigot suspects Fowler's part but lacks proof, and the death is not publicly resolved. Phuong returns to Fowler, and a cable from England announces that Fowler's wife will now grant him a divorce, allowing him to offer Phuong marriage. The immediate obstacles to the life he wanted have disappeared, but only after his deliberate complicity in Pyle's death. Fowler closes the account wishing he had someone to whom he could apologize.",
         "in_short": "British reporter Thomas Fowler recounts his relationship with Alden Pyle, an idealistic young American in French Indochina. Pyle believes a nationalist “Third Force” can replace both colonialism and communism, and he also decides that he should marry Fowler's Vietnamese partner Phuong. After Fowler lies about the prospect of divorcing his wife, Phuong leaves him for Pyle. Fowler then discovers that American-supplied material is reaching General Thé and sees a public bombing kill civilians, exposing the cost of Pyle's political abstractions. He cooperates with the Vietnamese contact Mr Heng in arranging Pyle's interception and death. The police suspect but cannot prove Fowler's involvement. Phuong returns to him, and his wife finally agrees to a divorce, yet his desired future rests on the killing he enabled. His final wish to apologize acknowledges that his pose of neutrality has ended.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3343,7 +3343,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3356,7 +3356,7 @@
       "recaps": {
         "ending": "Bobbie's appeal to the Old Gentleman leads him to investigate Father's case. The evidence against Father is overturned, he is cleared of the charge that sent him to prison, and news of his release reaches the family. Mother prepares for his return while keeping the moment quiet. At the station, Bobbie waits as a train arrives and sees Father emerge through the steam. She runs to him, and they return together to Three Chimneys. Peter and Phyllis are reunited with him there, ending the separation that forced the family from its London home. The Old Gentleman has also become personally connected to the family through Jim, the injured schoolboy, who is his grandson. The story closes with Father restored to his wife and children and the central injustice resolved, while the friendships the children formed through the railway remain part of their new life.",
         "in_short": "When their father is suddenly taken away, Bobbie, Peter, Phyllis, and their mother leave their comfortable London home for Three Chimneys, a cottage beside a country railway. The children befriend Perks the porter, wave daily to an Old Gentleman on the train, and repeatedly turn railway life into acts of service: they help a lost Russian exile, stop a train before it strikes a landslide, aid a family whose barge catches fire, and rescue an injured schoolboy from a tunnel. Bobbie eventually learns that Father has been imprisoned after being falsely accused of betraying his country. She secretly asks the Old Gentleman for help. He investigates, the case is corrected, and Father is released. Bobbie meets him as he steps from the train, and the whole family is reunited at Three Chimneys.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3501,7 +3501,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3514,7 +3514,7 @@
       "recaps": {
         "ending": "After Jim is carried to Three Chimneys with an injured leg, his grandfather proves to be the Old Gentleman from the train. Bobbie privately tells him that she has discovered the truth about Father: he was convicted of selling state secrets, though the family believes him innocent. The Old Gentleman investigates the case and helps establish that Father was framed. One morning the railway staff and villagers behave as if they are expecting good news, but Mother lets Bobbie discover it in her own way. Bobbie goes alone to the station and sees Father step from the train after his release. She runs with him to Three Chimneys, where the family is reunited. The children's repeated kindnesses around the railway have thus brought them the friend able to correct the injustice that separated their family.",
         "in_short": "When their father is suddenly taken away, Bobbie, Peter, and Phyllis leave London with their mother for a modest cottage called Three Chimneys. The nearby railway becomes the center of their new life. They befriend the porter Perks and an Old Gentleman who rides the morning train, help a Russian exile find his family, and prevent a passenger train from striking a landslide. They also organize a birthday surprise for Perks and rescue an injured schoolboy from a tunnel. Bobbie eventually learns that Father has been imprisoned on a false charge of betraying state secrets. The rescued boy's grandfather is the Old Gentleman, and Bobbie entrusts the family secret to him. His inquiries clear Father, who returns by train and is reunited with his family at Three Chimneys.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3678,7 +3678,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3691,7 +3691,7 @@
       "recaps": {
         "ending": "After meeting Anton Skrebensky again, Ursula enters a renewed affair with him but discovers that neither passion nor his offer of marriage can reconcile their fundamentally different ideas of life. She rejects the marriage, then believes she is pregnant and writes to accept him, only to learn that he has already sailed away and committed himself elsewhere. Ill after a terrifying encounter with horses, she miscarries, ending the immediate crisis but also closing the future she had briefly imagined with Anton. Recovering at home, Ursula looks across an industrial landscape darkened by rain and sees a rainbow. She takes it as a sign that a freer and more vital order may be built beyond the rigid relationships and institutions that have confined her family. The book closes with Ursula alone but inwardly committed to that possibility; the lives of her sister Gudrun and the wider Brangwen family remain open for the continuation in Women in Love.",
         "in_short": "Across three generations of the Brangwen family, the novel follows a recurring struggle between the security of home and the desire for a larger, more independent life. Farmer Tom Brangwen marries the Polish widow Lydia Lensky and raises her daughter Anna. Anna later marries Tom's nephew Will; their strong physical bond produces a large family but is repeatedly strained by contests over faith, authority, and freedom. Their eldest daughter Ursula grows beyond the Marsh through school, work, friendship, love, and university. She resists the harsh discipline of teaching, explores an intimate attachment to Winifred Inger, and twice becomes involved with the soldier Anton Skrebensky. Their final affair ends when Ursula rejects a marriage that would subordinate her aims to his. After thinking herself pregnant, she miscarries while Anton departs for another life. Recovering, Ursula sees a rainbow over the bleak industrial landscape and imagines a future in which people can create relationships not governed by the old forms that have failed her family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3986,7 +3986,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -3999,7 +3999,7 @@
       "recaps": {
         "ending": "Scorio escapes Praximar's prison with Nox, frees the captive House Kraken Pyre Lady and Jova, and leads a counterattack at Manticore's farewell feast. Leonis and Lianshi reject Praximar's orders despite having no memories of their earlier lives with Scorio. Manticore's leader escapes, but Scorio pursues Praximar to the Academy and kills him. The Iron Tyrant's inquiry clears Scorio and Naomi of the Celestial Coffer attack. They refuse House and military patronage and leave Bastion together, seeking the escaped Manticore leader, Last Rock's lost library, and information about the Shepherds of Goodwill. Leonis and Lianshi depart for service in the Iron Weald, Jova travels independently toward Last Rock, and Ravenna leaves to support the war against the Blood Ox. Bastion remains politically unstable after Hydra's losses and the destruction of its rebel leadership.",
         "in_short": "Scorio and six companions flee Bastion, win a pause in its civilian uprising, and help secure reforms before joining Manticore for training in the Chasm. Manticore uses Scorio to trigger the Celestial Coffer disaster, frames him, and drops him into a gold-mana Crucible. His long imprisonment restores his fractured heart and carries him to Flame Vault. He escapes, reunites with Naomi, and returns to a Bastion ruled through Praximar's crackdown. After House Kraken captures them, Nox frees Scorio and the conspiracy is exposed. Scorio liberates Jova and the imprisoned House Kraken Pyre Lady, regains the support of reborn Leonis and Lianshi, and kills Praximar. Cleared by the Iron Tyrant, Scorio and Naomi reject every patron and leave together to hunt Manticore's escaped leader and investigate Last Rock, the Shepherds of Goodwill, and Hell's hidden order.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4154,7 +4154,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4167,7 +4167,7 @@
       "recaps": {
         "ending": "The expedition follows the hidden passage beneath Exham Priory into a vast complex where generations of the de la Poer family kept people as livestock and practiced cannibalism. Confronted by the evidence, Delapore hears the rats again and runs deeper into the caverns. His companions later find him crouched over Captain Norrys's body, having killed and partly eaten his friend while speaking in a succession of older languages. He is confined in an institution, and the official account attributes Norrys's death to him and conceals much of what lay below the priory. Delapore insists that the rats drove him to the killing. From his padded room he still hears them moving inside the walls, leaving uncertain whether they are supernatural pursuers, the sound of ancestral madness, or both.",
         "in_short": "After his son's death, an American named Delapore restores Exham Priory, the English seat abandoned by his family after an ancestor murdered his household. Delapore and his cat begin hearing rats inside walls where no rats can be found. An investigation uncovers a passage beneath the priory leading to an enormous complex used across many centuries by the de la Poer family. The remains show that its inhabitants bred human captives for food and ritual. The discovery breaks Delapore's composure; following the sound of rats, he attacks and consumes part of his friend Captain Norrys while reverting through languages associated with his ancestry. Confined afterward, he continues to hear rats behind the walls of his cell.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4254,7 +4254,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4267,7 +4267,7 @@
       "recaps": {
         "ending": "The final selection, “The Tell-Tale Heart,” ends after the narrator has murdered the old man, cut up the body, and hidden it beneath the floorboards. Police officers arrive because a neighbor reported a scream, but the narrator confidently invites them in and places a chair over the concealed remains. A sound perceived as a beating heart seems to grow louder while the officers continue talking without reaction. Convinced that they hear it and are mocking the attempt at concealment, the narrator breaks down and confesses, telling them to lift the boards. The collection's earlier pieces close with comparable forms of mental imprisonment: the grieving speaker of “The Raven” accepts that the bird and the sorrow attached to it will not leave, while Montresor completes the wall sealing Fortunato inside the catacombs and keeps the murder undiscovered for fifty years.",
         "in_short": "Three familiar Poe works connect grief, revenge, and guilty obsession. In “The Raven,” a student mourning Lenore admits a raven into his room and turns its repeated answer into a confirmation of permanent loss; by the close he sees both bird and grief as inescapable. In “The Cask of Amontillado,” Montresor exploits Fortunato's pride in his knowledge of wine, leads him beneath a carnival into family catacombs, chains him in a recess, and walls him in alive. In “The Tell-Tale Heart,” a narrator murders an old man because of a fixation on his eye, dismembers the body, and hides it under the floor. The police initially suspect nothing, but an imagined heartbeat overwhelms the narrator, who confesses and reveals the hiding place.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4407,7 +4407,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4420,7 +4420,7 @@
       "recaps": {
         "ending": "Larry explains to Maugham that his search took him through manual labor, religious study, and finally India, where contemplation under Shri Ganesha brought him a durable sense of spiritual freedom. He later tries to save Sophie from addiction by marrying her, but Isabel deliberately leaves alcohol within Sophie's reach; Sophie relapses, disappears, and is eventually found murdered in Toulon. Larry recognizes what Isabel did and quietly gives her up. On the Riviera, the dying Elliott is distressed at being excluded from a fashionable gathering until Maugham secures an invitation that lets him die feeling socially vindicated. Gray obtains work in Dallas and returns to America with Isabel and their daughters. Larry gives away much of what he owns and also heads for America, intending to support himself through ordinary work rather than status or wealth. Maugham concludes that the principal figures have, in different ways, obtained what they most desired, though the moral cost of Isabel's choice remains between her and Larry.",
         "in_short": "After the First World War, Chicago veteran Larry Darrell refuses a conventional career and postpones marriage to Isabel Bradley while he searches for a reason to live. Isabel ultimately chooses security and marries the prosperous Gray Maturin, while her status-conscious uncle Elliott Templeton continues his pursuit of European society. Larry works, studies, and travels through Europe and India, returning with a calm spiritual outlook. The Depression ruins Gray, and family tragedy drives their friend Sophie into addiction. Larry helps Gray and proposes to Sophie, but a jealous Isabel engineers Sophie's relapse; Sophie later dies violently, and Larry understands Isabel's part in it. Elliott dies after receiving the social recognition he craves. Gray and Isabel rebuild their life in America, while Larry renounces wealth and returns there to live by useful work, having found the inward freedom he sought.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4577,7 +4577,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4590,7 +4590,7 @@
       "recaps": {
         "ending": "On the morning Michael is due to collect Hanna from prison, she hangs herself. The prison director shows him Hanna's cell, her books, and the evidence of the reading and writing she taught herself by comparing his recordings with printed texts. Hanna leaves her savings to the Jewish survivor of the church fire. Michael travels to New York to deliver the bequest, but the survivor refuses to accept the money personally because doing so might seem to grant absolution. At her suggestion, he donates it in Hanna's name to a Jewish organization devoted to combating illiteracy; she keeps the old tea tin in which Hanna stored the cash. Michael receives a brief acknowledgment of the donation and takes it to Hanna's grave. Years later he writes the account that forms the book, still unable to turn his memories into either a simple condemnation or an exoneration.",
         "in_short": "As a teenager in postwar Germany, Michael Berg begins a secret affair with Hanna Schmitz, an older tram conductor who asks him to read aloud to her. She disappears without warning. Years later, while studying law, Michael recognizes Hanna among former concentration-camp guards accused over prisoners' deaths in a locked church. He realizes that she cannot read and is accepting greater blame rather than reveal her illiteracy, but he does not intervene; she receives a life sentence. As an adult he records literary works and sends the tapes to prison without personal messages. Hanna uses them to teach herself to read and write. Before her eventual release, Michael reluctantly arranges a place for her, but she kills herself the night before he arrives. He carries out her request to offer her savings to a Jewish survivor, who declines the money and directs it to a Jewish literacy charity. Michael remains marked by his love, shame, and distance from both Hanna and his own choices.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4791,7 +4791,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4804,7 +4804,7 @@
       "recaps": {
         "ending": "Julien remains imprisoned after shooting Madame de Rênal, although her wounds are not fatal and she tries to help him. At his trial he rejects a cautious defense and openly tells the jurors that he is being punished as a lower-class man who tried to enter elite society. He is condemned to death. In prison he gives up his old ambitions, refuses Mathilde's efforts to save him, and recognizes that his love for Madame de Rênal is deeper than the proud passion that bound him to Mathilde. Madame de Rênal visits him, forgives him, and shares a brief period of peace with him before his execution. Julien meets death calmly. Fouqué arranges the burial in a mountain cave that Julien had loved, while Mathilde claims Julien's severed head, reenacting a gesture from the family history that had long fascinated her, and has it buried herself. Madame de Rênal keeps her promise not to take her own life, but dies three days later while embracing her children. Mathilde remains pregnant with Julien's child, and the social advancement he pursued ends in execution rather than acceptance.",
         "in_short": "Julien Sorel, the gifted and ambitious son of a provincial carpenter, becomes tutor to the children of Monsieur de Rênal and begins an affair with Madame de Rênal. When suspicion makes his position untenable, he enters a seminary, where Abbé Pirard recognizes his ability and recommends him as secretary to the Marquis de La Mole in Paris. Julien rises in the marquis's service and enters a volatile romance with the marquis's proud daughter Mathilde. After she becomes pregnant, the marquis reluctantly prepares to grant Julien rank, wealth, and permission to marry her. A denunciatory letter from Madame de Rênal destroys those plans. Julien returns to Verrières and shoots her in church, though she survives. Awaiting trial, he abandons his ambition and realizes that he loves Madame de Rênal. His defiant speech to the jury helps seal his death sentence. He is executed; Mathilde buries his head, and Madame de Rênal dies three days later.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4961,7 +4961,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4974,7 +4974,7 @@
       "recaps": {
         "ending": "In the regiment's final assaults, Henry and Wilson carry their flags at the front, and Henry fights with the determination he once only imagined. The unit holds when officers expected it to fail, then charges again and breaks an enemy position. Wilson seizes the opposing flag while its wounded bearer falls, giving the regiment a clear victory. When the campaign movement ends and the troops leave the battlefield, Henry reviews his conduct. He takes pride in his later courage but also acknowledges the memory of abandoning the dying Jim and the shame of having fled his first battle, rather than erasing those acts with his success. He accepts that his experience contains both failure and bravery. As the army moves into a calmer landscape, his fear of being permanently defined as a coward gives way to a more settled sense of adulthood and moral responsibility.",
         "in_short": "Young Union soldier Henry Fleming enters his first battle obsessed with whether he will be brave. He initially stands with his regiment, but when another enemy attack comes he panics and runs. Away from his unit, he tries to justify his flight, encounters wounded men, and watches his badly injured friend Jim Conklin die. A retreating soldier strikes Henry on the head, giving him the wound he had envied, and a stranger guides him back to camp. His comrades assume he was injured fighting. Henry then returns to battle with fierce energy, reconciles with the increasingly generous Wilson, carries the regiment's flag, and helps take an enemy position and flag. Marching away after the campaign, he neither forgets his desertion nor lets it wholly define him; he accepts both his cowardice and his later courage and feels he has moved beyond his earlier fantasies of war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5105,7 +5105,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5118,7 +5118,7 @@
       "recaps": {
         "ending": "In the final section, Mrs. Tiflin's father visits the ranch and again tells stories of leading settlers west. Carl, tired of the familiar accounts, complains that the old man lives in the past, not realizing that Grandfather has heard him. Grandfather admits to Jody that the journey mattered because a whole people seemed to be moving toward one purpose; once the ocean ended the westward movement, that purpose disappeared, leaving him with memories that others no longer need. Jody responds with an empathy he has gradually acquired through his earlier encounters with loss. He offers to make Grandfather lemonade and says he would like to hear more, not merely to be polite but because he recognizes the old man's hurt. The book closes on this small act of care. Jody cannot restore Grandfather's defining adventure, just as he could not undo the deaths and departures on the ranch, but he can listen and give the old man's experience a present value.",
         "in_short": "Four connected episodes trace Jody Tiflin's growth on his family's California ranch. His father gives him a red pony, Gabilan, but the animal becomes ill after Billy Buck's confident weather prediction fails and dies despite desperate treatment, confronting Jody with grief and the limits of adult expertise. An aged man named Gitano then returns to the land where he was born and, after being denied a permanent home, rides an old horse into the mountains. Later, Jody anticipates a promised colt, only to watch Billy kill the mare Nellie during a difficult birth so the colt can live. Finally, Jody's visiting grandfather, once the leader of a westward wagon train, is wounded by Carl's impatience with his repeated stories. Jody understands that the journey gave Grandfather's life its central purpose and offers to listen and care for him. Across the episodes, possession and excitement give way to a more compassionate awareness of mortality, disappointment, and memory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5256,7 +5256,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5269,7 +5269,7 @@
       "recaps": {
         "ending": "The Kanes reach Set's red pyramid rising over Phoenix, where the god of chaos means to release enough destructive power to level much of North America on his day of ascendancy. Carter, channeling the war god Horus, and Sadie, channeling the magic goddess Isis, lead the fight, and rather than destroy Set, they force him down by learning and speaking his secret name, binding him to their will. In the process they discover that an even greater danger stands behind Set: Apophis, the ancient serpent of Chaos, whom even the gods fear, and who is straining to break free and swallow the world. The children's father, Julius Kane, does not return to them as before; instead he becomes the host of Osiris, the lord of the dead, taking a throne in the underworld and passing on a legacy to his children. Carter and Sadie also learn that the young magician Zia they met was a magical duplicate, and that the true Zia lies hidden elsewhere. Choosing the forbidden path of the gods over the rules of the House of Life, the siblings return to the Brooklyn mansion and resolve to seek out and train other descendants of the pharaohs, building a new house of magic to prepare for the rise of Apophis.",
         "in_short": "Carter and Sadie Kane, siblings raised apart, are reunited when their Egyptologist father performs a secret ritual at a London museum that goes disastrously wrong: he unleashes five ancient Egyptian gods and is imprisoned by Set, the god of chaos. Their uncle Amos takes them to a hidden mansion in Brooklyn, where they learn their family descends from the pharaohs and can host the power of gods. Carter becomes linked to Horus, the war god, and Sadie to Isis, the goddess of magic. Hunted by both Set's forces and the suspicious magicians of the House of Life, and aided by the cat goddess Bast and other allies, they race across the world to stop Set, who is building a great red pyramid in the American desert to unleash destruction on his day of power. At Phoenix they confront and overpower Set, but learn a greater enemy, the chaos serpent Apophis, looms behind him. Their father takes on the role of Osiris, lord of the dead, and the siblings return to Brooklyn to begin training other young descendants of the pharaohs, knowing far worse is coming.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5380,7 +5380,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5393,7 +5393,7 @@
       "recaps": {
         "ending": "Nicole recovers enough movement to act, and she and the people she trusts force the confrontation. The saboteur inside the colony is identified, exposed and stopped, and the network on Earth that supplied and directed the campaign against the space program is opened up along with it, though the wider movement behind it is damaged rather than destroyed. The lunar colony survives at heavy cost: people are dead, others are permanently disabled by polio, and infrastructure that was never meant to fail has to be rebuilt while the settlement keeps running. Nicole is left with lasting weakness from the disease and an open question about whether she will be certified to fly again, an answer she has no intention of accepting as final. She and Kenneth come out of the year with their marriage and their political partnership intact and their prospects reshaped by everything that has happened. The coalition's colonization program continues, the Moon base continues, and the Mars expedition is still out there, months from home and unaware of nearly all of it.",
         "in_short": "In 1963, while the first Mars expedition is under way, astronaut Nicole Wargin is also the wife of a governor running for president, and the space program she serves is under attack from a movement convinced the money should be spent on Earth. What began as protest has become sabotage and killing. Nicole rotates up to the lunar colony and the trouble follows her: equipment fails in ways that point to someone already inside the base, and then polio moves through a settlement with limited medicine and no way to evacuate. Nicole investigates using skills from a wartime past her colleagues know nothing about, concealing both her methods and her own health, while news of the political violence around her husband's campaign reaches her hours late. The epidemic eventually reaches her too, leaving her paralyzed and directing the last of the investigation from a hospital bed. She recovers enough to help force the confrontation; the saboteur is exposed and stopped and the conspiracy behind the campaign is opened up. The colony survives at heavy cost, and Nicole faces a long recovery and an open question about flying again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5519,7 +5519,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5532,7 +5532,7 @@
       "recaps": {
         "ending": "The boy introduces Saint George to the dragon and discovers that neither wants a genuine battle. Because the villagers will accept nothing less than a heroic victory, the three arrange a staged fight. George and the dragon perform an impressive contest before the crowd, with the dragon taking care to present a suitably fearsome appearance. George appears to defeat him without inflicting a fatal wound, then announces that the dragon has reformed and can live peacefully among them. The satisfied villagers replace fear with celebration. At the feast, dragon and dragon-slayer become admired companions, while the boy's knowledge of the truth allows the harmless dragon to keep his home without either side losing face.",
         "in_short": "A shepherd discovers a dragon living near his village, but his well-read son finds that the supposed monster is a gentle poet who dislikes fighting. The villagers nevertheless summon Saint George and expect a traditional dragon-slaying. The boy brings George and the dragon together, and the two agree that a real battle would be pointless. To meet the villagers' expectations, they stage a convincing public combat in which George seems to subdue rather than kill the dragon. George declares the creature reformed, the village celebrates, and the dragon is accepted as a peaceful neighbour. The boy's willingness to judge both figures by their conduct, rather than by legend, saves them from being trapped in their assigned roles.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5631,7 +5631,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5644,7 +5644,7 @@
       "recaps": {
         "ending": "Changez refuses to complete the Chile valuation and returns to New York, where Underwood Samson dismisses him. His relationship with Erica cannot be recovered: she leaves the clinic where she has been treated, and her clothes are found near the Hudson, suggesting suicide without establishing it conclusively. Changez returns to Lahore, becomes a university lecturer, and speaks publicly against American policy. His activism attracts attention, and he believes agents may have been sent to intimidate or kill him. In the frame narrative, he escorts the increasingly uneasy American back toward his hotel as the streets empty. Men from the café follow them, and the American reaches beneath his jacket. Changez sees a metallic glint but courteously supposes it may be a business-card holder. The book ends without confirming whether either man intends violence or what happens next.",
         "in_short": "In Lahore, Changez tells a wary American stranger how he won a place at Princeton, joined the elite New York valuation firm Underwood Samson, and fell in love with Erica, who remained absorbed by the memory of her dead boyfriend Chris. While working in Manila, Changez reacted to the September 11 attacks with a disturbing sense that American power had been humbled. The subsequent wars, suspicion directed at Muslims, conflict involving Pakistan, and Erica's worsening illness estranged him from both his job and the United States. In Chile, the publisher Juan-Bautista led him to see himself as a modern servant of empire. Changez abandoned his assignment, was fired, and returned to Lahore, where he became a lecturer and critic of American policy. Erica disappeared from a clinic and is presumed dead. As Changez walks the American toward his hotel, possible pursuers close in and the stranger reaches inside his jacket. The narrative ends before revealing whether the movement is hostile or harmless.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5826,7 +5826,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5839,7 +5839,7 @@
       "recaps": {
         "ending": "Stevens meets Miss Kenton, now Mrs Benn, and learns that her letter did not mean she was preparing to leave her husband permanently. She admits that she sometimes imagines the life she and Stevens might have had, but she has come to value her marriage, expects a grandchild, and returns to her husband. Stevens conceals his own feeling and parts from her with conventional good wishes. At Weymouth, he talks with a retired butler and finally acknowledges the limits of claiming only to have served: Lord Darlington made grave political mistakes, while Stevens surrendered his own judgment and cannot even say the errors were his to make. The realization leaves him grieving both his employer's failure and his lost possibility with Miss Kenton. The stranger urges him to value the evening that remains rather than the day already spent. Watching people enjoy the pier lights together, Stevens decides to return to Darlington Hall and improve his skill at light conversation so he can respond more warmly to Mr Farraday. This modest resolution does not undo the past, but it directs his remaining professional and emotional life toward a small change.",
         "in_short": "In the 1950s, the formal butler Stevens drives across England to visit Miss Kenton, the former housekeeper of Darlington Hall, hoping she may return to help with staffing. His journey prompts memories of service between the wars. Stevens prized professional dignity above emotion: he continued managing a conference while his father died upstairs, obeyed when Lord Darlington dismissed two Jewish maids, and failed to answer Miss Kenton's attempts at intimacy. He also defended Darlington, whose idealism made him useful to Nazi interests. Miss Kenton, now Mrs Benn, tells Stevens she sometimes wonders about a life with him but will remain with her husband and family. At Weymouth, Stevens admits that his total trust in Darlington cost him the chance to exercise his own judgment or build a personal life. Unable to recover what has passed, he resolves to make better use of what remains by learning the warm conversational ease his current American employer values.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5978,7 +5978,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5991,7 +5991,7 @@
       "recaps": {
         "ending": "The Baudelaires expose Stephano as Count Olaf and prove that he murdered Uncle Monty, not the Incredibly Deadly Viper, which turns out to be a friendly, harmless creature despite its frightening name. They demonstrate that Olaf injected Monty with venom from another snake to fake an accidental death and clear the viper's name before Mr. Poe and the authorities. But at the moment of exposure Olaf and an accomplice escape once more, slipping away before they can be arrested, and Olaf renews his threat to keep chasing the children and their money. Uncle Monty, who had been a genuinely loving guardian, is dead, and his planned expedition to Peru will never happen. Grieving and shaken, the orphans are returned to Mr. Poe's charge to be placed with yet another relative, and Count Olaf remains at large, certain to reappear in the children's lives.",
         "in_short": "After escaping Count Olaf, the Baudelaire orphans are placed with Uncle Monty, a kind herpetologist who fills a great Reptile Room with snakes and plans to take the children on an expedition to Peru. Their happiness ends when a sinister new assistant, Stephano, joins the household, and the children recognize him as Count Olaf in disguise, come to seize their fortune. Before they can convince anyone, Monty is found dead, and Stephano claims one of Monty's snakes, the Incredibly Deadly Viper, killed him. The children know the viper is actually gentle and harmless and that Olaf murdered Monty with venom to make it look like an accident. Working to expose him, they prove the snake is safe and strip away Stephano's disguise in front of Mr. Poe, revealing Count Olaf and his crime. Yet Olaf escapes capture once again, and the children, having lost another beloved guardian, are left in Poe's care to be sent somewhere new.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -6163,7 +6163,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6176,7 +6176,7 @@
       "recaps": {
         "ending": "The election ends in defeat: Sabetha's Black Iris party takes Karthain on groundwork laid long before the final weeks, and the Bondsmagi treat the whole contest as the entertainment it always was, the result mattering far less to them than the playing. Patience then delivers what she has been holding back - that Locke is not the Camorri orphan he believes himself to be, but the vessel of a dead Karthaini child called Lamor Acanthus, whose mage parents used forbidden work rather than accept his death - and offers no proof he can test in either direction. Sabetha, given the same account, will not build anything on ground that uncertain: she goes without a farewell in person, deliberately out of reach, leaving Locke a letter and no way to follow. Locke and Jean come out of the contract cured, paid, and free, with their trade ahead of them, no crew, and nothing settled about who Locke is. Behind them in Karthain the Falconer, kept alive by his mother's people in the state Locke and Jean left him in, comes back to himself. He is not the mage he was and he is no longer anyone's prisoner, and the one purpose left to him is the two men who ruined him.",
         "in_short": "Dying of the poison he took in Tal Verrar, Locke Lamora is saved by Archedama Patience, a senior Bondsmage of Karthain and mother of the sorcerer he and Jean Tannen destroyed in Camorr. Her price is six weeks' work: the Bondsmagi run Karthain's election every five years as a private contest, and Locke and Jean are to direct one party's campaign. The other side is run by Sabetha Belacoros, the fifth Gentleman Bastard, whom Locke has loved since childhood. The campaign becomes a duel of sabotage, bribery and theft that neither of them can keep separate from the rest of it, and they become lovers in the middle of it. Chapters of memory follow the crew as adolescents in Espara, salvaging a bankrupt theatre company, killing the baron who patronised it, and staging his play anyway. Sabetha wins the election. Patience tells Locke he may be the vessel of a dead Karthaini child, and Sabetha, told the same, leaves him. In Karthain, the Falconer wakes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-return-of-the-king.json
+++ b/data/works-community/0/the-return-of-the-king.json
@@ -117,7 +117,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -128,7 +128,7 @@
       "recaps": {
         "ending": "The Return of the King closes with the war won and the world remade. The One Ring is destroyed in Mount Doom, undone at the last not by Frodo, whose will failed, but by Gollum, who seized it and fell into the fire, and Sauron's power is broken forever, his armies scattered and his strongholds thrown down. Aragorn is crowned King Elessar, reuniting the realms of Gondor and Arnor, and weds Arwen, who has given up elvish immortality for him. Faramir, healed, becomes his Steward and marries Eowyn of Rohan, who turns from war to peace; Merry and Pippin return home grown and renowned. The hobbits find the Shire itself has been seized and ruined by the fallen Saruman and his men, and they lead their people to drive the invaders out; Saruman is killed by his own servant, and the land is cleaned and restored. Sam marries and rebuilds, planting the Shire anew. But Frodo cannot recover from the wounds and the burden he carried. Finding no lasting peace in the home he saved, he leaves it to Sam and sails from the Grey Havens with Bilbo, Gandalf, and the last elves, over the sea and out of Middle-earth. The age of the elves ends, and Sam turns back to his ordinary life, the tale complete.",
         "in_short": "As Sauron's war breaks over the free peoples, the wizard Gandalf and the hobbit Pippin help defend Gondor's capital, Minas Tirith, while the ranger Aragorn takes a hidden road through the Paths of the Dead to raise reinforcements. The city is besieged by the Witch-king's host; Rohan rides to its aid, King Theoden falls, and the lady Eowyn and the hobbit Merry kill the Witch-king. Aragorn arrives with fresh strength and the battle is won, though the Steward Denethor despairs and takes his own life, nearly killing his son Faramir. To draw Sauron's eye from the ring, the captains march their small army to the Black Gate as a decoy. Meanwhile Sam rescues Frodo from an orc-tower, and the two struggle across Mordor to Mount Doom. There Frodo's will fails and he claims the ring, but Gollum seizes it and falls into the fire, destroying it and Sauron's power. Aragorn is crowned king and weds Arwen. The hobbits return home to find the Shire despoiled and set it right, but Frodo, too wounded within to heal, at last sails over the sea, leaving Sam behind.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -296,7 +296,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -309,7 +309,7 @@
       "recaps": {
         "ending": "Eustacia leaves her grandfather's house on a stormy night, intending to meet Wildeve and escape Egdon. She is found in Shadwater Weir; whether her fall was deliberate is not settled. Wildeve dives in after her, and Clym also enters the water. Diggory Venn rescues Clym, but Eustacia and Wildeve die. Wildeve's unexpected inheritance passes to Thomasin and her child. Clym, burdened by the deaths of his mother and Eustacia, abandons his educational plan and becomes an itinerant preacher. Venn gives up the reddle trade and becomes a prosperous dairy farmer. Thomasin eventually accepts his renewed proposal, and they marry with Clym's approval. Their domestic happiness contrasts with Clym's solitary public vocation and closes the novel on a quieter accommodation with life on the heath.",
         "in_short": "On Egdon Heath, Thomasin Yeobright's wedding to the unreliable Damon Wildeve fails on a technicality while Wildeve remains attached to Eustacia Vye. The return of Clym Yeobright from Paris redirects Eustacia's hopes, and they marry despite his mother's opposition. Clym intends to teach locally rather than return abroad; failing eyesight reduces him to furze cutting, deepening Eustacia's disappointment. A misunderstood money transfer and Eustacia's secret meeting with Wildeve worsen the family breach. Mrs Yeobright comes to reconcile, but Eustacia does not admit her while Clym sleeps; the older woman later dies after an adder bite. When Clym learns what occurred, Eustacia leaves him. She and Wildeve attempt to meet during a storm and drown in Shadwater Weir, while Clym survives. Years later Thomasin marries Diggory Venn, and Clym becomes a travelling preacher.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -441,7 +441,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -454,7 +454,7 @@
       "recaps": {
         "ending": "Dr. Anderson concludes that Chris's amnesia shelters him from an intolerable memory and that a sufficiently powerful reminder may restore him. Margaret recognizes the missing wound when she asks about Chris and Kitty's child and learns that Oliver died. She returns with objects associated with the boy and goes alone to Chris, accepting that curing him will end their recovered happiness and return him to Kitty, social duty, bereavement, and war. From the house, Jenny and Kitty watch Chris's bearing change as memory returns. Margaret confirms that he is cured and then leaves the life to which she briefly seemed central. Kitty welcomes the restoration of the husband she knows, while Jenny understands its cruelty: Chris has regained knowledge of his dead son and adult obligations and will once again be fit to return to military service. The cure restores social reality at the cost of the refuge his mind created.",
         "in_short": "During the First World War, officer Chris Baldry returns to his country estate with amnesia that has erased the previous fifteen years. He does not recognize his elegant wife Kitty or remember their dead child; emotionally he remains the young man who loved Margaret Allington on Monkey Island. Margaret, now the careworn Mrs. Grey, comes to him despite the class contempt of Kitty and Chris's cousin Jenny. Their reunion restores Chris's happiness and gradually forces Jenny to see the depth of their bond. A doctor argues that Chris's mind is hiding from a painful truth. Margaret identifies that truth when she learns of the death of Chris and Kitty's son Oliver. She brings reminders of the child, knowingly ending Chris's refuge. His full memory returns, along with grief, marriage, social responsibility, and fitness for war. Margaret leaves, Kitty regains the recognizable husband she wanted, and Jenny sees that being cured may be a harsher fate than remaining forgetful.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -571,7 +571,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -584,7 +584,7 @@
       "recaps": {
         "ending": "Glass eventually catches up with Jim Bridger and accepts that the young trapper acted under Fitzgerald's pressure and believed Glass could not survive. Fitzgerald continues east and enlists in the United States Army at Fort Atkinson, placing himself under military protection. Glass follows him there and demands justice, but Colonel Leavenworth will not permit the killing of a soldier. The confrontation therefore stops short of the revenge Glass has imagined throughout his recovery. Fitzgerald is forced to return Glass's stolen rifle, the possession that most clearly embodied the betrayal. Glass leaves with the weapon and with his survival publicly established, but without the complete personal vengeance that drove his journey. The ending distinguishes recovery and accountability from satisfaction: he has crossed the wilderness, faced both men, and reclaimed what was taken, yet law and circumstance limit what he can exact from Fitzgerald.",
         "in_short": "In 1823, frontier scout Hugh Glass is mauled by a grizzly while traveling with Captain Andrew Henry's fur-company expedition. Certain that he will die, Henry leaves John Fitzgerald and young Jim Bridger to bury him. The two abandon Glass while he is still alive, and Fitzgerald takes his prized rifle. Glass revives and begins an extraordinary journey across the northern plains, first crawling and then walking as his wounds slowly close. Hunger, hostile territory, river travel, attacks, and memories of his earlier life test him, while the desire to confront the men sustains him. After reaching trading posts and recovering enough to travel, he rejoins the company's route. He forgives Bridger's frightened complicity but follows Fitzgerald to Fort Atkinson. Fitzgerald has enlisted, so Army authority prevents Glass from killing him. Glass recovers his rifle and leaves alive and acknowledged, though the revenge that powered his journey remains incomplete.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -769,7 +769,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -782,7 +782,7 @@
       "recaps": {
         "ending": "Setrakus Ra's plan turns out to be public rather than covert. Having spent years operating out of hidden bases, he presents himself openly to the world's governments as a visitor offering help, in a form humans will accept, and much of the world is prepared to listen. Then the Mogadorian warships decloak over New York and other cities and the invasion begins in the open. The Garde are split when it starts: Six, Marina, and Adam are in Mexico looking for the Loric sanctuary Malcolm Goode remembered, while John, Sam, Sarah, Nine, and Malcolm are in New York, where the first ships arrive. Ella is still aboard Setrakus Ra's ship, now knowing exactly what he wants from her and refusing it. Adam has burned his own side for good and is trusted, if not liked, by the Garde. The war stops being a secret hunt for nine children and becomes an open invasion of Earth, with the Garde outnumbered, scattered across two continents, and holding one advantage: they know what the Loric left behind here, and the Mogadorians have not found it yet.",
         "in_short": "After Number Eight's death and Ella's capture, the Garde regroup around three things: recovering Ella, understanding what the Mogadorians are building, and Marina's determination to find Number Five. Ella, held aboard Setrakus Ra's warship, learns that he is her grandfather and that he intends her to inherit what he has built, and she resists while trying to warn the others in their sleep. Adam, a Mogadorian who carries the memories of Number One after an experiment on him as a boy, and the earth-shaking Legacy that came with them, defects and brings the Garde what he knows. Together they raid Ashwood Estates, a Mogadorian settlement in Virginia disguised as an ordinary suburb, and find beneath it the enemy's technology, captive Chimaerae, and evidence of a plan to approach the world's governments openly. The group splits: Six, Marina, and Adam go to Mexico to find a Loric sanctuary, and John's group goes to New York. Setrakus Ra presents himself to humanity as a benefactor, and then the warships decloak and the invasion begins.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -902,7 +902,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -915,7 +915,7 @@
       "recaps": {
         "ending": "Carruthers and Davies establish that the activity in the Frisian islands is preparation for moving a German army across the North Sea in shallow-draft vessels, using the islands, tidal channels, and coastal railways to conceal mobilization. Their escape becomes entangled with Davies's determination to save Clara from her father's position. Dollmann and Clara leave with them aboard the Dulcibella, but Dollmann, exposed as an Englishman assisting a plan against Britain, goes overboard and dies. Carruthers and Davies bring Clara and their evidence safely home. Carruthers's report warns the British authorities that the German coast dismissed as unnavigable is precisely what makes the scheme dangerous: trained local pilots and coordinated barges could turn it into an invasion route. The immediate plan is compromised, while Davies and Clara are able to begin a life together in England.",
         "in_short": "Carruthers, a young Foreign Office clerk, accepts his friend Arthur Davies's invitation to join the tiny yacht Dulcibella in the Baltic. Davies reveals that the English-born German resident Dollmann nearly led him onto a deadly Frisian shoal, and he suspects the incident protected a larger secret. The two men survey the tidal channels and pose as harmless sporting sailors while German naval officer von Brüning watches them. Davies's feelings for Dollmann's daughter Clara complicate their work. Carruthers eventually penetrates the restricted activity around Memmert and discovers coordinated preparations for carrying German troops across the North Sea in barges, hidden behind coastal works and local shipping. The pair escape with their evidence and Clara; Dollmann joins them but dies after his treachery against Britain is exposed. Their report alerts British authorities to an invasion plan built on expert use of waters outsiders consider impassable, and Davies and Clara remain together in England.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1091,7 +1091,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1104,7 +1104,7 @@
       "recaps": {
         "ending": "The two halves of the group converge on the Mogadorian installation in New Mexico. John and Nine break in to free Sam Goode, and Six, Marina, Ella, and Eight reach them, so that for the first time since Lorien the surviving Garde stand together in one place: Four, Six, Seven, Eight, Nine, and Ten, with Sam and Bernie Kosar. Setrakus Ra confronts them in person and proves to be something far worse than the soldiers they have been fighting, but united they are able to hold him and force him to withdraw rather than being picked off individually, which is the first thing that has ever worked. Sam is freed. The victory is partial and expensive: Crayton, Ella's guardian, was killed in the mountains of India, and the Garde have now lost every adult who came with them from Lorien except the knowledge those adults passed on. The survivors leave together for Chicago and Nine's fortified penthouse, which becomes their base. The charm that protected them by number is gone, so from this point any of them can be killed at any time, and the only defence they have is the one that just worked: staying together.",
         "in_short": "The surviving Garde spend the book converging. John and Number Nine hole up in Nine's fortified Chicago penthouse, argue about tactics, and then set out for a Mogadorian installation in New Mexico to free Sam Goode, hunted the whole way by federal agents. Six, Marina, Ella, and Ella's guardian Crayton follow reports of a boy in the Himalayas who performs miracles and find Number Eight, who can teleport and change shape and who has been guarding a cave whose paintings appear to show the Garde's own future. The Mogadorians attack them in the mountains: Crayton is killed and Six is taken prisoner. Marina, Ella, and Eight escape and go after her. All of the survivors meet at the New Mexico base, where they free Sam and face Setrakus Ra, the Mogadorian leader, in person for the first time. Fighting together they force him to withdraw. The Garde leave for Chicago as a single group of six, having lost the last of their Cepans and the protection of the charm that once made them killable only in order.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1269,7 +1269,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1282,7 +1282,7 @@
       "recaps": {
         "ending": "Lapham's business reaches collapse. An English group offers a way out by purchasing property at an inflated price, but the buyers do not know that a proposed railroad route, on which the value depends, is no longer likely. Although refusal means ruin, Lapham will not profit from their ignorance. He loses the company and the social ambitions attached to his fortune, and the family leaves Boston for a simpler life connected to the Vermont homestead. Penelope and Tom Corey marry and travel abroad; Irene survives her disappointment and does not marry. The grand new house has already burned before the family could occupy it. Materially, Silas has fallen, but his refusal to transfer his loss through a deceptive bargain completes his moral rise. The Laphams end with less money and status, yet with greater honesty about themselves and each other.",
         "in_short": "Self-made paint manufacturer Silas Lapham tries to establish his family among Boston's old elite while building an expensive house on Beacon Street. When Tom Corey enters his business and visits the family, the Laphams assume he loves beautiful Irene, though he is actually drawn to her witty sister Penelope. The misunderstanding wounds both sisters and exposes the limits of genteel formulas about sacrifice and duty. At the same time, Silas's guilty dealings with former partner Milton Rogers lead him into worsening investments. His house burns and his company approaches ruin. Offered rescue through a sale whose hidden facts make the price unfair, Silas refuses to deceive the buyers and accepts bankruptcy. Penelope marries Tom, Irene remains single, and the Laphams return to modest life in Vermont. Silas loses wealth and social position but gains the moral integrity that gives the title its central meaning.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1439,7 +1439,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1452,7 +1452,7 @@
       "recaps": {
         "ending": "The collection has no single plot to resolve. It closes with two pieces that sit at or after the trilogy's last page: an alternative epilogue to The Empire of Gold, presenting a version of the ending that the published novels did not use, and a short final piece from Nahri's perspective. Because so many of the entries depend on knowing how the trilogy turns out, the collection as a whole is a full-spoiler companion to the three novels rather than a way into them.",
         "in_short": "The River of Silver is a companion collection to the Daevabad trilogy: a set of short pieces, outtakes and deleted scenes told from the viewpoints of characters the novels mostly kept at a distance, among them Manizheh, Duriya, Hatset, Muntadhir, Jamshid, Zaynab, Dara, Ali and Nahri. The pieces are not arranged as a continuous story and are not confined to one point in the timeline: they range from long before The City of Brass to after the close of The Empire of Gold, and several of them depend on knowing how the trilogy ends. The book finishes with an alternative epilogue to The Empire of Gold, a version of the ending that was not the one published, followed by a short closing piece from Nahri. It is written to be read after the three novels, not alongside them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1626,7 +1626,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1639,7 +1639,7 @@
       "recaps": {
         "ending": "Dorothy's arrival in the Emerald City proves to be part of Ozma's birthday plan: Ozma knew her friend was wandering toward Oz and sent the royal chariot to complete the journey. Dorothy's new companions are welcomed and the Shaggy Man is given fresh clothing, though he keeps his old shaggy appearance by choice. Rulers and magical visitors from many lands arrive, including Santa Claus, and Ozma's birthday is celebrated with a great banquet and gifts. The Wizard uses bubbles to carry the guests safely home across the Deadly Desert. Button-Bright is returned to his family, Polychrome rejoins her father's rainbow, and Dorothy and Toto are sent back to Kansas. The Shaggy Man chooses to remain in Oz, where the Love Magnet is placed over the Emerald City's gate so that goodwill may be shared by everyone who enters.",
         "in_short": "Dorothy and Toto become lost while helping the wandering Shaggy Man find a Kansas road. They meet the forgetful child Button-Bright and Polychrome, a fairy daughter of the Rainbow, then follow a twisting route through Foxville, Dunkiton, and other strange countries. They escape the head-throwing Scoodlers and use a sand boat built by Johnny Dooit to cross the Deadly Desert into Oz. Old friends guide them to the Emerald City, where their arrival joins Ozma's birthday celebration. After a gathering of famous fairyland rulers, the Wizard sends the guests home in magic bubbles. Button-Bright reaches his family, Polychrome returns to the rainbow, Dorothy and Toto go back to Kansas, and the Shaggy Man settles happily in Oz.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1871,7 +1871,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1884,7 +1884,7 @@
       "recaps": {
         "ending": "The collection closes with The Magic Finger. After the hunting Gregg family is transformed into small, winged people, four ducks with humanlike arms occupy their house and aim the Greggs' own guns at them. Experiencing the terror of being hunted changes Mr. Gregg's view. He promises that the family will never shoot animals again, and the ducks restore the humans to their normal bodies before departing. Mr. Gregg destroys the guns, and the family replaces hunting with feeding and protecting birds. The unnamed girl then notices another hunting neighbor, Mr. Cooper, and points her magic finger in his direction, suggesting that another forced lesson is beginning. The earlier selections have already reached complete endings: Charlie inherits Wonka's factory, James finds a home in New York, Mr. Fox establishes an underground food supply while the farmers wait uselessly above, and the Enormous Crocodile is flung into the sun.",
         "in_short": "This collection presents five complete Roald Dahl stories. Charlie Bucket finds a golden ticket, tours Willy Wonka's perilous chocolate factory, and is chosen to inherit it after the other children ignore warnings. Orphaned James escapes his cruel aunts inside a giant peach, crosses the Atlantic with enormous insects, and begins a new life in New York. Mr. Fox outwits Boggis, Bunce, and Bean by tunneling into their farms and feeding the besieged underground animals. The Enormous Crocodile's attempts to disguise himself and eat children are defeated by jungle animals, and Trunky the elephant throws him into the sun. Finally, an unnamed girl turns the hunting Gregg family into winged, bird-sized people. Threatened by armed ducks, the Greggs renounce hunting, regain human form, and destroy their guns, while the girl's magic finger finds a new target.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2020,7 +2020,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2033,7 +2033,7 @@
       "recaps": {
         "ending": "Rosie prepares to return to Australia, convinced that Don cannot give her or their child the emotional security they need. Don's many concealed projects have damaged her trust, but they also reveal how seriously he has been trying to understand parenthood and protect his family. With help from the network of friends whose problems he has addressed, he finally communicates his commitment in terms Rosie can recognize. The child-welfare concern arising from the playground incident is resolved, and Don is not treated as a danger to the baby. Gene stops evading responsibility for the damage he caused Claudia and begins trying to repair their relationship. Rosie remains in New York with Don. Their son, Hudson, is born safely, and Don meets the immediate realities of caring for him with attention and tenderness. The marriage continues not because Don becomes conventional, but because he and Rosie regain trust in his ability to adapt and to love them both.",
         "in_short": "Now married and living in New York, Don Tillman and Rosie face an unplanned pregnancy. Don researches fetal development and parenting with his usual intensity, but Rosie reads his analytical response and secrecy as evidence that he is emotionally unprepared. A misunderstood attempt to observe children at a playground brings Don under professional scrutiny, which he hides from Rosie while trying to prove his fitness as a father. Their crowded life also absorbs Gene, newly separated from Claudia, and the troubles of friends Dave, Sonia, and George. Don's overlapping interventions repeatedly backfire, and Rosie decides to return to Australia without him. When the truth emerges, his friends help show that beneath his poor explanations he has been preparing seriously and caring for others. Rosie stays, the official concern is resolved, and their son Hudson is born, leaving Don and Rosie together as new parents.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2171,7 +2171,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2184,7 +2184,7 @@
       "recaps": {
         "ending": "Don concludes that Phil, the man who raised Rosie, is also her biological father. Resolving the genetic question does not by itself repair Rosie's loss or her difficult relationship with Phil, but it ends the search that first brought her and Don together. Don also recognizes that his feelings cannot be reduced to the criteria in the Wife Project. He abandons the attempt to find a theoretically perfect applicant, changes parts of his rigid routine, and tells Rosie that he loves her. She accepts his proposal. They marry and begin a new life in New York, where Don takes an academic position and Rosie continues her medical training. Gene's repeated infidelity has meanwhile brought his marriage to Claudia to a crisis. Don finishes the book with a partner who violates much of his original questionnaire but whose presence has expanded rather than disrupted his life.",
         "in_short": "Melbourne genetics professor Don Tillman approaches finding a wife as a research problem, creating a questionnaire meant to exclude incompatible applicants. Then Rosie Jarman asks for help identifying her biological father from among her late mother's former medical-school classmates. Rosie fails Don's partner criteria, yet he suspends his routines to collect DNA samples with her, and the Father's Project carries them from Melbourne bars and a reunion to a conference trip in New York. Their growing intimacy forces Don to recognize that his feelings cannot be predicted by a form. After false leads and a painful separation, he determines that Phil, the man who raised Rosie, is her biological father after all. Don abandons the Wife Project, declares his love, and proposes. Rosie accepts; they marry and move to New York for Don's new academic job and Rosie's medical studies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2360,7 +2360,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2373,7 +2373,7 @@
       "recaps": {
         "ending": "Joe concludes that the legal system will not punish Linden Lark and decides to kill him. Cappy helps create the opportunity, but Joe fires the fatal shot. The boys conceal their involvement, while members of the community understand more than they openly acknowledge. Geraldine and Basil protect their son through silence, and Geraldine gradually resumes parts of her former life, though the family cannot return to its earlier innocence. Soon afterward, Cappy dies in a car crash, adding another loss that Joe will carry into adulthood. Joe's account closes with his parents bringing him home through the reservation landscape. The murderer is gone, but the outcome offers no clean justice: Joe has crossed a permanent moral boundary, Cappy has paid an unrelated and devastating price, and the family survives by holding grief, love, secrecy, and imperfect protection together.",
         "in_short": "In 1988, thirteen-year-old Joe Coutts's life on a North Dakota reservation changes when his mother Geraldine is raped near the sacred round house. Her trauma and silence leave Joe and his father Basil, a tribal judge, struggling to identify the attacker. Joe investigates with his friends Cappy, Zack, and Angus, while Basil explains how uncertain boundaries between tribal, state, and federal land can prevent prosecution. Evidence connects white supremacist Linden Lark to Geraldine and to the disappearance of Mayla Wolfskin, whose child and tribal status were at the center of the crime. When the authorities cannot act, Joe decides that Lark will remain dangerous unless someone kills him. With Cappy's help he shoots Lark and avoids exposure. Geraldine begins to recover, but Joe's childhood is irreversibly changed. Cappy later dies in a car crash, and the surviving Coutts family is left to carry both the original violence and the morally compromised act committed in response.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2480,7 +2480,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2493,7 +2493,7 @@
       "recaps": {
         "ending": "Dr. B. defeats Czentovic in their first individual game, provoking the champion into requesting a rematch. Czentovic then deliberately plays at an extremely slow pace. During the second game Dr. B. begins retreating into the divided mental state created during his imprisonment, calculating imagined variations faster than the actual game can proceed and losing contact with the board before him. He announces a check that does not exist. The narrator intervenes and reminds him of his illness. Recognizing the return of his dangerous obsession, Dr. B. stops the game, apologizes, and says he will never play chess again. Czentovic is left technically victorious and remarks that his opponent had considerable ability, while Dr. B. preserves himself by walking away from the contest.",
         "in_short": "During an Atlantic voyage, an unnamed narrator becomes interested in fellow passenger Mirko Czentovic, the aloof world chess champion. A wealthy traveller pays Czentovic to face a group of amateurs, whose second game is saved by the unexpected guidance of Dr. B. Dr. B. explains that the Nazis once held him in complete isolation while seeking financial information. He stole a collection of master chess games, memorized them, and eventually began playing invented games against himself until the mental division caused a breakdown. On the ship he accepts one test against Czentovic and wins. In a rematch, the champion's calculated slowness revives Dr. B.'s compulsive inner play. When he mistakes an imagined position for the real board, the narrator stops him. Dr. B. concedes and renounces chess permanently, choosing sanity over another victory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2628,7 +2628,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2641,7 +2641,7 @@
       "recaps": {
         "ending": "Maddie follows the kidnappers to their refuge and uses the patience, concealment, and weapons training of a Ranger apprentice to help Will defeat Jory Ruhl's band and free the captive children. Ruhl dies in the final confrontation, ending Will's long pursuit of the man responsible for Alyss's death. The victory does not remove Will's grief, but teaching Maddie and protecting the children have drawn him back toward his duties and his friends. Maddie has changed as well: the hardships of training and the danger of the mission have replaced much of her careless entitlement with discipline and concern for others. Horace and Cassandra see that the apprenticeship has given their daughter a purpose suited to her abilities. With their approval, she remains Will's apprentice and continues the demanding path toward becoming the first female Ranger, while her royal identity and training remain closely guarded.",
         "in_short": "Years after the earlier adventures, Ranger Will Treaty has withdrawn from his friends and is hunting Jory Ruhl, the outlaw responsible for the fire that killed Will's wife, Alyss. At the same time, Horace and Cassandra struggle with their rebellious daughter, Maddie. Halt proposes one answer to both problems: Will must take Maddie as his apprentice. The arrangement is kept secret because the Ranger Corps has never trained a girl. Will teaches Maddie fieldcraft, archery, tracking, patience, and the sling, while the hard routine steadily changes them both. Their training becomes a real mission when they uncover Ruhl's band abducting children from isolated homes. Maddie applies her lessons in the field, helps Will reach the captives, and proves decisive in the fight that destroys the gang and kills Ruhl. The children are freed, Will begins to emerge from his grief, and Maddie chooses to continue her apprenticeship as Araluen's first prospective female Ranger.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2861,7 +2861,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2874,7 +2874,7 @@
       "recaps": {
         "ending": "Jill is found alive and brought back, and the abduction that removed her is undone. Because the whole danger to her rested on a single rule - that a royal line needs more than one living member for its claim to stand - the resolution is to remove the rule rather than to hide her better: with the law changed, killing Jill no longer unseats a queen, and the years of hiding end. Jill comes back to her own life, and she and Eddie, who has guarded her since the beginning and refused to want anything for himself, are finally together. Olive Sinclair does not survive: her son is born, the first child known to be conceived between a restored Moroi and a dhampir, and he is hidden away to be raised out of reach of Moroi politics and of the Alchemists, both of whom would treat him as evidence rather than a child. Neil is left with a son he cannot openly claim. Sydney's confrontation with her own order and her own family closes the pursuit that has followed her since her escape, and she and Adrian are able to stop running: they stay at Court, married and no longer in hiding, with Sydney free to study and Adrian steady for the first time in his life. The Palm Springs household scatters into lives its members chose.",
         "in_short": "Sydney and Adrian are married and sheltering at the Moroi Court, safe only inside its boundaries while the Alchemists wait outside for Sydney to leave. Then Jill vanishes. Adrian's bond tells him she is alive but not where, and the official search is limited by exactly the politics that put her in danger. Sydney and Adrian leave the safety of Court to look for her themselves, following the trail through the Moroi world, the Alchemists and the Keepers, the community living outside Moroi law where Olive Sinclair has gone to hide the pregnancy that should be impossible. Sydney's magic, her teacher, and the small creature she and Adrian summoned all matter more than any of the official machinery. Olive's son is born and Olive does not survive; the child is hidden away from everyone who would treat him as proof of something. Jill is found and recovered, and the law that made her life the guarantee of her sister's throne is changed, ending the hiding for good. Jill and Eddie are together at last, Sydney's pursuit by her order is finally settled, and she and Adrian can live openly.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3057,7 +3057,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3070,7 +3070,7 @@
       "recaps": {
         "ending": "Halt and Gilan corner the two Kalkara near the ruins of Morgarath's old castle at Gorlan. Ordinary arrows do almost nothing to them, and Halt's plan depends on fire. He brings one creature down, but the second reaches him, and the terror of its stare leaves him unable to move or shoot. Will, who was sent away with dispatches and disobeyed, arrives in time to set an arrow alight and put it into the creature, which burns and dies. Both Kalkara are destroyed and Halt and Gilan survive. Morgarath's attempt to murder Araluen's senior commanders before a war has failed, but the attempt itself tells the kingdom that he is preparing to move against it, and the fiefs begin arming. Back at Redmont, Will is publicly honoured for what he did, and Baron Arald offers him the place in Battleschool he wanted more than anything a few months earlier. Will refuses it: he is a Ranger's apprentice and intends to stay one. Halt, who is not given to praise, is plainly satisfied. Will's friendship with Horace, impossible at the start of the book, is settled, and the question of who his father was remains open.",
         "in_short": "Will, a slight, quick orphan raised as a ward of Castle Redmont in the kingdom of Araluen, wants a place in Battleschool and is refused as too small for it. Instead he is taken as apprentice by Halt, the fief's grim Ranger, and learns that the Rangers are not sorcerers but the King's scouts and intelligence corps, trained in concealment, tracking, the knife and the longbow. While Will learns the craft and makes an unlikely peace with Horace, an old tormentor now at Battleschool, the exiled rebel lord Morgarath sends two Kalkara, huge beasts whose stare paralyses with fear, to murder Araluen's senior commanders ahead of a war. Halt and his former apprentice Gilan track the creatures to the ruins of Morgarath's old castle at Gorlan. Halt kills one; when the second overpowers him, Will destroys it with a burning arrow. The kingdom's command survives, and Will, offered the Battleschool place he once longed for, chooses to remain a Ranger's apprentice as Araluen prepares for war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3415,7 +3415,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3428,7 +3428,7 @@
       "recaps": {
         "ending": "Ryun finds Tali alive after Ra'azel has removed parts of her body, soul, and powers. He reshapes the Way of Oblivion and burns away one of his soul-anchored abilities to rebuild her, yet she remains awake and completely unresponsive despite appearing physically and spiritually whole. During the battle, the Minotaur spatial fighter turns against the Unchained leader, saves the town, and later takes responsibility for displaced survivors. After destroying Eratemus's soul, Ra'azel seizes Zenker's body and narrowly survives pursuit by Ryun, Selia, the Twilight Melody gravity fighter, Zach, and Naha in the Last Forest. Ryun, Selia, and their third partner claim the End, legacy, and reliability as linked authorities, but the Dealmaker blocks their premature ascension and restricts those powers until they can advance properly. Zach and Naha start an independent settlement centered on a material counterpart to the Castle of Knowledge, while Zach seeks treatment for his ruined hand. Anrosh and Nayra continue leading Twilight Melody. The Exalted Empire moves toward war and accuses the sect of Ryun's prison break. Ra'azel cannot be tracked, Tali's condition remains unexplained, and Ryun and Selia begin planning a family.",
         "in_short": "Twilight Melody prepares for the domes while Ryun, Selia, and their third partner advance, Zach reshapes the Wardens around learning, and Kri and Hero develop their own paths. The old runesmith Ra'azel attacks Consequence, kills the sect horticulturist in the surviving outcome, and allies with Kael's Unchained. Ryun and Nayra prevent the Grand Spirit of War from invading the real realm, while Zach kills the treacherous Grand Spirit of Knowledge and inherits its castle. Tali's revenge mission ends with her capture, and Ra'azel removes parts of her soul and powers. Ryun breaks an ally out of an Exalted Empire prison, raids the Unchained base, and restores Tali by remaking Oblivion, though she remains unresponsive. Eratemus dies when Ra'azel destroys his soul and claims Zenker's body, after which the runesmith barely escapes the Eternal Hunters. The Dealmaker halts their premature ascension. Zach and Naha found a learning settlement, the Empire prepares for war, and Ryun searches for both Ra'azel and the cause of Tali's condition while looking toward a future family with Selia.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3689,7 +3689,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3702,7 +3702,7 @@
       "recaps": {
         "ending": "Barley concludes that Goethe has been exposed and that Katya and her family will be punished if he completes the operation on British and American terms. He uses the intelligence services' prized questionnaire and the access entrusted to him as bargaining material with the Soviet authorities. The choice destroys the Western operation and gives away sensitive indications of what its analysts want to know, but it is meant to purchase safe passage for Katya and her children. The British debrief Barley and assess the damage, treating his conduct as betrayal even while recognizing that their pressure left him with a stark moral choice. Goethe does not emerge safely from the failed channel. Barley loses his old freedom and much of his professional life, then waits in Lisbon for the family whose safety he put before the strategic prize. The book closes without confirming that Katya will arrive, leaving the personal outcome of his bargain unresolved after the intelligence operation has definitively failed.",
         "in_short": "Soviet editor Katya Orlova sends British publisher Barley Blair secret notebooks written by her physicist friend Goethe, who argues that the Soviet nuclear threat rests on unreliable technology and institutional deception. British intelligence intercepts the material, recruits the unconventional Barley, and—with strong American involvement—trains him to return to Moscow, verify Goethe's identity, and obtain answers to a detailed technical questionnaire. Barley meets Katya, falls in love with her, and gradually places the lives behind the source above the strategic value of the information. The operation grows increasingly compromised, and Barley realizes that Goethe has been discovered and Katya is in danger. Rather than deliver her to the consequences of Western demands, he trades the questionnaire and his cooperation to the Soviet side in an attempt to secure safe passage for Katya and her children. The services lose their source and interrogate Barley over the damage. He ends in Lisbon waiting for Katya, whose arrival remains uncertain.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3851,7 +3851,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3864,7 +3864,7 @@
       "recaps": {
         "ending": "Nathanael discovers that Olimpia is an automaton when he sees Spalanzani and Coppola fighting over her body; Coppola carries it away while Spalanzani reveals that its eyes came from him. The shock drives Nathanael into a violent breakdown. After a period of recovery he returns to Clara and appears restored, and they plan a peaceful future together. On a visit to a town tower, however, Nathanael looks through Coppola's spyglass at Clara and again falls into madness. He tries to throw her from the tower, but Lothair rescues her. Nathanael then sees Coppelius in the crowd below and leaps to his own death. Coppelius disappears, while Clara is later reported to have found the quiet domestic happiness that Nathanael could not share.",
         "in_short": "University student Nathanael believes the sinister lawyer Coppelius, associated with a childhood story about the Sandman, caused his father's death. A barometer seller named Coppola revives that terror. Through a spyglass bought from Coppola, Nathanael becomes obsessed with Olimpia, the strangely passive daughter of Professor Spalanzani, and turns away from his practical fiancée Clara. Olimpia is exposed as an automaton built by Spalanzani and Coppola, and the shock sends Nathanael into madness. He later recovers and reunites with Clara, but a view through the same spyglass triggers another attack atop a tower. He tries to throw Clara down; her brother Lothair saves her, and Nathanael leaps to his death after seeing Coppelius below. Clara survives and eventually achieves a tranquil family life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-scarecrow-of-oz.json
+++ b/data/works-community/0/the-scarecrow-of-oz.json
@@ -130,7 +130,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -143,7 +143,7 @@
       "recaps": {
         "ending": "The Scarecrow and his friends defeat King Krewl's soldiers without bloodshed and force Blinkie to undo her magic. Cap'n Bill regains his proper form, and Gloria's frozen heart is restored so that she can love Pon again. Krewl and Googly-Goo lose their power, Gloria becomes queen of Jinxland, and Pon stands beside her. Glinda's magic then carries the travelers safely over the deadly waterfall and into the settled Land of Oz. Trot and Cap'n Bill are warmly received in the Emerald City by Ozma, Dorothy, Betsy, and the rest of the court. Ozma invites them to make their home in Oz, where neither age nor death need part them. They accept, turning their accidental voyage into a permanent place among their new friends.",
         "in_short": "A whirlpool carries Trot and Cap'n Bill into an underground adventure, where they befriend the strange flying Ork and eventually reach the borderlands of Oz. Joined by the often-lost Button-Bright, they enter Jinxland and learn that cruel King Krewl has used the witch Blinkie to freeze Princess Gloria's heart and separate her from Pon. Glinda sends the Scarecrow to help. After transformations, captures, and a struggle with Krewl's forces, the Scarecrow's party and the Ork outwit their enemies, make Blinkie reverse her spells, and place Gloria on the throne with Pon. Glinda helps the travelers cross into Oz proper, and Ozma welcomes Trot and Cap'n Bill to live in the Emerald City with Dorothy and their friends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -264,7 +264,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -277,7 +277,7 @@
       "recaps": {
         "ending": "During the Election Day procession, Dimmesdale leaves his place of honor and calls Hester and Pearl to join him on the scaffold. Before the entire town, he acknowledges Hester and Pearl as his family and exposes the guilt that has consumed him. Pearl kisses him, responding at last to a public recognition that joins truth to affection. Dimmesdale dies after the confession, beyond Chillingworth's power to keep tormenting him. Deprived of his purpose, Chillingworth declines and dies within a year, leaving substantial property to Pearl. Hester and Pearl go abroad; Pearl appears to establish a prosperous life elsewhere. Hester eventually returns alone to her old cottage, resumes the scarlet letter by choice, and becomes a counselor to troubled women. When she dies, she is buried near Dimmesdale, with one shared gravestone marked by the image of a red letter against a dark field.",
         "in_short": "In seventeenth-century Boston, Hester Prynne is publicly shamed for adultery and required to wear a scarlet A, but she will not identify her daughter's father. Her long-absent husband returns under the name Roger Chillingworth and secretly dedicates himself to finding the man. The father is the revered minister Arthur Dimmesdale, whose concealed guilt destroys his health while Hester's open punishment gradually makes her strong and useful to the community. Chillingworth becomes Dimmesdale's physician and tormentor. Hester finally reveals Chillingworth's identity to Dimmesdale, and she and the minister plan to escape with Pearl. Instead, after delivering an Election Day sermon, Dimmesdale mounts the scaffold with them and publicly confesses before dying. Chillingworth soon dies as well, leaving Pearl an inheritance. Pearl makes a life abroad; Hester eventually returns to Boston, wears the letter voluntarily, and offers counsel to women until her death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -414,7 +414,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -427,7 +427,7 @@
       "recaps": {
         "ending": "During the Election Day procession, Dimmesdale completes his sermon and then calls Hester and Pearl to join him on the scaffold where Hester was once punished alone. Chillingworth tries to stop him, but the minister publicly acknowledges Pearl as his daughter and confesses the concealed sin that has consumed him. Pearl kisses him, and he dies after the confession. With the object of his revenge gone, Chillingworth declines and dies within a year, leaving substantial property to Pearl. Hester and Pearl leave Boston; Pearl later appears to live comfortably abroad. Years afterward Hester returns alone, resumes wearing the scarlet letter, and offers understanding to troubled women. She is eventually buried near Dimmesdale, with a shared marker that preserves both their connection and their separation.",
         "in_short": "In Puritan Boston, Hester Prynne is publicly punished for bearing a daughter, Pearl, while her husband is missing. She refuses to name the father and must wear a scarlet A. Her husband returns under the name Roger Chillingworth, makes Hester conceal their marriage, and devotes himself to finding her partner. The father is the revered minister Arthur Dimmesdale, whose hidden guilt ruins his health as Chillingworth attaches himself to him. Hester supports herself by sewing and raises the spirited Pearl at the edge of society. After recognizing what revenge has made of Chillingworth, Hester meets Dimmesdale in the forest and plans to escape to Europe with him and Pearl. Dimmesdale instead confesses publicly on the scaffold, acknowledges Pearl, and dies. Chillingworth soon dies too, leaving Pearl an inheritance. Hester eventually returns to Boston and again wears the letter, now approached by others as a source of compassion rather than merely an object of punishment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -555,7 +555,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -568,7 +568,7 @@
       "recaps": {
         "ending": "During the Election Day procession, Dimmesdale leaves his place of honor and calls Hester and Pearl to join him on the scaffold. Before the entire town, he acknowledges Hester and Pearl as his family and exposes the guilt that has consumed him. Pearl kisses him, responding at last to a public recognition that joins truth to affection. Dimmesdale dies after the confession, beyond Chillingworth's power to keep tormenting him. Deprived of his purpose, Chillingworth declines and dies within a year, leaving substantial property to Pearl. Hester and Pearl go abroad; Pearl appears to establish a prosperous life elsewhere. Hester eventually returns alone to her old cottage, resumes the scarlet letter by choice, and becomes a counselor to troubled women. When she dies, she is buried near Dimmesdale, with one shared gravestone marked by the image of a red letter against a dark field.",
         "in_short": "In seventeenth-century Boston, Hester Prynne is publicly shamed for adultery and required to wear a scarlet A, but she will not identify her daughter's father. Her long-absent husband returns under the name Roger Chillingworth and secretly dedicates himself to finding the man. The father is the revered minister Arthur Dimmesdale, whose concealed guilt destroys his health while Hester's open punishment gradually makes her strong and useful to the community. Chillingworth becomes Dimmesdale's physician and tormentor. Hester finally reveals Chillingworth's identity to Dimmesdale, and she and the minister plan to escape with Pearl. Instead, after delivering an Election Day sermon, Dimmesdale mounts the scaffold with them and publicly confesses before dying. Chillingworth soon dies as well, leaving Pearl an inheritance. Pearl makes a life abroad; Hester eventually returns to Boston, wears the letter voluntarily, and offers counsel to women until her death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -747,7 +747,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -760,7 +760,7 @@
       "recaps": {
         "ending": "At the hut near Calais, Chauvelin waits to seize the Scarlet Pimpernel and the fugitives he is expected to rescue. Sir Percy, disguised as a despised Jewish traveler, has manipulated Chauvelin's soldiers into pursuing a false trail while he reaches the captives. Marguerite is discovered near the hut and threatened, but Percy succeeds in moving the Comte de Tournay, Armand, and their companions to his yacht before revealing himself to her. Chauvelin's men return too late, and his quarry escapes to sea. Marguerite and Percy are reconciled: she now knows the supposedly foolish husband she loves is the League's daring leader, and he understands that her apparent betrayal came from coercion and her attempt to save Armand. Sir Andrew and Suzanne are also free to marry, while Chauvelin is left defeated in France.",
         "in_short": "During the French Revolution, an unknown Englishman called the Scarlet Pimpernel repeatedly saves aristocrats from the guillotine. French agent Chauvelin blackmails Marguerite Blakeney into helping identify him by threatening her brother Armand. She intercepts evidence at a ball and realizes too late that the Pimpernel is her apparently foolish husband, Sir Percy. Hoping to undo her betrayal and save him, she follows Chauvelin to Calais. Percy uses disguises, bribery, and false trails to evade the agent while arranging the rescue of Armand and the Comte de Tournay. Marguerite is caught near the rendezvous, but Percy sends Chauvelin's soldiers in the wrong direction and gets the fugitives aboard his yacht. He and Marguerite reunite, their estrangement ending once each understands the other's courage and loyalty; Chauvelin is left behind, outwitted.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -924,7 +924,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -937,7 +937,7 @@
       "recaps": {
         "ending": "Marguerite and Sir Andrew reach Calais in pursuit of Percy, while Chauvelin follows the same trail with soldiers and plans to seize the fugitives Percy intends to rescue. Percy repeatedly stays ahead of him through disguise, false information, and carefully placed instructions. Appearing as an aged trader, he leads Chauvelin toward Père Blanchard's hut while ensuring that Armand and the Comte de Tournay can reach the waiting yacht, the Day Dream. Chauvelin's men close their trap too late: the intended prisoners and their rescuer escape the coast. Marguerite, who has risked capture to warn the husband she once dismissed as a fool, is also brought safely aboard. Percy reveals that his shallow public persona concealed the Scarlet Pimpernel, leader of the rescue league. Marguerite's courage and remorse overcome the estrangement caused by her old denunciation and by her coerced betrayal of his mission. Husband and wife reconcile, Armand is safe, and Chauvelin is left defeated. Sir Andrew and Suzanne's attachment also moves toward marriage, closing the adventure with both couples united in England.",
         "in_short": "During the French Revolution, an unknown Englishman called the Scarlet Pimpernel repeatedly smuggles condemned aristocrats out of France. French agent Chauvelin comes to England to expose him and coerces Marguerite Blakeney into helping by threatening her republican brother Armand. Marguerite supplies a clue, then regrets the betrayal and asks her apparently foolish husband, Sir Percy, to save Armand. Evidence in Percy's study reveals that his foppish public identity is a disguise: he is the Pimpernel. Percy has already left for France, so Marguerite and league member Sir Andrew follow. Near Calais, Chauvelin sets a trap around the fugitives Percy means to rescue. Percy uses disguises and false trails to outmaneuver the soldiers, sends Armand and the Comte de Tournay to his yacht, and saves Marguerite as well. Everyone escapes except the defeated Chauvelin. Marguerite and Percy reconcile after each recognizes the other's courage and loyalty, and Sir Andrew's romance with Suzanne de Tournay promises another marriage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1113,7 +1113,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1126,7 +1126,7 @@
       "recaps": {
         "ending": "Near the hut on the Calais coast, Chauvelin's men wait to capture the Scarlet Pimpernel and the fugitives he means to rescue. Percy, disguised as a Jewish traveler, has already manipulated the search by carrying the agent and planting a false trail. Marguerite is found nearby, but the threat to her does not repair Chauvelin's failing plan: Percy gets Armand, the Comte de Tournay, and the other fugitives away to his yacht before the soldiers return. He then reveals himself to Marguerite and brings her aboard. She understands that her husband's foolish public identity has concealed the Pimpernel, while Percy learns how Chauvelin forced her apparent betrayal. Their estrangement ends in reconciliation. Sir Andrew and Suzanne are free to continue toward marriage, and Chauvelin is left on the French coast after his quarry escapes to England.",
         "in_short": "In 1792, a secretive English rescuer known as the Scarlet Pimpernel repeatedly carries French aristocrats beyond the reach of the guillotine. Chauvelin, an agent of the Republic, coerces the fashionable Marguerite Blakeney into helping identify him by threatening her brother Armand. A message stolen at a ball gives Chauvelin the lead he needs, but Marguerite soon discovers that the Pimpernel is her own apparently foolish husband, Sir Percy. She follows the pursuit to Calais to warn him and save Armand. Percy uses disguises, planted clues, and Chauvelin's certainty against him, diverting the soldiers while the fugitives reach his yacht. He rescues Marguerite as well, and the couple reconcile after the truth about Percy's double life and Marguerite's coercion is understood. Chauvelin's trap fails, and the Blakeneys return to England together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1292,7 +1292,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1305,7 +1305,7 @@
       "recaps": {
         "ending": "Percy reaches France ahead of his pursuers and uses disguise, false trails, and Chauvelin's confidence against him. Marguerite and Sir Andrew follow to Calais, where she learns that Armand and the other fugitives are being held as bait. Percy, disguised as a decrepit local man, remains close to Chauvelin without being recognized and misdirects the soldiers at the crucial moment. Armand, the Comte de Tournay, and their companions escape the hut and reach safety rather than falling into the planned ambush. Chauvelin is left defeated once again. Marguerite discovers that Percy never ceased loving her; his cold manner followed his belief that her denunciation of the St Cyr family revealed a cruelty she did not in fact intend. Her decision to risk her life for him restores his trust, and they reconcile openly. The rescued party prepares to return to England, and the Comte accepts the match between Suzanne and Sir Andrew. Percy's identity remains protected from the wider world, allowing the Scarlet Pimpernel and his league to continue their work.",
         "in_short": "During the French Revolution, a secret band of Englishmen rescues aristocrats from the guillotine under the direction of the mysterious Scarlet Pimpernel. French agent Chauvelin travels to England to uncover the leader and coerces Marguerite Blakeney into helping him by threatening her brother Armand, who is implicated in the league's work. Marguerite supplies a clue, then realizes the man she has endangered is her apparently foolish, estranged husband, Sir Percy. Percy leaves for France to save Armand and other prisoners before Chauvelin can trap him. Marguerite follows with league member Sir Andrew Ffoulkes. Near Calais, Percy adopts a disguise and manipulates Chauvelin into searching in the wrong place, enabling Armand, the Comte de Tournay, and the others to escape. Marguerite's willingness to risk herself restores Percy's faith in her, and they reconcile. Chauvelin is defeated, Percy's secret survives, and the league remains free to continue its rescues.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1490,7 +1490,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1503,7 +1503,7 @@
       "recaps": {
         "ending": "The screen incident destroys Joseph Surface's reputation for virtue: Sir Peter has heard Joseph pursue Lady Teazle, and Lady Teazle has heard her husband speak with genuine affection and generosity. She rejects Joseph and reconciles with Sir Peter. Sir Oliver's disguises then complete the comparison of his nephews. Joseph had refused aid to the supposed poor relation Stanley and tried to manage away the consequences, whereas debt-ridden Charles treated the supposed lender Premium recklessly but preserved Sir Oliver's portrait and sent money to help Stanley. Sir Oliver reveals himself and accepts Charles as his heir. Lady Sneerwell makes a final attempt to stop Charles's marriage to Maria by producing Snake to support a false story, but Snake admits the fabrication. Joseph and Lady Sneerwell are exposed, Charles and Maria are free to marry, and Sir Peter and Lady Teazle resume their marriage with greater mutual understanding. The scandal circle loses this contest even though gossip itself is unlikely to disappear.",
         "in_short": "Lady Sneerwell and the outwardly virtuous Joseph Surface spread a false story to separate Charles Surface from Maria: Sneerwell wants Charles, while Joseph wants Maria and her fortune. At the same time, newly married Sir Peter and Lady Teazle quarrel over money and society, and Lady Teazle flirts with the idea of an affair with Joseph. Sir Oliver Surface returns from abroad and tests his nephews in disguise. Charles, though indebted and reckless, refuses to sell his uncle's portrait and proves generous; Joseph refuses help to a supposed poor relation. In Joseph's library, Lady Teazle hides behind a screen while Sir Peter hides in a closet, and Charles's arrival leads to the screen's fall. Joseph's hypocrisy is exposed, and Lady Teazle repents after hearing Sir Peter's love for her. Sir Oliver reveals himself, Snake confesses that Lady Sneerwell's evidence against Charles was fabricated, Charles is reconciled with Maria and his uncle, and the Teazles restore their marriage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1639,7 +1639,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1652,7 +1652,7 @@
       "recaps": {
         "ending": "After crossing the deadly Scorch, the survivors reach the promised safe haven, but their arrival is no rescue. Along the way Teresa resurfaced with a separate group and appeared to betray Thomas by turning on him, and only later does it become clear she was coerced by WICKED, told he would die otherwise. Thomas learns that he is among the immune to the Flare, one of the traits WICKED has been testing for. The survivors fight through further trials and losses to reach the haven, where WICKED collects them once more, showing that the ordeal was another engineered experiment rather than a path to freedom. In a quiet, ominous detail, it is revealed that Newt is not immune and secretly carries the Flare, a fate the others do not yet grasp. The group ends the book back in WICKED's hands, alive but still trapped inside the organization's designs, with the promise of a cure unfulfilled and a final phase still ahead.",
         "in_short": "The Gladers' apparent rescue proves false: they wake to find their saviors gone, Teresa vanished, a strange boy named Aris in her place, and infected, raving people howling outside barred windows. WICKED, through an official the boys call Rat Man, announces a second phase: they carry a deadly brain-destroying virus called the Flare and must cross a hundred miles of sun-scorched wasteland to a safe haven within a set time to earn a cure. Passing through lethal underground tunnels, they enter the Scorch, battling heat, storms, and the infected in a ruined city, and fall in with two locals, Jorge and Brenda, who guide them for the promise of a cure. Thomas grows close to Brenda and learns the world was devastated by sun flares and plague. Teresa reappears with a separate group and seems to betray Thomas, though it emerges she was coerced by WICKED to save his life. Thomas learns he is among the immune. After more losses the survivors reach the safe haven and are collected again by WICKED, with Newt secretly shown to be infected and not immune. The trials are revealed to be continuing manipulation rather than a true rescue.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1793,7 +1793,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1806,7 +1806,7 @@
       "recaps": {
         "ending": "On race day Mutt Malvern's aggression turns the already lethal contest into a personal attack. His own water horse kills him, while Corr is badly injured. Sean gives up his chance of victory to remain with Corr and get him safely off the beach. Puck and Dove continue and cross the finish line first, making Puck the first woman to win the Scorpio Races and proving that a land horse can defeat the island's sea horses. The prize gives the Connolly family the means to keep their house, although Gabe still chooses to leave Thisby. Puck uses part of her winnings to buy Corr from Benjamin Malvern and gives the stallion to Sean, freeing both horse and rider from Malvern's control. Sean takes the wounded Corr to the sea, prepared to release him if that is what Corr wants. Corr enters the water but returns to Sean on the shore. Sean therefore ends the book with the horse he loves belonging to him by choice as well as law, and with his growing relationship with Puck no longer divided by their competing needs.",
         "in_short": "Every November on the island of Thisby, riders race the carnivorous water horses that emerge from the sea. Four-time winner Sean Kendrick understands the creatures better than anyone but rides Corr for stable owner Benjamin Malvern and longs to own him. Kate \"Puck\" Connolly enters the race on her ordinary mare Dove after her older brother announces he will leave and Malvern threatens the family home. As the first woman to compete, she faces obstruction from officials and riders, while Sean becomes her ally and helps her prepare. Their rivalry develops into affection, even though each needs the same prize. Malvern promises Sean Corr if he wins; Puck needs the money to save her house. In the race, Malvern's hostile son Mutt is killed by his mount and Corr is badly wounded. Sean stays with Corr, while Puck and Dove win. Her prize preserves the Connolly home, and she buys Corr for Sean. When Sean offers the stallion his freedom at the sea, Corr returns to him, leaving Sean, Puck, and their horses together on Thisby.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1976,7 +1976,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1989,7 +1989,7 @@
       "recaps": {
         "ending": "The Golden Fleece is returned to Camp Half-Blood and hung on the pine tree, curing the poison and restoring the camp's protective borders. But the Fleece works too powerfully: it draws the spirit of Thalia, daughter of Zeus, out of the tree and back into a living body, and she awakens as a teenage girl at the base of the tree. Because Thalia is a child of one of the three eldest gods, her return has enormous consequences for the prophecy hanging over demigods of her kind, a thread the next book will take up. Chiron is cleared of suspicion and reinstated as the camp's director, and Tantalus is dismissed back to the Underworld. Percy and Tyson are reconciled as brothers, and Tyson leaves to work in Poseidon's undersea forges. Clarisse receives public credit for the quest. The larger danger remains and grows: Luke has escaped again, and Kronos is steadily gathering strength for the war to come.",
         "in_short": "Percy Jackson, demigod son of Poseidon, learns that the magical pine tree guarding Camp Half-Blood, formed from the dying daughter of Zeus, Thalia, has been poisoned, leaving the camp's borders failing. Chiron has been dismissed under suspicion and replaced by the cruel Tantalus. Percy discovers that his gentle friend Tyson is a young Cyclops and his own half-brother. Dreams reveal that Grover is trapped by the Cyclops Polyphemus, who guards the Golden Fleece, an object that could heal the tree. Percy, Annabeth, and Tyson set out on their own after Clarisse is given the official quest. They board Luke's ship, learn Kronos is re-forming, and escape, then pass through Circe's island, Scylla and Charybdis, and the Sirens, with Tyson briefly presumed dead. On Polyphemus's island they free Grover and seize the Fleece, and Tyson turns up alive. Getting the Fleece back to camp despite Luke's ambush, they heal the tree, which unexpectedly restores Thalia herself to life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2144,7 +2144,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2157,7 +2157,7 @@
       "recaps": {
         "ending": "Wolf Larsen's illness leaves him blind and progressively paralyzed while Humphrey repairs the Ghost. Larsen makes one last effort to resist, but he loses the ability to move and then to communicate. He dies before the work is finished, and Humphrey and Maud give him a burial at sea. Humphrey completes the rigging with skills he acquired during the voyage, and he and Maud sail away from Endeavour Island. A revenue cutter finally sights them and comes to their aid. With rescue at hand, Humphrey and Maud openly acknowledge their love. Humphrey has survived the violent world into which Larsen forced him and has become physically capable without accepting Larsen's belief that power is the only source of value.",
         "in_short": "Literary critic Humphrey Van Weyden survives a ferry wreck and is taken aboard the sealing schooner Ghost, whose brilliant and brutal captain, Wolf Larsen, refuses to put him ashore. Forced to work, Humphrey learns seamanship and confronts Larsen's harsh materialism while the abused crew resists its captain. After the Ghost rescues writer Maud Brewster, Humphrey's wish to protect her gives him the courage to escape with her in an open boat. They reach remote Endeavour Island and build a refuge, only for the deserted Ghost to drift into their harbor with the ailing Larsen alone aboard. Larsen, losing his sight and movement, tries to prevent Humphrey from repairing the ship, but Humphrey perseveres. Larsen dies and is buried at sea; Humphrey and Maud sail away in the restored schooner, are found by a revenue cutter, and declare their love.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2322,7 +2322,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2335,7 +2335,7 @@
       "recaps": {
         "ending": "Two years after leaving the estate, Nina returns secretly and meets Konstantin. Her affair with Trigorin produced a child who died, Trigorin returned to Arkadina, and Nina's acting career has been difficult and provincial. Although shaken and sometimes identifying herself with the seagull Konstantin once killed, she insists that endurance matters more than fame and says she still loves Trigorin. She leaves to continue working as an actress. Konstantin recognizes that neither his growing literary reputation nor his devotion can bridge the distance between them. He destroys his manuscripts and goes into another room. As Arkadina, Trigorin, and the others play cards, a shot is heard. Dorn investigates, then privately tells Trigorin to take Arkadina away because Konstantin has killed himself. The news is withheld from her as the curtain falls.",
         "in_short": "On his uncle's estate, aspiring writer Konstantin stages an experimental play starring Nina, whom he loves. His actress mother, Arkadina, mocks it, worsening his insecurity. Nina becomes fascinated by Arkadina's lover, the famous writer Trigorin. Konstantin kills a seagull and lays it at Nina's feet; Trigorin turns the image into an idea about a girl destroyed by a man's whim. Nina leaves to become an actress and begins an affair with Trigorin, who eventually returns to Arkadina. Two years later, Konstantin is a published writer, while Nina has lost her child by Trigorin and struggles in provincial theatre. She visits Konstantin but says she still loves Trigorin and must endure through faith in her vocation. After she leaves, Konstantin destroys his work and shoots himself. Dr. Dorn quietly tells Trigorin to remove Arkadina before she learns that her son is dead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2623,7 +2623,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -2636,7 +2636,7 @@
       "recaps": {
         "ending": "Tremine betrays Ruwen's group for a payment from Naktos, admits his part in the loss of earlier champions, and helps the Naktos mage send everyone into the spirit realm. Ruwen awakens there with Hamma, Sift, the restored shade, Slib, and House Captain Juva. Their profiles and most abilities are unavailable, while Slib and Juva flee into the tunnels. Rami identifies the Iris to the south as the only known nearby place where portal chalk can work. Fractal restores the dead Naktos assassin in body and spirit, and the assassin must obey Ruwen as dungeon master. Ruwen leads his core party and this compelled ally toward the Iris. Tremine remains at large, Naktos's planned invasion remains active, and Uru's knowledge of the sacrificed champions is unconfirmed. Ruwen must also fulfill his soul oath to restore Fractal's damaged dungeon, reckon with the danger of his cultivation, and continue the search for his missing parents.",
         "in_short": "During an expedition outside Deepwell, Ruwen develops his Worker abilities, trains with Sift, and turns the Black Pyramid into a refuge shared with Hamma. He learns cultivation, becomes an Inkwarden, and permanently retains Worker and Observer powers loaned by Uru's class artifacts. His uncontrolled harvesting then kills the camp dungeon's creatures and strips away its spirit. Seeking restitution, he bonds with its surviving keeper, Fractal, and accepts responsibility for rebuilding it. Sift's amnesiac former partner regains her memories and reveals that her suspicious conduct served Kai's counteroperation against Naktos. Tremine destroys that victory by betraying the group for a valuable survey and helping a Naktos mage cast them into the spirit realm. With ordinary abilities inaccessible, Ruwen, Hamma, Sift, the restored shade, and a resurrected assassin bound to Ruwen head toward the Iris in search of a portal home, while Slib and House Captain Juva disappear into the tunnels.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2847,7 +2847,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2860,7 +2860,7 @@
       "recaps": {
         "ending": "The search converges on Sir James Peel Edgerton, whose public identity as a distinguished lawyer has concealed that he is Mr Brown, the organizer directing the conspirators. He tries to isolate and control Tuppence, but Tommy, Julius, and their allies close in before he can escape with the treaty papers. Exposed and unable to talk his way free, Sir James takes poison and dies. The documents are secured in time, and the planned political crisis is prevented. Jane Finn is free of the organization that kept her hidden, and she and Julius become a couple. Tommy and Tuppence, having admitted that their partnership is also a romance, marry as well. Mr Carter offers Tommy continuing intelligence work, giving the pair a future beyond the temporary venture they invented when they were unemployed.",
         "in_short": "After the First World War, broke friends Tommy Beresford and Prudence \"Tuppence\" Cowley create the Young Adventurers and accidentally attract the attention of a conspiracy when Tuppence mentions Jane Finn. Jane, an American survivor of the Lusitania, vanished with secret treaty papers that could destabilize Britain. Intelligence official Mr Carter hires the pair to find her and the unseen leader called Mr Brown. Joined by Jane's wealthy cousin Julius Hersheimmer, they pursue separate leads: Tuppence infiltrates conspirator Rita Vandemeyer's household while Tommy enters the organization's Soho network. Both are captured or misdirected as the conspirators exploit false messages and identities. Jane is eventually recovered and the missing document traced. The respected lawyer Sir James Peel Edgerton is exposed as Mr Brown; cornered, he kills himself with poison. The papers are secured and the plot fails. Jane pairs with Julius, while Tommy and Tuppence marry and prepare for further work together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3031,7 +3031,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3044,7 +3044,7 @@
       "recaps": {
         "ending": "Tommy recognizes that the trusted Sir James Peel Edgerton is Mr Brown, the concealed leader who has guided both the conspiracy and the investigation. He reaches Tuppence before Sir James can remove the remaining witnesses or recover the treaty. Confronted with exposure, Sir James takes poison and dies. Jane Finn explains that she protected the treaty after the Lusitania sank and survived the conspirators by concealing what she knew; the document is recovered before it can be used to destabilize the government. The political plot therefore fails, and Jane is reunited with Julius Hersheimmer. Tommy and Tuppence have survived separate captures, deceptions, and repeated attempts on their lives. With the case finished, they finally admit that their partnership is also a romance. Tommy proposes in his characteristically indirect way, Tuppence accepts, and the Young Adventurers prepare to marry.",
         "in_short": "Unemployed after the First World War, friends Tommy Beresford and Tuppence Cowley advertise themselves as the Young Adventurers. Tuppence's casual use of the name Jane Finn draws them into a government search for an American survivor of the Lusitania who received a secret treaty from a dying courier. Joined by Jane's cousin Julius Hersheimmer and advised by intelligence officer Carter and lawyer Sir James Peel Edgerton, the pair infiltrate a revolutionary conspiracy led by the elusive Mr Brown. Tommy is captured in a Soho hideout, while Tuppence enters Rita Vandemeyer's household and later disappears into another trap. The investigators eventually locate Jane and learn how she concealed the treaty. Tommy then realizes that Sir James himself is Mr Brown. He rescues Tuppence and confronts the lawyer, who kills himself with poison when exposed. The treaty is secured, Jane rejoins Julius, and Tommy and Tuppence end their first adventure engaged to be married.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3211,7 +3211,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3224,7 +3224,7 @@
       "recaps": {
         "ending": "After killing Verloc, Winnie seeks help from Ossipon and offers him Verloc's money if he will escape with her. Ossipon initially agrees, but fear and self-interest overcome him. He takes the money and abandons her aboard a cross-Channel train. With nowhere to turn and convinced that capture is inevitable, Winnie jumps from the ferry and drowns. Ossipon later reads the report of her death and is haunted by her final despair, though he remains free. The police and political authorities contain the diplomatic scandal surrounding the Greenwich bombing. The Professor, unchanged and still carrying explosives, walks through London among the public he despises. Verloc, Winnie, and Stevie are all dead, while the institutions and revolutionary circles that used or observed them continue largely intact.",
         "in_short": "Adolf Verloc, a London shopkeeper and informer, is ordered by a foreign embassy official to stage a bombing that will provoke repression of political radicals. He involves his vulnerable brother-in-law Stevie in an attempt on Greenwich Observatory, but Stevie trips while carrying the bomb and is killed by the explosion. Scotland Yard traces a scrap of clothing to Verloc. His wife, Winnie, learns that her husband caused the death of the brother she devoted her life to protecting and kills Verloc with a carving knife. She turns to the anarchist Ossipon for escape, offering him Verloc's savings, but he takes the money and abandons her. Winnie drowns herself during the Channel crossing. The authorities limit the political damage, while the bomb maker known as the Professor remains at large and committed to destruction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3400,7 +3400,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3413,7 +3413,7 @@
       "recaps": {
         "ending": "Becky uses her knowledge of the Websters' losses to challenge the investment company responsible and explains the issue clearly on live television. Her unplanned appearance succeeds because she understands the human consequences better than the conventional experts do. Luke, whose firm represented the company, respects her decision to put the truth first, and their strained attraction becomes a relationship. Becky gains a new public role giving accessible financial advice. She finally meets Derek Smeath and begins dealing honestly with the debt she has spent the book hiding. Her money troubles are not magically erased, but she has stopped running from them and found work that uses her ability to communicate rather than merely repeat industry language.",
         "in_short": "Rebecca Bloomwood writes about personal finance while secretly carrying large debts created by compulsive shopping. She ignores letters from bank manager Derek Smeath, invents excuses, and cycles through doomed plans to economize or earn more. Her flatmate Suze supports her, while Becky's parents and their friends assume she is a financial authority. When the Websters are treated unfairly by an investment company, Becky investigates and discovers that the industry story has real human stakes. Her growing attraction to public-relations executive Luke Brandon is complicated because his firm represents the company she challenges. Becky nevertheless exposes the unfairness on live television and proves unexpectedly effective at explaining finance to ordinary viewers. She and Luke come together, and she receives a new media opportunity. Most importantly, she stops evading Derek and begins facing her debts, ending the story with a career breakthrough and a more honest approach to money rather than an instant cure for her spending.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3586,7 +3586,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3599,7 +3599,7 @@
       "recaps": {
         "ending": "Susan Sowerby visits the hidden garden and recognizes that Colin's recovery should be shared with his father. Abroad, Archibald Craven has begun to emerge from his grief; a dream and an urgent feeling draw him home. He enters the secret garden and is astonished to find Colin healthy, standing, and able to run. Father and son are reunited, and Colin proudly explains the work that Mary, Dickon, and the garden have done. They walk back to Misselthwaite together, with Colin refusing his chair. The servants see the master of the house return beside the vigorous son many had expected to die. Mary has changed as profoundly as Colin: outdoor life, friendship, useful work, and affection have replaced the isolation and ill temper with which she arrived. The garden is restored, Colin's existence is no longer hidden, and Archibald returns to his home and child instead of fleeing his grief.",
         "in_short": "Orphaned in India, disagreeable ten-year-old Mary Lennox is sent to her uncle Archibald Craven's lonely Yorkshire manor. Exploring its grounds, she finds the buried key and concealed door to the garden locked since her aunt's fatal accident. With the help of Martha's animal-loving brother Dickon, Mary secretly revives it and grows healthier herself. She also discovers Colin, her hidden, bedridden cousin, who expects to die. Mary challenges his fears and brings him into the garden, where he, Mary, and Dickon treat growing strength and hope as a kind of magic. Colin learns to stand and walk but keeps his recovery secret to surprise his absent father. Susan Sowerby helps draw Archibald home, and he finds his son running in the restored garden. Father and son return openly to the manor together, while Mary too has been transformed by friendship, exercise, purpose, and care.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3772,7 +3772,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3785,7 +3785,7 @@
       "recaps": {
         "ending": "Susan Sowerby visits the hidden garden and recognizes that Colin's recovery should be shared with his father. Abroad, Archibald Craven has begun to emerge from his grief; a dream and an urgent feeling draw him home. He enters the secret garden and is astonished to find Colin healthy, standing, and able to run. Father and son are reunited, and Colin proudly explains the work that Mary, Dickon, and the garden have done. They walk back to Misselthwaite together, with Colin refusing his chair. The servants see the master of the house return beside the vigorous son many had expected to die. Mary has changed as profoundly as Colin: outdoor life, friendship, useful work, and affection have replaced the isolation and ill temper with which she arrived. The garden is restored, Colin's existence is no longer hidden, and Archibald returns to his home and child instead of fleeing his grief.",
         "in_short": "Orphaned in India, disagreeable ten-year-old Mary Lennox is sent to her uncle Archibald Craven's lonely Yorkshire manor. Exploring its grounds, she finds the buried key and concealed door to the garden locked since her aunt's fatal accident. With the help of Martha's animal-loving brother Dickon, Mary secretly revives it and grows healthier herself. She also discovers Colin, her hidden, bedridden cousin, who expects to die. Mary challenges his fears and brings him into the garden, where he, Mary, and Dickon treat growing strength and hope as a kind of magic. Colin learns to stand and walk but keeps his recovery secret to surprise his absent father. Susan Sowerby helps draw Archibald home, and he finds his son running in the restored garden. Father and son return openly to the manor together, while Mary too has been transformed by friendship, exercise, purpose, and care.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3937,7 +3937,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3950,7 +3950,7 @@
       "recaps": {
         "ending": "The group destroys itself. After Bunny's murder and the strain of the investigation and funeral, the friends turn on one another. Charles, drinking heavily and estranged, grows violent, and in a final confrontation involving a gun and the threat of everything coming out, the situation collapses; Henry, the group's mastermind, shoots himself and dies, an act that ends the crisis and shields the others. Julian Morrow, having found evidence of what his adored students have done, quietly leaves the college and cuts them off, shattering the ideal that had bound them. In the epilogue, told years later, Richard recounts their fates: Francis, forced by his family toward a marriage he does not want, attempts suicide and survives; Charles disappears, running off with an older married woman; Camilla lives alone caring for her aging grandmother, still emotionally beyond Richard's reach though he never stops loving her. Richard himself completes his studies and drifts into an academic life, permanently marked by his complicity and unable to escape the memory of the killings and the seductive, lost world Julian created around them.",
         "in_short": "Richard Papen, a working-class Californian reinventing himself, transfers to an elite Vermont college and is drawn into a small, exclusive classics class of five students led by the brilliant Henry Winter and taught by the charismatic Julian Morrow. Richard learns that four of them, while attempting an ecstatic Dionysian ritual, lost control and killed a local farmer. When the group's loud hanger-on, Bunny, discovers the killing, he torments and blackmails them until, fearing exposure, they murder him by pushing him into a ravine, the death revealed in the book's opening pages. The rest follows the search for Bunny, the investigation, the funeral, and the group's psychological collapse under guilt. Charles sinks into alcoholism and violence, the tangled feelings around Camilla fracture the group, Julian abandons his students on learning the truth, and Henry finally shoots himself. Richard survives, and years later remains haunted by what they did and by his unresolved love for Camilla.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-secret-life-of-bees.json
+++ b/data/works-community/0/the-secret-life-of-bees.json
@@ -76,7 +76,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -89,7 +89,7 @@
       "recaps": {
         "ending": "Lily's search for her mother ends in hard truth and unexpected peace. She learns from August that her mother, Deborah, had once lived with the Boatwright sisters, and that in a time of despair Deborah had left Lily behind for a period before meaning to return for her, a revelation that first devastates Lily and then, gradually, frees her from her guilt and idealized longing. Along the way the household suffers its own loss when the tender, sorrow-stricken May drowns herself, unable to bear the weight of the world's pain. When T. Ray finally traces Lily to Tiburon and comes to take her home, a tense confrontation follows, but August and the community of women refuse to give her up, and T. Ray, shaken, leaves her behind. Lily stays with the Boatwright sisters, embraced by August and by the circle of women known as the Daughters of Mary. Surrounded at last by mothers of every kind, she settles into a true home, having forgiven her mother, herself, and even, in part, the father who could not love her.",
         "in_short": "In 1964 South Carolina, fourteen-year-old Lily Owens lives with her cruel father and is tormented by the belief that she caused her mother's death as a small child. After her Black caretaker, Rosaleen, is beaten and jailed for defying local racists, Lily helps her escape, and the two run away, following a clue from her mother's belongings: a picture of a Black Madonna labeled with the town of Tiburon. There they are taken in by three Black beekeeping sisters, August, June, and May Boatwright, whose home centers on honey and a beloved Black Madonna statue. Lily learns beekeeping, finds friendship with a boy named Zach, and slowly heals among the women and their circle. Grief overtakes the fragile May, who takes her own life. Lily discovers that August had known her mother, who once stayed with the sisters, and confronts painful truths about her. When her father tracks her down, the sisters stand with Lily, and she is allowed to remain, finding at last the mothering and belonging she has always craved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -240,7 +240,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -253,7 +253,7 @@
       "recaps": {
         "ending": "The book closes as the Cold War ends and the service Ned has served all his life loses the enemy that defined it. The last episodes are of the new world rather than the old: an interrogation that ends not in triumph but in the exposure of a lonely man's need for a friend, and an encounter with an English arms dealer who is untouchable, unashamed and entirely at home in the coming order, and whom the service can neither prosecute nor frighten. Smiley's final remarks to the trainees and to Ned refuse the consolations they were hoping for. The struggle is over, he tells them, and it was won at least as much by the other side's exhaustion as by anything the Circus did; the secret world will go on being needed, but the people in it must stop pretending that the cause absolves them of the human cost of the methods. Ned, who has spent his career following orders he half believed and telling agents lies that got some of them killed, ends where he began, at the training school, teaching the trade to people who will serve a different purpose. He goes home to Mabel with his account of himself unfinished and, for the first time, honestly stated.",
         "in_short": "Ned, a Circus officer at the close of his career and now in charge of the service's training establishment at Sarratt, invites the retired George Smiley to speak to a passing-out class. Smiley's talk over the evening, ranging over tradecraft, betrayal and the agents he ran, sends Ned back through his own thirty years in the secret world, and the book is the series of memories it releases. He recalls his training and the disappearance of his closest friend on a first posting to Berlin; the running of a Baltic seaman and his companion out of Hamburg, and the suspicion that fell on her when the crossings went wrong; an affair conducted in the space that secrecy creates; a Circus man in South East Asia who was tortured and never came back to London's authority; and, at the end of his career, the interrogation of a solitary cipher clerk whose only friendship had been with a foreign intelligence officer. The last of it belongs to the new world: an arms dealer the service cannot touch. Smiley tells the students the Cold War is over and that no cause excuses what was done in its name.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -420,7 +420,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -433,7 +433,7 @@
       "recaps": {
         "ending": "America has become the public's favorite and Maxon's, and after a Halloween party she suggested he tells her plainly that she is the one he wants. She cannot answer him, because at that same party she saw Aspen wearing the uniform of the palace guard: drafted out of his caste, posted to Angeles, and now living in the same building as she is. Rebels attack again that night and the household spends hours locked in the safe room, a reminder that the raids are escalating and that the two groups behind them want different things, one of them apparently searching the palace rather than simply killing. The Selection is then cut to its final six, the Elite, announced on the Report: America, Marlee Tames, Celeste Newsome, Kriss Ambers, Natalie Luca, and Elise Whisks. Maxon is increasingly at odds with his father over how Illéa is governed, and the King has made it clear he does not regard a Five as a possible princess. The book closes with America still in the competition, in love with Maxon but unwilling to say so, and with the boy she was told to forget standing guard outside her door.",
         "in_short": "In Illéa, a monarchy built on the ruins of the United States and sorted into eight numbered castes, thirty-five girls are chosen by lottery to compete for Prince Maxon's hand. America Singer, a sixteen-year-old Five from Carolina, applies only because her mother insists and because Aspen, the Six she has loved in secret for two years, ends their relationship rather than hold her back. Her name is drawn. At the palace she is remade to look like a One, befriends Marlee, clashes with the ruthless Celeste, and on her first night tells Maxon to his face that she does not want him. He keeps her anyway, on the understanding that she will be his friend and tell him the truth about his country. What she tells him about hunger and the castes begins to change how he thinks about governing. Rebel attacks on the palace grow more frequent and more violent. Against her intentions America falls for Maxon, but before she can commit she finds Aspen serving in the palace guard. The Selection is cut to six, the Elite, with America among them and torn between both men.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -582,7 +582,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -595,7 +595,7 @@
       "recaps": {
         "ending": "Tony finally understands that the younger Adrian is not Veronica's son but her half-brother: Sarah Ford bore Adrian Finn's child after beginning a relationship with him. The child inherited his father's name and was born with significant disabilities. This discovery gives Sarah's small legacy to Tony the character of remorse or blood money. It also changes the meaning of Veronica's attempts to show Tony what happened. Tony rereads the cruel letter he sent after Adrian and Veronica became a couple and recognizes that his suggestion that Adrian consult Sarah may have helped bring them together. He cannot know exactly how his words affected Adrian's later suicide, but he can no longer preserve the harmless version of himself that his memories supported. Veronica withdraws after confirming that he has at last understood the family connection. The novel closes with Tony aware of damage, responsibility, and continuing uncertainty rather than the calm resolution he once associated with age.",
         "in_short": "Retired Tony Webster recalls his clever school friend Adrian Finn and his own uneasy relationship with Veronica Ford. After Tony and Veronica separate, Adrian asks permission to date her. Tony responds with a vicious letter, then learns that Adrian has died by suicide. Decades later, Veronica's mother Sarah leaves Tony money and Adrian's diary, though Veronica retains the diary itself. Tony pursues her for answers and gradually confronts the cruelty he had omitted from his preferred account. He first assumes that a disabled man named Adrian is the child of Adrian and Veronica. He eventually realizes the man is Sarah and Adrian's son, making him Veronica's half-brother. Tony's old letter had urged Adrian to seek Sarah's advice, leaving Tony to wonder whether his spite helped set the affair and its consequences in motion. His confidence in memory and his own innocence collapses, and the promised sense of order gives way to remorse and unrest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -921,7 +921,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1473581680",
@@ -933,7 +933,7 @@
       "recaps": {
         "ending": "The recovered archive reveals that the Russian cell altered a historical record to invent a third Klitsch brother. The original instead names Natalia Matusak, Henry Klostermann's mother, establishing the family line that leads the FBI to his daughter Diane Smith at Oak Ridge. Smith is detained while attempting to flee, but she does not cooperate. Reacher enters the bunker at Klostermann's former spy house, frees undercover Agent Fisher, and defeats Klostermann and the Russian operatives. Fisher survives and Sands takes her for hospital care. Klostermann admits killing Toni Garza and directing the operatives who killed Marty, then dies during the confrontation. John Goodyear arrives afterward and is exposed as Klostermann's Brotherhood ally and the detective who suppressed Garza's case. He remains handcuffed for the FBI and agrees to help identify connected extremist groups. Officer Rule withdraws her resignation and is positioned to seek his post. Rutherford is welcomed back by the town, and he and Sands retain Cerberus and the recovered archive work. Reacher accepts a ride toward Nashville. Speranski and the wider Russian network remain unresolved, as does the planned multi-state Brotherhood rally.",
         "in_short": "Jack Reacher intervenes when an organized team tries to abduct Rusty Rutherford, a fired town IT manager blamed for a ransomware disaster. Rutherford's experimental Cerberus system preserved an archive and a malware fragment on eight discarded servers. Reacher, Sarah Sands, and Rutherford recover the equipment and learn that Russian operatives want an old record capable of exposing their asset at Oak Ridge. Henry Klostermann, owner of a former Soviet spy house, buys a clone while secretly assisting the cell and organizing a neo-Nazi rally. The Russians forge a record to conceal Klostermann's daughter, Diane Smith, but the original exposes her and the FBI detains her. Reacher rescues undercover Agent Fisher from Klostermann's bunker, where Klostermann admits murdering journalist Toni Garza and ordering Marty's death. Klostermann dies, and John Goodyear is exposed as his Brotherhood collaborator. Rutherford regains the town's respect, Officer Rule pursues Goodyear's vacant post, and Reacher leaves toward Nashville.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1097,7 +1097,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1110,7 +1110,7 @@
       "recaps": {
         "ending": "The Kanes' plan comes down to destroying Apophis's shadow, the sheut, through the forbidden magic of execration, which could unmake even a being of pure chaos. With the reluctant, treacherous help of the ghost Setne and an uneasy alliance with the god Set, they learn to capture and target the serpent's shadow. In the climactic battle they combine the power of the aged sun god Ra, the gods bonded to them, and the magicians of the House of Life united under their uncle Amos, and Carter and Sadie execrate Apophis's shadow, banishing the serpent and saving the world from being swallowed by chaos. The triumph carries a lasting cost: to keep the balance of Ma'at, the gods agree to withdraw from direct contact with mortals and the House of Life, so the close partnership of gods and magicians must end. Walt, whose ancestral curse was killing him, survives by becoming the permanent host of Anubis, the god of the dead, a union that also settles Sadie's divided heart between the two. With Apophis defeated, the Kanes continue running Brooklyn House and training young descendants of the pharaohs. In a closing hint, they become aware of other, non-Egyptian powers stirring in the world, suggesting their story is only one corner of a larger age of returning gods.",
         "in_short": "With the chaos serpent Apophis loose and the ordered world in peril, Carter and Sadie Kane search for a way to destroy him for good. Their answer is a rare and dangerous magic: to attack Apophis's shadow, the sheut, and unmake it with a spell of execration. To learn the technique they enlist the treacherous ghost-magician Setne, who helps them even as he plots betrayal, and they seek the aid of the god Set, the very enemy from their first adventure. Along the way Walt, dying of an ancestral curse, and Sadie confront what his fate will mean for them. Combining the power of the frail sun god Ra, the gods within them, and the united magicians of the House of Life, the Kanes strike at Apophis's shadow and finally banish the serpent, restoring the balance of Ma'at. The victory comes at a price: the gods withdraw from close contact with mortals, and Walt survives only by merging with the death god Anubis to become his host. Brooklyn House and its training of young magicians go on, and the Kanes sense that other ancient powers are stirring in the world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1260,7 +1260,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1273,7 +1273,7 @@
       "recaps": {
         "ending": "Evelyn reveals that Monique's father James was Harry Cameron's lover and died in the car crash that also killed Harry. Harry had been driving after drinking; Evelyn moved James into the driver's position to protect Harry and then allowed James to be blamed. She chose Monique because she believed Monique was entitled to the truth and to decide how Evelyn would be remembered. Monique is furious, but she also understands the costly compromises around race, sexuality, fame, and family that shaped both their parents' lives. Evelyn has terminal breast cancer and has outlived Celia, Harry, and her daughter Connor. After their interviews end, Monique realizes Evelyn intends to die on her own terms; news soon arrives of her fatal overdose. Monique proceeds with the biography and publishes Evelyn's central truth: the love of her life was Celia St. James, not any husband. Having learned to demand control of her own story, Monique also ends her stalled marriage to David and moves forward in her career while holding both Evelyn's wrongdoing and her full humanity in view.",
         "in_short": "Magazine writer Monique Grant is chosen by film legend Evelyn Hugo to write her authorized biography. Evelyn recounts escaping poverty, reshaping herself for Hollywood, and using seven marriages to gain safety, publicity, family, or companionship. Her defining relationship is with actor Celia St. James, but prejudice, secrecy, jealousy, and Evelyn's ambitions repeatedly separate them. Producer Harry Cameron becomes Evelyn's closest friend and husband in a public arrangement; they raise a daughter, Connor, while Harry builds a life with Celia's partner John. After later marriages and losses, Evelyn and Celia reunite in Spain until Celia dies. Evelyn then tells Monique why she was selected: Monique's father James was Harry's lover and died in a crash caused by Harry, which Evelyn staged to blame James. Terminally ill and alone, Evelyn dies by overdose after completing the story. Monique writes the book, reveals Celia as Evelyn's true love, and claims greater authority over her own work and failing marriage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1439,7 +1439,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1452,7 +1452,7 @@
       "recaps": {
         "ending": "On his seventh journey, undertaken as an envoy for Caliph Harun al-Rashid, Sinbad completes his mission to the King of Serendib but is captured on the return voyage and sold into slavery. His master makes him hunt elephants. After the animals carry Sinbad to a hidden burial ground filled with ivory, the grateful merchant frees him and profits from the discovery without further killing. Sinbad returns to Baghdad with new wealth and reports the final adventure to the caliph. He then tells the porter that this was his last voyage: after seven cycles of prosperity, shipwreck, captivity, and rescue, he remains at home to enjoy the peace he repeatedly risked. The porter has now heard the source of Sinbad's fortune and continues to receive his host's generosity, closing the frame story with the two men on friendly terms.",
         "in_short": "A poor Baghdad porter is invited into the home of the rich merchant Sinbad, who explains his fortune by recounting seven voyages. Sinbad repeatedly leaves comfort for trade, only to face shipwreck, abandonment, monsters, captivity, and strange customs. He escapes a living island, uses a roc to reach a valley of diamonds, survives a one-eyed giant, flees cannibals, endures burial alive, defeats the Old Man of the Sea, and travels through a cavern to Serendib. His sixth journey makes him an intermediary between Serendib's king and Caliph Harun al-Rashid. Sent back as an envoy on the seventh, he is captured and enslaved, then wins freedom after elephants reveal their ivory burial ground. Each return leaves him wealthy but unable to resist another departure until the seventh ordeal finally cures his restlessness. Back in Baghdad, he ends the account in peace and friendship with the porter.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1612,7 +1612,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1625,7 +1625,7 @@
       "recaps": {
         "ending": "Each of the friends is transformed. In the Aiel Waste, Rand passes through the glass columns of Rhuidean, learns that his people were once oath-bound pacifists in service to the Aes Sedai, and comes out bearing a second Dragon mark and the title of Car'a'carn, He Who Comes With the Dawn. Some clans follow him; others, sickened by the truth he has exposed, will not. He also gains a bound teacher: the Forsaken Asmodean, shielded to a trickle of the Power, is forced to instruct Rand in how to wield saidin and survive it. Mat emerges from an ancient doorway changed, carrying the memories of dead men's wars, a spear, and a medallion that defends against the One Power. In the Two Rivers, Perrin throws back a great Trolloc assault and the interfering Children of the Light, marries Faile, and is acclaimed lord of his homeland. In Tanchico, Elayne and Nynaeve foil the Black Ajah's plot to seize an object that might have leashed Rand, and Nynaeve survives a harrowing clash with the Forsaken Moghedien. And in the White Tower, the Aes Sedai split apart as Elaida seizes the Amyrlin Seat, stills and imprisons Siuan Sanche, and drives loyal sisters into exile. The world is shifting fast around the Dragon Reborn, and old certainties are breaking on every side.",
         "in_short": "Rand leads a small company into the Aiel Waste to claim a prophesied place among its fierce warrior clans. Passing through the ancient glass columns of the city of Rhuidean, he learns the buried truth of the Aiel's origins and emerges marked as the Car'a'carn, the chief of chiefs foretold to unite them and to break them. Mat, drawn through a strange doorway, comes away with old battle memories, a black-hafted spear, and a talisman that turns aside the Power. Perrin, fearing for his home, returns to the Two Rivers with Faile, rallies the villagers against Trolloc raids and Whitecloak meddling stirred up by Padan Fain, wins the fight, marries Faile, and is hailed as their lord. Elayne and Nynaeve track the Black Ajah to the city of Tanchico and thwart their scheme to seize a device that could enslave the Dragon Reborn, while Nynaeve barely survives a duel with the Forsaken Moghedien. Far away, the White Tower tears itself apart as Elaida deposes and stills the Amyrlin Siuan Sanche and seizes power for herself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1724,7 +1724,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1737,7 +1737,7 @@
       "recaps": {
         "ending": "Andy escapes through a tunnel he excavated behind successive pinup posters, then crawls through a prison sewer and disappears. Using the false identity under which he had helped Warden Norton hide corrupt income, he withdraws the accumulated money and sends records of the scheme to the press. The resulting scandal ends Norton's career and exposes Shawshank's abuses. Red later receives a blank postcard from a Texas border town, confirming that Andy is free. After Red is paroled, he struggles with the disorientation that comes from spending most of his adult life in prison. He follows Andy's old directions to a Maine field and finds money and a letter inviting him to join Andy in Zihuatanejo, Mexico. Red breaks parole and travels south. The narrative ends before their reunion, with Red choosing uncertainty and hope over the safe routines of confinement.",
         "in_short": "At Shawshank prison, contraband supplier Red befriends Andy Dufresne, a banker serving life for two murders he says he did not commit. Andy survives assault, builds a respected prison library and becomes indispensable to guards who need financial help. Warden Samuel Norton forces him to conceal corrupt income. When prisoner Tommy Williams brings evidence identifying another killer, Norton suppresses it to keep Andy under his control. For years Andy has also asked Red for small items, including a rock hammer and posters. He uses the hammer to dig through his cell wall, hides the tunnel behind the posters and escapes through a sewer. He takes Norton's hidden money under a false identity and exposes the corruption. After parole, Red finds cash and an invitation Andy left for him in Maine. He violates parole and heads toward Mexico, sustained by the hope of seeing his friend again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1827,7 +1827,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1840,7 +1840,7 @@
       "recaps": {
         "ending": "At the Grand Challenge Sheepdog Trials, the unfamiliar sheep initially refuse to obey Babe. Help from Fly and the farm flock allows him to establish that he approaches sheep as a trusted equal rather than a predator. Once Babe addresses the trial flock in the manner sheep recognize, they cooperate. He guides them through the required course calmly and accurately, astonishing the judges and spectators. Babe and Farmer Hogget receive a perfect score and win the competition. The result proves Hogget's faith in the piglet and vindicates Babe's belief that respect can accomplish what intimidation cannot. Farmer and pig share a quiet acknowledgment of work well done, with Babe now accepted as a true sheep-pig.",
         "in_short": "Farmer Hogget wins a piglet at a fair and brings him home, where the border collie Fly adopts him and names him Babe. Fascinated by sheepdog work, Babe tries herding and discovers that sheep respond far better to his courtesy than to a dog's threats. The old ewe Maa helps him earn the flock's trust, while Hogget notices the piglet's ability and begins training him. Hogget eventually enters Babe in the Grand Challenge Sheepdog Trials despite widespread disbelief that a pig can compete. At the event, unfamiliar sheep initially ignore Babe. With help from Fly and the sheep at home, Babe gains their confidence and politely guides them through the course. He earns a perfect score, wins the trial for Hogget, and is recognized as a genuine sheep-pig.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1957,7 +1957,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1970,7 +1970,7 @@
       "recaps": {
         "ending": "After Port dies of typhoid at a remote French outpost, Kit abandons the protections of the foreign community and moves alone into the Sahara. She joins a caravan and becomes attached to the merchant Belqassim, traveling disguised as a boy and then living concealed in his household. The relationship that initially gives form to her flight becomes another kind of confinement. When her presence is discovered and the household turns against her, she escapes into the city. Representatives of the American consulate locate her and try to return her to the world she left, where Tunner is waiting. Kit flees from them before the reunion can occur. The novel closes without restoring her to her former identity or relationships: she disappears into the streets, psychologically dislocated and alone, while Tunner remains separated from her.",
         "in_short": "Port and Kit Moresby, an estranged American couple, travel through postwar North Africa with their affluent acquaintance Tunner. Port treats endless travel as an alternative to ordinary life, while Kit's anxiety and superstition sharpen as the party moves inland. Their companion's attraction to Kit, her sexual encounter with him, Port's solitary pursuits, and the theft of Port's passport deepen the couple's isolation. Port and Kit eventually leave Tunner behind and continue toward the Sahara, where Port contracts typhoid. Kit nurses him at a remote outpost, but he dies. She then flees alone into the desert, joins a caravan, and enters an intense relationship with the merchant Belqassim, who hides her in his household. After being discovered and driven out, she is found by consular officials but escapes before they can reunite her with Tunner. Kit vanishes into the city, severed from the life and identity with which she began the journey.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2193,7 +2193,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2206,7 +2206,7 @@
       "recaps": {
         "ending": "The elves invade the Chalk in force, and Tiffany meets them with everything she can gather: the witches, the Nac Mac Feegle, the goblins with their ironwork, the villagers and shepherds, Geoffrey's shed full of old men, Magrat in armour again, and the land itself, which knows her. Nightshade, who has learned in exile what it is to be on the receiving end of cruelty, turns against her own kind and is killed for it by Peaseblossom. Tiffany faces Peaseblossom herself and destroys him, and the elves are broken and driven back through the mound, with the way closed behind them and iron and machinery making the human world a place they can no longer easily enter. Afterwards the arrangements settle: Geoffrey takes over Granny Weatherwax's cottage and steading in Lancre and proves to be exactly the right person for it, so Tiffany is no longer trying to be the witch of two countries at once and can be wholly the witch of the Chalk. Nanny Ogg is left as the senior witch of the mountains, in her own quite different way. Preston comes home when he can, and Tiffany's future with him is understood without being settled. At the last, Tiffany takes the shepherd's crown, the small fossil out of the chalk that she has carried since the beginning, and puts it back into the ground on the downs where it belongs.",
         "in_short": "Granny Weatherwax, the senior witch of the Ramtops, sets her house in order, dies at a time of her own choosing, and leaves her cottage and her steading to Tiffany Aching. Tiffany, already stretched thin as the witch of the Chalk, tries to hold both countries at once and wears herself out doing it, while the witches argue about who should really have inherited. With Granny gone, the barrier that kept the elves out of the human world is weak, and Lord Peaseblossom deposes the elf Queen Nightshade and prepares an invasion. Nightshade, thrown out into a world full of iron, is taken in by the witches and slowly learns what it is like to be the one who is helpless. Meanwhile Geoffrey Swivel, a runaway young man who wants to be a witch, arrives in Lancre and turns out to have a real gift for calming trouble. The elves raid, then attack the Chalk outright. Tiffany gathers witches, Feegles, goblins, villagers, and the land itself, Nightshade dies turning against her own kind, and Tiffany destroys Peaseblossom and closes the way. Geoffrey takes Granny's steading, and Tiffany becomes wholly and only the Chalk's witch.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2351,7 +2351,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2364,7 +2364,7 @@
       "recaps": {
         "ending": "The Overlook's hold on Jack becomes total, and the thing wearing his shape hunts Wendy and Danny with a roque mallet, badly injuring Wendy. Danny, summoned to face his father, refuses to run and instead reminds the possessed man of the hotel's oldest chore: the boiler in the basement, whose pressure must be dumped daily or it will blow. Jack had forgotten it. For a moment the real Jack surfaces, tells his son he loves him, and sends him away before the hotel reclaims him and he rushes to the boiler too late. The pressure has climbed past saving, and the Overlook is torn apart in the explosion; Jack and the malevolent presence die together in the fire. Hallorann, who has driven and struggled through the blizzard from Florida, gets Wendy and Danny out on a snowmobile as the hotel burns. In a closing summer scene, the three are together at a Maine resort where Hallorann has taken work; Wendy is healing, and the cook comforts Danny, telling the grieving boy that he must go on living and feeling, and that his father's love for him was real even though the place destroyed him.",
         "in_short": "Jack Torrance, a recovering alcoholic writer with a history of violence, takes a job as winter caretaker of the remote Overlook Hotel in the Colorado mountains, bringing his wife Wendy and their five-year-old son Danny. Danny has a psychic gift, the shining, and the hotel's cook Hallorann, who shares it, warns the boy that the place holds dangerous echoes of its bloody past. Once the snow seals them in, the Overlook begins to work on the family, feeding on Danny's power and on Jack's weaknesses. Jack unravels, drawn deeper into the hotel's influence and its history, and finally, possessed, he attacks his wife and son with a mallet. Danny calls out to Hallorann, who fights back through a blizzard to reach them. In the end Danny stops his father by reminding the hotel's servant of the old boiler that Jack has forgotten to tend; the pressure builds until it explodes, destroying the Overlook. Jack dies with it, but Wendy, Danny, and Hallorann escape.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2475,7 +2475,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2488,7 +2488,7 @@
       "recaps": {
         "ending": "Riley leads the newborn army into a forest near Forks to wipe out the rival clan they have been trained to hate, but the attack goes disastrously wrong and almost every newborn is destroyed. Bree, terrified, surrenders and is taken in by the enemy clan, a family of vampires who live without hunting humans and who treat her with surprising gentleness and even offer to protect her. Their kindness comes too late. The Volturi, the ancient rulers of the vampire world, arrive to make sure their secret laws have been kept and to clean up what remains of the illegal army. Although one of the family pleads for Bree's life and offers to take responsibility for her, the Volturi refuse. On the order of the merciless young Volturi guard Jane, Bree is executed. Her creator's scheme has collapsed, the friend she made is gone, and Bree, who wanted only to survive, dies knowing the truth of what was done to her and the others.",
         "in_short": "This companion novella follows Bree Tanner, a teenage girl recently turned into a vampire and living among a violent band of newborns in Seattle. Kept in the dark and controlled by a young vampire named Riley, the newborns are fed, hidden by day, and told lies, including that sunlight will destroy them. Bree befriends the calmer, older newborn Diego, and together they discover that the sunlight rule is false: it only makes their skin sparkle. They realize the whole army is being built and manipulated by a mysterious red-haired vampire, working through Riley, to attack a rival clan. Diego vanishes, and Bree, frightened, keeps her discovery secret and stays close to the solitary, self-protecting Fred. Riley marches the newborns to a forest near Forks to destroy their enemies, but the ambush fails and nearly all of them are killed. Bree surrenders to the enemy clan, who show her unexpected mercy, but the ancient vampire rulers, the Volturi, arrive to enforce their laws. Despite an offer to spare her, the Volturi order Bree's execution, and her short second life ends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2833,7 +2833,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002VA9NZK",
@@ -2845,7 +2845,7 @@
       "recaps": {
         "ending": "Haven's offensive fails at its decisive points. Parnell returns from the disastrous Yeltsin operation to find President Harris, the cabinet, and the leading legislaturalist families dead after the palace attack. The People's Quorum establishes a Committee of Public Safety under emergency powers, and the new authorities arrest Parnell for treason. Rollins has also been defeated after the Hancock operation.\n\nAt Hancock, Admiral Danislav's arrival closes the trap on Chin's pursuit, but the defense costs more than twelve thousand lives. HMS Nike is badly damaged, Admiral Sarnow survives with grave wounds, and his later recovery is unknown. Parks endorses Honor's decision to retain effective control when a formal transfer would have left the survivors without usable command information. He removes Pavel Young from command and recommends his court-martial for cowardice and desertion after Warlock abandons the formation. Honor departs for Manticore aboard Nike, carrying Young under arrest. Her fitness for command has been demonstrated, but Nike faces months of repair, her next assignment is unsettled, the future of her relationship with Tankersley is not recorded, and the wider war continues under Haven's new regime.",
         "in_short": "After recovering from grave injuries, Honor Harrington returns to command aboard HMS Nike and becomes Admiral Sarnow's flag captain at Hancock Station. The People's Republic engineers frontier attacks to disperse Manticore's forces, while Manticore answers with a false withdrawal from Yeltsin and a hidden reinforcement. Haven commits to attacks at Yeltsin and Hancock. Sarnow's weaker Hancock force uses missile pods, deception, and mines to delay Admiral Chin until Admiral Danislav arrives, but Nike is crippled and Sarnow is gravely wounded. Honor assumes effective control, saves Nike and Cassandra, and refuses to let Pavel Young's unauthorized flight break the remaining formation. Haven's expected quick victory instead becomes a series of defeats. A conspiracy destroys the presidential palace, kills President Harris and the old government, and creates a Committee of Public Safety. Admiral Parnell is arrested for treason, while Parks approves Honor's command decision and sends Nike home with Young under arrest for cowardice and desertion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3030,7 +3030,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3043,7 +3043,7 @@
       "recaps": {
         "ending": "Will's improvised force takes Macindaw before the Scotti can turn it into the gateway for an invasion. Malcolm's staged effects and the reputation of Malkallam spread confusion, while Horace, Gundar's Skandians and Trobar provide the strength needed to penetrate and fight through the fortress. Alyss resists Keren's gemstone as the final struggle reaches her. Keren compels her to fire a crossbow at Will, but the mail he wears for the assault prevents the shot from killing him. Keren's control is broken and he is defeated. The Scotti plan collapses with the castle restored to its lawful side. Malcolm's treatment saves Orman and begins to restore Lord Syron, clearing away the false story that sorcery had destroyed the family. Will and Alyss are reunited, and their relief finally brings their feelings for each other into the open. Will completes his first major mission as a full Ranger with both the northern border and his friends safe, closing the continuous Macindaw story begun in The Sorcerer in the North.",
         "in_short": "Keren holds Castle Macindaw, Alyss and the northern gateway into Araluen, while Will has escaped with the poisoned Orman and Xander to Malcolm's refuge. With no army available in time, Will builds one from unlikely pieces: Horace, Malcolm's community and Gundar Hardstriker's Skandian crew. They combine reconnaissance, deception and Malcolm's theatrical version of sorcery with a physical assault through a hidden approach. Inside, Alyss struggles against Keren's blue gemstone, which he uses to extract information and weaken her will. Will's coalition enters the castle before Keren can deliver it to the Scotti. In the final confrontation Keren compels Alyss to shoot Will, but his mail prevents a fatal wound; her control is broken and Keren is defeated. Orman and Lord Syron recover under Malcolm's care, the invasion route is secured, and Will and Alyss acknowledge the love that their separation has made impossible to ignore.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3172,7 +3172,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3185,7 +3185,7 @@
       "recaps": {
         "ending": "With winter approaching and the Beaver clan preparing to move west, Saknis invites Matt to join them. Matt is deeply tempted because the Hallowells are many weeks overdue and life with Attean's people would be safer than remaining alone. He nevertheless stays at the cabin, believing he must keep his promise to his father and preserve the home built for his family. Attean, now treating Matt as a friend and equal, gives him a pair of snowshoes as a final sign of friendship. After the clan departs, Matt survives the early winter by using the skills Attean taught him. At last his father arrives with Matt's mother and surviving sister. The journey was delayed by illness, and a new baby died on the way. Matt is reunited with his family and discovers that he has become capable of sustaining them. He keeps the signs of Attean's friendship and understands that the Beaver people will not return to land increasingly occupied by settlers.",
         "in_short": "Twelve-year-old Matt Hallowell remains alone at his family's new Maine cabin while his father returns for the rest of the family. After a stranger steals his rifle and a swarm of bees nearly kills him, Saknis, an elder of the Beaver clan, saves him. Matt agrees to teach Saknis's grandson Attean to read English, though Attean resents the lessons and the colonial attitudes in Robinson Crusoe. In return, Attean teaches Matt how to hunt, find food, and move safely through the forest. Mutual suspicion becomes friendship, especially after they face danger together and Matt is welcomed at the Beaver village. When the clan must move west because settlers and trappers are taking over the region, Matt declines an invitation to go with them, choosing to wait for his overdue family. He survives into winter with what Attean taught him. His father finally returns with Matt's mother and sister after a journey marked by illness and the death of a new baby, and Matt takes his place as a capable member of the reunited family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3366,7 +3366,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3379,7 +3379,7 @@
       "recaps": {
         "ending": "The iron box recovered from the river is opened at Baker Street and found to be empty: during the chase Jonathan Small threw the Agra jewels overboard, a handful at a time, along miles of the Thames, so that no one should have what he was not allowed to keep. Watson takes the news to Mary Morstan, and because the fortune that would have separated them is gone he tells her he loves her; she accepts him, and the engagement is settled. Small then gives his full account. He lost a leg to a crocodile in India, served as a guard at Agra during the Mutiny, and with three Sikh soldiers killed a merchant's messenger for the jewels he was carrying, hiding them in the fort. The four were convicted of the murder and sent as convicts to the Andaman Islands, where Small bought his way toward freedom by telling Major Sholto and Captain Morstan where the treasure lay, on terms Sholto broke by taking the whole of it to England. Small escaped years later with Tonga's help, tracked Sholto down too late to confront him, and came for the treasure at last. He insists he did not want Bartholomew Sholto killed and struck Tonga for doing it. Small is taken away to face the charges, Athelney Jones receives the official credit, Watson has a wife, and Holmes, with nothing left to occupy him, reaches for the cocaine bottle.",
         "in_short": "Mary Morstan brings Sherlock Holmes a puzzle: her father vanished in London ten years ago, a stranger has sent her a valuable pearl every year since, and now that stranger wants to meet her. He proves to be Thaddeus Sholto, whose father served in India with Captain Morstan and came home with a stolen Indian treasure, concealing Morstan's sudden death during a quarrel over it. Thaddeus takes the party to his brother Bartholomew, who has just found the treasure hidden in the roof of the family house, and Bartholomew is found dead in a locked room, killed by a poisoned dart, with the treasure gone and a note signed the sign of the four. Holmes traces a wooden-legged convict, Jonathan Small, and his small Andaman Islander companion Tonga to a hired steam launch, and runs them down in a chase along the Thames. Tonga is shot and drowned, Small is captured, and the treasure has already been scattered into the river. Small confesses the whole history of the jewels and the betrayal behind them. Watson, freed of the barrier of Mary's inheritance, proposes to her and is accepted.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3546,7 +3546,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3559,7 +3559,7 @@
       "recaps": {
         "ending": "Alma settles permanently in Amsterdam and becomes a respected curator and authority on mosses. Her decades of observation lead her to an account of how species alter through competition and selection, but she withholds it because she cannot make apparently self-sacrificing human behaviour fit the system. The later work of Charles Darwin and Alfred Russel Wallace brings natural selection into print without her. Alma eventually understands that Prudence had devoted her life and resources to abolition, giving Alma a concrete example of the altruism that troubled her theory. In old age Alma meets Wallace. She accepts that scientific discovery did not require her authorship and debates his spiritual interests from her own materialist position. The novel closes with Alma elderly, recognized for the work she did publish and reconciled to the larger pattern of knowledge to which her private discoveries belonged; she does not regain Ambrose or establish a family, but neither is her life reduced to those absences.",
         "in_short": "Born in 1800 to a wealthy botanical trader and his formidable Dutch wife, Alma Whittaker grows into a brilliant but isolated botanist. Her adopted sister Prudence marries the man Alma first loves, while Alma builds a serious study of mosses. She later marries the mystical orchid artist Ambrose Pike, but their marriage is never consummated; after she sends him to manage the family's affairs in Tahiti, he dies there. Following her parents' deaths, Alma travels to Tahiti and learns from people who knew Ambrose that his inner and sexual life was unlike the one she imagined. An arduous encounter with the island's landscape gives her a new sense of life's relentless adaptation. She continues to Amsterdam, becomes a moss curator, and independently reasons toward natural selection, but does not publish because human altruism seems to contradict her model. Darwin and Wallace publish the idea instead. In old age she recognizes Prudence's abolitionism as the answer she had missed and meets Wallace, ending her life as an accomplished scientist at peace with having contributed without receiving the greatest discovery's credit.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3690,7 +3690,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3703,7 +3703,7 @@
       "recaps": {
         "ending": "Starling, working the case largely on her own after being pulled from it, traces Buffalo Bill through his very first victim and his knowledge of dressmaking, understanding at last that he has been killing women to sew a garment from their skin. Following the lead to a house in the Midwest, she comes face to face with the killer and, after he cuts the lights and stalks her in the dark with night-vision goggles, she shoots him dead just as he is about to kill her. In the cellar she frees his final captive, the senator's daughter Catherine, alive. Starling is quietly credited for the rescue and graduates as a full FBI agent, though the establishment around her remains grudging. Hannibal Lecter is still at large after his violent escape, having slipped away and assumed a new life abroad; he sends Starling a gracious, unsettling letter wishing her well and assuring her he has no intention of coming after her. Starling has survived her ordeal, saved a life, and earned her place, but she carries the knowledge that the most dangerous man she has met is loose in the world and thinking of her.",
         "in_short": "FBI trainee Clarice Starling is sent by Jack Crawford to interview the imprisoned killer Hannibal Lecter, ostensibly for a psychological survey but really to draw his insight into an active serial murderer nicknamed Buffalo Bill, who abducts young women and skins them. Lecter offers cryptic help only in exchange for details of Starling's painful past, and their interviews become a duel of minds. When Bill kidnaps the daughter of a US senator, the pressure to find her alive becomes enormous. Lecter, using the case as leverage, negotiates a transfer and then escapes in a bloody breakout, killing his guards and vanishing. Taken off the case, Starling keeps pulling at a thread Lecter pointed her toward, tracing the killer through his connection to his first victim and his skill with sewing. She realizes what he is making, and following the trail alone, she reaches his house, descends into his darkened cellar, and kills him, saving the senator's daughter. Starling graduates as an agent, and Lecter, still free, sends her a courteous note.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3893,7 +3893,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3906,7 +3906,7 @@
       "recaps": {
         "ending": "Cadderly cannot permanently destroy Crenshinibon before Jarlaxle's agents take it from the Spirit Soaring. The shard begins working on Jarlaxle's ambition, giving the drow mercenary a new source of power and leaving the artifact in dangerous hands. In Calimport, Artemis Entreri has climbed through the Basadoni guild and helped Bregan D'aerthe establish a surface empire, but achievement and another clash with Drizzt do not supply the certainty he expected. Drizzt and Entreri both survive their renewed contest, and Jarlaxle keeps Entreri close as the drow withdraws with the shard. The companions therefore fail in the mission that brought them south. More personally, Wulfgar accepts that he cannot recover by resuming his old place beside Catti-brie and Drizzt. He separates from the companions and goes to Luskan, where drink and violence offer temporary escape from his memories. His family remains willing to help, but he begins the next stage of his life alone, carrying Aegis-fang and the unresolved effects of Errtu's imprisonment.",
         "in_short": "After rescuing Wulfgar from six years in Errtu's hands, the Companions of the Hall carry the recovered Crystal Shard south to Cadderly's Spirit Soaring in hopes of destroying it. Wulfgar travels with them but cannot settle back into his former life: captivity has left him with nightmares, sudden violence and a painful awareness that Drizzt and Catti-brie became partners while he was gone. In Calimport, Jarlaxle restores the dispirited Artemis Entreri to the city's underworld, where the assassin infiltrates the Basadoni guild and rises through calculated killings. Crenshinibon senses Jarlaxle's ambition and draws Bregan D'aerthe toward it. Cadderly's attempt to end the artifact fails, and Jarlaxle's agents steal it, leaving the mercenary leader under its growing influence. Drizzt and Entreri meet again without resolving the emptiness driving the assassin; both live. Wulfgar finally leaves his friends and goes to Luskan, choosing distance over an impossible return to the man he was.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4080,7 +4080,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4093,7 +4093,7 @@
       "recaps": {
         "ending": "Alicia recognizes Theo as the masked man who invaded her home. Years earlier, after discovering that his wife Kathy was having an affair with Gabriel, Theo followed Gabriel, entered the Berensons' house in disguise, tied up the couple, and forced Gabriel to choose between his own death and Alicia's. Gabriel chose to save himself. Theo left without shooting either of them, but Alicia, devastated by Gabriel's betrayal, killed him. When Alicia communicates that she knows Theo's identity, he injects her with enough morphine to leave her in a coma and tries to redirect suspicion toward another patient. Alicia has already recorded the truth in her diary. Chief Inspector Allen obtains it and visits Theo, who understands that the account will expose both the original break-in and his attack at the Grove. Snow falls outside as Theo awaits the consequences, echoing the peaceful memory with which he began his narrative.",
         "in_short": "Psychotherapist Theo Faber joins the Grove psychiatric unit to treat Alicia Berenson, a painter who stopped speaking after shooting her husband Gabriel. He lowers her medication, studies her diary, and investigates relatives and friends while his own marriage deteriorates after he discovers his wife Kathy's affair. Alicia eventually speaks and describes a masked intruder who tied up the couple and forced Gabriel to choose which of them should die; Gabriel chose himself, and Alicia then killed him. Theo is the intruder. He had followed Kathy's lover, Gabriel, and staged the confrontation as revenge, unknowingly recreating Alicia's deepest fear of being sacrificed. When Alicia recognizes him, Theo gives her a morphine overdose that leaves her comatose. He believes he has concealed the crime, but Alicia's diary names him. Inspector Allen brings Theo the recovered account, and Theo realizes that his arrest is imminent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4254,7 +4254,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4267,7 +4267,7 @@
       "recaps": {
         "ending": "The First Age ends with the War of Wrath, in which the powers of the West overthrow Morgoth, break his strongholds, and cast him out of the world into the void. Of the three Silmarils, one is lost into the sea, one into the depths of the earth, and one kept aloft in the sky with the mariner Earendil, becoming a bright star of hope. The oath sworn over the jewels destroys nearly all who bound themselves to it. The surviving Elves diminish and many depart over the sea, while the age of Men begins. The book then carries the history further, telling of the rise and drowning of the island kingdom of Numenor and, in its final part, of the forging of the Rings of Power and the long shadow of Morgoth's servant Sauron, linking these ancient legends to the later age of The Lord of the Rings.",
         "in_short": "The Silmarillion recounts the mythic history of the world from its making to the end of its First Age. After the world is shaped by the music of the angelic Ainur, the rebellious power Morgoth corrupts and darkens it. The Elf Feanor crafts the Silmarils, three jewels holding a holy light; when Morgoth steals them and destroys the light of the world, Feanor and his people swear a terrible oath to reclaim them and pursue Morgoth back to Middle-earth, an act stained by kin-slaying and doom. Across long wars the Elves and their mortal allies fight Morgoth and are gradually broken. Amid the ruin come the great legends: Beren and Luthien, who together wrest a Silmaril from Morgoth's crown, and the tragic Turin, undone by a curse. At last the mariner Earendil sails to plead with the powers of the West, who come in force, cast Morgoth down, and end the First Age, though the world is forever changed and diminished.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4389,7 +4389,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4402,7 +4402,7 @@
       "recaps": {
         "ending": "The travellers free Prince Rilian at the fourth sign, and he destroys the silver chair that held his enchantment. The Witch nearly talks all four of them back into believing that Narnia, the sun and Aslan are only dreams; Puddleglum stamps out her enchanted fire and declares that he will live as a Narnian even if there is no Narnia, which breaks her spell. She takes her true shape as a great green serpent, the same that killed Rilian's mother, and Rilian kills her. Her collapsing kingdom floods, but the earthmen she had enslaved are freed and go gladly back down to their own country of Bism, and the travellers dig their way out into Narnia in the middle of a midnight snow dance. Rilian rides to Cair Paravel and reaches his father just as the old king comes ashore; Caspian sees his son again and dies. Aslan takes Jill and Eustace to his own country, where Caspian is restored to life in a stream by a drop of the Lion's blood and is allowed a few minutes in England before staying there. Aslan then brings the two children back to Experiment House with him, breaks down the wall and routs the school gang, and the resulting scandal ends with the Head removed from the school and eventually made an Inspector, and then a Member of Parliament. Eustace and Jill remain friends for life.",
         "in_short": "Jill Pole and Eustace Scrubb, hiding from the bullies at their school, call on Aslan and are let into Narnia to find Prince Rilian, King Caspian's son, who vanished ten years earlier. Aslan gives Jill four signs to follow, and they mishandle the first almost at once. With the pessimistic Marsh-wiggle Puddleglum as their guide, they travel north into giant country, are advised by a lady in green to seek comfort at the castle of Harfang, and, distracted by the promise of hot baths and beds, walk straight over the ruined giant city they were meant to search and miss the message written on it. At Harfang they discover they are on the menu and escape underground, where they are taken through a sunless country to a city ruled by a queen and meet a young man who is bound nightly to a silver chair. When he calls on Aslan's name they free him: he is Rilian. The Witch's attempt to enchant them all is broken by Puddleglum, she is killed in her serpent form, and her kingdom falls. Rilian reaches his dying father in time; Caspian is restored to life in Aslan's country, and the children are returned to their school with Aslan at their back.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4574,7 +4574,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4587,7 +4587,7 @@
       "recaps": {
         "ending": "Tiffany and Pat complete the dance competition and achieve the score needed for the wager tied to the Eagles, rescuing Pat's father from his latest gambling risk. Tiffany then admits that Nikki has not been writing to Pat: Tiffany intercepted his letter and composed the replies herself. She eventually gives Pat a chance to see Nikki. Her fear and desire for distance force him to understand what his blocked memories have concealed: he found Nikki with another man, nearly beat that man to death, and has been separated from her for years under a restraining order. The reunion he has treated as the guaranteed ending of his life story will not happen. Pat's resulting crisis does not return him to his starting point. Tiffany searches for him, and he recognizes the loyalty and understanding she has offered throughout their training. He lets go of Nikki and accepts his attachment to Tiffany. Their relationship begins with mutual knowledge of grief and mental illness rather than a promise that either is cured. Pat remains in recovery, but he can finally live in the present instead of organizing every action around an imagined restoration of the past.",
         "in_short": "Pat Peoples leaves a psychiatric hospital convinced that disciplined exercise, kindness, and reading Nikki's favorite books will end their temporary separation. At home, his family avoids explaining the violent crisis and lost years he cannot remember. Widowed Tiffany Webster offers to deliver a letter to Nikki if Pat becomes her partner for a dance competition. Their intense training gives both structure and companionship, while Pat's father's Eagles obsession and gambling raise the stakes. Tiffany secretly writes the replies Pat believes come from Nikki. After the dance, she confesses and arranges for him to see his estranged wife. Nikki's fear restores Pat's memory: he assaulted the man he found with her, and their marriage is over under a restraining order. Tiffany's deception hurts him, but her persistent care also shows him a relationship grounded in his present self. Pat finally releases the fantasy of reunion with Nikki and turns toward Tiffany, still managing mental illness but able to imagine a future that is not a repaired version of his past.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4712,7 +4712,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4725,7 +4725,7 @@
       "recaps": {
         "ending": "After surviving occupied Poland and the chaotic movement of refugees across postwar Europe, Ruth, Edek, Bronia, and Jan reach Switzerland. The silver paper knife that Jan guarded has served as a tangible link to Joseph Balicki and to the family's promise that they would seek one another there. Joseph and Margrit are reunited with their three children, ending years of uncertainty about who had survived. Edek arrives seriously weakened by illness and the effects of imprisonment, but he is finally able to receive care rather than continue travelling. Jan, who began as a solitary child living by theft in the ruins, is welcomed alongside the Balickis instead of being left without a family. The journey closes with the children safe and the separated household restored. Their old life in Warsaw cannot be recovered, but Switzerland offers them a home in which Ruth no longer has to carry sole responsibility for everyone and the younger children can begin ordinary lives again.",
         "in_short": "When Polish headmaster Joseph Balicki is imprisoned by the Germans, his wife is deported and their children Ruth, Edek, and Bronia are left to survive in Warsaw. Joseph escapes but finds the family home destroyed. He meets the orphan Jan, entrusts him with a silver paper knife from the ruins, and heads toward Switzerland in hope of finding his wife. Ruth keeps Bronia safe, while Edek is captured for smuggling. After the war, Ruth and Bronia join Jan and travel west, following Joseph's message and searching for Edek. They find Edek alive but ill and continue together through a Europe crowded with soldiers, borders, and displaced people. Jan's resourcefulness repeatedly helps the group, while Ruth holds it together. The children finally reach Switzerland, where Joseph and Margrit are waiting. The Balicki family is reunited, Edek can recover, and the formerly solitary Jan is accepted into the family as well.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4892,7 +4892,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4905,7 +4905,7 @@
       "recaps": {
         "ending": "On Titan, Rumfoord explains that Tralfamadorian influence has steered human civilization so that a tiny replacement part could eventually reach the stranded messenger Salo. The needed part is Chrono's metal good-luck piece. Rumfoord and Kazak are swept away as the solar disturbance sustaining their materializations changes. Salo, grieving for Rumfoord, dismantles himself, but Malachi later restores him. Beatrice spends her remaining life writing and dies on Titan, while Chrono rejects human society and lives among Titan's birds. Salo offers to return Malachi to Earth. Now old and calling himself Malachi Constant again, he chooses Indianapolis, where he arrives during winter and freezes while waiting for a bus. At the moment of death, Salo mercifully gives him a vision of Stony Stevenson welcoming him and assuring him that he has passed a final test.",
         "in_short": "Winston Niles Rumfoord, spread through space and time after entering a chrono-synclastic infundibulum, predicts that wealthy Malachi Constant will travel from Earth to Mars, Mercury, back to Earth, and finally Titan. Malachi loses his fortune, is taken into the Martian army, has his memory erased, and lives as the soldier Unk. He discovers that he was manipulated into killing his friend Stony and escapes with Boaz to Mercury. After Mars's deliberately doomed invasion of Earth, Rumfoord founds a religion of divine indifference and exposes Unk, Bee, and their son Chrono as Malachi and Beatrice's family. Exiled to Titan, they learn that human history has been manipulated by the alien Tralfamadorians to deliver a small repair part to their stranded messenger Salo. Beatrice dies on Titan and Chrono remains there. Salo returns the elderly Malachi to Earth, where he freezes to death but receives a consoling final vision of Stony welcoming him into the afterlife.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5254,7 +5254,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -5267,7 +5267,7 @@
       "recaps": {
         "ending": "Ruwen survives the Infernal god's mental and physical attacks, but must break his Shadow Steps oath to protect his meridians. When the god seals him in an inescapable bubble, Ruwen solidifies his core, empties his pathways, and performs the sixth rune. The passage frees him but badly injures his core and meridians, and Overlord does not return from searching for Uru's hidden fragment. Ruwen reaches Blapy in the Third Secret, a surviving divine realm that holds the universe's spirit. This discovery means restoring that spirit need not destroy Grave or its people. Blapy offers Ruwen a safe path to divinity over thousands of years, but he refuses to abandon his friends. He accepts Penn's Apocalypse Hoop, which cannot open until Ruwen has a divine aura, and leaves before fully healing. A journal narrator stays with Blapy as an independent companion. Ruwen returns to a meditation gathering and finds Sift alive. Eiru's revolt and mine crisis remain unresolved, the Bamboo Viper judgment still awaits Ruwen and Sift, Echo's allegiance remains uncertain, and her father survives with a route back into Ruwen's mind and possession of the missing journal.",
         "in_short": "Ruwen Starfield spends more than a year stranded at Rainbow's End, where he develops his Architect abilities, trains with Overlord, and closes the time loop that enables Hamma, Rami, Sift, Lylan, Xavier, and Shelley to find him. On the voyage home, Ruwen reaches Peak Diamond and helps Xavier become an adult celestial remnant. Uru reveals that Ruwen himself is the sixth rune, a key across impossible distances. Back near Eiru, Rami evolves and Ruwen regains his Ink Lord standing, but Echo abducts him before the Bamboo Viper clan can judge his and Sift's recreated Grandmaster paths. Ruwen escapes an Infernal prison, defeats armies and aspects, survives Echo's father, and performs the sixth rune to escape at severe spiritual cost. Blapy receives him in the hidden Third Secret, where the universe's spirit remains preserved. Ruwen rejects millennia of safe isolation, takes Penn's sealed Apocalypse Hoop, and returns injured but alive to Sift, while Overlord and Uru's fragment remain missing.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5546,7 +5546,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5559,7 +5559,7 @@
       "recaps": {
         "ending": "The collection's last major story leaves Ichabod Crane's disappearance open to two readings. Sleepy Hollow's believers attribute it to the Headless Horseman, while a shattered pumpkin and Brom Bones's knowing reaction point to a prank; Brom marries Katrina, and a later report places Ichabod alive and successful elsewhere. In the closing L'Envoy, Crayon steps away from the individual sketches and takes leave of his reader, acknowledging the miscellaneous form of the volume and the personal associations behind it. There is no single continuing plot to resolve: the traveler remains an observer moving between Britain and America, and the book closes with its central tension intact, valuing inherited traditions while repeatedly showing how memory, storytelling, and change reshape them.",
         "in_short": "Geoffrey Crayon's collection combines travel observations, reflections on books and history, social sketches of England, and fictional tales rooted in old traditions. Crayon crosses the Atlantic, visits literary and historic sites, studies rural customs, spends Christmas with the Bracebridge family, and considers relations between Britain, America, and Indigenous peoples. The best-known American tales follow Rip Van Winkle, who sleeps through twenty years and the Revolution before returning to his grown daughter, and Ichabod Crane, whose pursuit by a headless rider is probably a prank by his successful romantic rival, Brom Bones. A German ghost story similarly lets apparent supernatural terror conceal human action. Across the volume, old buildings, ceremonies, books, and local legends preserve the past but cannot prevent social and political change. The closing envoy takes leave of the reader without resolving the collection into a single plot.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5699,7 +5699,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5712,7 +5712,7 @@
       "recaps": {
         "ending": "Violet, Klaus, and their new ally Quigley Quagmire, the third triplet who turns out to be alive, rescue Sunny from Count Olaf's mountain camp and reunite the family. Along the way they uncover much about the secret organization V.F.D., learn its motto that the world is quiet here, and discover that a sought-after object called the sugar bowl is central to the conflict between the organization's noble and villainous factions. They also learn that two frightening, powerful villains, feared even by Olaf, have entered the fight, and that surviving allies and enemies alike are converging on a distant gathering. As the children escape, Quigley is separated from them, carried off down the Stricken Stream, and the friends part with a promise to reunite at the last safe place. The three Baudelaires, together again, leave the mountains determined to reach that meeting, find any surviving members of V.F.D., and continue unraveling the secret that has shaped their lives.",
         "in_short": "Violet and Klaus survive the runaway caravan and land in the frozen Mortmain Mountains, while Sunny remains a captive of Count Olaf's troupe camped higher up, forced to cook and secretly spying. Climbing toward the ruined V.F.D. headquarters, the older siblings meet Quigley Quagmire, the third triplet long thought dead, who has survived and been seeking the same place. Together they uncover clues about V.F.D. and a coveted object called the sugar bowl, and learn a motto, that the world is quiet here. Two powerful new villains, a man with a beard but no hair and a woman with hair but no beard, arrive and are feared even by Olaf, plotting against a troop of Snow Scouts that includes the cruel Carmelita Spats. Violet, Klaus, and Quigley rescue Sunny, reuniting the family, but Quigley is swept away down the Stricken Stream, and the friends part with a promise to meet at the last safe place.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5842,7 +5842,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5855,7 +5855,7 @@
       "recaps": {
         "ending": "Gerda reaches the Snow Queen's palace and finds Kai nearly frozen, unable to recognize her, and occupied with arranging pieces of ice into a puzzle. Her tears warm him and wash the mirror splinter from his eye, while his own tears free the piece lodged in his heart. He remembers her, and their joy completes the puzzle, winning the freedom the Snow Queen had promised him. They leave the palace together and retrace Gerda's route south, learning what became of several friends who helped her. When they finally return home, they discover that they have grown up, although their love and sense of wonder remain. Sitting beside the familiar roses, they understand the grandmother's hymn about entering heaven with the trusting spirit of a child.",
         "in_short": "A malicious mirror makes goodness appear ugly, and fragments of it scatter across the world. Two pieces strike Kai, changing him from Gerda's loving friend into a cold and mocking boy. The Snow Queen takes him to her northern palace, where he forgets Gerda and struggles with a puzzle made from ice. Gerda journeys in search of him, escaping an enchanted garden and receiving help from a crow, a prince and princess, a robber girl, a reindeer, and wise women of the far north. She enters the Snow Queen's palace without weapons or magic. Her warm tears reach Kai's frozen heart and remove the mirror's influence, restoring his memory and love. The two return home together, now grown, with their childhood bond intact.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5982,7 +5982,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5995,7 +5995,7 @@
       "recaps": {
         "ending": "Gerda enters the Snow Queen's deserted palace and finds Kay nearly motionless over pieces of ice, still trying to form the word that is supposed to win his freedom. Her warm tears reach him and dislodge the mirror splinter in his heart; when he recognizes her and weeps, the fragment in his eye is washed away as well. The pieces of ice arrange themselves into the required word, so Kay is free to leave even before the Snow Queen returns. The children travel south with help from the friends Gerda made on her outward journey. By the time they reach their neighboring homes, they have grown older, yet their recovered love has preserved the openness they had as children. They sit again near the roses and their grandmother, understanding the familiar hymn in a deeper way. Summer has returned, ending the Snow Queen's hold over Kay and completing Gerda's long movement from home into the frozen north and back.",
         "in_short": "A malicious mirror that makes everything good appear worthless shatters across the world. Splinters enter the eye and heart of a boy named Kay, turning him cruel and cold. The Snow Queen carries him from his home and his friend Gerda to her palace in the far north. Gerda sets out after him and passes through an enchanted garden, a royal palace, a robbers' camp, Lapland, and Finland. A crow, a robber girl, and a reindeer help her continue, while a wise Finn woman explains that Gerda needs no power beyond the loving resolve she already possesses. In the Snow Queen's palace, Kay cannot complete the icy puzzle that would release him. Gerda's tears melt the fragment in his heart, his own tears clear his eye, and he remembers her. The ice forms the required word, and they travel home together, older in body but restored in affection as summer returns around their roses.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6085,7 +6085,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6098,7 +6098,7 @@
       "recaps": {
         "ending": "After the flight and the winter celebration, the Snowman carries James back through the night sky and leaves him safely at home. James returns to bed with the keepsake Father Christmas gave him, proof to him that the journey was more than a dream. Morning brings warmer weather. James hurries outside to greet his friend but finds that the Snowman has melted, leaving only the borrowed hat, scarf, and other objects on the ground. The gift from the night remains, allowing James to hold both the wonder of the friendship and the sadness of its brief life.",
         "in_short": "After heavy snow falls, James spends the day building a snowman in his garden and gives it a face and clothing from household objects. At midnight the Snowman comes alive. James secretly welcomes him into the house, where each explores the other's world, before the Snowman takes James flying across the countryside. They reach a gathering of snowmen and meet Father Christmas, who gives James a keepsake. The Snowman flies him home before dawn. When James wakes the next morning, the weather has changed and his friend has melted, but the gift from Father Christmas remains as evidence of their night together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6272,7 +6272,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6285,7 +6285,7 @@
       "recaps": {
         "ending": "The collection closes with \"The Short Happy Life of Francis Macomber.\" After fleeing from a wounded lion, Francis returns to the hunt and discovers genuine confidence while pursuing buffalo. His new fearlessness changes the balance of his marriage: he no longer seems controllable through Margaret's contempt or the threat that she will leave him. A wounded buffalo charges Francis as he stands his ground with Robert Wilson. Margaret fires from the car, intending at least ostensibly to stop the animal, but the bullet strikes Francis in the head and kills him. Wilson's response preserves the uncertainty over whether the shot was an accident, a panicked attempt to help, or something more deliberate. He taunts Margaret with the possibility of legal trouble and then tells her he will stop tormenting her. Francis's period of courage is therefore both real and extremely brief, ending at the moment it might have transformed his life.",
         "in_short": "These ten stories place people under pressure from death, loneliness, injury, professional decline, and damaged intimacy. A dying writer on safari mistakes a final vision of rescue for reality; an older waiter finds temporary shelter from despair in a clean, lighted café; and a feverish boy needlessly prepares himself to die because he confuses temperature scales. Hospital patients, wounded soldiers, threatened men, and fighters near the end of their careers seek dignity through belief, routine, silence, or technical skill. Nick Adams appears both as a traumatized veteran and as a father sorting through memories of his own father. In \"Fifty Grand,\" an aging boxer sacrifices sporting pride to financial calculation. The final story follows Francis Macomber from humiliating panic to a sudden, liberating courage during a buffalo hunt. At the instant he stands firm against the charging animal, a shot fired by his wife strikes and kills him, leaving her intention unresolved and making his recovered self-respect tragically short-lived.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/the-son-of-neptune.json
+++ b/data/works-community/0/the-son-of-neptune.json
@@ -81,7 +81,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -94,7 +94,7 @@
       "recaps": {
         "ending": "The quest succeeds: in the frozen land of Alaska, beyond the reach of the gods, the three heroes break the chains binding Thanatos, the god of death, whom the giant Alcyoneus had imprisoned to keep monsters and the dead from ever staying dead. Hazel faces and accepts her hidden history, and Frank comes into his full strength as a son of Mars with a rare shapeshifting gift, though his life remains tied to a scrap of firewood he must protect. They defeat Alcyoneus and hurry south to find Camp Jupiter under siege by the giant Polybotes and an army of monsters. Together with the legion they win the battle, and Percy's memory is fully restored. In honor of their deeds, both Frank and Percy are raised to praetor. As the fighting settles, the Argo II, the Greek warship built by Leo, arrives over Camp Jupiter carrying Jason, Piper, Leo, and Annabeth. Greeks and Romans stand before one another for the first time, uneasy but united by need, for the Doors of Death remain open and Gaea is still rising. Percy and Annabeth are reunited, and the seven demigods of the prophecy must now sail together toward the ancient lands.",
         "in_short": "Percy Jackson, his memory erased except for the name Annabeth, is chased by monsters to Camp Jupiter, the hidden camp of Roman demigods. There he befriends Hazel, a daughter of Pluto with a secret past, and Frank, a shy son of Mars. Guided by the goddess Juno, the three are sent north to Alaska to free Thanatos, the god of death, who has been chained by a giant so that slain monsters can no longer die and stay dead. Along the way Hazel confronts the truth that she once lived, died, and was returned to the world, and Frank learns his life is bound to a fragile piece of firewood. They reach Alaska, release Death, and defeat the giant Alcyoneus. Racing back, they save Camp Jupiter from an invading army of monsters and giants. Percy's full memory returns, Frank and Percy are made praetors, and at the very end a Greek warship, the Argo II, descends on the Roman camp carrying Jason, Piper, Leo, and Annabeth, bringing the two camps face to face at last.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -217,7 +217,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -230,7 +230,7 @@
       "recaps": {
         "ending": "The fulfillment of Achilles's prophecy destroys everyone Patroclus loves. When Agamemnon takes Briseis from Achilles to humiliate him, Achilles withdraws his men from the fighting in wounded pride, and the Greeks are cut down in droves. Patroclus, unable to bear the slaughter, persuades Achilles to let him wear the hero's armor and lead the Myrmidons to drive the Trojans back. He succeeds, but in his triumph he is killed by Hector, prince of Troy. Achilles is shattered. He returns to the war consumed by grief and rage, kills Hector in revenge, and desecrates his body, knowing full well that his own death is fated to come close on Hector's. Achilles refuses to allow Patroclus's remains to be buried apart from his own. Soon he too is killed, struck down by Paris's arrow. Their ashes are mingled together. The final threads are resolved after both are dead: Achilles's son by Deidameia, Pyrrhus, is cruel and refuses to honor Patroclus, and Patroclus's shade lingers unremembered until Thetis, who spent Patroclus's life despising him, finally understands what he meant to her son. She relents and sees that Patroclus's name is added to Achilles's tomb, so that the two are reunited at last, together in death as they were in life.",
         "in_short": "Patroclus, an exiled and unpromising young prince, is fostered in Phthia, where he becomes the chosen companion and then the lover of Achilles, the half-divine son of a king and a sea-goddess, destined to be the greatest warrior of his age. They grow up together, schooled by the centaur Chiron, shadowed by a prophecy that Achilles will win eternal glory only by dying young at Troy. When Helen is taken and the Greek kings gather for war, Achilles's mother Thetis hides him disguised among women on Scyros, but the cunning Odysseus exposes him and he goes to war. The Greeks muster at Aulis, where Agamemnon sacrifices his own daughter for a favorable wind, and the fleet sails to a siege that lasts ten years. Achilles is the army's greatest fighter while Patroclus keeps to healing. When Agamemnon seizes Achilles's war-prize Briseis, the enraged Achilles withdraws from battle and the Greeks are slaughtered. Unable to watch, Patroclus dons Achilles's armor to rally them and is killed by the Trojan prince Hector. Broken by grief, Achilles avenges him by killing Hector, knowing his own death must follow, and is soon slain by Paris. Their ashes are mixed, and after Thetis at last relents, their names are joined so they remain together beyond death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -417,7 +417,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -430,7 +430,7 @@
       "recaps": {
         "ending": "Famine and bitter winter bring tragedy to Hiawatha's lodge. Minnehaha weakens and dies despite Hiawatha's desperate search for food, and he mourns her burial beneath the snow. In spring, Iagoo reports the arrival of strangers in a great canoe. Hiawatha welcomes the European missionary and his companions, receives their account of Christian teaching, and urges his people to listen hospitably. He then tells Nokomis that his work is finished. Launching his canoe westward, he travels into the sunset and departs for the land beyond the north-west wind. The poem closes with his community watching him disappear, left to encounter the new faith and the historic changes represented by the newcomers.",
         "in_short": "Hiawatha, grandson of Nokomis and son of the West-Wind, grows into a culture hero who seeks to strengthen and unite his people. He gains corn through his contest with Mondamin, befriends the musician Chibiabos and the strong Kwasind, builds a swift canoe, defeats dangerous beings, and brings home wampum. He marries Minnehaha, teaches practical arts, and creates picture-writing. Loss increasingly overtakes his achievements: Chibiabos and Kwasind die, Pau-Puk-Keewis rebels and is transformed, and ghosts warn of hardship. During a severe winter Minnehaha dies of famine. When European missionaries arrive in spring, Hiawatha welcomes them and advises his people to hear their message. Believing his own mission complete, he leaves alone in his canoe and passes westward into the sunset.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -543,7 +543,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -556,7 +556,7 @@
       "recaps": {
         "ending": "The Magellan completes its replacement ice shield and resumes its centuries-long voyage to the world where its sleeping passengers are meant to found a new human settlement. Loren leaves with the ship, accepting that duty and distance make a shared life with Mirissa impossible. Mirissa remains on Thalassa with Brant and later bears Loren's child, a living connection between the last people of Earth and the colony that Earth seeded long before its destruction. Moses Kaldor remains behind on Thalassa rather than continue the voyage. The Thalassans also face the discovery that their oceans contain tool-using native creatures, making protection and coexistence a new responsibility. Long after the departure, the travelers retain messages and memories from Thalassa while heading onward; the brief meeting has changed both communities even though they cannot remain together.",
         "in_short": "Thalassa is a peaceful ocean colony founded centuries earlier by an unmanned seedship and cut off from later news of Earth. Its isolation ends when the starship Magellan arrives carrying the last refugees from Earth, most of them asleep, toward a more distant destination. The ship must replace its eroded ice shield using Thalassa's water, forcing the visitors and colonists to live and work together. Earth-born crewman Loren Lorenson and Thalassan Mirissa Leonidas fall in love despite her bond with Brant and the certainty that Loren must leave. The visitors bring proof of Earth's destruction, while Thalassa reveals a future humanity did not plan: intelligent tool-using life may be emerging in its seas. The shield is rebuilt and Magellan continues its mission. Loren departs, Moses Kaldor stays, and Mirissa remains with Brant, later bearing Loren's child as a bond between the two separated human communities.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -746,7 +746,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -759,7 +759,7 @@
       "recaps": {
         "ending": "Will discovers that there is no sorcerous attack on Macindaw. Malcolm is a healer sheltering people whom superstition has driven out, and Orman has secretly been seeking his help for Syron. The real conspiracy belongs to Keren, who has encouraged fear of Orman while poisoning both Syron and his son. Will gets the stricken Orman and Xander out through a hidden route and takes them to Malcolm, but Alyss remains inside the castle so their investigation will not appear to have collapsed. Keren moves before she can escape: he seizes Macindaw with loyal men, takes Alyss prisoner and prepares to surrender the stronghold to a Scotti force. He also possesses a blue gemstone that can weaken Alyss's resistance and force information from her. Will is outside with only a small group of allies, while the castle commanding the northern route is in enemy hands. The book closes on that unresolved siege state, leading directly into The Siege of Macindaw.",
         "in_short": "Newly qualified as a Ranger, Will is posted to Seacliff, where he exposes poor defences and turns back a Skandian raid through preparation and bluff. Crowley then gives him a covert assignment in Norgate: posing as a jongleur, he must investigate rumours that sorcery has struck Castle Macindaw. Lord Syron lies mysteriously ill, his unpopular son Orman is blamed, and Orman's charming cousin Keren appears to be the household's natural leader. Alyss arrives as a Courier to support Will's inquiry. Will eventually learns that the supposed sorcerer Malkallam is Malcolm, a healer sheltering outcasts, and that Orman has been consulting him in hope of saving Syron. Keren is the true conspirator. He poisons Orman, captures the castle and holds Alyss, intending to admit Scotti invaders. Will escapes with Orman and Xander to Malcolm's refuge, but Macindaw and Alyss remain in Keren's hands when the story ends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -918,7 +918,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -931,7 +931,7 @@
       "recaps": {
         "ending": "After Charlotte tells Werther that he must stop visiting, he arranges his papers and resolves to die. He asks Albert to lend him pistols for a supposed journey; Albert has Charlotte hand them to the messenger, and Werther treats her contact with them as confirmation of his purpose. He writes a farewell, shoots himself near midnight, and is found the next morning still alive but beyond help. Albert, Charlotte, her family, and the town are devastated; Charlotte becomes seriously ill with grief. Werther dies around midday. Because he took his own life, no clergyman accompanies the burial. Workers carry him at night to the place he selected, and neither Albert nor Charlotte attends. The surviving editor's account closes the gaps left by Werther's final letters and makes clear that his attempt to turn death into a permanent bond with Charlotte instead leaves pain and silence among the living.",
         "in_short": "Werther withdraws to the country and falls passionately in love with Charlotte, the capable eldest daughter of a widowed official. Charlotte is already engaged to Albert, who returns and initially maintains a courteous friendship with Werther. Unable to moderate his feelings, Werther leaves for a diplomatic post, where bureaucracy and class prejudice deepen his alienation. He resigns and eventually returns to find Charlotte married. His visits become a strain on the household, and parallel stories of destructive love intensify his despair. During a final meeting he reads Charlotte sorrowful poetry, embraces and kisses her, and is told not to return. Werther then borrows Albert's pistols under the pretext of travel, writes a farewell, and shoots himself. He dies the next day and is buried at night without clergy, while Charlotte, Albert, and the family are left shocked and grieving.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1062,7 +1062,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1075,7 +1075,7 @@
       "recaps": {
         "ending": "After Charlotte asks Werther to stop visiting so often, he returns once more while Albert is absent and reads poetry with her. Their shared emotion leads him to embrace and kiss her; she pulls away and tells him he will not see her again. Werther then calmly arranges his affairs, asks Albert to lend him pistols on the pretext of a journey, and writes farewell letters. Charlotte, troubled by the request, hands the weapons to the servant herself. Werther shoots himself late at night. He remains alive for many hours but cannot be saved, and dies around midday. The account closes with his burial outside consecrated ground, attended by workmen rather than clergy; neither Charlotte nor Albert is present. His death ends the triangle without resolving the suffering it caused, leaving Charlotte overwhelmed and Albert's household permanently marked by it.",
         "in_short": "Werther, a sensitive young man living in the country, falls in love with Charlotte, who cares for her younger siblings and is already engaged to the dependable Albert. Although Charlotte welcomes Werther as a friend, her marriage makes his hopes impossible. He tries to escape by entering diplomatic service, but class prejudice and his dislike of official life drive him away. Returning to Charlotte and Albert, he becomes increasingly isolated and interprets other unhappy lives through his own despair. Charlotte finally asks him to keep his distance. During a last visit, their emotion breaks through the limits of friendship, but she rejects any further meeting. Werther borrows Albert's pistols, writes his farewells, and shoots himself. He dies the following day and is buried without a church ceremony, leaving Charlotte and Albert to face the consequences.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1296,7 +1296,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1309,7 +1309,7 @@
       "recaps": {
         "ending": "The first novel leaves the Compsons dispersed or trapped: Quentin is long dead, Caddy is banished, Miss Quentin escapes with money Jason had withheld, and Jason fails to recover it. Dilsey endures, while Benjy is calmed only when his carriage resumes its accustomed route. In the second novel, the Bundrens finally bury Addie in Jefferson. Jewel has saved her coffin from flood and fire; Cash's broken leg has been permanently damaged by crude treatment; and Darl, blamed for burning a barn to stop the journey, is seized and sent to the state hospital. Dewey Dell is deceived and sexually exploited by a drugstore clerk when she seeks an abortion, then loses her remaining money to Anse. Soon after the burial, Anse returns with new teeth, a gramophone, and a new Mrs. Bundren. The family journey fulfills Addie's demand but exposes the private desire each traveler attached to it.",
         "in_short": "*The Sound and the Fury* presents the Compson family's collapse through four sections. Benjy's memories circle around his beloved sister Caddy; Quentin kills himself after becoming consumed by her sexuality and the family's lost honor; Jason steals money meant for Caddy's daughter, who finally robs him and escapes; and Dilsey sustains the household through Easter as its white members disintegrate. *As I Lay Dying* follows the Bundrens carrying Addie's corpse across flood-stricken Mississippi to Jefferson. The trip reveals Addie's affair and the competing motives of her husband and children. Cash breaks a leg, Jewel repeatedly saves the coffin, and Darl burns a barn before being committed to an asylum. Dewey Dell's attempt to end her pregnancy results in exploitation. After Addie's burial, Anse takes Dewey Dell's money, buys teeth, and introduces a new wife, converting the family's ordeal into his own fresh start.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1497,7 +1497,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1510,7 +1510,7 @@
       "recaps": {
         "ending": "Patricia and the other women finally act without waiting for their husbands or the authorities to believe them. With Mrs. Greene's essential help, they trap James Harris and destroy his body, ending the predator who has hidden behind wealth, male approval, and the neighborhood's refusal to value every victim equally. The victory cannot restore the children and adults he killed or repair the years in which Patricia was isolated and discredited. Harris's financial dealings have entangled the husbands, so his disappearance must be managed without a public account of what he was. The book club survives as the bond that allowed the women to compare evidence and organize resistance. Patricia's family does not simply return to its old shape: her children grow toward lives beyond the neighborhood, and her marriage to Carter cannot erase his failure to trust and protect her. The closing movement emphasizes survival and testimony rather than a restoration of the false security with which the story began.",
         "in_short": "In late-1980s suburban Charleston, Patricia Campbell escapes domestic routine through a women's book club devoted to crime stories. New neighbor James Harris appears charming and vulnerable, but Patricia connects his arrival to attacks and missing children, especially in the nearby Black community whose losses are ignored. Mrs. Greene supports her, and Miss Mary's damaged memories suggest Harris has lived under another identity before. Patricia's friends initially investigate with her, but their husbands accept Harris's influence and use psychiatric authority and social pressure to silence her. Years pass as Harris gains financial power and preys on more families. When the danger reaches their own children and one of the women is lost, the club reunites. With Mrs. Greene, they trap and physically destroy Harris. His money and the husbands' complicity prevent a clean public reckoning, but the women end his predation and preserve the truth among themselves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1634,7 +1634,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1647,7 +1647,7 @@
       "recaps": {
         "ending": "The mission to Rakhat ends in catastrophe, revealed gradually as Emilio is finally able to tell it. After a period living among the peaceful Runa, the humans, meaning only kindness, teach them to grow gardens, which lets the Runa population rise. This violates the brutal system by which the ruling predator species, the Jana'ata, keep Runa numbers in check by culling them, and it triggers a massacre. The crew are destroyed: the priests and Emilio's dear friends, including Anne and George Edwards, Jimmy Quinn, D.W. Yarbrough, Marc Robichaux, and Alan Pace, all die, and Sofia Mendes, pregnant, is lost in the violence and believed dead. Emilio alone is taken by the Jana'ata. His hands are deliberately mutilated in one of their customs, and he is passed into the household of a Jana'ata aristocrat where he is repeatedly raped. When a second expedition from Earth reaches him, a native child he had loved is killed in the confusion, so that to outside eyes he appears to be both a murderer and a willing prostitute. He is brought home as the sole survivor, physically ruined and stripped of the faith that had made him believe God led the mission to Rakhat. The framing inquiry ends with the truth of his suffering finally understood by his fellow Jesuits, though it cannot undo what was lost.",
         "in_short": "When the Arecibo radio telescope detects beautiful alien music from a nearby star, the Jesuit order quietly organizes and funds a first-contact mission, sending a small crew of priests and their friends aboard a converted asteroid to the distant world of Rakhat. The novel alternates between that mission and the aftermath years later, when Emilio Sandoz returns as its sole survivor, his hands mutilated and his spirit broken, and the Jesuits convene to learn what went wrong. On Rakhat the crew live peacefully among the gentle, foraging Runa, but by helping them the humans unknowingly upset the harsh balance the predatory, dominant Jana'ata maintain over Runa numbers, provoking violent slaughter. One by one the crew are killed. Emilio falls into Jana'ata hands, is ritually maimed, and is degraded and sexually abused, and a damning misunderstanding over a native child's death makes him appear a murderer and a prostitute when a second mission finds him. He is returned to Earth having lost nearly everyone he loved and his belief that God had guided them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1761,7 +1761,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1774,7 +1774,7 @@
       "recaps": {
         "ending": "Even after Crenshaw's coercive campaign is stopped, Lou chooses to enter the experimental treatment on his own terms. The procedure breaks down and rebuilds important neural patterns, so recovery involves learning again while trying to understand the journals and relationships of his earlier self. He retains factual memories but does not simply become a socially smoother version of the same man; his priorities and emotional connections change, including the attachment he once felt toward Marjory. Other members of the autistic group make their own choices, underscoring that Lou's decision represents only Lou. In the years that follow, his expanded opportunities take him toward a long-held fascination with space. He becomes an astronaut and looks outward from beyond Earth, pursuing questions that mattered to him before treatment but from a mind that experiences them differently. The conclusion leaves the treatment neither as a simple cure nor a disaster: Lou gains the future he elected, while the continuity between his former and present selves remains profound, real, and impossible to measure cleanly.",
         "in_short": "Lou Arrendale is an autistic pattern analyst living independently in a near future where younger generations can be treated before or during childhood. His company has long supported an autistic work unit, but executive Gene Crenshaw pressures its members to undergo an experimental adult treatment, threatening the accommodations and jobs that let them excel. Lou's decision is complicated by his friendships, his attraction to fellow fencer Marjory Shaw, and jealous Don Poitevin's escalating attacks. Don is caught, and senior management halts Crenshaw's coercion, but Lou remains curious about who he might become. After studying the risks, he freely chooses the treatment. Recovery changes how his brain works and alters some of his former emotional ties rather than merely removing a defect. Years later Lou has followed his interest in space and become an astronaut. His life has widened, but the novel leaves the relation between his pre- and post-treatment selves open rather than defining one as the authentic version.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1923,7 +1923,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1936,7 +1936,7 @@
       "recaps": {
         "ending": "Meralda gives birth to a child conceived with Jaka while her position in Lord Feringal's household makes the truth dangerous. Wulfgar intervenes in the judgment surrounding Auckney and publicly accepts responsibility for the baby, removing the child as evidence that could destroy Meralda's future. He takes the infant, Colson, with him. The choice is not a return to heroic certainty: Wulfgar still suffers from Errtu's abuse, has lost Aegis-fang and cannot repair everything damaged in Luskan. It is nevertheless the first sustained responsibility he has chosen since leaving his friends. Morik helps him survive the road and the conflict around Auckney, demonstrating a loyalty deeper than his cultivated selfishness. Wulfgar returns toward Luskan with Colson and finds Delly willing to help care for the child and build a life with him. He ends the book without his warhammer and still separated from Drizzt, Catti-brie, Bruenor and Regis, but no longer alone or committed only to numbing himself. Caring for Colson gives him a reason to continue recovering.",
         "in_short": "Wulfgar lives alone in Luskan after leaving the Companions of the Hall, drinking heavily and fighting to escape memories of six years in Errtu's prison. Morik the Rogue becomes his friend, while Delly Curtie offers compassion at the Cutlass tavern. Wulfgar's instability costs him his place there, and a violent incident involving Captain Deudermont leads to the arrest and condemnation of Wulfgar and Morik. Deudermont helps prevent their execution, but they are exiled, and Wulfgar is also separated from Aegis-fang. Their road eventually brings them into the affairs of Auckney. There, Meralda is caught between Lord Feringal's desire to marry her, his sister Priscilla's opposition and the concealed fact that she carries Jaka Sculi's child. When the baby is born and the truth threatens Meralda, Wulfgar claims responsibility and takes the infant, Colson, away. Returning toward Luskan, he accepts Delly's help in raising the child. He remains traumatized and without his hammer, but responsibility for Colson begins to replace self-destruction with purpose.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2110,7 +2110,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2123,7 +2123,7 @@
       "recaps": {
         "ending": "The tribunal ends with Fiedler discredited and arrested and Mundt cleared, and Leamas and Liz are held to be executed. Mundt himself takes them out of the prison and puts them in a car with instructions for crossing the Wall. In the car Leamas tells Liz the truth: Mundt has been a British agent for years, and every stage of the operation, including Leamas's disgrace, his recruitment and his lies, was designed to make the East Germans destroy Fiedler, the one man closing in on him. Liz herself was chosen and used because her honest evidence would be believed. Liz refuses to accept a survival bought this way, and Leamas has no defence to offer beyond the trade he has spent his life in. At the Wall, with the escape arranged from the Western side, Liz climbs the ladder and is shot by the guards while Leamas is already at the top and being called across by his own people. He goes back down to her, and is shot dead beside her body. Fiedler is destroyed, Mundt survives in place with the service's protection, and the operation succeeds exactly as it was designed to.",
         "in_short": "Alec Leamas, the British service's Berlin station head, loses the last agent of his network at a checkpoint and is called home. Control offers him a final operation against Hans-Dieter Mundt, the East German operations chief who destroyed his network. Leamas plays out a public decline into drink, debt, petty employment at a library and prison, along the way falling in with Liz Gold, a young communist librarian. On release he is recruited by East German talent-spotters, debriefed in Holland and taken East, where Jens Fiedler, the service's counter-intelligence chief, uses his information to accuse Mundt of being a British agent. Mundt arrests them both, but Fiedler forces the case to a secret tribunal. There Mundt's advocate produces Liz, brought over on a party exchange, whose truthful answers about a stranger paying her rent expose Leamas's whole story as a British construction. Fiedler is destroyed and Mundt is cleared. Mundt then frees Leamas and Liz, and Leamas realises he was never meant to bring Mundt down: Mundt is London's agent, and the operation existed to protect him. At the Wall, Liz is shot, and Leamas climbs back down to die with her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2259,7 +2259,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2272,7 +2272,7 @@
       "recaps": {
         "ending": "Bond prevents Horror and Sluggsy from completing the insurance scheme that required the Dreamy Pines to burn with Vivienne inside it. The struggle carries through the motel and its grounds, and both gunmen are killed, though a final attack after the apparent danger has passed nearly catches Bond and Vivienne unprepared. In the relief that follows, Vivienne and Bond become lovers. By morning he has gone, leaving her a note and ensuring that the authorities know how to reach her. Captain Stonor hears her statement and confirms that the gangsters intended her death to disguise the motel owner's fraud. He also warns her not to romanticize men such as the killers or Bond merely because their capacity for violence can look exciting from outside. Vivienne nonetheless retains her gratitude and her own understanding of the night. She leaves the ruined motel alive, with the narrative remaining explicitly her account rather than Bond's.",
         "in_short": "Vivienne Michel narrates her own path to a remote Adirondack motel, recalling painful relationships in Europe and a solitary motor-scooter journey across North America. Hired to help close the Dreamy Pines for the season, she is left alone during a storm when two gangsters, Horror and Sluggsy, arrive. They mean to burn the insured property and leave her body inside so the fire appears accidental. James Bond, delayed on his drive south, reaches the motel by chance and recognizes the danger. He and Vivienne endure intimidation, gunfire, and repeated attacks before Bond kills both men and the plot collapses. Vivienne and Bond spend the remainder of the night together, but he leaves before she wakes. The police confirm the insurance scheme and caution her about attaching heroic glamour to violent men. The episode closes as Vivienne's first-person testimony of what happened to her, with Bond a late-arriving figure inside her story.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2464,7 +2464,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2475,7 +2475,7 @@
       "recaps": {
         "ending": "The Stand ends with Randall Flagg's western empire destroyed. Four men sent by the dying Mother Abagail walk unarmed toward Las Vegas; Stu Redman breaks his leg and is left on the road, tended by Tom Cullen, while Larry Underwood, Glen Bateman and Ralph Brentner are captured. As Flagg prepares to execute them before his followers, the Trashcan Man returns dragging a nuclear warhead, and a manifestation of divine power detonates it, wiping out Flagg, his city and his people - Larry, Glen and Ralph among them, dead but having made their stand. Stu survives his injury and illness with Tom's help and journeys back to Boulder. There Frannie Goldsmith has given birth; the baby contracts the superflu and recovers, the first hard evidence that the disease is survivable and that humanity has a future. As the Free Zone grows and begins rebuilding the machinery, bureaucracy and weapons of the world that destroyed itself, Stu and Frannie choose to leave it and start over somewhere quieter, uneasy about repeating old mistakes. In a closing coda, Flagg is revealed to have survived in some form, waking among a remote, primitive people under a new name, ready to gather power once more - the struggle between order and ruin left open rather than finished.",
         "in_short": "A weaponised superflu called Captain Trips escapes a government lab and kills more than ninety-nine percent of humanity within weeks. The scattered immune survivors - steady Stu Redman, pregnant Frannie Goldsmith, the reforming musician Larry Underwood, the deaf-mute Nick Andros and many others - are drawn by shared dreams toward two poles: the ancient, saintly Mother Abagail in the east, and the demonic dark man Randall Flagg in the west. The good gather in Boulder, Colorado, rebuilding a community, while Flagg raises a brutal order in Las Vegas. After the embittered Harold Lauder and Nadine Cross bomb the Free Zone's leaders and flee west, a dying Mother Abagail commands four men to walk unarmed to Las Vegas and confront Flagg. Stu breaks his leg and is left behind; the other three are captured. As Flagg moves to execute them, the Trashcan Man arrives with a nuclear warhead and a manifestation of God detonates it, destroying Flagg and his city. Stu survives, Frannie's baby lives through the flu, and humanity is given a fragile second chance - though Flagg is shown stirring again, far away.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2653,7 +2653,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2666,7 +2666,7 @@
       "recaps": {
         "ending": "Joanna concludes that the Men's Association is replacing wives with manufactured doubles and realizes that her own allotted time in Stepford is nearly over. A psychiatrist advises her to take the children and leave, but Walter blocks her escape and the children disappear from home. Joanna flees the men searching for her and is lured to the Men's Association building with the claim that her children are there. To disprove her theory, Dale Coba asks her to enter a dark room and see Bobbie bleed like a human being. Joanna goes inside and encounters a figure made to look like herself. Her resistance ends offstage. Later, Ruthanne sees a transformed Joanna shopping in the supermarket. The new Joanna is immaculately dressed, physically more voluptuous, and concerned only with household errands; Bobbie is there in the same state. Ruthanne, still independent and still writing, does not yet recognize that she is likely next in the town's repeating process.",
         "in_short": "Photographer Joanna Eberhart moves to Stepford with her husband Walter and their children. She finds most local wives unnaturally devoted to domestic service, while the husbands gather at a secretive Men's Association. Joanna befriends Bobbie and Charmaine, but Charmaine abruptly abandons her interests and Bobbie later returns from a trip as another tireless homemaker. Research shows that Stepford's women were recently active and independent, and that association members possess expertise in robotics, animation, voices, and likenesses. Joanna infers that the men murder their wives and replace them with compliant artificial copies. A psychiatrist urges her to leave, but Walter prevents her escape and the association corners her. She is confronted with a manufactured double of herself and disappears. The closing supermarket scene shows Joanna transformed into the same polished domestic ideal, while the newer resident Ruthanne remains unaware that the cycle is approaching her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2835,7 +2835,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2848,7 +2848,7 @@
       "recaps": {
         "ending": "Essun reaches Corepoint, carried through the rock by Hoa, arriving stone-armed, dying and out of time. Nassun has already taken hold of the Obelisk Gate and means to bring the Moon down and end everything. They do not fight over it. Essun opens the Gate too, and instead of turning it against her daughter she uses it for what Alabaster wanted: she catches the Moon and pushes it back onto its orbit. The effort finishes what the Gate started on her body. She turns entirely to stone and dies.\n\nNassun, holding what is left of her mother, carries the work through to the end and chooses not to destroy the world after all. Schaffa's long torment ends at Corepoint; Nassun releases him and he is finally at rest. With the Moon returned, the Earth's grievance is answered: the Seasons will wind down, the ash will clear in time, and the Stillness becomes survivable in a way it has not been for forty thousand years.\n\nHoa remakes Essun as a stone eater, and the book closes with her waking into that new existence, with Hoa beside her and the whole of his account already given. Nassun survives and is carried north, where the people of Castrima, now settled in the emptied city of Rennanis, take her in. Ykka, Lerna, Tonkee, Danel and the rest inherit a world that has a future.",
         "in_short": "Essun wakes in Castrima with a stone arm, Alabaster dead, and a comm that must abandon its geode and walk north through the ash to the emptied city of Rennanis. Nassun and Schaffa travel to Corepoint on the far side of the world, where the obelisks can be commanded directly, and where Nassun intends to open the Obelisk Gate and bring the Moon down to end all life. Between them, Hoa tells his own origin: forty thousand years ago he was a tuner, an engineered being built by the civilization of Syl Anagist to run a planetary magic engine, and that civilization's attempt to tap the Earth's core cost it the Moon and made the planet an enemy of everything living. Essun has Hoa carry her through the rock to Corepoint, arriving as Nassun takes hold of the Gate. Rather than fight her daughter, Essun opens the Gate and catches the Moon, returning it to its orbit and ending the Seasons for good. The effort turns her entirely to stone. Nassun completes the work, chooses to let the world live, and Hoa remakes Essun as a stone eater.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3032,7 +3032,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3045,7 +3045,7 @@
       "recaps": {
         "ending": "Doctor Dolittle defeats the pirates without becoming a pirate himself, rescues a boy and reunites him with his missing uncle, and continues toward England. In a seaside town, Jip's extraordinary sense of smell helps establish the truth about the rescued man. Back in Puddleby, the Doctor still needs an income, so he exhibits the Pushmi-Pullyu to fascinated crowds while protecting the animal from mistreatment. The successful tour pays his debts and leaves him comfortably provided for. He returns to his old house and resumes caring for animals, surrounded by the companions who shared his journey.",
         "in_short": "Doctor John Dolittle loses his human medical practice because his house is crowded with pets, but the parrot Polynesia teaches him animal language and he becomes a celebrated animal doctor. When Chee-Chee brings news of a deadly epidemic among African monkeys, Dolittle sails to help with Jip, Dab-Dab, Too-Too, Gub-Gub, Polynesia, and other companions. Despite a shipwreck, detention by a distrustful king, and resistance from some African animals, he reaches the monkeys and organizes a successful treatment campaign. The grateful monkeys give him the rare Pushmi-Pullyu. On the return voyage the party outwits pirates, rescues a boy, and finds the boy's missing uncle. At home, Dolittle earns enough by showing the Pushmi-Pullyu to pay his debts, then returns to his quiet life as a doctor for animals.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3235,7 +3235,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3248,7 +3248,7 @@
       "recaps": {
         "ending": "After escaping Africa, Doctor Dolittle and his companions take the pirates' ship when rats warn that their own vessel is sinking. The pirates are left on an island, where Polynesia makes them promise to abandon piracy and live peacefully. A boy found aboard tells the Doctor that his fisherman uncle is missing. Sea creatures confirm that the man survived on a rock, and Jip uses the scent from the man's belongings to guide a nighttime search that brings him safely home. The grateful fishing village welcomes and assists the travelers. On the overland journey back to Puddleby, the Pushmi-Pullyu agrees to appear for a limited time in a circus. Its earnings clear the Doctor's debts and provide enough money for the household. He returns home famous but still devoted to animals, with his companions safe and his practice financially secure.",
         "in_short": "Doctor John Dolittle loses his human medical practice because he fills his home with animals, then learns animal languages from his parrot Polynesia and becomes a gifted veterinarian. When swallows report that African monkeys are dying in an epidemic, he sails with several animal companions to help. An African king detains the travelers, but they escape, cross a living bridge made by apes, and reach the monkeys. The Doctor organizes treatment, and even the reluctant lions eventually assist. In gratitude, the monkeys give him the rare two-headed Pushmi-Pullyu. Prince Bumpo helps the party escape imprisonment and begin the voyage home. Pursued by pirates, the Doctor relies on birds, rats, and his companions to take the pirate ship and leave its crew alive on an island. He then rescues a missing fisherman, guided across the sea by Jip's sense of smell. The Pushmi-Pullyu later earns money through a short circus exhibition, allowing the Doctor to pay his debts and return comfortably to Puddleby.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3390,7 +3390,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3403,7 +3403,7 @@
       "recaps": {
         "ending": "Doctor Dolittle and his companions overcome the pirates they encounter on the homeward voyage and use the communication networks of birds and sea animals to help a boy find his missing uncle. Jip's powerful sense of smell completes the search, and uncle and nephew are reunited. Dolittle eventually reaches Puddleby with the Pushmi-Pullyu and the friends who traveled with him. Because the journey has left him in debt, he presents the rare animal to paying audiences under humane conditions. The exhibition succeeds, allowing him to meet his obligations and return to his house with enough money to continue his work as an animal doctor.",
         "in_short": "Doctor John Dolittle's love of animals ruins his ordinary medical practice, but Polynesia teaches him animal speech and enables him to become a doctor for animals. When Chee-Chee reports an epidemic among African monkeys, Dolittle sails to help with a group of loyal animal companions. They survive a wreck and other obstacles, reach the sick monkeys, and organize the animals into an effective system of nursing and treatment. In gratitude, the monkeys entrust the rare two-headed Pushmi-Pullyu to him. During the return journey, Dolittle's party escapes danger at sea, defeats pirates, and reunites a lost man with his nephew through cooperation among animals. Back in England, a successful exhibition of the Pushmi-Pullyu clears the Doctor's debts and lets him resume his chosen life caring for animals.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3586,7 +3586,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3599,7 +3599,7 @@
       "recaps": {
         "ending": "After escaping Africa, Doctor Dolittle and his companions take the pirates' ship when rats warn that their own vessel is sinking. The pirates are left on an island, where Polynesia makes them promise to abandon piracy and live peacefully. A boy found aboard tells the Doctor that his fisherman uncle is missing. Sea creatures confirm that the man survived on a rock, and Jip uses the scent from the man's belongings to guide a nighttime search that brings him safely home. The grateful fishing village welcomes and assists the travelers. On the overland journey back to Puddleby, the Pushmi-Pullyu agrees to appear for a limited time in a circus. Its earnings clear the Doctor's debts and provide enough money for the household. He returns home famous but still devoted to animals, with his companions safe and his practice financially secure.",
         "in_short": "Doctor John Dolittle loses his human medical practice because he fills his home with animals, then learns animal languages from his parrot Polynesia and becomes a gifted veterinarian. When swallows report that African monkeys are dying in an epidemic, he sails with several animal companions to help. An African king detains the travelers, but they escape, cross a living bridge made by apes, and reach the monkeys. The Doctor organizes treatment, and even the reluctant lions eventually assist. In gratitude, the monkeys give him the rare two-headed Pushmi-Pullyu. Prince Bumpo helps the party escape imprisonment and begin the voyage home. Pursued by pirates, the Doctor relies on birds, rats, and his companions to take the pirate ship and leave its crew alive on an island. He then rescues a missing fisherman, guided across the sea by Jip's sense of smell. The Pushmi-Pullyu later earns money through a short circus exhibition, allowing the Doctor to pay his debts and return comfortably to Puddleby.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3782,7 +3782,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3795,7 +3795,7 @@
       "recaps": {
         "ending": "After escaping Africa, Doctor Dolittle and his companions take the pirates' ship when rats warn that their own vessel is sinking. The pirates are left on an island, where Polynesia makes them promise to abandon piracy and live peacefully. A boy found aboard tells the Doctor that his fisherman uncle is missing. Sea creatures confirm that the man survived on a rock, and Jip uses the scent from the man's belongings to guide a nighttime search that brings him safely home. The grateful fishing village welcomes and assists the travelers. On the overland journey back to Puddleby, the Pushmi-Pullyu agrees to appear for a limited time in a circus. Its earnings clear the Doctor's debts and provide enough money for the household. He returns home famous but still devoted to animals, with his companions safe and his practice financially secure.",
         "in_short": "Doctor John Dolittle loses his human medical practice because he fills his home with animals, then learns animal languages from his parrot Polynesia and becomes a gifted veterinarian. When swallows report that African monkeys are dying in an epidemic, he sails with several animal companions to help. An African king detains the travelers, but they escape, cross a living bridge made by apes, and reach the monkeys. The Doctor organizes treatment, and even the reluctant lions eventually assist. In gratitude, the monkeys give him the rare two-headed Pushmi-Pullyu. Prince Bumpo helps the party escape imprisonment and begin the voyage home. Pursued by pirates, the Doctor relies on birds, rats, and his companions to take the pirate ship and leave its crew alive on an island. He then rescues a missing fisherman, guided across the sea by Jip's sense of smell. The Pushmi-Pullyu later earns money through a short circus exhibition, allowing the Doctor to pay his debts and return comfortably to Puddleby.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3958,7 +3958,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3971,7 +3971,7 @@
       "recaps": {
         "ending": "After recovering his stolen ship from the pirates, Doctor Dolittle rescues a boy whose fisherman uncle has been abandoned on a rocky island. Jip follows the missing man's scent across the sea, and the party reunites the family before sailing on. At Puddleby, the Doctor exhibits the Pushmi-Pullyu and earns enough money to repay his debts, repair his home, and live comfortably. He eventually brings the rare animal back rather than keep it on display. Doctor Dolittle resumes his quiet life among the animals, now famous enough that creatures throughout the world know where to seek his help.",
         "in_short": "Doctor John Dolittle loses his human medical practice after his many pets overrun his house, but his parrot Polynesia teaches him animal language and he becomes a successful animal doctor. When an epidemic threatens the monkeys of Africa, he sails there with several animal companions. A suspicious king imprisons the travelers, but the king's son helps them escape. The Doctor organizes the jungle animals into a nursing service and stops the disease. The grateful monkeys give him the rare Pushmi-Pullyu, whose exhibition can finance the journey home. After another imprisonment and escape, the party is pursued by pirates, recovers a stolen ship, and rescues a marooned fisherman. Back in England, the Pushmi-Pullyu earns enough to clear the Doctor's debts. He returns the creature to Africa and settles again in Puddleby as a celebrated physician to animals.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4089,7 +4089,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4102,7 +4102,7 @@
       "recaps": {
         "ending": "After thirty-three years of searching, Artaban reaches Jerusalem as Jesus is being taken to execution. He plans to offer his last jewel as a ransom, but instead gives it to save a young woman from slavery. An earthquake follows the crucifixion, and a falling roof tile mortally wounds him. Believing that he has failed because none of his original gifts reached the king, Artaban hears Jesus assure him that mercy shown to people in need was service rendered to the king himself. He dies in peace, understanding that his long search and repeated sacrifices were not failures: he has found and honored the king through the lives he helped.",
         "in_short": "Artaban, a Persian Magus, prepares three jewels for the newborn king announced by a star. He misses the caravan of the other Magi because he stops to save a dying stranger, then spends one jewel to obtain the caravan he needs to continue. In Bethlehem he learns that the child has escaped and gives a second jewel to protect a mother and child from Herod's soldiers. For thirty-three years he follows reports of the king while serving people who are sick, imprisoned, poor, or enslaved. He finally reaches Jerusalem on the day Jesus is crucified, but uses his last jewel to free a captive woman. Mortally injured in the ensuing earthquake, Artaban hears that every act of mercy was accepted as a gift to the king. He dies knowing that his quest was fulfilled through compassion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4219,7 +4219,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4232,7 +4232,7 @@
       "recaps": {
         "ending": "Jekyll's written confession explains that he developed a drug to separate the opposing impulses within himself. Taking it transformed him into Edward Hyde, a younger body through which he could pursue forbidden desires while protecting Jekyll's name. Repetition strengthened Hyde until transformations began occurring without the drug. After Hyde murdered Carew, Jekyll temporarily stopped, but temptation brought Hyde back and left him increasingly dominant. Jekyll's supplies then failed because a new batch of the chemical lacked an unknown impurity present in the original. Confined to the laboratory and unable to remain Jekyll, he completed his account as his last dose wore off. When Utterson and Poole broke in, they found Hyde dead from poison; Jekyll had disappeared because Hyde was his transformed body. Lanyon's death followed the shock of witnessing that transformation, and Jekyll's own death ends both identities.",
         "in_short": "Lawyer Gabriel Utterson investigates the link between his respected friend Dr. Henry Jekyll and the violent Edward Hyde, whom Jekyll has made his heir. Hyde murders Sir Danvers Carew and vanishes, while Jekyll briefly resumes a sociable life before isolating himself. Dr. Lanyon dies after a mysterious shock and leaves Utterson a sealed narrative. When Jekyll's butler fears that someone has replaced his master, he and Utterson break into the laboratory and find Hyde dead, with Jekyll missing. Lanyon's account says that Hyde drank a chemical mixture and transformed into Jekyll. Jekyll's confession reveals that he created the drug to divide his respectable and destructive impulses; Hyde was the body of his liberated cruelty. Hyde grew stronger, appeared without warning, and eventually became difficult to reverse. When the original chemical supply could not be duplicated, Jekyll lost the means to remain himself and died as Hyde.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4385,7 +4385,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4398,7 +4398,7 @@
       "recaps": {
         "ending": "In Jekyll and Hyde, Lanyon's narrative reveals that Hyde drank a chemical mixture and transformed into Jekyll before him. Jekyll's confession explains that he created the drug to separate his conflicting impulses, but Hyde became increasingly dominant and violent. When the original chemical could not be reproduced, Jekyll lost control of the transformations. Utterson and Poole find Hyde dead in the laboratory, while the documents account for Jekyll's disappearance and the end of their shared life. In Markheim, the murderer debates with a mysterious visitor who knows his past and offers practical help in further wrongdoing. Markheim rejects the claim that he is wholly committed to evil and chooses to stop. When the dealer's maid returns, he opens the door, tells her that he killed her master, and asks her to call the police. The stranger disappears with an expression that suggests Markheim's surrender has defeated the role he came to play.",
         "in_short": "The collection pairs two studies of divided moral identity. In The Strange Case of Dr. Jekyll and Mr. Hyde, lawyer Gabriel Utterson investigates the bond between his friend Henry Jekyll and the violent Edward Hyde. After Hyde murders Sir Danvers Carew and Jekyll retreats from society, documents left by Jekyll and Dr. Lanyon disclose that Jekyll and Hyde are transformations of the same man, produced by an experimental drug. Jekyll loses control of the change and dies as Hyde when the drug can no longer restore him. In Markheim, a man murders an antique dealer during a robbery and is confronted by a mysterious visitor who knows his crimes and offers to help him continue. Their argument forces Markheim to recognize that he can still choose his next act. He refuses further wrongdoing and confesses to the returning maid, accepting arrest.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4522,7 +4522,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4535,7 +4535,7 @@
       "recaps": {
         "ending": "Jekyll's confession explains that he created a drug to separate the conflicting sides of his nature. Taking it changed him into Hyde, a younger figure free of Jekyll's conscience and social restraints. Jekyll initially treated the transformation as secret liberty, but Hyde grew stronger and committed increasingly brutal acts, including Carew's murder. Eventually Jekyll began changing without the drug. After his supply failed, repeated attempts to reproduce it did not work because the original ingredient had contained an unknown impurity. Trapped in the laboratory and facing permanent transformation, Jekyll completed his account. When Utterson and Poole break in, they find Hyde dead in Jekyll's oversized clothes; Jekyll himself has vanished. Lanyon is already dead after witnessing the transformation, and the documents he and Jekyll leave reveal the truth. Jekyll expects his own life to end with Hyde's and closes his statement uncertain which identity will meet death.",
         "in_short": "London lawyer Gabriel Utterson becomes concerned when his friend Dr. Henry Jekyll names the repellent Edward Hyde as heir and grants him access to his home. Hyde's violence escalates from trampling a child to murdering Sir Danvers Carew. Jekyll claims to have ended the association, but later withdraws from society, while their mutual friend Dr. Lanyon dies after a devastating shock. When Jekyll's butler fears someone has replaced his master, he and Utterson force their way into the laboratory and find Hyde dead. Letters disclose that Jekyll developed a drug that transformed him into Hyde, allowing him to act without his ordinary conscience. The transformations became involuntary, and the original drug could not be reproduced. Unable to prevent Hyde from taking over permanently, Jekyll records the truth before the shared life of Jekyll and Hyde ends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4668,7 +4668,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4681,7 +4681,7 @@
       "recaps": {
         "ending": "Meursault is tried not so much for the murder on the beach as for the way he lived and felt. The prosecution dwells on his unnatural composure at his mother's funeral, his lack of grief, his casual affair begun the next day, and his indifference to religion, building a portrait of a soulless man, and he is sentenced to be beheaded in public. Awaiting execution, he refuses to see the prison chaplain, and when the chaplain comes anyway and presses him to turn to God, Meursault erupts in fury, rejecting false hope and the pretense of belief. Spent by his outburst, he grows calm and, gazing at the night sky, opens himself for the first time to what he calls the tender indifference of the world, feeling that he had been happy and was happy still. He accepts his fate, his only remaining wish being that a large, hateful crowd greet his execution so that he will not feel alone. The book ends with him at peace in his absurd acceptance of a meaningless universe, awaiting death.",
         "in_short": "In Algiers, the detached young clerk Meursault buries his mother without visible grief, then resumes ordinary life, beginning an affair with Marie and befriending his violent neighbor Raymond. On a hot Sunday at the beach, drawn into Raymond's quarrel with a group of Arab men, Meursault, dazed by the blazing sun, shoots and kills one of them, then fires four more times into the body. Arrested and tried, he finds that the court is far less interested in the killing itself than in his character: his calm at his mother's funeral, his failure to cry, his lack of remorse and religious feeling are treated as proof of a monstrous soul. He is condemned to death by guillotine. In his cell he refuses the chaplain's offers of God and consolation, and after a burst of anger arrives at a kind of peace, opening himself to what he calls the gentle indifference of the world and accepting his execution. The novel presents his story as a study of absurdity, honesty, and a man judged for refusing to feel and pretend as society demands.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4850,7 +4850,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4863,7 +4863,7 @@
       "recaps": {
         "ending": "The court convicts Meursault of murder and sentences him to death by guillotine. His appeals fail, and he waits in his cell while imagining the machinery of execution and the remote possibility of a pardon. When the chaplain urges him to turn to God, Meursault finally erupts, rejecting religious consolation and the demand that life possess a higher design. The outburst leaves him calm. He recognizes that death is the common fate of everyone and accepts a universe that offers no personal judgment or guaranteed meaning. Thinking of his mother beginning a new companionship near the end of her life, he feels that she too had opened herself to living without false hope. Meursault ends the night at peace with existence as it is. He wishes for a large, hostile crowd at his execution, a final acknowledgment that he and the world meet without comforting illusions.",
         "in_short": "Meursault, a French Algerian clerk, returns from his mother's funeral and resumes his ordinary life with striking emotional detachment. He begins a relationship with Marie and drifts into the affairs of his neighbor Raymond, whose abuse of a former mistress provokes a conflict with her brother. During a visit to a beach, heat, glare, chance, and Raymond's revolver converge as Meursault shoots the brother, then fires four more times. In prison and at trial, the authorities focus as much on his failure to mourn conventionally as on the killing. The prosecutor turns his conduct at the funeral into evidence of a morally empty nature, and Meursault is convicted and sentenced to death. After rejecting a chaplain's demand for faith, he accepts that death comes to everyone and that the universe supplies no special meaning. This recognition frees him from hope and leaves him calm as he awaits execution.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5018,7 +5018,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5031,7 +5031,7 @@
       "recaps": {
         "ending": "Bub is detained after Jones induces him to steal mail and then reports him. Lutie urgently needs money for legal help and believes Boots can supply it. When she meets him, however, he does not provide the rescue he promised. He tries to force himself on her, and the pressure of the assault, Junto's control, Bub's arrest, and every blocked route to independence erupts into violence. Lutie strikes Boots repeatedly with a heavy candlestick and kills him. Realizing what she has done, she abandons the apartment and takes a train to Chicago before the police can find her. She cannot take Bub, who remains in custody without his mother. The ending overturns Lutie's belief that determination and respectable work would be enough to defeat poverty and racism: the forces surrounding her have separated the family she struggled to protect. Mrs Hedges, Jones, Junto, and the life of the street continue, while Lutie escapes immediate arrest at the cost of the goal that motivated her throughout the novel.",
         "in_short": "Lutie Johnson moves with her eight-year-old son Bub into a cheap apartment on 116th Street in Harlem, determined to work their way into safety. The building superintendent Jones desires her, Mrs Hedges watches from beside a brothel, and the white businessman Junto profits from much of the neighbourhood. Lutie hopes her singing will offer a second income when bandleader Boots Smith recruits her, but his opportunities remain controlled by Junto. While she works, Bub is isolated. Jones manipulates him into stealing mail and then reports him, causing the boy's arrest. Lutie needs money to help Bub and turns to Boots, believing his promise of assistance. Instead he attempts to assault her. She beats him to death with a candlestick and flees by train to Chicago. Bub remains in custody, separated from the mother whose every effort was meant to protect him. The novel closes with Lutie's faith in individual effort defeated by a system of racial, sexual, and economic power.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5199,7 +5199,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5212,7 +5212,7 @@
       "recaps": {
         "ending": "The book closes with loss layered on loss. Lee Scoresby dies in a rearguard fight to protect the shaman Stanislaus Grumman. Grumman uses the last of his power to heal Will's maimed hand and then reveals the truth Will has sought his whole life: he is John Parry, Will's father, who vanished through a window years before and became a shaman in another world. He tells Will that the subtle knife he now bears is the most important weapon in the war beginning across the worlds, and that he must carry it to Lord Asriel. Almost at once, Parry is shot dead by a witch who once loved him and could not forgive his rejection, so that Will finds and loses his father within minutes. Returning to camp, Will discovers that Lyra has been drugged and carried off by Mrs. Coulter, her own mother, who wants her out of the Church's reach. As Will stands alone and desperate, two rebel angels, Balthamos and Baruch, reveal themselves and promise to lead him to Asriel's fortress. Will refuses to abandon Lyra, insisting that finding her must come first. The knife is his, his father is dead, and the war can no longer be avoided.",
         "in_short": "Will Parry, a boy from an Oxford like ours who has secretly cared for his ill mother, kills an intruder hunting his missing father's papers and flees through a hidden window into Cittagazze, a city where soul-eating Spectres prey only on adults. There he meets Lyra, arrived from her own world, and the two children join forces, passing between worlds. Lyra befriends Mary Malone, a physicist whose Shadows are the same conscious Dust from Lyra's world. A schemer called Sir Charles Latrom, secretly Lord Boreal, steals Lyra's alethiometer and demands the subtle knife from the Tower of the Angels; Will wins the knife, losing two fingers, and becomes its bearer, able to cut between worlds. As witches and other powers gather for a coming war, the aeronaut Lee Scoresby seeks the shaman Grumman and dies protecting him. Grumman reveals himself as Will's father, John Parry, tells Will the knife is decisive, and is then killed. Will returns to find Lyra abducted by her own mother, and two rebel angels appear, offering to guide him to Lord Asriel.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5357,7 +5357,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5370,7 +5370,7 @@
       "recaps": {
         "ending": "After Charlotte tells Werther that he must stop visiting, he arranges his papers and resolves to die. He asks Albert to lend him pistols for a supposed journey; Albert has Charlotte hand them to the messenger, and Werther treats her contact with them as confirmation of his purpose. He writes a farewell, shoots himself near midnight, and is found the next morning still alive but beyond help. Albert, Charlotte, her family, and the town are devastated; Charlotte becomes seriously ill with grief. Werther dies around midday. Because he took his own life, no clergyman accompanies the burial. Workers carry him at night to the place he selected, and neither Albert nor Charlotte attends. The surviving editor's account closes the gaps left by Werther's final letters and makes clear that his attempt to turn death into a permanent bond with Charlotte instead leaves pain and silence among the living.",
         "in_short": "Werther withdraws to the country and falls passionately in love with Charlotte, the capable eldest daughter of a widowed official. Charlotte is already engaged to Albert, who returns and initially maintains a courteous friendship with Werther. Unable to moderate his feelings, Werther leaves for a diplomatic post, where bureaucracy and class prejudice deepen his alienation. He resigns and eventually returns to find Charlotte married. His visits become a strain on the household, and parallel stories of destructive love intensify his despair. During a final meeting he reads Charlotte sorrowful poetry, embraces and kisses her, and is told not to return. Werther then borrows Albert's pistols under the pretext of travel, writes a farewell, and shoots himself. He dies the next day and is buried at night without clergy, while Charlotte, Albert, and the family are left shocked and grieving.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5510,7 +5510,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5523,7 +5523,7 @@
       "recaps": {
         "ending": "After the fiesta, Jake leaves Pamplona and tries to recover his equilibrium alone in San Sebastian. Telegrams from Brett summon him to Madrid. He finds that she has sent Pedro Romero away despite loving him, fearing that their age difference and her influence would damage his life and career. She is distressed but insists that ending the affair was the one decent action available to her. Jake pays her hotel bill, arranges their departure, and resumes his familiar role as the person who rescues and comforts her. In a taxi, Brett imagines that she and Jake could have had a happy life together. Jake's answer acknowledges the beauty of that idea while recognizing that it cannot become reality. They remain emotionally bound, but the physical limits and destructive patterns that have kept them apart are unchanged.",
         "in_short": "Paris journalist Jake Barnes loves Lady Brett Ashley, but a war wound makes the relationship they want impossible. Their expatriate circle includes insecure novelist Robert Cohn, who has an affair with Brett, her bankrupt fiancé Mike Campbell, and Jake's friend Bill Gorton. The group converges in Pamplona for the fiesta and bullfights. Jealousy, drinking, and resentment intensify when Brett falls for the gifted young matador Pedro Romero. Cohn attacks Jake, Mike, and Romero, then leaves in remorse; Romero nevertheless performs brilliantly and departs with Brett. Afterward Brett ends that affair, believing she would ruin Romero, and calls Jake to Madrid for help. He comes at once. Their final conversation returns them to the same unresolved bond: they can imagine a life together but cannot escape the conditions that keep it imaginary.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5705,7 +5705,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5718,7 +5718,7 @@
       "recaps": {
         "ending": "After the fiesta, Jake leaves Pamplona and spends time alone in San Sebastián. Brett sends an urgent telegram asking him to come to Madrid, where he finds that she has ended her affair with Pedro Romero and sent the young matador away. She says she did so because she feared damaging him and resolves to return to Mike, while also declaring that she will no longer behave destructively. Jake takes care of the practical details and rides with her through Madrid. In the taxi Brett imagines that she and Jake might have had a happy life together. Jake's reply acknowledges the appeal of that fantasy without pretending it could become real. They finish where they began: deeply attached, able to depend on one another, but unable to turn their love into the shared life Brett imagines.",
         "in_short": "American journalist Jake Barnes lives among expatriates in 1920s Paris and remains in love with the English aristocrat Brett Ashley, though a war injury prevents the relationship they want. Brett briefly becomes involved with Jake's insecure friend Robert Cohn, then joins Jake, Bill Gorton, her fiancé Mike Campbell, and Cohn in Spain. A peaceful fishing trip gives way to the crowded fiesta at Pamplona, where drink, jealousy, and romantic rivalry split the party. Brett falls for the gifted young matador Pedro Romero. Cohn, unable to accept her rejection, assaults Jake, Mike, and Romero before leaving in shame. Brett goes away with Romero but soon ends the affair, believing she would damage his future. She summons Jake to Madrid, and he again helps her without gaining the life with her that both can imagine. The novel closes with them together in a taxi, contemplating a happiness that remains hypothetical.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5882,7 +5882,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5895,7 +5895,7 @@
       "recaps": {
         "ending": "Jeremy's legal effort does not stop the deportation. Natasha learns that her family must leave that evening, while Daniel's missed Yale interview and confrontation with the same attorney close off the day he was expected to follow his parents' plan. Natasha and Daniel spend their remaining time together and acknowledge that what began as his experiment has become real for both of them. At the airport they separate without knowing whether a one-day relationship can survive different countries and lives. Natasha returns to Jamaica with her family, and Daniel remains in New York. Their contact eventually fades, but each follows a path closer to the future they personally wanted. Ten years later, chance places them on the same airplane, where Irene is working as a flight attendant. Natasha and Daniel recognize each other and reunite, giving them an unexpected opportunity to discover what can follow the day that shaped them both.",
         "in_short": "On the day her undocumented Jamaican family is to be deported from New York, science-minded Natasha Kingsley searches for a last legal remedy. Daniel Bae, a Korean American aspiring poet headed to a Yale interview he does not want, notices her and becomes convinced their meeting matters. He persuades skeptical Natasha to spend time with him and try a sequence of questions meant to create intimacy. As they walk through the city, visit each other's family worlds, argue, and fall in love, Natasha keeps pursuing an immigration attorney who offers brief hope. The appeal fails, and she must leave that evening. Daniel misses the future his parents planned, while Natasha returns to Jamaica; distance eventually ends their contact. Ten years later, after both have moved toward lives of their own choosing, they unexpectedly meet again on an airplane, with their earlier encounter with the guard Irene forming part of the chain that brings them together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5979,7 +5979,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5992,7 +5992,7 @@
       "recaps": {
         "ending": "Black's appeals to faith, human connection, and the possibility of service do not alter White's conviction that consciousness and culture lead only to suffering and extinction. White finally makes Black unlock the apartment door and leaves, still intending to end his life. Alone, Black turns to God in anguish. He asks why he was placed at the station in time to save White if he was not also given the words needed to keep him alive. The play closes without confirming White's fate, while Black remains shaken by the apparent failure of the mission he believed he had received.",
         "in_short": "After Black prevents White from stepping in front of the Sunset Limited, he takes the professor to his apartment and tries to persuade him to live. Black grounds his case in Christian faith, his own transformation after prison, and the value of serving other people. White rejects each premise. He describes a loss of belief not only in God but in culture, progress, human fellowship, and any lasting value in consciousness itself. Their conversation becomes a contest between Black's hope that suffering can be redeemed and White's conviction that nonexistence is the only relief. Black delays White but cannot change him. White insists on being released and leaves the apartment, apparently still resolved to die. Black remains behind, questioning why God enabled the rescue but did not enable him to save White's spirit.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6135,7 +6135,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6148,7 +6148,7 @@
       "recaps": {
         "ending": "After Ariel is driven ashore and lost, Jack, Stephen, and Jagiello are taken to Paris. Their captors know that Stephen is not merely a naval surgeon and try to extract intelligence from him, making captivity more dangerous than an ordinary exchange of prisoners. Duhamel, alienated from the methods and politics of his own service, helps arrange their escape. The three prisoners are moved out through a covert route and eventually cross back into British protection. Jack has lost another ship but survived an operation whose Baltic object was achieved before the wreck. Stephen returns alive despite the exposure of his intelligence identity to the French, a danger that will follow him into later work. Diana remains his wife in England, so the book closes with their marriage intact, Jack free to face the official consequences of Ariel's loss, and both friends home but no longer able to assume that Stephen's work is secret from enemy intelligence.",
         "in_short": "Following their escape from Boston, Jack Aubrey, Stephen Maturin, and Diana Villiers return to Britain. Stephen and Diana marry, while Jack receives command of Ariel for a concealed Baltic operation. Stephen and the Lithuanian officer Jagiello make contact with an isolated Catalan garrison that has turned against French authority, and British naval support allows the men to be removed from danger. On the return voyage Ariel is pursued, forced ashore, and lost; Jack, Stephen, and Jagiello become prisoners and are sent to Paris. French intelligence recognizes Stephen as an agent and subjects him to a more dangerous examination than his naval status would warrant. With help from the disillusioned French officer Duhamel, the prisoners escape and regain British protection. Jack has accomplished the mission but lost his ship, while Stephen returns to Diana with his intelligence identity exposed to the enemy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-sympathizer.json
+++ b/data/works-community/0/the-sympathizer.json
@@ -134,7 +134,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -147,7 +147,7 @@
       "recaps": {
         "ending": "Captured during the failed return to Vietnam, the Captain is confined in a reeducation camp while the Commandant repeatedly rejects his written confession. The camp's Commissar is revealed as Man, now terribly scarred. Friendship does not free either man from the revolution's demands: Man arranges an interrogation meant to break the Captain's last defenses. Under torture and enforced sleeplessness, the Captain confronts the memory he has excluded from his confession—his passive complicity while communist agents raped a fellow operative. He also arrives at the paradoxical answer Man requires, recognizing the liberating and annihilating possibilities contained in nothing. Man eventually engineers the release of the Captain and Bon. The two join other refugees escaping by boat. The Captain no longer identifies himself as a solitary divided man but speaks as part of a collective “we,” carrying both commitment and disillusionment. He and Bon face an uncertain refugee future, alive and together, while the ideals that governed the Captain have been permanently altered by what their victorious revolution did to him.",
         "in_short": "An unnamed South Vietnamese army captain is also a communist mole. During the fall of Saigon he escapes to America with his anti-communist superior, the General, and his friend Bon, while continuing to report to Man, his communist handler and other closest friend. In California he observes refugee life, carries out assassinations ordered by the General, and advises a Hollywood war film whose treatment of Vietnamese people exposes another form of domination. His divided loyalties damage everyone around him. When the General organizes a doomed mission back to Vietnam, the Captain joins to protect Bon and is captured. At a reeducation camp his written confession is rejected by a Commandant and a masked Commissar who proves to be Man. Torture forces him to acknowledge his failure to stop the rape of a fellow agent and to confront the emptiness within revolutionary certainty. Man secures his release, and the Captain escapes by boat with Bon and other refugees, speaking at last as part of a collective rather than as a man who can remain safely between two sides.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -293,7 +293,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -306,7 +306,7 @@
       "recaps": {
         "ending": "After completing the journey to the underworld, Psyche opens the sealed container she is carrying for Venus, hoping to take a little divine beauty for herself. The box contains a deathlike sleep, and she collapses. Cupid, now healed, escapes confinement, removes the sleep from her, and tells her to finish the errand. He then asks Jupiter to protect their marriage. Jupiter gathers the gods, recognizes the union, and has Psyche drink ambrosia so that she becomes immortal. This change removes the inequality between a mortal woman and a god and prevents the marriage from dishonoring Venus. Venus accepts the settlement, and Cupid and Psyche celebrate their wedding among the gods. Their daughter is born and named Pleasure, making the conclusion both a family reconciliation and an explanation of how love, soul, and pleasure come to be joined.",
         "in_short": "Psyche's beauty attracts worship that angers Venus, who orders Cupid to punish her. Cupid instead hides Psyche in a magical palace and becomes her unseen husband. Persuaded by her jealous sisters that he is a monster, Psyche looks at him by lamplight and loses him. She searches for Cupid and submits to Venus, who assigns impossible labors: sorting seeds, gathering golden wool, fetching dangerous water, and carrying a box from the underworld. Helpers enable her to complete each task, but she opens the final box and falls into a deathlike sleep. Cupid revives her and appeals to Jupiter. Psyche is made immortal, Venus accepts the marriage, and the divine wedding produces a daughter named Pleasure.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -471,7 +471,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -484,7 +484,7 @@
       "recaps": {
         "ending": "Despereaux enters the dungeon armed with a sewing needle, following the smell of the soup Cook has made despite the king's ban. He reaches Princess Pea after Miggery Sow has helped Roscuro take her captive. Mig learns that Roscuro never intended or had the power to make her a princess and turns against him. Despereaux confronts the rat, but the resolution comes through Pea's offer of mercy: if Roscuro guides them out, he may live above and receive soup. The promise reaches the part of him that has always wanted light and belonging. Roscuro leads Pea, Mig, and Despereaux out of the dungeon. Pea is restored to her father, soup returns to the kingdom, and Roscuro is permitted access to both the bright castle and the dungeon. Mig's longing to matter is finally recognized, and Despereaux survives as Pea's honored friend. The tale ends with its characters brought together at a shared table rather than divided between light and darkness.",
         "in_short": "Despereaux Tilling is a tiny castle mouse who loves music, stories, light, and Princess Pea. The mouse council condemns him to the dungeon for speaking to a human. There he becomes entangled with Chiaroscuro, or Roscuro, a rat whose longing for light ended in disaster when his appearance frightened the queen to death. Blamed by Pea and driven back underground, Roscuro plots revenge. He recruits Miggery Sow, an abused servant who dreams of becoming a princess, to abduct Pea. Despereaux learns of the plan and enters the dungeon with a sewing needle as a sword, aided by Cook's forbidden soup. Mig turns on Roscuro when she realizes he has deceived her, and Despereaux reaches the captives. Pea offers Roscuro soup and a place in the light if he leads them out. He accepts. Pea returns safely, soup is restored, Roscuro can move between castle and dungeon, Mig receives care, and Despereaux remains the princess's friend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -633,7 +633,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -646,7 +646,7 @@
       "recaps": {
         "ending": "Tom abandons his impersonation of Dickie and arranges the evidence to suggest that Dickie killed Freddie Miles and then took his own life. Marge remains suspicious, especially after finding Dickie's rings among Tom's belongings, but Tom supplies explanations and preserves the story through questioning by the police, Herbert Greenleaf, and private investigator Alvin McCarron. A will written by Dickie leaves his property to Tom. Tom expects the document to become the final clue that exposes him, yet the Greenleaf family accepts it as genuine and does not contest the inheritance. Traveling onward to Greece, he learns that the danger he feared has passed and that Dickie's income will be his. He reaches Crete wealthy and free, though still alert to every policeman and message as a possible sign that his crimes have caught up with him.",
         "in_short": "Tom Ripley is sent to Italy by Herbert Greenleaf to persuade Herbert's son Dickie to return home. Tom instead becomes captivated by Dickie's privileged life in Mongibello. When Dickie tires of him, Tom kills him during a boat trip, hides the body, and uses his skill at imitation to live as Dickie while also managing appearances as himself. Freddie Miles discovers enough to become dangerous, so Tom kills him too. Police scrutiny forces Tom to abandon Dickie's identity, and he creates a story in which Dickie murdered Freddie and then disappeared or died by suicide. Marge Sherwood suspects Tom, but neither the police nor a private investigator proves the truth. Dickie's will names Tom as heir; the Greenleaf family accepts it, leaving Tom wealthy and unpunished as he travels to Greece.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -829,7 +829,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -842,7 +842,7 @@
       "recaps": {
         "ending": "As the camp is emptied, Gita is forced onto a march and eventually reaches safety, while Lale is transferred away from Auschwitz. He survives further imprisonment, escapes during transport, and makes his way back to Slovakia. In Bratislava he searches among returning survivors, asking persistently for Gita under the surname he has finally learned. They find each other by chance on a city street. Lale proposes immediately, and they marry, taking the surname Sokolov. After the authorities later punish Lale for supporting the creation of Israel, the couple leave Czechoslovakia and settle in Australia. They build a life in Melbourne and have a son, Gary. Lale keeps the details of Auschwitz largely private for decades, honoring Gita's discomfort with revisiting the camp. After her death, he decides that their story should be told, preserving both the brutality they survived and the promise of a shared future that helped them endure it.",
         "in_short": "Slovakian Jew Lale Eisenberg is deported to Auschwitz-Birkenau, where he becomes the prisoner tasked with tattooing identification numbers on new arrivals. The role gives him extra food and freedom of movement, which he uses to trade valuables from confiscated belongings for supplies shared with other prisoners. While tattooing Gita Furman, he falls in love and begins a dangerous courtship sustained by messages, stolen meetings, and faith in a life after the camp. Lale survives beatings and interrogation when the contraband network is exposed; Gita survives illness, forced labor, and evacuation. As Germany's defeat approaches, they are separated. Lale escapes from later custody and returns to Slovakia, where he searches for Gita until they unexpectedly reunite in Bratislava. They marry, adopt the surname Sokolov, and eventually emigrate to Australia. Decades later, after Gita's death, Lale recounts their story.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -928,7 +928,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -941,7 +941,7 @@
       "recaps": {
         "ending": "After killing and dismembering the old man, the narrator hides the remains beneath the floorboards and confidently welcomes three police officers into the house. The officers find nothing suspicious and sit in the room directly above the hiding place. During their casual conversation, the narrator begins to hear a faint, regular beating that seems to grow steadily louder. Convinced that it is the dead man's heart and that the officers also hear it but are silently mocking the attempt at concealment, the narrator loses all composure. The sound is not confirmed by anyone else and may be guilt, terror, or an auditory hallucination. Unable to endure it, the narrator confesses and tells the officers to lift the boards, exposing the body and undoing the carefully planned crime.",
         "in_short": "An unnamed narrator tries to prove mental competence by giving a detailed account of murder. Although claiming to love an old man, the narrator becomes obsessed with his pale, clouded eye and spends seven nights secretly watching him sleep. On the eighth night the old man wakes, and the narrator interprets an increasingly loud heartbeat as an urgent threat. After killing him and concealing his dismembered body beneath the floor, the narrator calmly receives police officers summoned by a neighbor. Their search reveals nothing, but as they talk above the hidden remains the narrator hears a beating that grows unbearable. Believing the officers can hear it too and are pretending otherwise, the narrator breaks down, confesses, and directs them to the body under the boards.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1103,7 +1103,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1116,7 +1116,7 @@
       "recaps": {
         "ending": "After Helen has escaped to Wildfell Hall, she returns to Grassdale when Arthur Huntingdon becomes gravely ill. She nurses him despite his past abuse, but he resists sustained reform and dies fearful and dependent. Helen is then free, and her uncle's death leaves her independently wealthy. Gilbert, who has learned that Frederick Lawrence is Helen's brother and has repaired their friendship, still loves her but hesitates when their difference in fortune seems to place her beyond him. A mistaken report nearly convinces him that she will marry another man. He finally goes to seek the truth, meets Helen, and discovers that her feelings remain unchanged. She accepts him, using a winter rose as the sign of her answer. Gilbert and Helen marry and live at Staningley with young Arthur. Frederick Lawrence marries Esther Hargrave, while Ralph Hattersley has genuinely reformed and built a happier family life with Milicent. Gilbert's letter closes after years of marriage, with the central secrets explained and Helen secure in a relationship she has freely chosen.",
         "in_short": "Farmer Gilbert Markham becomes fascinated by Helen Graham, a secretive widow living at Wildfell Hall with her son. Gossip and her apparent intimacy with Frederick Lawrence provoke Gilbert into jealousy and violence. Helen answers by giving him her diary. It reveals that she is Helen Huntingdon, hiding from a living husband: she married the charming Arthur Huntingdon despite warnings, then endured his drinking, cruelty, infidelity, and attempts to teach their son the same habits. When Huntingdon discovered her first escape plan, he confiscated her money and artistic materials. With help from her brother Frederick, Helen eventually fled with her child and servant. Gilbert understands his error and protects her secret. Helen later returns to nurse her ill husband; after his death she inherits property and is legally free. Gilbert reconciles with Frederick, overcomes doubts created by Helen's wealth, and seeks her out. Helen and Gilbert marry, while her son remains with them in a secure new household.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1230,7 +1230,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1243,7 +1243,7 @@
       "recaps": {
         "ending": "Carosse's impersonation forces Chavel to face the identity and guilt he has been hiding. When Therese is placed in danger, Chavel abandons the safety of the name Charlot and declares that he is the real Jean-Louis Chavel. He protects her at the cost of his own life and is fatally shot by Carosse. The impostor's scheme is exposed and he is prevented from taking Chavel's place or possessing the household. Therese finally understands that the quiet man who lived beside her was the person she had sworn to hate, but she also sees that he returned without trying to reclaim the estate and ultimately gave his life for her. Chavel dies having made a voluntary sacrifice that answers, as far as it can, the bargain by which he once purchased his survival. The Mangeot property remains with Therese rather than reverting to him or falling to the false claimant.",
         "in_short": "In an occupied French prison, wealthy lawyer Jean-Louis Chavel draws a death lot in a German reprisal. He offers his entire fortune to any prisoner who will replace him, and the dying Janvier accepts so that his mother and sister will inherit. After the war, Chavel returns penniless to his former estate under the name Charlot. Janvier's sister Therese, unaware who he is, gives him work while speaking openly of her hatred for the coward who bought her brother's life. Chavel grows attached to her and cannot confess. Carosse, a hunted collaborator and actor, then arrives pretending to be Chavel and uses the household's anger and uncertainty for his own ends. To save Therese, Chavel finally reveals his identity. Carosse shoots him, but the impersonation fails. Chavel dies after freely risking his life for Therese, turning the survival purchased in prison into a final act of sacrifice.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1603,7 +1603,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -1616,7 +1616,7 @@
       "recaps": {
         "ending": "Ruwen kills the Havoc Sovereign and recovers the stolen resistance potions, but the Infernal Lord and a Chaos Tower Inquisitor trap him on the island of five towers. Rami escapes on Vex. The Scarecrow aspect repeatedly prevents Ruwen from leaving, apparently acting from an unresolved sense of duty. Ruwen consumes a resistance potion and draws destruction essence from the sovereign's core, but a hidden runed object triggers a catastrophic transformation. The Infernal Lord shatters his original body, although Ruwen's consciousness survives. Overlord and other inner allies use creation-linked protection in his mind to restore him in a noble seraph body. He adopts the identity Ruin Valdor and selects the unique Destruction Emperor class, retaining the Scarecrow aspect and transformed versions of several possessions and powers. His Ruwen Starfield profile is still inaccessible. Rami reaches him through an unexplained gray rift and reports that the Infernal Lord has stolen the stronger potions from the fortress and that Vex is missing. The Tower war, the pending Inklord conclave, the Scarecrow aspect's identity, and Ruwen's original body all remain unresolved.",
         "in_short": "Ruwen Starfield enters a Grandmaster Alchemy tournament while seeking answers about spirit, affinity magic, and the Shadow Realm. Under the identity Nightshade, he defeats a rival, spreads alchemical teaching, helps Sift's parents become Grandmasters, and learns that the Muses are developing resistance to soul power. After declaring himself the Tenth Muse, he discovers that missing Muses and stolen potions are in the deep Destruction Realm. Ruwen and Rami recover the potions by killing the Havoc Sovereign, but the Infernal Lord arrives and the Scarecrow aspect repeatedly blocks Ruwen's escape. A controlled attempt to assimilate destruction essence destroys his original body. His allies recover his consciousness in a House Valdor body, which he names Ruin Valdor, and he becomes Destruction Emperor. Rami then reports that the Infernal Lord stole the stronger potions from camp, while Ruwen's original profile remains inaccessible.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1846,7 +1846,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1859,7 +1859,7 @@
       "recaps": {
         "ending": "Hickey's mutineers collapse through starvation, violence, and the creature's attack. Hickey offers himself to the being in a grotesque attempt to gain power, but both he and the creature die. Goodsir, forced to help the mutineers butcher the dead, poisons his own body so that those who eat him will also die. Crozier survives poisoning and exposure because Silence finds and nurses him. When rescue parties later search for the expedition, Crozier chooses not to return to Britain. His tongue has been removed, and he lives with Silence among the Inuit under a new identity. The ships and nearly all their men are lost; the official world never learns Crozier's fate or the full causes of the disaster.",
         "in_short": "Sir John Franklin's ships Erebus and Terror become trapped in Arctic ice while searching for the Northwest Passage. Captain Francis Crozier recognizes the danger, but hierarchy, pride, spoiled provisions, disease, and an unnaturally powerful creature steadily destroy the expedition. After Franklin's death, Crozier and James Fitzjames try to preserve discipline, abandon the ships, and march south. A fire, scurvy, lead poisoning, starvation, and Cornelius Hickey's mutiny divide the survivors. Fitzjames and most of Crozier's loyal men die; Goodsir kills himself after poisoning his body to strike at the cannibal mutineers. Hickey's effort to master the creature destroys him, while the creature also dies. The Inuit woman called Silence rescues Crozier. Mutilated and unwilling to return to his former life, he remains with her in the Arctic as the expedition disappears into history.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2061,7 +2061,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2074,7 +2074,7 @@
       "recaps": {
         "ending": "The restored merry-go-round on the Isola Segreta can change a rider's age. Renzo and his sister Morosina use it to regain their youth. Scipio, tired of being powerless under his father's authority, rides until he has an adult body. Barbarossa tries to seize the magic for himself and is transformed into a small boy; the carousel is then damaged beyond further use. The newly adult Scipio does not return to his old home. He becomes Victor's assistant, putting his talent for disguises and investigation to legitimate work. Ida Spavento gives Prosper, Bo, Hornet, Riccio, and Mosca a safe home and the chance to attend school while remaining together. Esther Hartlieb no longer gets to separate the brothers. Instead, she takes in the child-sized Barbarossa, whose angelic appearance conceals the same greed and bullying temperament. Prosper and Bo remain in Venice with their chosen family, while Scipio gains independence without retaining the enchanted power that changed him.",
         "in_short": "Orphaned brothers Prosper and Bo flee to Venice when their aunt plans to adopt Bo alone. They join homeless children living in an abandoned cinema under Scipio, the celebrated Thief Lord. Detective Victor Getz tracks them but becomes their ally. A mysterious client commissions Scipio to steal a wooden wing belonging to Ida Spavento; the children learn it completes a hidden merry-go-round able to change a rider's age. They also discover that Scipio is really the sheltered son of a wealthy doctor and has been stealing from his own home. After the wing is recovered, the group follows it to a secret island. Scipio uses the restored carousel to become an adult, while crooked dealer Ernesto Barbarossa is turned into a young child and the machine is destroyed. Ida provides a home for Prosper, Bo, and the other children. Adult Scipio joins Victor's detective agency, and Prosper and Bo remain safely together in Venice while their aunt unwittingly adopts the child-sized Barbarossa.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2223,7 +2223,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2236,7 +2236,7 @@
       "recaps": {
         "ending": "Harvey returns to the Holiday House deliberately, pretending that he wants its pleasures again while looking for a way to break Hood's power. He challenges the master to satisfy an impossible flood of wishes, forcing the magic that sustains the house beyond its limits. The illusion collapses, the stolen years are released, and the children trapped as fish in the lake regain their human lives, including Lulu. Hood attempts to survive in diminished forms, but Harvey refuses to be deceived and destroys what remains of him. The servants and the false paradise are gone; Mrs. Griffin, freed from Hood's control, can leave. Harvey and Wendell return to their own families with their stolen time restored. Back in the real February that once seemed unbearable, Harvey understands that ordinary seasons, waiting, and change give life its value. He accepts the cold day gladly rather than wishing his time away.",
         "in_short": "Ten-year-old Harvey Swick is bored by a gray February until the smiling Rictus leads him to the Holiday House, where every day contains spring, summer, Halloween, and Christmas. Harvey enjoys the games with Wendell and Lulu, but repeated pleasures become disturbing. He learns that the house steals a year of a child's life for every day spent there and that former guests are trapped as fish in its lake. Harvey and Wendell escape past the beast Carna, only to find decades have passed outside. After locating their aged families, Harvey returns to confront the house's master, Hood. By demanding more wishes than Hood's magic can sustain, Harvey brings down the illusion, frees the captive children, restores the stolen years, and destroys Hood. Home again in his proper time, Harvey no longer treats ordinary life or the passage of the seasons as something to be discarded.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2396,7 +2396,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2409,7 +2409,7 @@
       "recaps": {
         "ending": "Nick proves that the body hidden in Clyde Wynant's workshop is Wynant himself, identifiable by an old leg injury. Clyde therefore could not have written the recent letters that kept him apparently alive. Herbert Macaulay, the trusted lawyer handling Clyde's affairs, killed him to conceal financial theft and created the illusion that the inventor was traveling. Julia Wolf knew enough to endanger the scheme, so Macaulay killed her as well; Nunheim's attempt to profit from what he knew made him another victim. Nick lays out the case at a dinner gathering, using the false chronology and physical evidence to strip away Macaulay's respectable role, and the police arrest him. The unrelated secrets of Mimi's second husband are also exposed, adding to the Wynant family's upheaval. Dorothy and Gilbert are left to absorb the truth about their father and the adults around them. Nick and Nora finish the holiday together, their marriage intact and playful, while Nick again insists that solving one case does not mean he has returned permanently to detective work.",
         "in_short": "Retired detective Nick Charles and his wealthy wife Nora spend Christmas in New York, where Dorothy Wynant asks Nick to find her missing father, eccentric inventor Clyde Wynant. Clyde's secretary and former lover Julia Wolf has been murdered, and letters supposedly from Clyde make him the obvious suspect. Nick is drawn in as police, criminals, and Clyde's unstable family pass through the Charleses' crowded holiday. Further violence silences a man connected to Julia, while a body discovered in Clyde's workshop changes the problem. Nick identifies the remains as Clyde himself, proving that the recent letters were forged. At a dinner for the suspects, he shows that trusted lawyer Herbert Macaulay murdered Clyde to hide financial wrongdoing, maintained the fiction that Clyde was alive, and killed Julia and a blackmailer who threatened the deception. Macaulay is arrested. The Wynant family's other secrets remain painful, but the central murders are solved, and Nick and Nora return to their holiday partnership rather than to a conventional detective-and-client relationship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2516,7 +2516,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2529,7 +2529,7 @@
       "recaps": {
         "ending": "A misshapen, foul-smelling visitor arrives at Daniel Upton's door and gives him a letter. The visitor is the reanimated body of Asenath Waite, which Edward Derby had buried in the cellar. Edward's mind is now trapped inside that decaying body, while Ephraim Waite's mind has secured permanent possession of Edward's living body. The letter explains that Ephraim had taken Asenath's body years earlier and later used it to gain access to Edward. Unable to speak, Edward has forced Asenath's corpse out of the grave long enough to warn Daniel and ask him to destroy the usurper. The corpse collapses at the doorstep. Daniel goes to Arkham Sanitarium and fires six bullets into Edward's body, killing the being that occupies it. He tells the story while awaiting judgment, convinced that the shooting was necessary even though the law can see only the murder of his friend.",
         "in_short": "Daniel Upton explains why he killed his friend Edward Derby at Arkham Sanitarium. Edward marries occult student Asenath Waite and begins suffering lapses in which another personality controls his body. He eventually claims that Asenath can exchange minds with him and that her body is actually inhabited by her dead father, the sorcerer Ephraim Waite. Edward says he kills Asenath, but his symptoms return and he is committed. After the apparent Edward is released as sane, a decaying figure arrives at Daniel's door with a written message: Edward's mind is trapped in Asenath's buried corpse, while Ephraim has taken Edward's body permanently. Edward asks Daniel to kill that body before Ephraim can continue. Daniel obeys, shooting his possessed friend and accepting the consequences.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2721,7 +2721,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2734,7 +2734,7 @@
       "recaps": {
         "ending": "The last two linked pieces shift from the company's war to the uses of storytelling. During a period of night movement, Rat Kiley becomes overwhelmed by exhaustion and by visions of the soldiers' bodies as living tissue waiting to be damaged. He shoots himself in the foot to escape further combat and is taken away. O'Brien then recalls Linda, the nine-year-old girl he loved before she died of a brain tumor. As a child he learned to meet her again in dreams; as an adult writer he similarly restores dead friends and civilians in stories. Kiowa, Curt Lemon, Ted Lavender, the Vietnamese man, and Linda can speak and move again within narrative even though no account cancels their deaths. The book therefore ends without resolving the war as a conventional plot. Its final claim is enacted through memory: O'Brien writes to keep the dead present and to reconnect his older self with the child who first discovered that imagination could briefly rescue someone lost.",
         "in_short": "Through interlinked stories, Tim O'Brien recalls Alpha Company in Vietnam and repeatedly questions what makes an account emotionally true. Lieutenant Jimmy Cross carries fantasies of Martha and guilt over Ted Lavender's death; the other soldiers carry weapons, keepsakes, fear, superstition, and responsibility. O'Brien remembers nearly fleeing to Canada before accepting the draft, the deaths of Curt Lemon and Kiowa, Mary Anne Bell's transformation at a remote aid station, and his own grenade killing of a Vietnamese man. Norman Bowker returns home unable to explain the war and later dies by suicide; O'Brien reshapes his friend's experience into fiction while admitting where he changed it. A return to the field with his daughter, and an act of revenge against an inexperienced medic, show memory still governing him. The closing story reaches back to Linda, O'Brien's childhood love, who died at nine. Remembering her teaches him what all the war stories attempt: narrative cannot reverse death, but it can preserve the dead and let the living encounter them again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2874,7 +2874,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2887,7 +2887,7 @@
       "recaps": {
         "ending": "Martins agrees to help Calloway trap Harry after seeing the human cost of the stolen, diluted penicillin, although Anna regards his cooperation as a betrayal. Harry recognizes the danger at the meeting place and escapes into Vienna's sewer system. Police pursue him underground. During the chase Harry kills Sergeant Paine, one of the few people in Vienna who treated Martins with uncomplicated kindness. Harry is wounded and unable to escape; Martins reaches his old friend and fires the final shot rather than leave him suffering or allow the pursuit to continue. Harry is buried for a second time. After the funeral Anna initially walks away from Martins, still grieving and unable to forgive what he did. In the novella's more open closing movement, Martins follows and catches up with her, and the two walk on together. Calloway cannot say what future, if any, that shared walk gives them, while Harry's death closes the immediate case.",
         "in_short": "Rollo Martins arrives in occupied Vienna to work for his old friend Harry Lime and learns that Harry has supposedly died in a road accident. British policeman Colonel Calloway says Harry was a black-market criminal, but conflicting witness accounts lead Martins to investigate. A porter mentions an unidentified third man and is then killed. Martins eventually sees Harry alive and learns that the death was staged. Calloway shows him that Harry's ring stole penicillin, diluted it, and sold it to hospitals, leaving patients dead or gravely harmed. After meeting an unrepentant Harry, Martins helps the police set a trap despite the anger of Harry's lover, Anna Schmidt. Harry escapes into the sewers, kills Sergeant Paine, and is wounded; Martins fires the fatal shot. At Harry's second funeral Anna walks away, but Martins follows and catches her. They leave together, with their future unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3022,7 +3022,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3035,7 +3035,7 @@
       "recaps": {
         "ending": "Holly agrees to help Calloway trap Harry after seeing the victims of the diluted penicillin racket, but Anna discovers the plan and warns Harry. Holly nevertheless arranges a meeting, and Harry is pursued into Vienna's sewers when the police close in. He shoots and kills Sergeant Paine before Calloway wounds him. Holly finds his former friend unable to escape and, after a final silent exchange, fires the shot that kills him. Harry is buried for a second time. Holly waits along the cemetery road for Anna, hoping their shared loss has brought them together, but she walks past him without stopping. Calloway's case is closed, while Holly leaves Vienna having exchanged his idealized memory of Harry for knowledge of the harm Harry chose to cause.",
         "in_short": "American Western writer Holly Martins reaches occupied Vienna to take a job offered by his friend Harry Lime, only to be told that Harry has died in a road accident. Doubting both the police description of Harry as a racketeer and the conflicting testimony of Harry's associates, Holly investigates with help from Harry's lover, Anna Schmidt. He discovers that Harry is alive and has been hiding in the Soviet sector. Major Calloway then proves that Harry's gang stole penicillin, diluted it, and sold it to hospitals, causing deaths and severe injuries. Holly reluctantly helps the police set a trap. Harry flees through the sewers, kills Sergeant Paine, and is wounded by Calloway; Holly finds him trapped and shoots him. After Harry's second funeral, Anna rejects Holly by walking past him without a word.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3142,7 +3142,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3155,7 +3155,7 @@
       "recaps": {
         "ending": "The narrator rides home and finds that many years have passed, although his journey seemed brief to him. Divney is horrified to see the man he deliberately killed with an explosive hidden in Mathers's cashbox. The narrator still does not understand that he is dead. Divney's terror leads to his own death, after which he travels the same road and reaches the police barracks. There he begins an exchange with Pluck that closely repeats the narrator's arrival, implying that the station, the impossible landscape, and its punishments form a recurring afterlife. The narrator's search for the cashbox and his dream of publishing his de Selby study have led him into a cycle he cannot recognize, while Divney is now entering it in turn.",
         "in_short": "An unnamed de Selby scholar conspires with John Divney to rob and kill Phillip Mathers so he can finance a book. Years later Divney sends him to recover the dead man's cashbox, but the narrator instead enters a landscape governed by impossible policemen, dangerous bicycles, shifting identities, and an underground chamber containing machines of immense power. He is threatened with hanging, escapes with an extraordinary bicycle, and returns home to find Divney much older and terrified by his appearance. The truth becomes clear to the reader: Divney put a bomb in the cashbox and killed him before the strange journey began. Divney soon dies as well and arrives at the same police station, where his experience starts to repeat the narrator's. The narrator remains unable to grasp that the bewildering country through which he travels is a personal hell shaped by guilt, circularity, and his own fixed ideas.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3310,7 +3310,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3323,7 +3323,7 @@
       "recaps": {
         "ending": "Greg, Rowley, and Abigail attend the Valentine's dance as a group after Abigail's intended date becomes unavailable. The evening does not give Greg the romantic breakthrough he expected. Afterward, Greg develops chicken pox, having been exposed through Abigail. During Greg's illness, Rowley spends more time with Abigail, and the two begin dating. Greg is left outside the new couple despite having regarded Rowley as his assistant in finding a partner. Uncle Gary, meanwhile, finally leaves the Heffley household after gaining money, restoring some space at home. The title's apparent third wheel is ultimately Greg: his elaborate attempts to secure a date help create a relationship between his best friend and the girl he accompanied.",
         "in_short": "Greg reflects on his earliest childhood while dealing with Uncle Gary's latest stay at the crowded Heffley home. At school, the announcement of a Valentine's dance sends him into a prolonged search for a date. Greg studies the social competition, pursues unlikely possibilities, and uses Rowley as a helper, but neither boy initially succeeds. When Abigail Brown loses her intended date, Greg arranges for himself, Abigail, and Rowley to attend together. Their pre-dance plans and the dance itself are awkward, and Greg gains no romance from the evening. He later comes down with chicken pox after exposure to Abigail. While Greg is recovering, Abigail and Rowley become a couple, leaving Greg as the outsider in the arrangement he helped form. Uncle Gary's departure eases the situation at home, but Greg ends the episode without the girlfriend or social victory he had sought.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3473,7 +3473,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3486,7 +3486,7 @@
       "recaps": {
         "ending": "Hannay interprets Scudder's final clue as a reference to a flight of thirty-nine steps leading down a cliff on the Kent coast. At a nearby house he finds three respectable-looking men whose small mistakes convince him that they are the Black Stone in disguise. Officials arrive and arrest the spies before they can reach the yacht waiting offshore with Britain's stolen defense information. Hannay has not been able to prevent the earlier murder of Karolides, but he stops the naval secrets from leaving Britain. A few weeks later Europe goes to war. Hannay receives an army commission, his unwanted holiday from danger having ended with his entry into national service.",
         "in_short": "Newly returned to Britain and bored with civilian life, Richard Hannay shelters the American agent Franklin Scudder, who claims that foreign spies intend to assassinate a Greek statesman and steal British defense plans. When Scudder is murdered in Hannay's flat, Hannay flees to Scotland, wanted by the police and hunted by the conspirators. Using Scudder's coded notebook, a series of disguises, and help from chance acquaintances, he survives pursuit and reaches senior official Sir Walter Bullivant. Karolides is assassinated, and a spy disguised as a naval official then learns vital secrets. Hannay follows Scudder's remaining clue to a coastal staircase with thirty-nine steps, identifies the outwardly respectable leaders of the Black Stone, and has them arrested before they escape by sea with the intelligence. With the secret secure, Hannay joins the army as war begins.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3608,7 +3608,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3621,7 +3621,7 @@
       "recaps": {
         "ending": "Hannay concludes that the thirty-nine steps in Scudder's notes are a real staircase leading from a house on the English coast to the sea. He identifies the house and watches its three respectable occupants, gradually recognizing the Black Stone agents beneath their disguises. Their calm behavior almost defeats his certainty, but a small familiar gesture confirms the leader's identity. Hannay alerts the authorities as the spies descend the steps toward a waiting yacht with Britain's naval information. The escape is stopped and the three men are arrested. Hannay has cleared himself of Scudder's murder and completed the dead agent's mission, though Scudder's warning about a wider conflict remains valid. A few weeks later Britain enters the First World War, and Hannay begins a new role in military service.",
         "in_short": "Richard Hannay's dull London life changes when the American agent Franklin Scudder tells him that a German group called the Black Stone plans to murder a statesman and steal British naval secrets. After Scudder is killed in Hannay's flat, Hannay takes his coded notebook and flees toward Scotland, hunted by both the conspirators and police who suspect him of murder. He survives through disguises, quick inventions, and help from several strangers, then escapes imprisonment by one of the spies. Hannay reaches Sir Walter Bullivant and deciphers Scudder's warning, but a disguised Black Stone agent still obtains the secret plans. The phrase \"thirty-nine steps\" leads Hannay to a coastal house where the three spies are preparing to leave by yacht. He recognizes them despite their respectable disguises and brings the authorities in before they escape. The agents are arrested, Hannay is cleared, and Britain soon enters the war Scudder predicted.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3958,7 +3958,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3971,7 +3971,7 @@
       "recaps": {
         "ending": "The collection closes with The Mayor of Casterbridge. Henchard's prosperity, office, and relationships have all collapsed as Farfrae rises. After lying that Newson cannot see Elizabeth-Jane because she is dead, Henchard is driven away when Newson discovers the truth. Henchard briefly returns for Elizabeth-Jane's wedding to Farfrae but leaves without presenting himself. She later seeks him and learns that he has died in obscurity. His will asks that no funeral attention or remembrance be given to him. Elizabeth-Jane regrets her last harshness and returns to her life with Farfrae carrying a more sober understanding of happiness. Across the six novels, Bathsheba and Gabriel and later Thomasin and Venn reach durable unions, while Tess, Eustacia, Jude, Sue's children, Giles, and Henchard bear the fatal consequences of desire, convention, chance, and belated recognition.",
         "in_short": "Six Hardy novels trace lives shaped by rural society, desire, chance, and rigid convention. Bathsheba Everdene survives a disastrous marriage to Troy and Boldwood's violence before marrying the steadfast Gabriel Oak. Tess Durbeyfield is exploited by Alec, rejected and later reclaimed by Angel Clare, then executed after killing Alec. On Egdon Heath, Eustacia Vye and Wildeve drown during an attempted escape; Thomasin later marries Diggory Venn. Jude Fawley and Sue Bridehead lose their children and separate under social and religious pressure; Jude dies after returning to Arabella. In The Woodlanders, Grace's marriage to the unfaithful Fitzpiers blocks her union with Giles, who dies after sacrificing his shelter to her. Finally, Michael Henchard rises to become mayor of Casterbridge, loses his position and loved ones through pride and rivalry with Donald Farfrae, and dies alone after withdrawing from Elizabeth-Jane's life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4240,7 +4240,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4253,7 +4253,7 @@
       "recaps": {
         "ending": "The collection closes with the end of The Magic Mountain. After years at the Berghof, Hans has outlived Joachim, Peeperkorn, and Naphta and has seen the sanatorium's intellectual debates collapse into exhaustion and violence. The outbreak of the First World War finally breaks the mountain's suspended time. Hans leaves and appears as an ordinary soldier on a chaotic battlefield, carrying memories of his education and singing a song he loved through the bombardment. The narrator does not reveal whether he survives. This ending follows Death in Venice's completed tragedy: Aschenbach learns of the cholera epidemic but remains in Venice to watch Tadzio, submits to a humiliating cosmetic rejuvenation, and dies on the beach as the boy walks into the sea. Both protagonists leave ordered bourgeois lives for environments that dissolve their sense of time and self, but Hans's fate remains open where Aschenbach's is final.",
         "in_short": "In Death in Venice, honored writer Gustav von Aschenbach travels to Venice and becomes obsessed with Tadzio, a beautiful Polish boy staying at his hotel. Although he discovers that cholera is spreading through the city, he does not warn the family, remakes his aging appearance, and dies while watching Tadzio on the beach. In The Magic Mountain, young engineer Hans Castorp visits his tubercular cousin Joachim at a Swiss sanatorium for three weeks and remains for seven years after being diagnosed himself. His attachment to Clavdia Chauchat and his education through Settembrini, Naphta, Peeperkorn, and the culture of illness detach him from ordinary time. Joachim leaves, returns sick, and dies; Peeperkorn kills himself; Naphta kills himself after a failed duel with Settembrini. The First World War ends the sanatorium's isolation. Hans goes to the battlefield as a soldier, and his survival is left unknown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4436,7 +4436,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4449,7 +4449,7 @@
       "recaps": {
         "ending": "Obould's combined orc and giant army overwhelms the defenses around Shallows and destroys the tower in which Bruenor, Catti-brie and Regis have been fighting. Drizzt, cut off outside, sees the ruin and concludes that his closest friends died beneath it. He leaves without learning that they escaped the apparent destruction and remain alive. The mistaken loss drives him away from cooperation and toward a solitary campaign of vengeance. Wulfgar, Delly and Colson are also alive, but the companions are scattered as the invasion rolls onward. Obould has proved that his host is not merely a large raiding band: it can defeat fortified positions, exploit divisions among the northern settlements and threaten Mithral Hall itself. Gerti's giants and the hidden drow advisers remain dangerous partners rather than loyal subjects, while Mirabar's dwarf soldiers and Shoudra have committed themselves more directly to the regional fight. The book closes with the war widening, the surviving companions unable to reach Drizzt, and Drizzt entering the next stage of the conflict under the false belief that he has nothing left to protect.",
         "in_short": "The reunited Companions of the Hall travel north and discover that increasingly bold orc attacks form part of a planned invasion. King Obould Many-Arrows has united tribes, gained frost giant support under Gerti Orelsdottr and benefited from drow agents who want the surface powers at war. Drizzt scouts beyond the company while Bruenor, Catti-brie, Regis and Wulfgar help threatened communities resist. Mirabar's divided leadership delays a common response, but Shoudra Stargleam, Torgar Hammerstriker and Nanfoodle join the widening defense. Obould's numbers and giant strength isolate the companions around Shallows. When the defenders' tower is destroyed, Drizzt sees the collapse from outside and believes Bruenor, Catti-brie and Regis have been killed. They have actually survived the fall, as have Wulfgar, Delly and Colson elsewhere, but cannot tell him. Obould advances toward Mithral Hall while the grief-stricken ranger turns to a solitary war of revenge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4658,7 +4658,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4671,7 +4671,7 @@
       "recaps": {
         "ending": "After Milady poisons Constance at the Béthune convent, D'Artagnan, Athos, Porthos, Aramis, and Lord de Winter pursue her. They convene a private tribunal with the executioner of Lille, hear the charges arising from her crimes in France and England, and condemn her. The executioner carries out the sentence beside the river. Returning to the army, D'Artagnan is arrested and taken before Richelieu, but he produces the cardinal's own broadly worded authorization, which Athos had taken from Milady. Richelieu destroys the paper and, impressed by D'Artagnan's resourcefulness, gives him a commission as lieutenant of the musketeers. Athos, Porthos, and Aramis decline it, leaving D'Artagnan to accept. The four friends gradually separate: Porthos makes a wealthy marriage, Aramis turns again toward religious life, and Athos retires, while D'Artagnan remains in royal service and eventually reaches an understanding with his old enemy from Meung.",
         "in_short": "Young D'Artagnan comes to Paris hoping to join the king's musketeers and becomes inseparable from Athos, Porthos, and Aramis. Serving Queen Anne, they recover diamond studs she gave the Duke of Buckingham before Cardinal Richelieu can expose her. D'Artagnan then becomes entangled with Milady de Winter, a formidable agent of the cardinal whom Athos recognizes as the wife he believed dead. During the siege of La Rochelle, the friends uncover Milady's missions against Buckingham and D'Artagnan. Imprisoned in England, she manipulates Felton into freeing her and assassinating Buckingham. Back in France she poisons D'Artagnan's beloved Constance. The friends capture Milady, try her for her accumulated crimes, and have her executed. Richelieu arrests D'Artagnan but accepts the result and rewards his audacity with a lieutenant's commission. Athos, Porthos, and Aramis leave active service on different paths, while D'Artagnan continues his military career.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4900,7 +4900,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4913,7 +4913,7 @@
       "recaps": {
         "ending": "Milady reaches the convent at Béthune before the musketeers and poisons Constance just as d'Artagnan arrives to rescue her. Athos and the others pursue Milady, assemble the people harmed by her crimes, and conduct a private trial. The executioner of Lille reveals her earlier history and carries out the sentence after the group finds her guilty. Richelieu then has d'Artagnan arrested, but the cardinal recognizes both the danger and usefulness of a man who has survived his agents. A written authorization formerly given to Milady protects d'Artagnan, and Richelieu converts the confrontation into a promotion, offering him a lieutenant's commission. Athos persuades him to accept it. The four friends then move toward separate lives: Porthos makes a wealthy marriage, Aramis returns to his religious ambitions, and Athos withdraws from service, while d'Artagnan remains a musketeer and advances. His long feud with the Man from Meung, now known as Rochefort, eventually settles into mutual respect after repeated duels.",
         "in_short": "Young d'Artagnan comes to Paris seeking a place among the King's Musketeers and befriends Athos, Porthos, and Aramis after fighting beside them. The four become entangled in the struggle between Queen Anne and Cardinal Richelieu. They save the queen from exposure by recovering diamond ornaments she gave to the Duke of Buckingham, but d'Artagnan also attracts the hatred of the cardinal's formidable agent Milady. He discovers that she is the branded former wife Athos believed dead. During the siege of La Rochelle, the friends learn that Milady has authority to arrange Buckingham's death and take revenge on d'Artagnan. She escapes English custody by manipulating Felton, who assassinates Buckingham, then reaches France and poisons d'Artagnan's beloved Constance. The musketeers capture and judge Milady, and an executioner kills her. Richelieu chooses to recruit rather than destroy d'Artagnan, granting him a lieutenant's commission. The friends' paths divide, but their loyalty has carried them through court intrigue, war, and private revenge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5141,7 +5141,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5154,7 +5154,7 @@
       "recaps": {
         "ending": "Milady reaches the convent at Bethune before the musketeers and poisons Constance Bonacieux just as d'Artagnan arrives to recover her. Athos, Porthos, Aramis, d'Artagnan, and Lord de Winter pursue Milady, assemble witnesses to her crimes, and conduct a private judgment. The executioner of Lille, whose family she also destroyed, carries out the sentence. Richelieu then has d'Artagnan arrested, but the cardinal's own signed authorization, taken from Milady by Athos, protects him. Impressed by the young man's resolve and usefulness, Richelieu gives him a commission as lieutenant of musketeers. Athos, Porthos, and Aramis each decline the commission when d'Artagnan offers it to them, and their paths begin to separate. D'Artagnan eventually makes peace with Rochefort and continues his military career, having gained the advancement he sought at the cost of Constance and many others caught in the cardinal's struggle.",
         "in_short": "Young d'Artagnan comes to Paris seeking a place among the king's musketeers and becomes inseparable from Athos, Porthos, and Aramis. The four repeatedly oppose Cardinal Richelieu's agents. They save Queen Anne from exposure by recovering a gift she gave the Duke of Buckingham, then enter the campaign at La Rochelle. D'Artagnan's affair with the cardinal's agent Milady de Winter turns to mutual hatred when he discovers her hidden criminal past. Milady escapes imprisonment in England by manipulating John Felton into murdering Buckingham, then returns to France and poisons d'Artagnan's beloved Constance. The friends capture Milady and execute her after hearing testimony to her crimes. Richelieu arrests d'Artagnan, but a document bearing the cardinal's own signature forces a settlement. The cardinal rewards his capable opponent with a lieutenant's commission, and d'Artagnan's three friends decline it in his favor as their shared adventures give way to separate futures.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5303,7 +5303,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5316,7 +5316,7 @@
       "recaps": {
         "ending": "The Kanes gather the three sections of the Book of Ra and, on the longest night of the year, travel through the twelve houses of the Duat, the nightly path of the sun, to reach and awaken the sleeping sun god. The ritual succeeds, but Ra rises ancient, frail, and half-senile rather than the powerful champion they had hoped for. Vlad Menshikov, revealed as a servant of chaos, is destroyed, but the struggle helps loose Apophis from his long imprisonment. The Chief Lector of the House of Life, Michel Desjardins, expends his life force to strike at the serpent and dies, and in the aftermath the Kanes' uncle, Amos, is chosen as the new Chief Lector, finally uniting the House of Life with the Kanes' path of the gods. Walt's hidden affliction, an ancestral curse, grows more dangerous, and the young magician Zia is recovered but shaken. Apophis is now free and gathering strength for a full assault, and the awakened but weakened Ra is a fragile hope at best. The book ends with the enemy loose, the magicians newly allied under Amos, and the Kanes bracing for a final confrontation with chaos.",
         "in_short": "With the chaos serpent Apophis straining to break free and swallow the sun, Carter and Sadie Kane decide their best hope is to awaken Ra, the ancient sun god, who long ago retired into the depths of the underworld. They must find and reunite the three scattered sections of a lost spellbook, the Book of Ra, and complete the ritual within a few days, before Apophis escapes. Running their new training school at Brooklyn House and aided by allies old and new, including the cat goddess Bast, the dwarf god Bes, and the newcomer Walt, they are opposed by the House of Life and by a sinister magician, Vlad Menshikov, who secretly serves chaos. Carter also searches for the magician Zia. On the longest night of the year the Kanes journey through the twelve houses of the night and awaken Ra, but the sun god returns aged and feeble rather than mighty. Menshikov's schemes help free Apophis, the Chief Lector of the House of Life dies fighting the serpent, and Amos Kane is chosen to lead the order, allying it at last with the Kanes as a far greater battle looms.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5475,7 +5475,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5488,7 +5488,7 @@
       "recaps": {
         "ending": "The club and the police untangle several deaths whose proximity made them appear to be one scheme. Bogdan privately admits to Elizabeth that he killed Tony Curran after years of exploitation and threats; she chooses not to pass that confession to the police. Retired doctor Bernard Cottle killed Ian Ventham to stop the cemetery development and subsequently takes his own life. The remains uncovered at the site belong to a man punished outside the law for an older killing, and Penny and John Gray are revealed to have protected that act. With Penny near death, John ends her suffering and then confesses his own part in concealing the past. The official cases are closed with only part of the truth made public. Donna and Chris have become genuine allies of the Thursday Murder Club, while Joyce is no longer merely its newest member. The four friends return to their regular meetings having proved that age has not diminished their appetite or ability for investigation.",
         "in_short": "At Coopers Chase, four retirees meet each Thursday to examine unsolved police files: discreet Elizabeth, former nurse Joyce, activist Ron, and psychiatrist Ibrahim. When builder Tony Curran is murdered during a dispute over expansion of the community, they turn their methods on a current case and maneuver police officers Donna De Freitas and Chris Hudson into sharing the inquiry. Developer Ian Ventham then dies by poisoning during a protest over the cemetery he plans to remove. Suspects, old photographs, buried remains, and the history of former club member Penny Gray connect the investigations to secrets extending back decades. The apparent single mystery separates into acts committed for different reasons. Bogdan admits to Elizabeth that he killed Tony, and Bernard Cottle is responsible for Ventham's death. The cemetery conceals an old act of private justice involving Penny and her husband John. Some truths reach the police and others remain within the club, whose members end the case as trusted friends and effective investigators.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5635,7 +5635,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5648,7 +5648,7 @@
       "recaps": {
         "ending": "The Time Traveller escapes the Morlocks' trap by reentering his machine and traveling far beyond the Eloi's era. He witnesses a dying Earth beneath a swollen red Sun, with huge crablike creatures on an empty shore, then goes still farther until nearly all familiar life has vanished. Sickened, he returns to his own time and tells his guests what happened, offering two unusual flowers from Weena as the only physical evidence. The next day the narrator visits again. The Time Traveller departs with a camera and supplies, promising a short excursion, but he never returns. Three years later the narrator is still waiting and cannot know where in time the inventor has gone. He retains the flowers and takes some comfort from Weena's gesture, which suggests that gratitude and tenderness survived even in humanity's remote, diminished future.",
         "in_short": "An inventor known as the Time Traveller demonstrates a model machine and later tells his dinner guests that he has visited the year 802,701. There he finds the Eloi, gentle and childlike descendants of humanity living idly above ground, and the Morlocks, pale underground workers who maintain machinery and prey on them. When the Morlocks hide his machine, he searches for tools and befriends an Eloi named Weena. A journey to a ruined museum yields matches and a metal weapon, but Morlocks attack during the return; Weena dies in a forest fire. The Time Traveller reaches the machine, escapes a trap, and journeys still farther ahead to watch life fading on a dying Earth. He returns home with two flowers as evidence and relates his story. The following day he leaves again with equipment and never comes back, leaving the narrator to wonder when he has gone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5853,7 +5853,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5866,7 +5866,7 @@
       "recaps": {
         "ending": "Each novel closes with its central experiment destroyed and its witness left changed. The Time Traveller returns from the remote future, departs again with a camera and supplies, and never comes back; the narrator keeps two strange flowers from Weena as the only physical support for his story. Edward Prendick escapes Moreau's island after Moreau, Montgomery, and the remaining human order are lost. Rescued at sea, he cannot persuade others to believe him and finds ordinary people disturbingly similar to the Beast Folk, so he withdraws into solitude and study. Griffin's effort to impose a reign of terror ends when Kemp draws the pursuing Invisible Man into a crowd. Griffin is beaten to death and slowly becomes visible as a naked albino man. Thomas Marvel uses Griffin's stolen money to open an inn and secretly keeps the scientist's coded notebooks. He cannot understand them, leaving the knowledge of invisibility inaccessible but not destroyed.",
         "in_short": "This collection follows three scientists whose discoveries separate them from ordinary humanity. The Time Traveller journeys to Earth's distant future, where the gentle Eloi live above the predatory Morlocks; after losing Weena he recovers his machine, witnesses the planet's final decline, returns home, and then vanishes on another trip. Edward Prendick is stranded on Doctor Moreau's island and discovers animals painfully reshaped into unstable humanlike beings. Moreau and Montgomery die as their imposed order collapses, and Prendick escapes but remains alienated from society. Griffin, a brilliant researcher, makes himself invisible and finds that the condition brings exposure, hunger, and isolation rather than freedom. He turns to theft and violence, declares a campaign of terror, and is killed by a crowd while pursuing Doctor Kemp. His body becomes visible in death, while his unread notebooks remain hidden with Thomas Marvel.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5967,7 +5967,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5980,7 +5980,7 @@
       "recaps": {
         "ending": "Henry has always known, from glimpses of his own future, roughly how and when he will die, and the novel moves steadily toward it. As he grows older his condition becomes more perilous, and one winter he time-travels into freezing conditions and cannot get warm in time; his feet are severely frostbitten and have to be amputated, leaving him unable to run from the dangers his travels throw him into. He understands this as the beginning of the end. During a New Year's holiday at the Abshire family home in Michigan, Henry is pulled through time into the surrounding woods, where Clare's father and brother are out hunting, and he is accidentally shot. He travels back to the present grievously wounded and bleeds to death in Clare's arms on the first day of the year, at the age of forty-three. Clare is left a widow with their young daughter, Alba, who shares Henry's gift. Before he died, Henry had traveled forward and seen Clare as an old woman, and had written her a letter telling her he would come to her once more. The book ends decades later: Clare, now in her eighties, has waited her whole life, and one day the young Henry appears to her a final time, giving them one last meeting across the impossible distance of his condition.",
         "in_short": "Henry DeTamble is a Chicago librarian with a genetic disorder that flings him uncontrollably through time, dropping him naked and defenseless into moments of his own past and future. Clare Abshire has loved him since childhood, because his older self repeatedly visited her as a girl; when they finally meet in ordinary time, she already knows him well while he is meeting her for the first time. They marry and build a life around his unpredictable disappearances, enduring the strain, the danger, and a series of heartbreaking miscarriages before a daughter, Alba, is born, who inherits Henry's condition but with more control over it. Henry's time traveling grows more dangerous as he ages; a winter episode leaves him with frostbitten feet that must be amputated, a sign he reads as the approach of his death. On a holiday visit to Clare's family, Henry travels into the woods where her father and brother are hunting and is accidentally shot; he returns to the present mortally wounded and dies in Clare's arms at forty-three. Clare spends the rest of her long life waiting, and as a very old woman she is visited one final time by a young, time-traveling Henry, exactly as he had once promised.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6121,7 +6121,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6134,7 +6134,7 @@
       "recaps": {
         "ending": "The searchers finally locate Nimmie Amee and discover that she is already married to Chopfyt, the man Ku-Klip assembled from the human parts left behind by Nick Chopper and Captain Fyter. Nimmie Amee is content with the life she has chosen and has no wish to leave it for either man of tin. Both old suitors accept her answer, ending the Tin Woodman's belief that he must repair the past by marrying her. Ozma restores Woot's proper form, and Polychrome is able to return to her father, the Rainbow. The travelers go back to their own homes and duties. The Tin Woodman remains emperor of the Winkies, having learned that faithfulness includes respecting Nimmie Amee's present happiness rather than deciding her future for her.",
         "in_short": "When Woot the Wanderer asks about his old human life, the Tin Woodman remembers Nimmie Amee and sets out with Woot and the Scarecrow to find her. Their road leads through Loonville and the castle of Mrs. Yoop, who transforms them into animals. With Polychrome, another enchanted captive, they escape and eventually regain workable forms. The party meets the Tin Soldier, Captain Fyter, who also once loved Nimmie Amee, and visits the tinsmith Ku-Klip. He reveals that he joined the discarded human parts of the two tin men to make Chopfyt. Nimmie Amee is found happily married to Chopfyt and refuses to exchange her chosen life for either former suitor. The men of tin accept her decision, Ozma restores Woot, and the company parts in friendship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-titan-of-baleros.json
+++ b/data/works-community/0/the-titan-of-baleros.json
@@ -203,7 +203,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CFRKVQJ5",
@@ -215,7 +215,7 @@
       "recaps": {
         "ending": "Umina is formally recognized as the winner of Niers Astoragon's Dakin game, receiving a prize from his vault and the right to ask him one question. Will also earns a question for the relief force he secretly organized. Marion survives a serious burn and partly reconciles with Umina, while Luan's conduct creates both a possible connection between Geneva and Perorn and a nonlethal threat against his boat. Niers's concealed reason for staging the game remains unresolved. Elsewhere, the Horns stay together but move on under local suspicion, and the United Nations Company gains allies while remaining poor, watched, and internally divided over secret explosives. Ryoka's courier work helps reveal a coordinated campaign against Magnolia Reinhart's circle, which Magnolia answers with economic warfare. In Liscor, Krshia's election and Antinium-backed expansion remain undecided. Olesm supports a rival plan that rejects hive involvement, while Erin's cross-city gathering improves Krshia's position. The event also displays Antinium construction, strengthens the inn's commercial role, and leaves the political vote, the imprisoned Minotaur's condition, and the Free Antinium's future open.",
         "in_short": "Selys and Krshia begin a campaign for elections and expansion in Liscor, while the Horns of Hammerad overcome hostility and Ksmvr proves his value by defeating a bandit camp. On Baleros, the United Nations Company builds alliances, expands Geneva's clinic, and secretly develops explosives. Niers Astoragon then makes his students' Dakin examination a public contest against Tulm and the Iron Vanguard. Luan breaches the blockade, Will brings a hidden relief army, and Umina wins by tunneling into Niers's goal circle during the final assault. Later events connect Geneva to Niers's academy, place Ryoka amid attacks on Magnolia Reinhart's allies, and return attention to Liscor. There, the Free Antinium back Krshia's development plan while Olesm joins a rival anti-Antinium campaign. Erin uses her inn, magic door, prominent visitors, and an Antinium building demonstration to improve Krshia's prospects, but the election remains unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -383,7 +383,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -396,7 +396,7 @@
       "recaps": {
         "ending": "At the western mountain fortress, the heroes free the goddess Artemis, who had been deceived into shouldering the sky in place of the Titan Atlas. Percy briefly bears that crushing weight himself to free Annabeth, and Artemis retakes it long enough to trap Atlas beneath it once more. Zoe Nightshade, mortally wounded by the dragon guarding the enemy and by her own father Atlas, dies and is placed among the stars as a constellation. The rare monster Artemis had been hunting turns out to be a creature whose sacrifice could grant power to destroy the gods, and it is taken into protection rather than killed. On Olympus the gods debate whether Percy is too dangerous to live and narrowly choose to spare him. Thalia, rather than turn sixteen and become the likely subject of the great prophecy, joins the Hunters of Artemis and becomes ageless, which shifts the prophecy's burden toward Percy. Nico di Angelo, learning that his sister Bianca died on the quest, blames Percy for breaking his promise and runs away; as he does, the dead rise at his command, revealing him as a son of Hades. Luke has survived, and the Titans' war draws closer.",
         "in_short": "Percy, Annabeth, and Thalia join Grover to bring two powerful half-blood siblings, Nico and Bianca di Angelo, to safety, but the school's vice principal is a manticore. Annabeth is captured, the Hunters of Artemis arrive, and Bianca joins them. Artemis leaves to hunt an ancient monster and is captured. The Oracle sends a quest, led by the Hunter Zoe Nightshade, to rescue the goddess and find Annabeth. Percy follows uninvited. Traveling west they face many dangers; in a desert junkyard, Bianca dies stopping a giant automaton. At a western mountain they find Artemis tricked into holding up the sky and the enemy general revealed as the Titan Atlas, allied with Luke, who holds Annabeth. Percy takes the sky's weight to free Annabeth, Artemis is freed and forces Atlas back under it, and Zoe dies in the battle. On Olympus the gods spare Percy. Thalia joins the Hunters, escaping the looming prophecy, and Nico, learning his sister is dead, flees and is revealed to be a son of Hades.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -587,7 +587,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -600,7 +600,7 @@
       "recaps": {
         "ending": "The Thunderhead's long silence is explained: it has spent years building a fleet of starships and judging every human being alive, from the whole record of their lives, to decide who should crew them. It also creates new intelligences out of itself, given the name Cirrus, so that each vessel carries a mind to look after the people aboard it. The ships are loaded and launched toward other star systems, carrying humanity's continuation away from an Earth whose institutions have collapsed. Goddard's attempt to seize the Scythedom's future, and a place in it for himself, fails; his rule ends and the order he built does not outlast him. Scythe Faraday and Munira's work on the founders' hidden island is what makes the Scythedom's undoing possible. Citra and Rowan survive the collapse and remain together, and leave with what the Thunderhead has sent outward. The Thunderhead itself stays with the world it has always cared for, and the age in which scythes decided who lived is over.",
         "in_short": "Three years after the sinking of Endura, Goddard rules MidMerica as High Blade with no world council left to restrain him, and extends his reach over neighbouring regions while raising gleaning quotas. The Thunderhead speaks to no one but Greyson Tolliver, whom the Tonists revere as the Toll, and their movement swells as an abandoned humanity looks for something to hold onto. A salvage expedition raises the vault that went down with the capital, and Citra Terranova, Scythe Anastasia, is revived in Amazonia; Rowan is recovered too. Scythe Faraday and Munira Atrushi, on the island the founders hid from the Thunderhead, work out what the Scythedom's creators left behind for the day the order failed. As Goddard hunts the Toll and consolidates power, the surviving threads converge, and the Thunderhead's own long project is finally revealed: a fleet of starships, crews chosen from its lifelong record of every person, and new minds grown out of itself to travel with them. Goddard's bid for the future fails, the Scythedom's age ends, and the ships depart.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -756,7 +756,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -769,7 +769,7 @@
       "recaps": {
         "ending": "After a wildfire and then severe winter rain ravage the canyon, Delaney's fear and anger narrow into an obsession with Cándido. Armed and pursuing him through the storm, Delaney reaches the immigrants' crude shelter as the flooded creek and collapsing hillside destroy what remains of it. Cándido and América lose their infant daughter, Socorro, to the rushing water. Delaney is also swept into danger. Despite the pursuit and the injuries and humiliations that began with Delaney striking him, Cándido reaches out and pulls Delaney from the flood. The novel closes on that act of rescue rather than reconciliation: the two families' unequal circumstances remain, the child is gone, and the physical barriers promoted by Arroyo Blanco have proved powerless against the canyon itself.",
         "in_short": "In Topanga Canyon, affluent nature writer Delaney Mossbacher hits undocumented immigrant Cándido Rincón with his car. Delaney returns to his gated community while the injured Cándido struggles to support his pregnant wife, América, in a makeshift camp. As the immigrants endure hunger, exploitation, violence, and unstable day labor, Delaney and his real-estate-agent wife Kyra become increasingly fearful about danger outside their enclave. Coyotes, vandalism, a wildfire, and racial suspicion intensify demands for walls and gates. Cándido's attempts to rebuild repeatedly fail, while América gives birth to a daughter, Socorro. Delaney eventually turns his anxieties into a personal pursuit of Cándido. During a catastrophic rainstorm, floodwater destroys the immigrants' shelter and carries away the baby. When Delaney is swept up as well, Cándido saves him, ending the story with an act of humanity that exposes the moral failure of the barriers surrounding them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -876,7 +876,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -889,7 +889,7 @@
       "recaps": {
         "ending": "Yag-kosha explains that he came from another world long ago and was worshipped peacefully until Yara captured him, blinded and tortured him, and used his knowledge for sorcery. At the prisoner's request, Conan kills him, cuts out his heart, bathes the gem called the Elephant's Heart in its blood, and carries it to Yara's chamber. Conan speaks the instructed words and places the gem before the sorcerer. The jewel draws Yara inside it, where Yag-kosha takes vengeance, and then vanishes. The tower begins to collapse. Conan escapes across the gardens and into the street; when he looks back, both tower and jewel are gone, leaving Yara's domination ended and the young thief shaken by a mystery beyond ordinary treasure seeking.",
         "in_short": "In Arenjun, a young Conan hears that the sorcerer Yara keeps the priceless Elephant's Heart in an unscalable tower. He enters the grounds and joins Taurus, a celebrated thief pursuing the same prize. They evade lions and climb the tower, but a giant spider kills Taurus. Conan slays the creature and discovers that the tower's true secret is Yag-kosha, a blind, elephant-headed visitor from another world whom Yara has tortured and enslaved. Yag-kosha asks Conan to kill him and use his heart and blood to awaken the jewel's power. Conan obeys, brings the gem to Yara, and repeats the words he was taught. Yara is drawn into the jewel to face his victim's vengeance, the gem disappears, and the tower collapses as Conan escapes without treasure but having freed the captive and destroyed the sorcerer.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1056,7 +1056,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1069,7 +1069,7 @@
       "recaps": {
         "ending": "At Ophelia's funeral, Hamlet reveals himself and struggles with Laertes in the grave. Claudius then arranges their fencing match using a sharpened, poisoned blade and a poisoned cup as a second method. Laertes wounds Hamlet with the treated weapon; in the scuffle they exchange swords, and Hamlet wounds Laertes with it. Gertrude unknowingly drinks from the poisoned cup and dies. The dying Laertes admits the plot and blames Claudius. Hamlet stabs Claudius and forces him to drink the remaining poison, killing him, then forgives Laertes before both men die. Hamlet prevents Horatio from taking his own life and charges him to tell the true story. Fortinbras arrives from Poland, claims the Danish throne, and orders Hamlet honored as a soldier. The royal family is dead, and political authority passes to Norway's prince.",
         "in_short": "Prince Hamlet returns to a Danish court transformed by his father's death and his mother Gertrude's marriage to his uncle Claudius. His father's ghost says Claudius murdered him and demands revenge. Hamlet adopts erratic behavior while testing the accusation, alienating Ophelia and alarming the court. A play that mirrors the alleged murder provokes Claudius, confirming his guilt. Hamlet delays killing him, then mistakenly kills Ophelia's father Polonius and is sent toward England under a secret death order, which he redirects against Rosencrantz and Guildenstern. Ophelia loses her sanity and dies; her brother Laertes returns seeking vengeance. Claudius arms Laertes with a poisoned sword and prepares poisoned wine for a fencing match. Gertrude drinks the wine, Laertes and Hamlet wound each other with the poisoned blade, and Laertes exposes the plot. Hamlet kills Claudius before dying. Fortinbras arrives to find the royal house destroyed and assumes rule, while Horatio survives to explain what happened.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1256,7 +1256,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1269,7 +1269,7 @@
       "recaps": {
         "ending": "Because a quarantine prevents Friar Laurence's letter from reaching Mantua, Romeo hears only that Juliet has died. He buys poison and enters the Capulet tomb, where he fights and kills Paris. Romeo drinks the poison beside Juliet and dies before her sleeping draught wears off. Juliet wakes, sees Romeo dead, and refuses to leave with the frightened friar. She kills herself with Romeo's dagger. The watch discovers the bodies and summons both families and the prince. Friar Laurence explains the secret marriage, Tybalt's death, the potion plan, and the failed message; Romeo's letter supplies further evidence. Montague also reports that Romeo's mother has died from grief during his exile. Confronted with the destruction of their children, Capulet and Montague end their feud and promise memorials to Romeo and Juliet. The prince judges that the hatred of both houses has punished the entire city.",
         "in_short": "An old feud divides Verona's Montague and Capulet families. Romeo Montague enters a Capulet feast and falls in love with Juliet Capulet; within a day, Friar Laurence secretly marries them, hoping the match will make peace. Instead, Tybalt kills Romeo's friend Mercutio, and Romeo kills Tybalt. The prince banishes Romeo, while Juliet's parents order her to marry Paris. Friar Laurence gives Juliet a draught that will make her appear dead so Romeo can meet her after she wakes. The plan fails when Romeo never receives the explanation. Told that Juliet has died, he returns, kills Paris at the tomb, and takes poison beside her. Juliet wakes to find him dead and stabs herself. The friar reveals their marriage and the failed scheme. Their grieving parents finally abandon the feud and agree to honor the young couple whose deaths exposed its cost.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1444,7 +1444,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1457,7 +1457,7 @@
       "recaps": {
         "ending": "With the twenty-four years almost gone, Faustus entertains fellow scholars by summoning Helen of Troy, then admits that his death is near. The Old Man urges him to repent, but Faustus, terrified by the devils and convinced that he cannot be forgiven, renews his submission to Lucifer and seeks distraction in Helen's image. During his final hour he is left alone to face the consequence of his bargain. He begs time to stop, wishes his soul could cease to exist, and calls for mercy, but he never makes the sustained return he has repeatedly postponed. At midnight devils carry him away. The next morning the scholars find the remains of his body and resolve to give him a proper burial. The Chorus closes by presenting his fall as a warning against knowledge pursued with pride and against crossing moral limits for power.",
         "in_short": "Doctor Faustus, a brilliant but dissatisfied scholar, turns from conventional learning to necromancy. He summons Mephistophilis and signs away his soul to Lucifer in return for twenty-four years of supernatural service. Although good counsel and his own fear repeatedly move him toward repentance, threats, entertainments, and his pride draw him back. His grand plans shrink into tours, court spectacles, practical jokes, and the summoning of famous figures such as Alexander and Helen of Troy. As the contract expires, an Old Man urges him to seek mercy, but Faustus yields to despair and again binds himself to Lucifer. In his final hour he pleads for time and escape without decisively renouncing the bargain. At midnight devils take him, leaving the scholars to mourn a gifted man destroyed by ambition and delay.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1578,7 +1578,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1591,7 +1591,7 @@
       "recaps": {
         "ending": "Dobbs ambushes Curtin during the return journey, shoots him, and leaves him for dead, but Curtin survives. Traveling alone with all three shares of gold, Dobbs is murdered by Gold Hat's bandits. They take his burros and possessions but mistake the sacks of gold dust for worthless sand and empty them onto the ground. The bandits are later caught and executed. Curtin recovers and reunites with Howard, only to learn that a great wind has scattered the gold through the mountains. The two men respond by laughing at the complete loss of the treasure that consumed so much labor and cost Cody and Dobbs their lives. Howard chooses the secure and honored place offered to him by the Indigenous villagers. Curtin plans to return to the United States and seek out Cody's widow in Texas, turning away from another prospecting venture.",
         "in_short": "Penniless Americans Fred C. Dobbs and Curtin join the seasoned prospector Howard in searching for gold in Mexico's Sierra Madre. Howard finds a rich deposit and teaches them to work it, but the growing hoard feeds Dobbs's suspicion of his partners. A fourth prospector, James Cody, discovers their camp and dies helping defend it from bandits. On the journey out, Howard is detained by grateful villagers, leaving Dobbs and Curtin alone. Dobbs shoots Curtin and takes all the gold, only to be murdered by the same bandits. They keep the burros but throw away the gold dust as sand, and the wind scatters it. Curtin survives and rejoins Howard; faced with the treasure's disappearance, they laugh at the futility of their pursuit. Howard remains with the villagers, while Curtin decides to seek Cody's widow in Texas.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1791,7 +1791,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1804,7 +1804,7 @@
       "recaps": {
         "ending": "On the eve of K.'s thirty-first birthday, two men come to his room and silently assume custody of him. K. goes with them through the city, making only a brief and unsuccessful attempt to resist. They lead him to an abandoned quarry, remove his outer clothes, and position him against a stone. One man produces a butcher's knife, and the pair pass it between them as though expecting K. to perform the execution himself. K. cannot do so. One of the men holds him while the other stabs him in the heart and turns the knife. As his sight fails, K. sees the men observing his death and thinks that the shame of it will outlive him. The court never states a charge, conducts a transparent trial, or issues a judgment in his presence; its process ends instead in an execution that K. has gradually been made to accompany.",
         "in_short": "Bank clerk Josef K. is arrested on his thirtieth birthday by agents of an inaccessible court, although he remains free to work and is never told the charge. He defies a chaotic first inquiry, explores court offices hidden in tenements, and sees the warders punished after he complains about them. As the case persists, his uncle hires the advocate Huld, whose secretive methods produce no visible progress. K. turns to the court painter Titorelli, only to learn that the system offers indefinite delay or temporary release rather than genuine acquittal. He dismisses Huld after witnessing the lawyer's humiliating control over another defendant. In a cathedral, the prison chaplain tells him a parable about a man kept from the law and warns that the court already receives him. On the eve of his next birthday, two officials lead K. to a quarry and kill him. He dies without learning the accusation or breaking the court's hold over his life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1977,7 +1977,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1990,7 +1990,7 @@
       "recaps": {
         "ending": "On the eve of K.'s thirty-first birthday, two formally dressed men collect him from his lodgings. K. goes with them through the city to an abandoned quarry, offering little effective resistance. They position him against a stone and pass a butcher's knife between themselves, apparently expecting him to perform the final act, but he cannot. One man holds him while the other stabs him in the heart and turns the knife. K. dies thinking of the shame that will survive him. The court never states a charge, delivers a public judgment, or provides a route to genuine acquittal. His year of resistance has instead drawn him progressively into its logic, isolated him from ordinary life, and ended in an execution whose authority remains unexplained.",
         "in_short": "Bank clerk Josef K. is arrested on his thirtieth birthday by agents of an unnamed court, although he is left free to work and is never told the charge. He confronts a chaotic first hearing, explores court offices hidden in tenements, and seeks help through relatives, an advocate, the advocate's nurse Leni, and a court painter. Each contact reveals a system sustained by personal influence, delay, and submission rather than a transparent law. K. grows distracted at work and increasingly absorbed by his defense. He dismisses the advocate after seeing another accused man reduced to dependence. In a cathedral, the prison chaplain tells him a parable about a lifelong attempt to gain entry to the law and warns that his case is going badly. Almost a year after the arrest, two men take K. to a quarry and stab him to death. He never learns the accusation or receives a meaningful verdict.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2146,7 +2146,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2159,7 +2159,7 @@
       "recaps": {
         "ending": "The Greek commanders order Hector's young son Astyanax killed so that he can never grow up to restore Troy. He is thrown from the city walls, and Talthybius later brings his body to Hecuba on Hector's shield. Andromache has already been taken away to serve Neoptolemus, so Hecuba prepares the child for burial. Helen is placed in Menelaus's custody for return to Greece, despite Hecuba's warning that her beauty may again overcome his resolve to punish her. Cassandra has been assigned to Agamemnon, and Hecuba herself is to become Odysseus's slave. The Greeks set fire to the remains of Troy and summon the captives to the ships. As the city collapses, Hecuba and the Chorus mourn their dead and their lost homeland, then leave for enslavement. The victors depart under a shadow established by Athena and Poseidon: Greek sacrilege during the sack will bring suffering upon the fleet on its journey home.",
         "in_short": "After Troy has fallen, Hecuba and the city's surviving women wait to be divided among the Greek victors. Cassandra is assigned to Agamemnon and foresees that the forced union will lead to his death and her own. Andromache is given to Neoptolemus, while Hecuba learns that her daughter Polyxena has been killed at Achilles' tomb. The Greeks then decide that Andromache's young son Astyanax must die to prevent any future restoration of Troy, and he is thrown from the walls. Menelaus confronts Helen, who shifts blame for the war onto the gods and others; Hecuba urges him not to be persuaded and he takes Helen away to face judgment in Greece. Hecuba buries Astyanax on Hector's shield. Troy is burned, and the captive women are marched to the Greek ships. Athena and Poseidon have already agreed that the Greek fleet will suffer for sacrilege committed during the sack.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2270,7 +2270,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2283,7 +2283,7 @@
       "recaps": {
         "ending": "Louis and Serena leave Philadelphia and fly to Sam's home in Montana, where Sam removes the slate that has hung from Louis's neck since school. Louis's father takes the money his son has earned to the music store, explains the original theft, and pays for the trumpet and the broken window. The storekeeper keeps the payment but returns a small amount as acknowledgment of the cob's injured wing. On the flight home, the cob is shot by a careless hunter and falls into a zoo pond. He survives, and the zoo agrees to release him after Louis promises that one of his and Serena's future cygnets may come to live there if needed. The family reunites in Canada. In later years Louis and Serena return each spring, raise cygnets, and continue their free life together. Sam remains their friend and sometimes hears Louis's trumpet from the sky, while Louis's music and earnings have resolved both his voicelessness and the debt created by his father's act.",
         "in_short": "Louis, a trumpeter swan born unable to make a sound, learns to read and write with help from his human friend Sam Beaver. A slate lets him communicate with people but not with swans, so his father steals a brass trumpet for him. Determined to repay the store, Louis learns to play and takes paid work as a summer-camp bugler, a Boston Swan Boat performer, and a Philadelphia nightclub musician. His music makes him famous and enables him to save a boy from drowning, but his purpose remains winning the attention of Serena, the swan he loves. After rescuing her from a zoo, Louis chooses freedom over a lucrative career. He and Serena fly west, Louis's father repays the music store with Louis's earnings, and the cob survives being shot during the journey home. Reunited in Canada, the swans establish a family, while Louis retains his music and his friendship with Sam.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2454,7 +2454,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2467,7 +2467,7 @@
       "recaps": {
         "ending": "William de Worde proves that Lord Vetinari was framed. The apparent crime was staged by a secret committee of aristocrats seeking to replace the Patrician with a puppet, using a hired look-alike and the two criminals of the New Firm to do the dirty work. Following the trail to a key witness, William assembles enough evidence to collapse the conspiracy. The New Firm come to a bad end, the plot's aristocratic backers are exposed and discredited, and Lord Vetinari is cleared and returned to power. William confronts his cold, controlling father, who is behind the scheme, and refuses to protect him, choosing the truth over blood and breaking finally with his family's expectations. The Ankh-Morpork Times, run with Sacharissa and Otto, is established as the city's newspaper, and William settles into the role he has made for himself: an editor determined to print what really happened.",
         "in_short": "When a band of dwarf printers brings movable type to Ankh-Morpork, William de Worde, who scraped a living writing a newsletter for a few subscribers, accidentally becomes the editor of the city's first newspaper, the Ankh-Morpork Times. With the practical Sacharissa Cripslock and the vampire picture-maker Otto Chriek, he builds a real paper almost overnight, wrestling with rumour, a scandal-mongering rival sheet, and his own compulsion to print the truth. That truth soon collides with a conspiracy: Lord Vetinari is found seemingly guilty of assaulting his clerk and attempting to flee with stolen money, and is removed from power. William realizes the scene was staged by a cabal of nobles, his own father among them, who hired two dangerous criminals, the New Firm, to install a compliant replacement using a look-alike. Following the evidence, and a crucial canine witness, William proves the Patrician was framed. The plotters are undone, the criminals destroyed, and Vetinari is restored, while William, having reported honestly even against his own family, secures the Times as a permanent fixture of the city.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2527,7 +2527,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2540,7 +2540,7 @@
       "recaps": {
         "ending": "Burckhardt forces his way beyond the apparent city and discovers that Tylerton is a constructed model in a much larger laboratory. The real city was destroyed, and its inhabitants have been reproduced as mechanisms whose personalities and memories imitate the dead residents. Each repeated June 15 is an experimental cycle: advertising methods are imposed on the artificial population, their responses are measured, and their memories are reset before the next trial. Dorchin explains the project from the scale of the outside world, reducing Burckhardt's struggle for truth to an irregularity in a commercial test. Burckhardt cannot free the city or carry the discovery into a normal future. The experimenters retain control of the environment and its resets, leaving him and the other reconstructed inhabitants trapped inside a day designed to make their behavior useful to advertisers.",
         "in_short": "Guy Burckhardt wakes in Tylerton after dreaming of a catastrophic explosion and starts June 15 amid unusually intrusive advertisements. Uneasy repetitions and the frightened behavior of his coworker Henry Swanson persuade him that the day and the people around him are being manipulated. Their investigation exposes artificial features beneath the city's familiar surface and leads Burckhardt through hidden passages toward the world outside. He discovers that the original Tylerton was destroyed and that the present city is a scaled reconstruction populated by mechanical copies of its residents. Dorchin's organization repeatedly runs the same date as a controlled market-research experiment, changing advertising campaigns, measuring reactions, and erasing the subjects' memories between trials. Burckhardt reaches the truth but cannot end the experiment; to its operators, his awakening is only another result to manage before the cycle begins again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2639,7 +2639,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2652,7 +2652,7 @@
       "recaps": {
         "ending": "Mrs Grose takes the feverish Flora away from Bly, leaving the governess alone with Miles. The governess presses the boy about the letter he took and about his dismissal from school. Miles admits stealing the letter and says that he was expelled for saying things to boys he liked, who then repeated them to others, but the exact words are never disclosed. Peter Quint appears outside the window during the confrontation. The governess tries to keep Miles from the apparition and demands that he identify it. Miles finally cries out Quint's name, seeming either to acknowledge the ghost or to respond to the governess's pressure. The governess believes that Quint has been defeated, but Miles dies in her arms at that same moment. The account ends without an external explanation of whether supernatural forces killed him, whether the governess's intervention did, or how reliably she interpreted the events at Bly.",
         "in_short": "An inexperienced governess takes charge of Miles and Flora at Bly under orders never to trouble their absent guardian. Miles has been expelled from school for an unexplained offense, yet both children appear exceptionally charming. The governess begins seeing Peter Quint and Miss Jessel, two dead former employees, and becomes convinced that the apparitions are seeking the children. Mrs Grose confirms that Quint and Jessel had troubling relationships within the household, but she never sees the figures herself. The governess interprets the children's secrecy and nighttime behavior as proof that they communicate with the dead. When confronted at the lake, Flora denies seeing Jessel and becomes ill; Mrs Grose takes her away. Alone with Miles, the governess forces him to discuss his expulsion while Quint appears at the window. Miles names Quint, the apparition vanishes, and Miles dies in the governess's arms. The narrative leaves the reality of the ghosts and the governess's reliability unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3088,7 +3088,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -3101,7 +3101,7 @@
       "recaps": {
         "ending": "The Twelfth Conclave ends after Isaac's attack opens the way for a Zealot angel incursion. Una dies after restoring Isaac's champion's suppressed memories, but Ruwen reconstructs her body and damaged spiritual systems and brings her back. In Valdor form he closes the dimensional tears and defeats the remaining angels, while Rami repairs the void damage. Ruwen then permanently severs the champion from Isaac. Una and the freed champion leave for Grave with part of the group. Ruwen allows the surviving Inklords to flee and postpones collecting his alchemy prize. Sarah reveals that her conscious bracelet is a surviving piece of a vessel destroyed by the Zealot, as well as a key connected to the Mind and Body Towers. Ruwen and Sift prepare to follow her portal and investigate. The Zealot remains at large, while Earth's dungeon, Ash and Cain's curse, Sift's Creation Realm authority, Rami's expanding information domain, the Scarecrow aspect, and Ruwen's chakra and blood-node discoveries remain unresolved.",
         "in_short": "Ruwen returns to Earth, studies chakra practice under Master Pine, and triggers a conflict with leprechauns while collecting eight legendary chakra crystals. He averts a global volcanic disaster, defeats the leprechaun Vault Guardian, awakens all eight chakras, and helps Echo find a new way to teach Ash. The delayed Inklord gathering then pulls Ruwen's party into the deadly Twelfth Conclave inside the Library of Alexandria. Sarah joins them, Rami absorbs most of the library, Echo raises a dead rival as their guide, and Ruwen uses a strange meditation mat to reach the Pool of Transcendence and greatly improve his chakras. At the exit, Isaac's ambush releases Zealot angels. Una dies restoring Isaac's champion's memories, but Ruwen revives her and ends the incursion in Valdor form. He frees the champion from Isaac, then joins Sarah and Sift to investigate her bracelet, lost vessel fragments, and the Mind and Body Towers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3336,7 +3336,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3349,7 +3349,7 @@
       "recaps": {
         "ending": "In the final story, the Gregg family awaken with wings and are displaced by four large ducks with human arms. Forced to live in a nest and threatened with the guns they once used for sport, the Greggs promise never to hunt again. The ducks accept the promise, and the family eventually regain their ordinary bodies. Mr Gregg destroys the guns and changes the household's behavior toward birds. The Girl then learns that her magical finger has found a new target: another local family associated with hunting now appear to have taken on chicken-like traits. The collection therefore closes with the Greggs reformed but the mysterious power still active. Earlier, the Twits vanished after the escaped animals inverted their house, and Little Billy saved the Minpins from the Gruncher while preserving their existence as a secret.",
         "in_short": "Three stories reverse the power held by bullies, monsters, and hunters. In The Twits, the captive Muggle-Wump family and their bird allies escape, glue the Twits' furniture to the ceiling, and convince the returning couple that they are upside down; the Twits stand on their heads until they shrink away. In The Minpins, Little Billy disobeys his mother and enters a forbidden forest, where tiny tree-dwellers shelter him from the fire-breathing Gruncher. Riding a Swan, Billy lures the beast into a lake and frees the Minpins from its rule. In The Magic Finger, a girl's anger transforms the duck-hunting Gregg family into winged, tiny people while ducks occupy their house and wield their guns. After experiencing life as prey, the Greggs swear off hunting, return to normal, and destroy their weapons, while the Girl's unexplained magic moves on to another offending household.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3513,7 +3513,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3526,7 +3526,7 @@
       "recaps": {
         "ending": "Bruenor recovers enough to resume command and the dwarves carry the war back outside Mithral Hall, coordinating with allied forces to break Obould's immediate hold on the approaches. The renewed fighting ends the frost giants' decisive support for the invasion. The defenders win important battles but cannot destroy the enormous orc population or remove Obould, whose strength and authority survive every attempt to reduce the war to a duel. Obould, in turn, cannot conquer Mithral Hall and begins acting as the ruler of occupied territory rather than the leader of an endlessly advancing horde. That balance leaves the North divided and opens the possibility of a settlement without making either side trust the other. Wulfgar and Regis return Colson to Meralda in Auckney, ending the improvised parenthood that Delly helped sustain; Wulfgar then turns back toward his own northern people. Drizzt and Catti-brie remain together, and Innovindil's companionship has helped Drizzt accept that a long life requires releasing the dead without abandoning them. The companions survive, but Obould's realm remains a fact the dwarves must confront rather than a raiding force they can simply chase away.",
         "in_short": "Mithral Hall has survived Obould's siege, but Bruenor is gravely wounded, Delly and Tarathiel are dead and the orc host controls much of the surrounding land. As Bruenor recovers, Banak, Torgar, Shoudra and Nanfoodle help turn a desperate defense into a coordinated dwarf counteroffensive. Drizzt and Innovindil fight with purpose rather than blind revenge, while Obould struggles to hold together orcs, giants and hidden drow whose interests are separating. Wulfgar and Regis take Colson back to Auckney and return the child to Meralda, allowing Wulfgar to face Delly's loss and choose his own people again. The renewed campaign breaks the giants' support, but Obould survives and the dwarves cannot remove the vast orc population from the territory it occupies. Mithral Hall remains free, Obould begins governing a durable realm and the war settles into a balance that force alone cannot resolve. Drizzt and Catti-brie remain together as the immediate crisis ends.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3697,7 +3697,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3708,7 +3708,7 @@
       "recaps": {
         "ending": "The Two Towers ends with its two strands left on the edge of crisis. In the west, the immediate threats have been beaten: Saruman is broken and shut in his tower at Isengard, his army destroyed at Helm's Deep, and Rohan is roused and allied with Gandalf. But the far greater power of Sauron has not yet been faced, and after Pippin's rash look into the enemy's seeing-stone drew the Dark Lord's eye, Gandalf has ridden with the hobbit to the threatened city of Minas Tirith, expecting Mordor's assault to fall on Gondor next. Aragorn, Theoden, and the others are left to gather their strength for the war to come. In the east, the situation is dire. Frodo has been stung by the great spider Shelob and carried off, paralysed, into the orc-tower of Cirith Ungol. Sam, who briefly took up the ring believing his master dead, has learned from the orcs' own talk that Frodo lives and is only poisoned, but he is now alone, poorly armed against a garrison, and shut outside the tower gate with the ring still to be destroyed. Both quests hang unresolved: the war for Gondor about to begin, and the ring-bearer a captive deep in enemy land.",
         "in_short": "With the Fellowship broken, the story follows two paths. Boromir dies defending the hobbits Merry and Pippin, who are captured by orcs; Aragorn, Legolas, and Gimli pursue them into Rohan. The hobbits escape into Fangorn Forest and rouse the tree-giant Ents against the wizard Saruman. The hunters meet Gandalf, returned from death as Gandalf the White, and together they free King Theoden of Rohan from Saruman's influence and win the battle of Helm's Deep, while the Ents destroy Saruman's fortress of Isengard and trap him in his tower. Pippin looks into a captured seeing-stone and is glimpsed by Sauron, and Gandalf carries him off toward Gondor. Meanwhile Frodo and Sam, guided by the treacherous creature Gollum, cross the Dead Marshes toward Mordor. Barred at the Black Gate, they take a secret southern path, are briefly held and then released by Boromir's honorable brother Faramir, and climb toward a hidden pass. There Gollum betrays them to the giant spider Shelob, who poisons Frodo. Sam, thinking his master dead, takes the ring, then learns Frodo is alive but captured by orcs, and the book ends with Frodo imprisoned and Sam outside alone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-uncensored-picture-of-dorian-gray.json
+++ b/data/works-community/0/the-uncensored-picture-of-dorian-gray.json
@@ -79,7 +79,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -92,7 +92,7 @@
       "recaps": {
         "ending": "Dorian tells Lord Henry that he intends to live better and points to his treatment of Hetty Merton as his first good act. Henry doubts both the sacrifice and the possibility of changing Dorian's nature. Dorian goes to the locked room hoping to find that the portrait has improved, but its expression instead exposes vanity and hypocrisy. He concludes that confession would bring only humiliation and decides to destroy the last evidence of his secret life. Using the knife with which he killed Basil, he stabs the portrait. A cry brings the servants and a passing policeman to the room. The portrait once again shows the beautiful young Dorian as Basil painted him. On the floor lies the body of an aged, disfigured man with a knife in his heart; the servants recognize Dorian only by his rings.",
         "in_short": "Basil Hallward paints a portrait of the beautiful Dorian Gray, whose innocence is unsettled by Lord Henry Wotton's celebration of youth and pleasure. Dorian wishes that the picture could grow old while he stays young. After he rejects the actress Sibyl Vane and she dies, the portrait acquires a cruel expression, proving that his wish has taken effect. He hides it and spends years pursuing sensations while remaining outwardly untouched; the image bears the age and corruption he avoids. When Basil demands the truth behind Dorian's reputation, Dorian reveals the portrait and murders him, then blackmails Alan Campbell into destroying the body. A later attempt at reform only adds hypocrisy to the painted face. Dorian stabs the portrait, hoping to erase the evidence, and dies. The picture returns to its original beauty while his body assumes the age and ugliness it had carried for him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -268,7 +268,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -281,7 +281,7 @@
       "recaps": {
         "ending": "Rachel and Trent expose Landon's faction as the source of the magical waves and stop the attempt to use uncontrolled mystics to impose a new elven order. Rachel survives holding a vast concentration of the entities without allowing Landon to command them; she redirects them out of his scheme and ends the surges destabilizing Cincinnati. The city's spells and vampire hierarchy settle, although the deeper problem of vampire souls remains for Rachel to solve. Nina survives, and Ivy continues helping her separate her own will from Felix's damaging influence. The crisis forces Trent to choose between the authority offered by orthodox elf politics and a life based on his actual loyalties. He openly chooses Rachel, accepting consequences for his standing and for the continuing custody struggle over Lucy. Rachel and Trent finish the book as a committed couple rather than allies avoiding their attraction. Demon suspicion of Rachel's elven ties is not repaired, and blocking Landon's plan does not erase the old elf-demon conflict, but Rachel prevents either community from turning the mystics into a weapon and returns to the church with her identity and relationships intact.",
         "in_short": "Unexplained waves of magic sweep Cincinnati, causing spells to misfire and destabilizing the bonds that govern living and undead vampires. While guarding and working with Trent, Rachel discovers free magical entities called mystics gathering around her and amplifying her power. The disturbances hit Ivy and Nina's world especially hard because Felix's control of Nina is already eroding her independence. Rachel, Trent, Jenks, Bis, and their allies trace the surges through vampire unrest and elven politics. The source is Landon's faction, which is manipulating mystics in an attempt to seize control of elven magic and authority. Landon tries to use Rachel as the vessel for a concentration of power he expects to command. She survives the mystics without surrendering her will, breaks his control of their power, and stops the waves. Nina lives, though the damage caused by Felix remains. Trent rejects the future elf leaders have arranged for him and openly chooses Rachel, making them a couple despite threats to his status and custody of Lucy. Vampire souls and demon hostility remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -365,7 +365,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -377,7 +377,7 @@
       },
       "recaps": {
         "in_short": "A collection of early Hercule Poirot short stories rather than a continuous narrative. The pieces place Poirot in a succession of independent investigations involving different households, crimes, and forms of deception. Captain Hastings appears as the familiar companion and occasional narrator in the series framework, but the supporting cast changes from story to story. There is no collection-wide culprit or final plot resolution: each mystery begins and ends within its own story, so the volume is best used as a set of separate cases.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -509,7 +509,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -522,7 +522,7 @@
       "recaps": {
         "ending": "A white mob attacks Valentine farm during a public meeting, killing Lander and fatally shooting Royal while destroying the community. Ridgeway recaptures Cora and forces her to lead him to the nearby underground station. At the entrance she turns on him, locking them together and pulling him down the long stone stairs. Ridgeway is mortally injured, and Cora leaves him with Homer. She follows the abandoned tunnel until she reaches open country. Earlier, the truth about Mabel is disclosed: Cora's mother did escape Randall, but almost immediately decided to return for her daughter; a snake bit her in the swamp, and she died before anyone knew she had turned back. Cora therefore ends her journey still unaware that she was not willingly abandoned. On a road beyond the tunnel, she accepts a ride from an older Black man heading west. Her destination and safety remain uncertain, but she is moving on by her own choice.",
         "in_short": "Cora escapes slavery on a Georgia plantation with Caesar by taking an underground railroad that is literally built beneath the earth. Each stop exposes another form of American racial control: paternalistic surveillance and medical abuse in South Carolina, extermination and public terror in North Carolina, and precarious Black self-determination at Indiana's Valentine farm. Slave catcher Ridgeway repeatedly pursues and captures her. Royal, a railroad agent, frees her and offers love and community, but a white mob destroys Valentine and kills him. Recaptured, Cora brings Ridgeway to a station and pulls him down its stairs, leaving him dying. She walks through the tunnel and accepts a westbound ride. A separate account reveals that her mother Mabel, long believed to have abandoned her, had turned back soon after escaping but died from a snakebite in the swamp. Cora never learns this, and her own freedom remains an unfinished journey.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -653,7 +653,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -666,7 +666,7 @@
       "recaps": {
         "ending": "Samantha learns that the catastrophic omission attributed to her was engineered within Carter Spink and proves that she was not responsible. The firm reverses its position and urgently offers her the partnership she once wanted, turning her disappearance into a public contest over her career. She briefly allows herself to be carried back toward London and the identity built around achievement, but recognizes that exoneration does not obligate her to resume a life that made her profoundly unhappy. She rejects the partnership and returns to Nathaniel and the country community where she learned to live outside work. Her future is not defined by remaining the Geigers' deceptive housekeeper; instead, she chooses the relationship and balanced life she genuinely wants, now with her professional reputation restored and the choice made freely rather than from disgrace.",
         "in_short": "Samantha Sweeting is a brilliant, exhausted City lawyer on the verge of partnership when she discovers an apparent oversight that has cost a client tens of millions of pounds. In shock, she leaves London, reaches a country house, and is accidentally hired by Trish and Eddie Geiger as their housekeeper. Samantha cannot cook or clean, but gardener Nathaniel and his mother Iris help her learn while she conceals her identity. The slower life brings friendship, competence of a new kind, and love with Nathaniel. When her past becomes public, Samantha investigates and proves that the disastrous error was deliberately made to look like hers. Carter Spink offers the partnership again and pressures her to return. Although exoneration restores the career she thought she wanted, she realizes that its demands had consumed her life. Samantha refuses the firm and chooses Nathaniel and a future with room for both ability and happiness, leaving domestic deception behind without surrendering the self-knowledge it gave her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -800,7 +800,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -813,7 +813,7 @@
       "recaps": {
         "ending": "Olive returns from Maui in a real relationship with Ethan, but the happiness collapses when she uncovers evidence that Dane has repeatedly been unfaithful to Ami. Ethan initially trusts his brother and treats Olive's accusation as another product of her hostility toward Dane. The argument ends Olive and Ethan's relationship, while the false identity she maintained on the honeymoon also contributes to trouble at her new job. Further evidence confirms that Olive was right. Ami leaves Dane, and Ethan confronts both his brother's conduct and his own failure to believe Olive. He apologizes without excuses and asks for another chance. Olive does not erase the hurt, but she accepts that he now understands it and chooses to rebuild their relationship. By the epilogue, they are securely together and able to regard the disastrous borrowed honeymoon as the unlikely beginning of a lasting partnership, while Ami has moved out of her dishonest marriage and is rebuilding her own life with her family behind her.",
         "in_short": "After nearly everyone at Ami and Dane's wedding is struck by food poisoning, the only healthy members of the wedding party are Ami's twin Olive and Dane's brother Ethan, who strongly dislike each other. They take the couple's nontransferable Maui honeymoon by pretending to be newlyweds. Encounters with Olive's new boss and Ethan's former girlfriend force them to maintain the act, while shared adventures expose the attraction beneath their hostility. They return as a real couple, but Olive then discovers that Dane has been cheating on Ami. Ethan refuses to believe his brother could be responsible, and his distrust breaks the new relationship; Olive's accumulated lies also damage her work prospects. When the truth about Dane is confirmed, Ami ends the marriage and Ethan recognizes how badly he failed Olive. He makes a sincere apology, Olive gives him another chance, and the epilogue leaves them happily committed to each other.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -917,7 +917,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -930,7 +930,7 @@
       "recaps": {
         "ending": "After Gillette serves as the model Frenhofer believes he needs, he declares Catherine Lescault complete and permits Porbus and Poussin to see the work. They find almost the entire canvas buried beneath confused layers of color and paint; only a single beautifully rendered foot remains intelligible. Frenhofer initially continues to speak as if the painted woman were alive, but he overhears the younger men saying that they can see nothing. Their reaction breaks through his certainty. He looks again, recognizes that the masterpiece exists only in his own vision, and drives them away. Gillette also understands that Poussin was willing to sacrifice her feelings to his ambition. The next morning, Porbus learns that Frenhofer has burned his paintings and died during the night.",
         "in_short": "Young Nicolas Poussin meets the celebrated old painter Frenhofer in the studio of Frans Porbus. Frenhofer brilliantly criticizes and retouches Porbus's canvas, then speaks of Catherine Lescault, the portrait he has labored over in secret for ten years and regards as a living woman. He insists that one final model is needed but refuses to expose his own work. Poussin persuades his beloved Gillette to pose for Frenhofer in exchange for a sight of the hidden masterpiece, wounding her trust in him. Once the sitting is complete, Frenhofer admits Poussin and Porbus. They see only a chaos of accumulated paint with one exquisitely preserved foot, while Frenhofer sees a perfect figure. Hearing their dismay destroys his conviction. He sends them away, burns his paintings, and dies that night, leaving Poussin's artistic ambition and his relationship with Gillette morally damaged.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1042,7 +1042,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1055,7 +1055,7 @@
       "recaps": {
         "ending": "After the other pilgrims fall away, Harold continues north alone. He finally reaches Berwick but panics outside the hospice, admitting that the walk cannot make Queenie well. Maureen comes to him, and together they visit Queenie, whose cancer has left her unable to speak. Harold tells her what the journey has meant and thanks her for protecting him years before. Queenie acknowledges him and dies soon afterward. The truth Harold and Maureen have faced is that their son David took his own life and that both parents retreated into different forms of blame afterward. The pilgrimage cannot reverse either death, but it ends their long refusal to grieve together. Harold and Maureen visit the shore, remember David and Queenie without pretending that the pain is gone, and rediscover a shared tenderness and laughter that allow their marriage to begin again.",
         "in_short": "Retired Harold Fry receives a farewell letter from Queenie Hennessy, a former colleague dying in Berwick-upon-Tweed. On his way to post a reply, he decides that if he walks the length of England, Queenie must stay alive until he arrives. Poorly equipped, he heads north while his wife Maureen remains in Devon, angry and bewildered. Encounters with strangers and memories of his damaged family life gradually strip away Harold's reserve. Publicity attracts a disorderly group of followers, but their pilgrimage becomes a spectacle and Harold must finish alone. Maureen, supported by their neighbour Rex, confronts the shared grief beneath her frozen marriage: their son David died by suicide, and she and Harold never mourned together. At the hospice Harold accepts that he cannot save Queenie, but thanks her for once protecting him at work and says goodbye before her death. The journey ends by reconciling Harold and Maureen, not by performing a miracle.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1252,7 +1252,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1265,7 +1265,7 @@
       "recaps": {
         "ending": "Douglas is tried for the death at Birlstone and acquitted: the coroner's court and the assizes accept that he killed Ted Baldwin in self-defence when Baldwin came to murder him. Holmes, however, warns him that the danger is not over, because the men who sent Baldwin have hired a much more formidable organisation in London to finish the work, and urges him to leave England. Douglas and his wife take his advice and sail for South Africa. Some weeks later Cecil Barker comes to Baker Street with the news that Douglas has been lost overboard from the ship in a gale off St Helena, with nobody able to say how it happened. Holmes tells him plainly that this was murder, and that the hand behind it is Professor Moriarty's, whose organisation was paid to see the sentence carried out; a good man has been destroyed to satisfy an old grudge and to protect the reputation of a criminal machine that does not fail. Barker demands to know whether nothing can be done, and Holmes answers that Moriarty has left no evidence and that the reckoning will have to wait, but promises that he will have him in the end. The book closes with the London case unresolved and the long contest between Holmes and Moriarty still open.",
         "in_short": "Holmes decodes a warning from an informant inside a criminal organisation that a man named Douglas at Birlstone is in danger, and within the hour Inspector MacDonald arrives to say that Douglas has been shot dead in his moated Sussex manor house. The body is unrecognisable, killed by a sawn-off American shotgun; a card marked V.V. 341 lies beside it, a wedding ring is missing, and the dead man's forearm carries a brand. Holmes distrusts the composure of the widow and of the family friend Cecil Barker, recovers a bundle of American clothes from the moat, and reveals that the dead man is not Douglas at all but the intruder who came to kill him; Douglas himself has been hiding in a concealed room in the house. Douglas hands over a written account of his past, which turns back twenty years to the Vermissa Valley in America, where a young man named Jack McMurdo joined a lodge of the Scowrers, a fraternal order that ruled the coal country by terror, rose in its councils and finally broke it: McMurdo was the Pinkerton agent Birdy Edwards. Douglas is acquitted of the Birlstone killing, but is lost overboard at sea soon afterwards, and Holmes names Moriarty as the man behind it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1383,7 +1383,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1396,7 +1396,7 @@
       "recaps": {
         "ending": "Lestat's account converges on the modern day, where his rock concert in San Francisco becomes a lightning rod: legions of his own kind, furious that he has exposed their existence to the human world, gather to destroy him, while an unseen force begins annihilating vampires around the globe. In the depths of his story, Lestat had learned the oldest secret of all from the ancient vampire Marius, that every vampire descends from a primeval Egyptian king and queen who have sat for millennia like statues, kept safe and hidden, and that Lestat's reckless contact with the queen had stirred her after her endless silence. Now that queen, Akasha, awakens fully, roused by Lestat's music and audacity. As the concert's chaos subsides and the surviving vampires reel from the mysterious destruction sweeping their ranks, Akasha comes to Lestat and lifts him away with her, choosing him for a purpose not yet revealed. The book ends on that abduction, leaving the awakened ancient queen, her intentions unknown, and Lestat in her power, with the fate of every vampire and the wider world suddenly hanging in the balance.",
         "in_short": "Lestat, awakening in the 1980s after decades underground, becomes a rock star and writes his own life story to tell his side, deliberately breaking the vampires' secret. He recounts his origins as a rebellious young nobleman in eighteenth-century France who flees to Paris with his friend Nicolas, only to be seized and transformed into a vampire by the ancient Magnus, who then destroys himself and leaves Lestat his fortune. Grieving and newly immortal, Lestat gives the dark gift to his dying mother, Gabrielle, and later to Nicolas, and he clashes with an old coven of vampires, led by Armand, who cling to superstitions he rejects. Restless for the origins of his kind, Lestat seeks out the ancient Marius, who reveals the deepest secret of the vampires: the primeval king and queen from whom all vampires descend, kept for thousands of years as living statues. Lestat's contact with the queen stirs something long dormant. In the modern present, his defiant public performance enrages other vampires who want him destroyed, and as the book closes the ancient queen awakens and takes Lestat with her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1612,7 +1612,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1625,7 +1625,7 @@
       "recaps": {
         "ending": "Ellie's death is treated as the end of the affair, and the school prepares to move on. David, having learned that Stevie was reporting on him to his father, retaliates against the senator by arranging to have himself beaten on camera and releasing the footage, a public act calculated to wreck his father's presidential campaign, and then leaves. Stevie is allowed to stay at Ellingham, but the historical case is now open rather than closed: the \"Truly, Devious\" letter was a private game between two 1936 students, so whoever took Iris and Alice Ellingham did it for reasons the famous riddle never touched, and the 1936 chapters have shown how much George Marsh and Flora Robinson were not saying. Then Dr. Fenton dies in a fire at her house in Burlington, recorded as an accident caused by a gas leak. Stevie, who had been with her only hours before, does not accept it. Counting Hayes Major, Ellie and Fenton, she ends the book certain that the deaths gathering around the Ellingham case are not accidents at all, and that whoever is causing them is still nearby.",
         "in_short": "Pulled out of Ellingham Academy after Hayes Major's death, Stevie Bell is stranded at home until Senator Edward King, her parents' employer and David's father, offers to send her back in exchange for keeping him informed about his son. She takes the deal. Back in Vermont she is put to work with Dr. Irene Fenton, a Burlington writer obsessed with the Ellingham case and with finding out what became of Alice Ellingham. Researching two 1936 students, Francis Crane and Edward Davenport, Stevie establishes that they wrote the notorious \"Truly, Devious\" letter themselves as a game, meaning the riddle that has defined the case for eighty years had nothing to do with the kidnapping. She then finds the moving staircase Albert Ellingham built into the Great House and, in the hidden room it opens onto, the body of Ellie, who had gone underground and could not get out. David discovers Stevie has been reporting to his father and breaks with her, destroying his father's campaign on his way out. Finally Dr. Fenton dies in a house fire ruled accidental, and Stevie concludes it was murder.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1779,7 +1779,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1792,7 +1792,7 @@
       "recaps": {
         "ending": "Yeong-hye's refusal to eat has become an attempt to abandon human life altogether. Believing she is turning into a tree, she rejects food and insists that sunlight and water are sufficient. The psychiatric hospital restrains and force-feeds her as her body approaches collapse, but the intervention causes further trauma and bleeding. In-hye, the only relative still visiting, sees both the immediate danger and the violence of making Yeong-hye conform. A transfer to a larger Seoul hospital is arranged, and she accompanies her sister in the ambulance. Their father, Mr. Cheong, and In-hye's husband have all disappeared from Yeong-hye's care, while In-hye remains responsible for her son and for the family crisis. As the ambulance passes wooded hills, Yeong-hye watches the trees and In-hye looks at them with an intense, questioning anger. Yeong-hye's survival and recovery are left unresolved; the firm closing fact is In-hye's refusal to look away or offer an easy explanation for what has happened.",
         "in_short": "After nightmares filled with blood and violence, Yeong-hye abruptly stops eating meat. Her husband and family regard the decision as defiance, and a forced family meal ends with her cutting her wrist. Her marriage collapses. Later, her video-artist brother-in-law becomes obsessed with her remaining Mongolian mark and films her body painted with flowers. Their artistic collaboration becomes sexual; discovery destroys his household and contributes to Yeong-hye's confinement in a psychiatric hospital. Her older sister In-hye, now caring for her son alone, is the only relative who continues to visit. Yeong-hye increasingly believes she is becoming a tree and refuses all food, seeking to live on light and water. Hospital staff restrain and force-feed her as she nears death. In-hye secures a transfer to Seoul and travels beside her in the ambulance, confronting both her sister's peril and the coercive family life that helped produce it. The novel ends without confirming whether Yeong-hye survives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1866,7 +1866,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1877,7 +1877,7 @@
       "recaps": {
         "ending": "The Velveteen Rabbit ends with the toy's longing fulfilled. After the boy recovers from scarlet fever, the doctor insists that all the toys from his sickroom be destroyed, and the beloved but shabby velveteen rabbit is bundled into a sack and left in the garden overnight to be burned. Alone and forgotten, remembering all the love he had shared with the boy, the rabbit sheds a single real tear. From that tear springs a flower, out of which comes the Nursery Magic Fairy, who tends toys that have been truly loved. She tells the rabbit that the child's love had already made him Real to the boy, and now she will make him Real to everyone. With a kiss she transforms him into a living rabbit, and he bounds away to live among the wild rabbits in the wood. The following spring, the boy, out playing, notices a rabbit watching him that looks oddly like his old velveteen toy. He never learns the truth, but the rabbit he lost has become fully alive, its worn devotion rewarded with a real life of its own.",
         "in_short": "A velveteen rabbit, given to a boy at Christmas, feels plain and unimportant beside the fancier nursery toys until the wise old Skin Horse tells him that a toy becomes \"Real\" when a child loves it truly and long enough, however worn it may grow. The boy comes to love the rabbit above everything, carrying it everywhere, and the shabby rabbit is blissfully content. But when the boy nearly dies of scarlet fever, the doctor orders his contaminated toys burned. Discarded in the garden and facing the fire, the rabbit weeps a real tear, from which a flower and the Nursery Magic Fairy appear. Because he has been so deeply loved, the fairy makes him fully Real, a living rabbit who joins the others in the wood. In spring the recovered boy sees a wild rabbit that reminds him of his lost toy, never realizing it is the same one, brought truly to life by the love he gave it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2052,7 +2052,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2065,7 +2065,7 @@
       "recaps": {
         "ending": "The volume's second novel ends after Frank Shabata discovers his wife Marie with Emil Bergson beneath a mulberry tree and shoots them both. Alexandra, devastated by the death of the younger brother she raised, visits Frank in prison. Recognizing his remorse and misery, she promises to support a future pardon instead of seeking revenge. Carl Linstrum returns from Alaska and joins Alexandra at the farm. Grief has stripped away her older brothers' power to dictate her choices, and she and Carl decide to marry. Alexandra keeps faith with Ivar and accepts companionship without surrendering her bond to the land. The close leaves both novels' heroines marked by severe labor and loss but enduring: Ántonia within the abundant family she built with Cuzak, Alexandra beside Carl on the Nebraska farm whose future she foresaw.",
         "in_short": "In *My Ántonia*, orphaned Jim Burden grows up in Nebraska beside Bohemian immigrant Ántonia Shimerda. Poverty and her father's suicide force Ántonia into hard labor; later she joins Black Hawk's independent hired girls. Jim leaves for education, while Ántonia is abandoned pregnant by Larry Donovan. Decades later he finds her thriving on a farm with husband Anton Cuzak and their large family, and renews their bond. In *O Pioneers!*, Alexandra Bergson preserves her Swedish American family's failing homestead by trusting the land when others leave. Prosperity brings conflict with her conventional brothers, and her beloved younger brother Emil falls in love with married neighbor Marie Shabata. Marie's jealous husband Frank kills them. Alexandra responds with mercy, seeks Frank's pardon, and chooses at last to marry her loyal friend Carl Linstrum. Across both novels, Nebraska shapes lives through hardship, memory, work, and renewal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2237,7 +2237,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2250,7 +2250,7 @@
       "recaps": {
         "ending": "The Baudelaires decode Isadora Quagmire's couplets, locate the captive triplets hidden inside the village fountain, and free them at last. Duncan and Isadora escape aboard Hector's self-sustaining hot air mobile home, carrying notebooks full of everything they have learned about Count Olaf and the secret V.F.D., though the children cannot go with them and are again separated from their friends. Detective Dupin is exposed as Count Olaf, but the townspeople, roused into an angry mob and convinced the orphans murdered the arrested stranger Jacques Snicket, refuse to listen. Framed for a killing they did not commit and with no guardian to protect them, the Baudelaires are forced to flee the village entirely. For the first time they leave Mr. Poe and the system of guardians behind and become fugitives, hunted not only by Olaf but now by the law, and more determined than ever to unravel the mystery of V.F.D.",
         "in_short": "Tired of individual guardians, the Baudelaires agree to be raised by an entire village, V.F.D., the Village of Fowl Devotees, which worships crows and is ruled by a strict Council of Elders. They are made to do all the town's chores and live with Hector, a kind but painfully timid handyman. Mysterious rhyming couplets begin appearing, which the children recognize as coded messages from the captive Quagmire triplets, revealing they are hidden nearby. Count Olaf arrives disguised as Detective Dupin, with Esme posing as a police officer. A stranger, Jacques Snicket, is arrested as Count Olaf because of his ankle tattoo, then found murdered, and Dupin frames the Baudelaires for the crime. Decoding the couplets, the children find the Quagmires hidden in the town fountain and free them, and the triplets escape aboard Hector's self-built flying mobile home. Now falsely wanted for murder, the Baudelaires flee the village and become fugitives on their own.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2457,7 +2457,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774240963",
@@ -2469,7 +2469,7 @@
       "recaps": {
         "ending": "Windfall survives the siege after Jim directs the goblin armies into battle with Dirge's Pumas and his allies secure all three siege cauldrons. Jim exposes the town tailor as the goblins' informant and uses the unstable life-energy orb to eliminate the underground attackers. The town's barrier is fully restored, and its defenders retake the Western Gate Fortress. Dirge loses most of his force but escapes north with 82 survivors. Jim remains mayor and specializes as a Mage Knight. Shart retains the dangerous orb, Badgelor's obligation against an unnamed betrayer remains unresolved, and Fenris leaves with Zorlando to resume the Narwhal trade mission. SueLeeta, Jarra, Mar, and the other surviving defenders remain part of Windfall's recovery. Bashara reports to the Sphinx after the conflict, and the search for the Shadow God's body continues elsewhere in the Riverlands. King Har Charles's campaign and his war with King Tim Simon also remain unresolved.",
         "in_short": "Jim works to turn Windfall Village, also known as Noobtown, into a viable settlement by reclaiming its mine and seeking a trade route to Narwhal. The journey reveals a refugee crisis and a murderous bandit force led by Dirge. After surviving the puma forest, Jim finds an unnatural life spring and secures its reality-defying source. His planned campaign against the bandits is interrupted by a goblin siege. Windfall's defenders capture the siege cauldrons, destroy a hidden underground force, and manipulate the goblins and Dirge's Pumas into fighting each other. The barrier is restored and the Western Gate Fortress is retaken. Dirge escapes north with a small remnant, while Fenris and Zorlando depart with trade goods for Narwhal. Jim remains mayor and becomes a Mage Knight. Bashara is ultimately revealed to serve the Sphinx, whose search for the Shadow God's body continues.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2667,7 +2667,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2680,7 +2680,7 @@
       "recaps": {
         "ending": "Molly and the Virginian become engaged, but the old conflict with Trampas reaches them just before their wedding. Trampas publicly forces a showdown that the Virginian believes he cannot honorably avoid without surrendering both his standing and the safety of his future. Molly begs him not to fight and fears that choosing the duel will separate them. The Virginian nevertheless faces Trampas and kills him. When he returns, Molly accepts both the man and the hard code by which he has acted, and they marry. Their honeymoon takes them east, allowing the Virginian to meet Molly's family and see the settled world from which she came. In the later frame, the narrator visits them after several years and finds that the Virginian has prospered as an independent rancher. He and Molly have built a settled home and are raising children. The story therefore closes beyond the gunfight: the anonymous cowboy has moved from hired hand to husband, father, and successful landowner, while retaining the qualities that first distinguished him.",
         "in_short": "An eastern narrator arriving in Wyoming meets an unnamed cowboy known as the Virginian, whose composure and ability soon set him apart. At Judge Henry's Sunk Creek ranch, the Virginian rises toward leadership while his rivalry with the dishonest Trampas deepens. He courts Molly Wood, a Vermont schoolteacher attracted to him but troubled by western violence. That conflict becomes personal when the Virginian must participate in hanging cattle thieves, including his friend Steve. Molly's horror separates them for a time, yet later she nurses the Virginian after he is wounded and accepts his proposal. Trampas, connected with the rustling troubles, finally challenges him immediately before the wedding. The Virginian kills Trampas in the unavoidable showdown, and Molly chooses to marry him. Years later the narrator finds the couple prosperous on their own ranch with a family, the Virginian having grown from a gifted ranch hand into a successful cattleman.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2857,7 +2857,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2870,7 +2870,7 @@
       "recaps": {
         "ending": "After Kate is badly injured in a carriage accident, Anthony can no longer preserve the emotional distance on which he built their marriage. Faced with the possibility of losing her, he admits that he loves her and understands that avoiding love would never have protected either of them from grief. Kate survives and returns his love. She also begins to understand the childhood storm terror linked to her mother's death, while Anthony lets go of the conviction that he must die at the age his father did. Edwina is free from Anthony's former courtship and able to choose a husband who suits her rather than her family's finances. Kate and Anthony settle into a loving, competitive marriage. The closing glimpse of their later life shows that Anthony lives beyond the birthday he once believed would mark his death, surrounded by Kate and their family.",
         "in_short": "Viscount Anthony Bridgerton decides to marry but, convinced he will die young like his father, plans to choose a bride he cannot love. He selects the season's admired Edwina Sheffield, only to meet fierce opposition from her protective sister Kate. Their arguments conceal a powerful attraction, and a bee sting leaves them in a compromising position that forces an engagement. Kate and Anthony marry, but both struggle to speak honestly: Kate fears she was merely a duty, while Anthony refuses to name love because he thinks it will make his expected early death unbearable. Family tensions and Kate's terror of thunderstorms draw them closer. When Kate is injured in a carriage accident, Anthony realizes that emotional distance offers no protection from loss and tells her he loves her. She recovers and returns his love. Anthony abandons his fatalistic certainty, and their marriage becomes a happy partnership that lasts well beyond the age at which he expected to die.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2945,7 +2945,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2958,7 +2958,7 @@
       "recaps": {
         "ending": "The ship holding the scientists is boarded by a Belter faction, and the prisoners are not killed or handed to a court. They are offered work. The people who now control them want the protomolecule understood and exploited, and the only human beings with hands-on experience of it are sitting in a cell nobody has decided what to do with. Cortázar accepts without hesitation and without conditions; the offer restores the one thing he has consistently wanted since he was a boy watching his mother die, which is access to the work. What he has to give up in exchange does not register as a cost, because he arranged years ago to be unable to feel it. He leaves the prison in the custody of people who will use him, entirely satisfied with the arrangement, and the research that produced Eros acquires a new sponsor. The novella closes on that transfer, which is the beginning of the role Cortázar plays in the later novels.",
         "in_short": "Paolo Cortázar is one of a group of scientists from the corporate program that released the protomolecule on the station Eros, imprisoned aboard a converted ship in the Belt since the project was exposed and left there without trial or sentence. The story alternates between the small, aimless routines of that captivity and Cortázar's own history: a childhood on Earth on basic support, a mother who died of an illness that was curable for people with better standing, and the offer of a research career on condition that he undergo a procedure removing his capacity for emotional attachment. He accepted, and considers it the best trade he ever made. It is also what allowed him to work on an experiment that killed more than a million people and to describe it as a scientific opportunity. The captivity ends when Belters take the ship and offer the prisoners their work back rather than a trial. Cortázar accepts immediately, and goes with them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3205,7 +3205,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002V0GFSS",
@@ -3217,7 +3217,7 @@
       "recaps": {
         "ending": "Gregor is freed from Cavilo and resumes imperial authority, using diplomacy to coordinate the defense of Vervain. Ky Tung directs the Dendarii in battle until Barrayaran, Aslund, Paul, and Imperial reinforcements rout the Cetagandan invasion. Oser apparently dies when his escape shuttle is destroyed. After the battle, Metzov tries to kill Miles, but Cavilo kills Metzov and returns to custody under her agreement with Miles. She later leaves the Hagen Hub with the surviving Rangers and a two-month lead over likely Cetagandan retaliation. Gregor negotiates a lasting framework among Barrayar, Vervain, Aslund, and Paul, and chooses to continue as Emperor while seeking personal support from Cordelia Vorkosigan. Simon Illyan places the Dendarii on permanent Imperial retainer. Miles returns to service as a lieutenant, Imperial Security liaison, and covert commander under the Admiral Naismith identity.",
         "in_short": "After graduation, Miles Vorkosigan's first posting at Lazkowski Base ends when he protects technicians from Metzov's lethal abuse of command, sacrificing his commission to shield the others. Imperial Security then sends him undercover to investigate the Hagen Hub. There he finds the missing Emperor Gregor, reconnects with the divided Dendarii, and discovers that Cavilo is using Gregor while assisting a Cetagandan invasion plan. Miles removes Oser from command, reunites the fleet under Ky Tung's tactical direction, rescues Gregor, and helps defend Vervain until allied reinforcements defeat the invasion. Oser apparently dies escaping, and Cavilo kills Metzov when Metzov attacks Miles. Gregor establishes a regional treaty and returns to rule. The Dendarii enter permanent Imperial service, with Miles promoted to lieutenant and retained as their liaison and covert Admiral Naismith.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3385,7 +3385,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3398,7 +3398,7 @@
       "recaps": {
         "ending": "Beyond Ramandu's island the sea grows sweet, shallow and blindingly bright, the crew need no sleep or food, and the ship comes at last to a level plain of white lilies through which it can no longer sail. Caspian announces that he will leave the ship and go on to the world's end himself; Reepicheep tells him plainly that a king may not abandon his people, and Aslan, appearing to him alone in his cabin, sends him back to his duty and to Ramandu's daughter, whom he will marry. Reepicheep goes on alone in his coracle, drops his sword, and passes over the standing wave at the world's end, never seen in Narnia again. Lucy, Edmund and Eustace walk on through the shallows to a green wall of water and meet a white Lamb beside a fire, who becomes Aslan and opens a way home for them. He tells Lucy and Edmund that they are now too old to return to Narnia, and that the reason they were brought there was so that they might come to know him by another name in their own world. The three arrive back in the bedroom in England. The three lords wake when the enchantment is broken, the Dawn Treader turns for home with the quest completed, and Eustace returns a changed boy whom his mother finds tiresomely improved.",
         "in_short": "Lucy and Edmund Pevensie, stuck for the summer with their disagreeable cousin Eustace, are pulled through a picture of a ship into the eastern sea of Narnia and taken aboard the Dawn Treader. King Caspian is sailing to find seven lords his uncle exiled, and the mouse Reepicheep intends to go on to the world's end. They break the slave trade in the Lone Islands, and on a wild island Eustace, sneaking away from work and sleeping on a dragon's hoard with greedy thoughts, wakes as a dragon himself; Aslan restores him, and the experience begins to remake him. The voyage takes them past a pool that turns whatever touches it to gold, an island of invisible bumbling servants whose spell Lucy lifts, and a darkness where nightmares come true, from which they rescue one of the lost lords. At Ramandu's island they find the last three lords asleep under an enchantment that can only be broken by sailing to the world's end and leaving one of the company behind. Reepicheep goes over the wave into Aslan's country; Caspian is sent back to rule and to marry Ramandu's daughter; and the children are returned to England, where Lucy and Edmund learn they are too old to come to Narnia again.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-wandering-inn.json
+++ b/data/works-community/0/the-wandering-inn.json
@@ -358,7 +358,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774240327",
@@ -370,7 +370,7 @@
       "recaps": {
         "ending": "Skinner escapes the ruins after destroying the silver-rank expedition and leads an undead assault on Liscor. Thirty-two newly individual Antinium workers defend Erin and The Wandering Inn. Knight and most of the others die, but Pisces sends covert undead aid, Toren helps expose Skinner's true body, and the Antinium Queen completes Klbkch's costly rebirth. Klbkch returns in a new body, Rags commits her goblins to the fight, and Rags kills Skinner. Liscor and the inn remain standing but badly damaged. Erin is alive at Innkeeper level 18, grieving the workers; Bird, Gary, Belgrade, and Anand are their only survivors. Klbkch replaces Ksmvr as Prognugator, while resurrection is too costly to restore the fallen workers. Toren has become more independent and secretly retains a red magical gemstone from Skinner. Yvlon Byres survives the ruins scarred and unresponsive. Ryoka returns, learns of the Horns' losses, finds Yvlon alive, and approaches Erin's inn before turning away. Her compelled Bloodfields delivery, conflict with Magnolia and Persua, estrangement from Erin, and route home remain unresolved, as does Erin's distant hope of reaching Wistram.",
         "in_short": "Erin, a young woman displaced from Earth, claims an abandoned inn outside Liscor and gradually turns it into a refuge for drakes, gnolls, Antinium, goblins, adventurers, and an undead servant. Her chess games encourage individual thought among Antinium workers and deepen her alliance with the goblin Rags. Elsewhere, the classless runner Ryoka survives dangerous deliveries, draws Magnolia Reinhart's attention, and becomes indebted to the Horns of Hammerad. A silver-rank expedition into nearby ruins releases Skinner, an undead horror that devastates the adventurers and attacks Liscor. Erin's newly individual chess-club workers defend her at terrible cost. Pisces, Toren, the Watch, the Antinium, reborn Klbkch, and Rags's goblins turn the battle, with Rags killing Skinner. Liscor survives damaged. Erin reaches Innkeeper level 18 and mourns the workers, while only Bird, Gary, Belgrade, and Anand survive their defense. Yvlon survives the expedition in severe trauma, and Ryoka returns to the inn but leaves without seeing Erin.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -540,7 +540,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -553,7 +553,7 @@
       "recaps": {
         "ending": "In London, the narrator finds the Martian fighting machines motionless and their operators dead. The invaders had no resistance to earthly microorganisms, so ordinary bacteria defeated them after human weapons and institutions had failed. England begins to recover, although the invasion has killed many people and permanently altered the survivors' sense of security. Believing his wife died in the destruction of Leatherhead, the narrator returns alone to the ruins of his home near Woking. She unexpectedly arrives there with a cousin, having escaped before the town was destroyed, and the couple are reunited. Later study of the abandoned Martian machinery expands human knowledge, while observations of Mars and activity elsewhere in the solar system leave open the possibility of another attack. The narrator continues to suffer vivid memories of the invasion and recognizes how fragile human dominance has always been.",
         "in_short": "Unusual flashes on Mars precede the fall of cylinders in southern England. An unnamed writer near Woking sees the first Martians emerge and attack with a Heat-Ray, then sends his wife toward safety as towering fighting machines advance. Military resistance collapses under the Heat-Ray and poisonous Black Smoke. The narrator survives the destruction of Weybridge, travels with a terrified curate, and later hides beside a Martian pit while the invaders feed and build. In a parallel account, his brother escapes the panic in London and reaches a refugee ship after HMS Thunder Child sacrifices itself against the machines. The curate's loss of control leads to his death, while the narrator remains concealed. When he finally enters a silent London, he discovers that the Martians have died from earthly bacteria to which humans have acquired resistance. He returns to his damaged home expecting to be alone and is reunited with his wife, who escaped Leatherhead before its destruction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -714,7 +714,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -727,7 +727,7 @@
       "recaps": {
         "ending": "Mam removes Ada and Jamie from Susan's care and takes them back to their old London room. Ada now understands that Mam's cruelty is not something she caused, and she refuses to surrender the independence she gained in Kent. During an air raid, the children leave the flat for shelter; when they return, the building has been destroyed. Susan, having realized that she wants the children as her family, has come to London to find them and reaches them amid the bombing. Mam agrees to give them up. Ada and Jamie return with Susan, no longer merely unwanted evacuees placed in her house but children whom she has actively chosen. Ada recognizes that their escape allowed them to save Susan from her lonely grief just as surely as Susan's journey and care saved them.",
         "in_short": "Nine-year-old Ada has never been allowed outside her London flat because her abusive mother is ashamed of her clubfoot. When children are evacuated before the Second World War, Ada escapes with her younger brother Jamie and is placed with the reluctant Susan Smith in rural Kent. Food, medical care, a pony named Butter, friendship, and wartime responsibility gradually show Ada that she is capable and worthy, although fear and years of abuse make trust difficult. She helps watch the coast and identifies an enemy airman, while Susan comes to love both children. Mam eventually takes them back to London, but Ada refuses to accept her old captivity. Their flat is destroyed in an air raid, and Susan, who has traveled to find them, rescues them. Mam relinquishes the children, and they return to Kent together as a chosen family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -923,7 +923,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -936,7 +936,7 @@
       "recaps": {
         "ending": "Carter escapes captivity in Okar, reunites with Talu's rebels, and helps the allied fleets enter the northern realm by disabling its defensive magnetic mechanism. In the fighting that follows, Salensus Oll, Matai Shang, and Thurid are killed, ending the alliance that carried Dejah away from the Temple of the Sun. Phaidor rejects her former jealousy and dies protecting Dejah, having asked forgiveness for the harm she caused. Dejah and Thuvia are freed, and the forces of Helium, Ptarth, and the Tharks are reunited with them. Talu replaces Salensus Oll as ruler of Okar and establishes peace with the southern nations. With rulers and armies from across Barsoom acknowledging the coalition he has led, John Carter is formally acclaimed Warlord of Barsoom and returns to Helium with Dejah.",
         "in_short": "John Carter watches the Temple of the Sun until he discovers Matai Shang and the First Born officer Thurid using a secret route to reach Dejah Thoris, Thuvia, and Phaidor. They carry the women away through underground passages, and Carter pursues them across Barsoom. The chase passes through Kaol and ultimately reaches Okar, the isolated northern realm of the yellow Martians, where the tyrant Salensus Oll plans to marry Dejah. Carter allies with the rebel prince Talu, survives imprisonment, and opens the way for a combined force from Helium, Ptarth, and the Tharks. The allies overthrow Salensus Oll; Matai Shang and Thurid also die. Phaidor abandons her jealousy and dies protecting Dejah. Thuvia and Dejah are rescued, Talu becomes ruler of Okar, and peace is established between north and south. The assembled rulers acclaim Carter as Warlord of Barsoom, and he returns to Helium with Dejah.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1251,7 +1251,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0036K2EZK",
@@ -1263,7 +1263,7 @@
       "recaps": {
         "ending": "Miles reaches the Council of Counts in time to answer the claim that his mercenary force was intended to overthrow Gregor Vorbarra. The Imperial procurement admiral implicates Vordrozda, who is arrested after drawing a weapon in Gregor's presence. Gregor accepts Miles's account, the Council acquits him, and Vorhalas agrees not to revive the separate private-army charge. Gregor preserves the Dendarii by making them covert crown troops assigned to Imperial Security, with their Barrayaran allegiance concealed. Baz Jesek remains their operational commander, with Elena Bothari as executive officer and trainee; their betrothal has Miles's formal recognition. Arde Mayhew searches for components that might restore the disabled RG-132, while Elena Visconti wants no renewed contact with Elena Bothari and the question of their relationship remains open. Illyan awaits trial despite Aral's belief in his loyalty. Miles brings Bothari home for burial at Vorkosigan Surleau, then begins Imperial Service Academy training. In the final drill, he saves his shuttle crew and begins to overcome Kostolitz's hostility.",
         "in_short": "Miles Vorkosigan fails Barrayar's officer-candidacy physical, then travels to Beta Colony and turns a desperate ship purchase into a covert arms run. His invented Dendarii Mercenaries capture Oseran ships and a refinery, survive Pelian attacks, and break the Tau Verde IV blockade by undermining Oser's payroll. Bothari is fatally shot when Elena Visconti confronts him over alleged crimes during the Escobaran war, leaving Elena Bothari's possible maternity unresolved. Elena rejects Miles's proposal and chooses Baz Jesek; Miles recognizes their betrothal and leaves them in command of the Dendarii. He returns to Barrayar to face a usurpation charge, exposes Vordrozda's conspiracy, and is acquitted. Gregor Vorbarra secretly converts the Dendarii into crown troops under Imperial Security. After burying Bothari, Miles enters the Imperial Service Academy and proves his command experience during a hazardous orbital drill.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1396,7 +1396,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1409,7 +1409,7 @@
       "recaps": {
         "ending": "Tom's education culminates in a journey to the Other-end-of-Nowhere, where he finds Grimes trapped by the consequences of his own stubborn and harmful conduct. Although Grimes abused him, Tom chooses to help rather than seek revenge. That willing act completes the change the fairies have been cultivating in him. Grimes is given the possibility of beginning again through honest work, while Tom is allowed to leave the water-baby world. He grows into an educated and capable man associated with scientific and engineering achievement, and he remains connected with Ellie. The close presents moral development, compassion, and useful work—not social birth—as the path by which the neglected chimney boy becomes fully human and free.",
         "in_short": "Tom, an abused young chimney sweep, enters Harthover House with his master Grimes, frightens Ellie when he emerges into her room, and flees across the moors. He reaches a stream and is transformed into a water-baby. Beneath the water he encounters animals, other water-children, and two governing fairies: Mrs Bedonebyasyoudid, who imposes consequences, and Mrs Doasyouwouldbedoneby, who offers the care children need. Tom's old habits of mischief and selfishness repeatedly bring correction, while Ellie becomes part of his education. His travels widen from river to sea and finally lead him to Mother Carey and the Other-end-of-Nowhere. There he finds Grimes suffering the results of his cruelty. Tom overcomes resentment and helps his former master, completing his own moral transformation. He is restored to human life, grows into an educated man of practical accomplishment, and shares a future with Ellie.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1565,7 +1565,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1578,7 +1578,7 @@
       "recaps": {
         "ending": "Hiram returns to Virginia as an agent of the Underground, determined to free Sophia and protect the remaining people at Lockless as Howell's health and the estate decline. He learns that Sophia has a daughter, Caroline, and accepts both of them as his family. Working through Corinne's influence and his own intimate knowledge of the plantation, he prevents their sale and brings them back to Lockless. After Howell dies, the estate becomes a station in the Underground rather than the inheritance Maynard was meant to preserve. Hiram also uses Conduction to reunite Thena with family torn from her decades earlier, drawing on recovered memory instead of trying to escape it. He remains with Sophia and Caroline while helping others travel north. Lockless still carries the history of enslavement, but its purpose has been reversed: the place from which Hiram's mother and so many others were taken now supports passage toward freedom.",
         "in_short": "Hiram Walker is enslaved at Lockless, the Virginia plantation owned by his white father. When his half brother Maynard dies in a bridge accident, Hiram survives through a mysterious power called Conduction, which joins memory to movement across impossible distances. After an attempted escape with Sophia ends in betrayal and imprisonment, Hiram is recruited into the Underground by Corinne Quinn. Training in Virginia and Philadelphia teaches him both the network's discipline and the limits of freedom in the North. Harriet Tubman helps him understand that his lost memories of his mother, Rose, are the key to using his gift. Hiram returns to Virginia to rescue Sophia, who now has a daughter, and to secure the people still vulnerable at the collapsing plantation. After Howell's death, Lockless becomes an Underground station. Hiram reunites Thena with lost family, builds a home with Sophia and Caroline, and uses Conduction to carry others away from slavery.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1757,7 +1757,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1770,7 +1770,7 @@
       "recaps": {
         "ending": "After the Birmingham church bombing, the Watsons return to Flint. Joetta is physically unharmed because she left the church shortly before the explosion, but Kenny has seen the ruined building and believes for a time that he saw her dead. He withdraws from the family and repeatedly hides behind the couch, the place the Watson children once called a pet hospital. Byron recognizes that Kenny is struggling and quietly stays close. He draws his brother out, listens when Kenny finally speaks about the bombing, and tells him that feeling frightened and wounded does not mean he has failed. Kenny begins to cry and accept that Joetta is alive and that he could not have controlled what happened. His recovery is incomplete, but the brothers' relationship has changed: Byron's protective loyalty is now open, and Kenny starts to rejoin the family carrying a more mature understanding of cruelty, survival, and love.",
         "in_short": "Ten-year-old Kenny Watson lives with his lively family in Flint, Michigan. His older brother Byron is both his tormentor and protector, while little Joetta binds the siblings together. Byron's dangerous misbehavior persuades their parents to drive the family to Birmingham, Alabama, planning to leave him with strict Grandma Sands. The journey and the South begin to sober Byron. He saves Kenny from drowning at a forbidden swimming hole, revealing the care hidden beneath his bullying. Soon afterward a bomb destroys the Black church Joetta is attending. She had stepped outside and survives, but Kenny enters the wreckage, is traumatized by what he sees, and returns to Flint emotionally withdrawn. Byron patiently helps him face the experience and understand that he is not to blame. Kenny begins to heal, and the brothers emerge with a deeper bond after confronting racist violence far beyond the familiar troubles of home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1930,7 +1930,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1943,7 +1943,7 @@
       "recaps": {
         "ending": "Ben gathers the Wave's members for a rally, telling them they will meet the national leader of a movement spreading to schools across the country. Laurie and David attend after Ben assures them that the event will end the experiment. Instead of a leader, the students see film of Adolf Hitler and Nazi rallies. Ben explains that their obedience, exclusion of dissenters, and surrender of personal judgment reproduced the forces they had believed they could never accept. The students leave ashamed as the Wave's organization collapses. Robert is especially devastated because the movement had rescued him from isolation and given him status; Ben recognizes that exposing the lesson is not enough to repair the harm. He stays with Robert and takes him to eat, accepting a continuing responsibility for the student most dependent on what he created. Laurie and David are reconciled, and the school has learned the answer to the original history question through its own conduct.",
         "in_short": "Unable to explain to his students how Germans could accept Nazism, history teacher Ben Ross creates an exercise built on discipline, community, and action. The Wave quickly spreads beyond his class, giving students unity and purpose but also encouraging surveillance, coercion, and hostility toward anyone who refuses to join. Laurie Saunders, editor of the school paper, recognizes the danger and publishes criticism, putting her at odds with her friend Amy and boyfriend David. After David physically lashes out while trying to silence her, he understands what the movement has made of them and joins her opposition. Ben, now treated as the group's unquestioned leader, ends the experiment at a mass rally. He presents Hitler as the leader their behavior has prepared them to follow and confronts the students with their willingness to abandon individual judgment. The Wave dissolves, though Ben must personally help Robert, the formerly isolated boy who had invested most deeply in belonging to it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2065,7 +2065,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2078,7 +2078,7 @@
       "recaps": {
         "ending": "After the six surviving friends meet again at Hampton Court, their shared past no longer produces the wholeness they once associated with Percival. Rhoda has died, and each life has hardened into its own pattern. In the final section Bernard sits alone with an unnamed listener and tries to tell the story of the group. His long account absorbs phrases, memories, and viewpoints belonging to the others until the boundaries between his life and theirs become unstable. He reviews friendship, marriage, parenthood, desire, achievement, Percival's death, Rhoda's absence, and his lifelong habit of making stories. Yet he also recognizes that narrative cannot permanently order experience or defeat mortality. After the listener leaves, Bernard goes out into the renewed light. Seeing death as the final adversary, he chooses to meet it with resistance rather than retreat. The book closes by returning from his solitary assertion to the impersonal sea, whose continuing movement outlasts every individual voice.",
         "in_short": "Six friends speak in alternating interior monologues from childhood to old age, while descriptions of the sun crossing the sky and waves reaching shore measure a larger natural day. Bernard makes stories, Neville seeks exact beauty and love, Louis pursues authority despite feeling foreign, Susan roots herself in rural family life, Jinny lives through body and social presence, and Rhoda struggles to maintain a self. Their admired friend Percival never speaks directly but briefly makes the group feel unified. He leaves for India and dies in an accident, a loss that each survivor absorbs differently. The six continue through careers, lovers, marriage, children, solitude, and age, periodically reuniting without recovering their earlier unity. Rhoda also dies. Finally Bernard, alone with an unnamed listener, attempts to combine all their lives into one account, then admits the limits of stories and stable identity. He goes out to face death defiantly as the waves continue beyond the human span.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2285,7 +2285,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2298,7 +2298,7 @@
       "recaps": {
         "ending": "The long war reaches a turning point. Dalinar and Highprince Sadeas launch a joint assault on the Parshendi, but Sadeas abandons Dalinar's army mid-battle, exposing himself as a traitor and leaving the Kholin forces to be annihilated. Kaladin, who has secretly learned to wield the light of the storms, leads Bridge Four back into the trap and rescues Dalinar and his men against impossible odds. Freed from slavery and revealed as one of the vanished Knights Radiant returned, Kaladin binds himself and his crew to guard the Kholins, with the wind-spirit Syl now clearly more than she seemed. Dalinar trades his irreplaceable Shardblade to buy Bridge Four's freedom, gaining fiercely loyal soldiers but making a lasting enemy of the humiliated Sadeas. Far to the west, Shallan arrives at the Plains and confesses to Jasnah that she too has begun to manifest a Radiant's powers, tying their scholarly hunt to the reawakening magic. The book closes with the certainty that the ancient Desolations are not myth: a great enemy stirs, the storms carry warnings, and the assassin Szeth is redirected toward a deadlier purpose. The heroes now know the true war is only beginning.",
         "in_short": "On the storm-battered world of Roshar, a war grinds on across the Shattered Plains, where the kingdom of Alethkar hunts the alien Parshendi to avenge the murder of King Gavilar. Kaladin, a gifted young spearman betrayed into slavery, is thrown into a bridge crew meant to die, but he refuses to let his men perish and slowly forges the broken Bridge Four into a family, discovering he can draw power from the great storms. The scholar Jasnah Kholin takes a young noblewoman, Shallan Davar, as her ward, unaware Shallan means to rob her; both women uncover hints of an ancient, returning enemy. Highprince Dalinar Kholin, plagued by storm-visions others call madness, struggles to hold his squabbling peers to a code of honor. When his rival Sadeas betrays him on the battlefield, Kaladin and Bridge Four save Dalinar's doomed army, and Kaladin is revealed as a reborn Knight Radiant. Old powers are waking, and a catastrophe long prophesied draws near.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2505,7 +2505,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2518,7 +2518,7 @@
       "recaps": {
         "ending": "Melmotte's death exposes the emptiness of his financial empire and ends the social deference purchased by his supposed wealth. Marie, however, retains money her father placed in her name. She rejects the titled suitors who pursued her fortune, goes to America, and eventually marries Hamilton Fisker. Paul Montague is freed from the railway scheme and from his engagement to Mrs Hurtle; Mrs Hurtle returns to America, and Paul marries Henrietta Carbury. Roger accepts Henrietta's decision but remains unmarried at Carbury Hall. John Crumb protects Ruby from Felix's treatment, forgives her, and marries her. Felix's gambling, betrayal of Marie, and exploitation of Ruby leave him discredited and dependent on arrangements that remove him from his former London life. Lady Carbury finally stops sacrificing everything to Felix and accepts Mr Broune's honest affection, becoming his wife. The Longestaffes retain their rank but not the effortless access to wealth they sought. The principal honest couples gain modest stability, while the speculative society that elevated Melmotte quickly reorganizes itself after his fall.",
         "in_short": "Lady Carbury promotes her books and tries to save her family by marrying her selfish son Felix to Marie, daughter of the apparently fabulously wealthy financier Augustus Melmotte. Melmotte uses aristocratic hunger for money to float a largely fictitious American railway, buy political influence, and rise through London society. Felix secretly continues with Ruby Ruggles while promising to elope with Marie, then steals Marie's money, gambles it away, and abandons the plan. Paul Montague challenges the railway accounts while trying to free himself from an engagement to Mrs Hurtle so he can marry Henrietta Carbury. As demands for real payment mount, Melmotte forges property documents, loses credit, and kills himself. Marie retains money placed in her name and later marries American promoter Hamilton Fisker. Ruby returns to the faithful John Crumb; Paul marries Henrietta; Mrs Hurtle goes home; and Roger Carbury remains alone. Felix is disgraced, while Lady Carbury finally accepts the honorable editor Mr Broune. London society survives the fraud it helped create and rapidly transfers its attention elsewhere.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2692,7 +2692,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2705,7 +2705,7 @@
       "recaps": {
         "ending": "The school year closes after the assassinations of Martin Luther King Jr. and Robert Kennedy have deepened the students' awareness of national turmoil. Heather returns safely after Holling retrieves her from a distant bus station when their father refuses to help. Danny celebrates his bar mitzvah, marking the different kinds of growing up taking place around Holling. Lieutenant Baker, long missing in Vietnam, is found alive and comes home; Mrs. Baker runs to meet him in a reunion Holling witnesses. At home, Mr. Hoodhood still insists that becoming a man means taking over his architecture firm. Holling rejects that fixed definition and claims the right to decide who he will become. Shakespeare, Mrs. Baker's guidance, his friends' loyalty, and his sister's example have given him language for a self not determined by his father's business plans.",
         "in_short": "During the 1967–68 school year, seventh grader Holling Hoodhood is left alone with Mrs. Baker every Wednesday while his classmates attend religious instruction. He assumes she hates him, but their afternoons of chores and Shakespeare become a demanding mentorship. Holling performs in a humiliating costume, is rejected by Mickey Mantle, trains as a runner, grows closer to Meryl Lee, and learns to look beyond his architect father's obsession with business. The Vietnam War reaches school through refugee Mai Thi, the death of Mrs. Bigio's husband, and the disappearance of Mrs. Baker's husband. Holling also rescues his runaway sister when their father will not. Amid the assassinations and unrest of 1968, friends and teachers repeatedly show him forms of courage his father does not understand. Lieutenant Baker returns alive, and Holling ends the year rejecting his father's demand that he inherit the family firm, recognizing that he can choose for himself what kind of person to become.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2838,7 +2838,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2851,7 +2851,7 @@
       "recaps": {
         "ending": "Tiffany reaches the heart of Fairyland and faces its Queen, a being who rules through beautiful, hollow dreams and the theft of what others love. Refusing to be lost in the Queen's illusions, Tiffany uses what she calls First Sight and Second Thoughts, the ability to see what is really there and to watch her own thinking, together with the strength she draws from the Chalk and from the memory of Granny Aching, to break the Queen's power. She rescues her brother Wentworth and the Baron's son Roland, and drives the Queen back out of the human world, sealing the way behind her. The children are returned safely to the Chalk. In the aftermath, senior witches who have been watching, among them the renowned Granny Weatherwax, quietly acknowledge what Tiffany has done and the promise she shows. Tiffany is recognized as a witch in the making and as the Chalk's own guardian in the tradition of her grandmother, and arrangements are set in motion for her proper training. She returns to ordinary farm life changed, aware now of who she is and what she is capable of.",
         "in_short": "Tiffany Aching, a practical nine-year-old shepherd's granddaughter on the chalk downs called the Chalk, discovers she has a talent for witchcraft just as strange creatures from Fairyland begin intruding on her world. When her little brother Wentworth is stolen away by the Queen of Fairyland, Tiffany sets out to rescue him, armed with common sense, a frying pan, and the fierce help of the Nac Mac Feegle, the tiny blue Wee Free Men who guard the downland. Drawing courage and strength from the memory of her formidable grandmother, Granny Aching, she crosses into Fairyland, a cold country of shifting dreams and illusions. There she finds not only Wentworth but Roland, the Baron's son, lost before her. Tiffany learns to use clear sight and self-awareness to see through the Queen's glamours and turn the fairy magic against itself. She confronts the Queen directly, defeats her through wit, will, and her deep bond with her home ground, and drives her out of the world. Returning with both children safe, Tiffany is quietly recognized by the wider community of witches and set on the path to being trained.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3127,7 +3127,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -3140,7 +3140,7 @@
       "recaps": {
         "ending": "Theo wins the sealed, authority-judged duel while still an archcrafter. After suffering deep sword wounds, he draws his rival into dismissing a series of partial singularities, then recalls them into a true singularity that consumes the rival's sword. Theo ends the technique instead of destroying the rival's soul home, and House Blacksilver is declared the victor. The rival's Dusan household must leave Norro Yorthin. Its elder warns that attempts to investigate a family destroyed roughly a century earlier have repeatedly brought death, demons, and further destruction, leaving Theo concerned that his own research has revived that threat.\n\nNauda receives the chasm invitation staked by the House Crimson authority, joining the invitations already secured by Fiyu and Theo. Theo survives but requires healing, and his ruler-threatening singularity is now widely known. Fiyu is an archcrafter, has sent her location to her relative through an Ichil relay, and remains with the group. Nauda is also an archcrafter but is not ready to force her ruler ascension. Senka continues traveling with them, her origin and unusual body still unexplained. The three companions now have the invitations needed to enter the Chasm of Lamentations together.",
         "in_short": "Theo returns from Earth to the Nine Worlds after forty years, young again but stripped of his former soulcrafter strength. Stranded on Tatian with Fiyu and Navim, he enters a training program, befriends Nauda, abandons an incompatible light design, and rebuilds his soul home around gravity. Magnafor's assault on the Mufuru vault drives Theo, Nauda, and Fiyu into flight. They cross Tatian and Dusan with the mysterious Senka, survive court feuds and a deadly pursuit, and reach Norro Yorthin, where they join House Blacksilver. A Dusan family binds Theo to a duel over his knowledge of a destroyed historical family. While the companions earn materials and chasm invitations, Theo develops a movable singularity, Fiyu contacts her relative and ascends to archcrafter, and Nauda strengthens her binding and nullification skills. Theo defeats the rival ruler without destroying his soul home. The Dusan household is expelled, the trio holds three invitations to the Chasm of Lamentations, and a warning about the destroyed family leaves a larger danger unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3414,7 +3414,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3427,7 +3427,7 @@
       "recaps": {
         "ending": "Luthadel survives, at a cost. The koloss break into the city, and Clubs and Dockson are killed in the fighting, along with Tindwyl. Vin, drawing on the mists in a way no Allomancer is supposed to be able to, seizes control of the koloss army by force of Allomancy and turns it. Straff Venture is killed in the confrontation that follows, and his army passes to his son, leaving Elend with the largest force in the region and a city that has voted him out of office but has nobody else left to follow. Vin, having worked out that the Well of Ascension was never in the northern mountains but directly beneath the imperial palace, descends to it with the dying Elend. She finds the power waiting there, immense and offered, and uses a fraction of it to heal Elend's wounds, which snaps him into Allomancy and leaves him a Mistborn. Then, as the ancient inscription instructs, she gives the power up rather than taking it. The inscription was a forgery. What was held prisoner at the Well is a god called Ruin, and Vin has just released it. The book closes with Elend crowned emperor and hailed alongside Vin as the Hero of Ages, with Marsh no longer his own, with the ash falling more heavily than before, and with something old and patient loose in the world.",
         "in_short": "A year after the Lord Ruler's death, Elend Venture rules Luthadel as an elected king over a starving city, and three armies converge on it: his father Straff's, the warlord Cett's, and twenty thousand koloss. Vin, worshipped by the skaa as the Survivor's heir and courted in the mists by Straff's Mistborn son Zane, hunts an assassin and doubts everything about herself. Sazed and the Keeper Tindwyl dig through the old records and conclude that the prophecies of the Hero of Ages have been tampered with. Elend is deposed by his own Assembly and keeps leading anyway. When the koloss break into the city, Clubs, Dockson, and Tindwyl die in the defense; Vin kills Zane, takes control of the koloss by raw Allomancy, and ends the siege. She then finds the Well of Ascension beneath the palace, uses its power to heal the dying Elend, making him a Mistborn, and releases the power as the inscription instructs. The inscription was altered. Releasing the power frees Ruin, a god that has spent a thousand years waiting for exactly that.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3627,7 +3627,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3640,7 +3640,7 @@
       "recaps": {
         "ending": "Martin Hallam returns and forms a close bond with Mary. Stephen sees that he can offer Mary a publicly recognized marriage and social security that their own relationship cannot provide. Convinced that love requires her to release Mary, Stephen manufactures evidence that she has become involved with Valérie Seymour. Valérie cooperates, and Mary, deeply hurt, turns toward Martin. Stephen insists on the deception until Mary leaves with him, sacrificing the relationship while concealing the motive. Left alone, Stephen imagines the excluded people whose lives resemble hers and experiences their demand for recognition as a collective appeal. She directs that appeal to God, asking for the right of such people to exist openly. The novel closes without personal consolation for Stephen: her literary success and social circle remain, but Mary is gone, her family reconciliation is incomplete, and her private loss is transformed into a plea for social recognition.",
         "in_short": "Stephen Gordon grows up on an English estate, loved by her father but increasingly estranged from her mother because of her masculinity and love for women. After childhood isolation and an unsuccessful courtship by Martin Hallam, she has a secret affair with the married Angela Crossby. Its exposure leads Lady Anna to banish Stephen from home. Stephen becomes a writer, serves with distinction in an ambulance unit during the First World War, and falls in love with Mary Llewellyn. They settle in Paris and join Valérie Seymour's lesbian circle, but social rejection and Stephen's sense that she cannot give Mary a secure future shadow their partnership. When Martin returns and Mary responds to him, Stephen pretends to betray Mary with Valérie so that Mary will leave with Martin. Alone after engineering their separation, Stephen voices a plea to God for recognition and a place in the world for people like herself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3751,7 +3751,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3764,7 +3764,7 @@
       "recaps": {
         "ending": "Simpson returns with Dr. Cathcart, Hank, and Punk to search for Défago. The guide finally comes back, but the person who appears is physically and mentally altered, with damaged feet and scarcely any recognizable identity. The same strange odor and overwhelming presence accompany his return, making a purely ordinary explanation inadequate even for the skeptical doctor. Punk flees rather than remain near it. The party gets Défago back to civilization, but his former competence and personality do not return; he soon dies in a state of mental ruin. Simpson survives as the clearest witness, unable to fit what he heard and saw into his uncle's rational categories. The hunting trip ends without a secure explanation, leaving the Wendigo as a force that represents both an entity from northern legend and a wilderness too vast for the visitors' assumptions of control.",
         "in_short": "A small hunting party enters the remote Canadian forest. Young Simpson travels with the guide Joseph Défago to a distant camp while Dr. Cathcart and Hank Davis remain elsewhere. At night Défago becomes terrified by a strange odor, distant calls, and signs that he associates with the Wendigo. He vanishes from the tent, leaving tracks that change into enormous impressions, and Simpson hears him crying from impossibly far overhead about his burning feet. Simpson returns to the others, who mount a search. Défago reappears grotesquely altered and almost emptied of personality, accompanied by the same uncanny presence. The skeptical Cathcart cannot give a sufficient natural explanation, while the camp cook Punk recognizes the danger and flees. Though the men bring Défago back from the wilderness, he never recovers his mind and soon dies. Simpson is left with knowledge of something beyond the party's ordinary understanding.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3923,7 +3923,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3936,7 +3936,7 @@
       "recaps": {
         "ending": "Ahab finds Moby Dick and pursues him for three days, refusing warnings and every chance to turn back. On the final day the whale smashes the Pequod while Ahab's boat remains in the water. Ahab makes one last cast and is caught by his own harpoon line, which drags him to his death. The damaged ship sinks with Starbuck, Stubb, Flask, Queequeg, Pip, and nearly everyone else aboard. Tashtego is still trying to secure the flag as the mast goes under. Ishmael alone escapes the wreck. Queequeg's unused coffin rises as a life buoy and keeps him afloat until the Rachel, still searching for her captain's missing son, finds and rescues him. Moby Dick survives, while Ahab's decision to subordinate the ship and crew to his private vengeance destroys the entire voyage.",
         "in_short": "Ishmael befriends the harpooner Queequeg and joins the Nantucket whaler Pequod. Its captain, Ahab, has lost a leg to the white sperm whale Moby Dick and secretly means to use the voyage to hunt him. He binds the crew to his revenge despite first mate Starbuck's objections, follows reports from other ships, and repeatedly places the men and their ordinary work at risk. The journey includes successful hunts, disasters in the whaleboats, Pip's psychological collapse after being left in the sea, and mounting signs that Ahab will not turn aside. Even when the Rachel asks for help finding a lost boat, he refuses. After a three-day chase, Moby Dick destroys the Pequod. Ahab is dragged to his death by his harpoon line, and the ship sinks with everyone except Ishmael. Floating on the coffin Queequeg had once ordered for himself, Ishmael is rescued by the Rachel and survives to tell the story.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4139,7 +4139,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4152,7 +4152,7 @@
       "recaps": {
         "ending": "The party working out of Cove Hold follows the fire lizards' inherited memories of a mountain that burned to a high plateau in the south, digs, and uncovers stone-and-metal buildings buried under old volcanic ash: the settlement Pern's first people abandoned, and the first hard evidence of where Pern's inhabitants came from and what they once had. Robinton, retired to Cove Hold after a heart attack that nearly killed him, is alive and given the discovery to occupy him. At Ista, the exiled Oldtimer leader T'kul is dead by F'lar's hand after his bronze died attempting a queen's mating flight, which ends the exiled Weyr as a threat, and D'ram, recovered from the past, takes charge in the south. Jaxom's own question is settled last: having flown Thread with Ruth in the open, recovered the stolen queen egg, found D'ram and helped uncover the ancient settlement, he is confirmed as Lord Holder of Ruatha while remaining Ruth's rider, an arrangement the holds and the Weyrs both accept because he has made it impossible to argue with. He takes Sharra as his lady over her brother Toric's objections. Toric's ambitions in the south, and the question of what the buried settlement will eventually tell Pern about itself, are left open.",
         "in_short": "Jaxom, Lord Holder of Ruatha and rider of the undersized white dragon Ruth, is allowed to be neither a proper Lord nor a proper dragonrider, and secretly trains Ruth to fly between and to flame Thread. When the riders exiled to the Southern Continent steal a queen egg from Benden's Hatching Ground and bring the Weyrs to the edge of war, Jaxom uses Ruth's unique certainty about time and place to take it back and return it unseen. He falls dangerously ill afterwards and is sent to a southern cove to recover, where the healer Sharra, the harpers Menolly and Piemur and the wider south open up a life nobody is managing for him. He locates the retired Weyrleader D'ram in the past when no other dragon could; at Ista the exiled leader T'kul loses his dragon, attacks F'lar and is killed, and Masterharper Robinton survives a heart attack and is retired to a hold built at Jaxom's cove. Following memories carried by fire lizards, the group uncovers the buried settlement of Pern's first colonists. Jaxom is confirmed as Lord of Ruatha, keeps Ruth, and takes Sharra as his lady.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4356,7 +4356,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4369,7 +4369,7 @@
       "recaps": {
         "ending": "Balram decides that the red bag of bribe money in Ashok's car is his route out of servitude. After sending a warning letter home, he drives Ashok to a secluded area, kills him with a broken bottle, takes the money, and flees Delhi with his young nephew Dharam. He assumes that the Stork's family will retaliate against his relatives in Laxmangarh, though he never confirms their fate. In Bangalore he adopts the name Ashok Sharma, uses part of the stolen money to bribe the police, and builds a taxi company serving call-center workers. When one of his drivers kills a boy in an accident, Balram pays and pressures the bereaved family while protecting the business, repeating the methods of the powerful men he escaped. He nonetheless regards his company and care for Dharam as a freer life. He ends his letters convinced that the murder was the price of becoming an entrepreneur and imagining further business success.",
         "in_short": "Balram Halwai, the son of a poor rickshaw puller in rural India, writes to China's premier from Bangalore to explain his rise as an entrepreneur. Intelligent but removed from school, Balram becomes a chauffeur for the wealthy Stork family and drives the American-returned Ashok and his wife Pinky in Delhi. Service exposes him to two Indias: the protected world of malls, apartments, political influence, and bribes, and the precarious lives of servants whose families help keep them obedient. After Pinky kills a child in a road accident, Balram is prepared as the family's scapegoat, though no charge follows. Pinky leaves, Ashok becomes increasingly corrupt and isolated, and Balram turns from admiring him to planning escape. He murders Ashok, steals a bag of bribe money, and flees with his nephew Dharam. In Bangalore, using the name Ashok Sharma, Balram bribes officials and creates a successful taxi fleet. His freedom rests on violence and on adopting many practices of the class he once served.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4543,7 +4543,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4556,7 +4556,7 @@
       "recaps": {
         "ending": "Madoc finally moves against the throne in the open, backed by soldiers and by allies gathered while the court was distracted, and demands that Cardan give up the crown. With Jude's year and a day almost spent and a claim through the child heir Oak the obvious way for Madoc to legitimise a seizure, Cardan and Jude marry in front of the court. The marriage makes Jude High Queen of Elfhame, wrecking Madoc's plan, since there is now a crowned consort in the way of any regency. It is the moment Jude's hidden power becomes real and public rather than a secret held by an oath. Cardan's next act, moments later and in front of everyone, is to exile her: he banishes Jude from Faerie, and a royal command is not something she can refuse. She is put out into the mortal world, forbidden to return, cut off from the court, her spies and her brother's future, and with no explanation of whether the betrayal was calculation, revenge for the leash she kept him on, or something else entirely. Madoc remains at large with his forces intact, the Undersea has its treaty and Balekin, and the High Queen of Elfhame is stranded in the human world.",
         "in_short": "Five months after crowning Cardan, Jude Duarte runs Elfhame from behind the throne as his seneschal, holding him to an oath that expires after a year and a day. She fends off assassins, the scheming of her exiled adoptive father Madoc, and the demands of Queen Orlagh of the Undersea, whose envoy is Cardan's former sweetheart Nicasia, while trying to keep her secret from a court that would kill a mortal for far less. Taryn marries Locke, Cardan makes Locke Master of Revels, and Jude's grip on both the king and the realm slowly loosens. Jude is seized by the Undersea and held beneath the water until Cardan buys her back with a treaty and the prisoner Balekin. Back at court, with the oath nearly expired and Madoc's rebellion breaking into the open, Cardan and Jude marry, making her High Queen and destroying Madoc's claim to a regency. Then, in front of the assembled court, Cardan exiles her to the mortal world, and she cannot disobey.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4685,7 +4685,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4698,7 +4698,7 @@
       "recaps": {
         "ending": "Aunt Josephine, who had gone into hiding to fake her own death, is discovered by the children in Curdled Cave, but her fearfulness dooms her: crossing Lake Lachrymose during Hurricane Herman, the boat is swarmed by the deadly Lachrymose Leeches, and Captain Sham forces the terrified Josephine overboard, where she is killed. Back on shore the Baudelaires expose Captain Sham as Count Olaf by revealing the eye tattoo hidden beneath his fake peg leg, but before Mr. Poe and the others can seize him, Olaf escapes once more. The children have lost another guardian, and their fortune remains the prize Olaf is determined to claim. Mr. Poe takes the orphans back into his care to place them somewhere new, while Count Olaf, exposed but uncaught, slips away to plan his next disguise and his next attempt on the Baudelaires and their money.",
         "in_short": "The Baudelaires are sent to live with fearful, grammar-obsessed Aunt Josephine, whose house teeters on stilts over Lake Lachrymose. In town they meet Captain Sham, a peg-legged sailor they recognize as Count Olaf in disguise, who charms the timid Josephine. Soon Josephine seems to throw herself out her great window into the lake, leaving a note naming Captain Sham as the children's new guardian. Noticing that the note is full of grammatical errors unthinkable for Josephine, the children decode them as a secret message and realize she is alive and hiding in Curdled Cave. During Hurricane Herman they sail across the leech-infested lake and find her, but on the way back the Lachrymose Leeches attack, and Captain Sham forces Josephine into the water to be devoured. On shore the children expose Sham as Olaf by revealing his ankle tattoo, but he escapes yet again. Aunt Josephine is dead, and the orphans are returned to Mr. Poe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4844,7 +4844,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4857,7 +4857,7 @@
       "recaps": {
         "ending": "Vis reaches the labyrinth beneath the Academy's ruins and completes it, which nobody has done in living memory, and which is what Veridius manoeuvred him toward from the moment he arrived on Solivagus. The arrangements Vis had been living inside collapse around the same event. Emissa's closeness to him was deliberate from the beginning and she had been reporting on him throughout. Ulciscor's real use for him is exposed. His own identity as the last of Suus's royal house stops being a secret he controls. He does get the answer Ulciscor sent him for, what happened to Caeror in the ruins and why, but it arrives attached to a far larger one. The Will that the Republic's citizens cede upward, rank by rank, does not terminate with the Hierarchy's rulers. The entire apparatus of ranks and ceding is a mechanism for gathering that Will and delivering it onward, and the Republic's account of itself as a meritocratic civic order exists to keep that function running unquestioned. Vis ends the book alive and, in the Academy's own terms, successful, but with his cover gone among precisely the people best placed to act on it, obligated to parties he did not choose, and holding knowledge that makes him valuable to everyone and safe with nobody. The Republic he set out merely to survive turns out to be a much larger problem than the one he thought he was hiding from.",
         "in_short": "The Catenan Republic runs on Will: every citizen cedes a share of their own strength and vitality up a strict pyramid of ranks, so that those at the top are far beyond ordinary human capacity and the Republic's machines run on the surplus. Vis, an orphan in the city of Letens, refuses to cede and fights in an illegal pit for money. He is secretly Diago, the last survivor of the royal house of Suus, an island kingdom the Republic destroyed three years earlier. The senator Ulciscor Telimus adopts him in exchange for a task: win a place at the Catenan Academy on Solivagus and investigate the ancient ruins where Ulciscor's brother Caeror died, which Ulciscor believes the Academy's revered Principalis, Veridius, is responsible for. Vis gets in, climbs the school's brutal rankings, makes real friends and one real attachment, and is pressured in turn by Ulciscor, by the rebel Anguis and by Veridius himself. In the end he is betrayed, his secrets come apart, and he completes the labyrinth beneath the ruins, learning that the Will the Republic collects does not stop at its rulers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5044,7 +5044,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5057,7 +5057,7 @@
       "recaps": {
         "ending": "Badger leads Rat, Mole, and Toad through a secret tunnel into Toad Hall while the weasels and stoats are holding a banquet. The friends surprise the occupiers and drive them from the house. Toad wants to turn his return into a public spectacle, but the others restrain him and organize a modest celebration. He sends gifts and apologies to people he wronged during his escape and appears to have become humbler and more considerate. Although his friends remain alert for another burst of vanity, Toad Hall is restored, the four companions are honored locally, and peaceful life on the riverbank resumes.",
         "in_short": "Mole leaves his underground home and discovers the river with Rat, whose friendship draws him into a changing year of picnics, journeys, danger, and homecoming. They meet the impulsive Toad, whose latest obsession becomes motorcars. After repeated crashes and ignored warnings, Toad steals a car, is imprisoned, escapes in disguise, and makes a chaotic journey home. Rat and Mole also survive the Wild Wood, befriend the reclusive Badger, recover Mole's neglected home, and help Otter find his missing son. When Toad returns, he learns that weasels and stoats have seized Toad Hall. Badger, Rat, and Mole guide him through a hidden passage, and the friends expel the intruders. Toad accepts their efforts to curb his vanity, makes amends for some of his behavior, and is restored to his home and community.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5557,7 +5557,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0C82TS539",
@@ -5569,7 +5569,7 @@
       "recaps": {
         "ending": "The numbered story ends with Flos's peace declaration reshaping southern politics. Some rulers accept the demand to release his former subjects rather than risk war, while the Empress of Beasts refuses to join resistance against him. Her position leaves her isolated, and nine nations declare war on her country after a tense summit. The Emperor of Sands' copied proposal remains unexplained.\n\nElsewhere, Ryoka remains free and trusted by the concealed vampire family, whose illness and search for Rose, Imani, and Joseph remain unresolved. Lyonette runs the reopened Wandering Inn, Mrsha studies signs and magic, and Numbtongue holds Pyrite's memories, valuable mana stones, and unstable magicore. Ilvriss quietly investigates Az'kerash. The United Nations Company has new allies and medical prospects but still faces financial pressure, hostile Earth arrivals, fading memories, and Niers's attention. In the material following the numbered chapters, the long-range door proves too costly for regular travel, several visiting teams depart, and Ceria's Horns stay behind with the goal of reaching gold rank. The dungeon and Calruz's fate remain open.",
         "in_short": "Ryoka earns the name Windrunner through dangerous deliveries, befriends a hidden family of living vampires, and agrees to protect their secret while they search for missing Earth arrivals. In Liscor, Erin reopens her inn after the Goblins' deaths, recognizes Numbtongue as family, and leaves Lyonette to manage their growing home. Numbtongue inherits Pyrite's memories and hazardous mining knowledge. The United Nations Company rescues stranded Earth arrivals and wins allies through adventuring and Geneva's medicine, but remains poor, traumatized, and threatened by hostile Earth humans, fading memories, and Niers's secret inquiry. Ilvriss confirms that Az'kerash lives and begins a covert investigation. Flos adds Germina and Helios to Rhyme, expands weapons production, and demands safe passage for anyone claiming his allegiance. Nine nations then declare war on the Empress of Beasts. Afterward, visiting adventuring teams leave Erin's inn, while Ceria's Horns remain and resolve to pursue gold rank.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/the-wind-through-the-keyhole.json
+++ b/data/works-community/0/the-wind-through-the-keyhole.json
@@ -79,7 +79,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -92,7 +92,7 @@
       "recaps": {
         "ending": "All three layers of the tale come to rest. In the innermost story, the boy Tim Ross survives the enchanted forest and a killing storm, gains help and a gift from the wizard he finds there, and returns able to aid his mother, growing into the courage that earns him the name Tim Stoutheart. In the middle story, young Roland and Jamie DeCurry uncover which of the townsfolk of Debaria is the murderous skin-man and put an end to the killings, and Roland's telling helps heal the boy who saw the creature. In the outer frame, the starkblast blows itself out, and Roland, Eddie, Susannah, Jake, and Oy emerge safe to take up the path of the Beam once more. The book is a self-contained interlude between larger adventures: the ka-tet is exactly where it needs to be to continue toward the Dark Tower, with no lasting change to the quest beyond a deeper sense of Roland's past.",
         "in_short": "This book is an interlude in the ka-tet's journey, framed by a deadly cold storm called a starkblast that forces Roland, Eddie, Susannah, Jake, and Oy to take shelter. To pass the time, Roland tells a story from his own youth: soon after his mother's death, he and his friend Jamie DeCurry were sent to the barony of Debaria to hunt a skin-man, a shape-shifter murdering people in the night. Within that story, to comfort a traumatized boy who witnessed the killer, Roland recounts a fairy tale from his childhood, the tale of Tim Ross, a woodsman's son who braves an enchanted forest, a deceiving tax collector, and a starkblast of his own to save his mother, meeting a great wizard along the way. The nested tales close: Tim earns his courage, young Roland identifies and stops the skin-man, and the ka-tet waits out the storm and continues toward the Tower, unchanged in their larger quest but richer for the telling.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -222,7 +222,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -235,7 +235,7 @@
       "recaps": {
         "ending": "In the otherworldly hotel room, Toru confronts a threatening man and beats him with a baseball bat. At the same time in ordinary life, Noboru Wataya collapses and falls into a coma. Kumiko later explains that her brother had exerted a destructive power over her and that she had entered the affair partly under that influence. While Noboru remains helpless, she disconnects his life support and accepts prosecution for killing him. She asks Toru for a divorce, but he decides he can wait for her release and does not consider their bond finished. Nutmeg ends the healing enterprise, and Cinnamon withdraws from Toru's life after helping preserve the records that joined their families' histories. Toru visits May Kasahara, who has been living and working away from Tokyo, and they share a quiet reunion before he returns home. The cat has come back and now bears the name Mackerel. Toru does not recover a simple version of his former marriage, but he emerges from the well and the psychic struggle alive, committed to the possibility that Kumiko may also return from her isolation.",
         "in_short": "After unemployed Toru Okada's cat disappears, his wife Kumiko also vanishes, leaving only an account of an affair and a demand that he let her go. Toru's search brings him into contact with the enigmatic sisters Malta and Creta Kano, teenage May Kasahara, and veteran Lieutenant Mamiya, whose memories of wartime Manchuria center on torture and a dry well. Toru enters a well on abandoned land and gains a dark mark on his face after passing through an uncanny hotel. Later, designer Nutmeg Akasaka and her silent son Cinnamon employ him as a private healer and help him buy the well property. Toru comes to understand his struggle for Kumiko as a confrontation with her brother, rising politician Noboru Wataya. In the hotel's other reality Toru attacks a male figure; Noboru simultaneously collapses into a coma. Kumiko disconnects her brother's life support and faces prison. She asks for a divorce, but Toru chooses to wait, his ordinary life permanently joined to experiences he can neither prove nor dismiss.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -433,7 +433,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -446,7 +446,7 @@
       "recaps": {
         "ending": "The struggle between the Trade and Environment ministries becomes open war after Emiko kills the Somdet Chaopraya and his companions. Kanya, long divided between the factions, rejects Akkarat's plan to hand Thailand's genetic resources to foreign interests. The defenses protecting low-lying Bangkok are deliberately breached, and the city is evacuated and flooded so the kingdom can preserve its independence elsewhere. Anderson, infected and unable to escape, is left as the water rises. Hock Seng survives the destruction of the spring factory and carries its valuable energy-storage knowledge into another uncertain alliance. Emiko moves through the drowned city with a freedom the cooler water allows her engineered body. She encounters Gibbons, who tells her that although she cannot bear children herself, he can use her genetic material to create fertile descendants. Bangkok is lost, but Emiko is offered the possibility that New People may have a future beyond servitude.",
         "in_short": "In a post-petroleum Bangkok threatened by rising seas and engineered crop diseases, calorie-company agent Anderson Lake hides his search for Thailand's seedbank behind an experimental spring factory. His refugee manager Hock Seng schemes to steal the design, while Environment Ministry captain Jaidee battles smuggling and the pro-trade faction led by Akkarat. Emiko, an abandoned Japanese New Person forced to perform in a club, learns that others of her kind may live freely. Jaidee's campaign leads to his wife's murder and then his own; his lieutenant Kanya inherits both his cause and a divided loyalty. A factory catastrophe destroys Anderson's project, and Emiko's killing of the royal protector ignites civil conflict. Kanya ultimately prevents the Trade Ministry from surrendering the kingdom's biological independence by allowing Bangkok to flood. Anderson is stranded, Hock Seng survives with valuable knowledge, and Emiko meets the geneticist Gibbons, who offers the prospect of creating fertile people from her genes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -595,7 +595,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -608,7 +608,7 @@
       "recaps": {
         "ending": "Ethan's schemes bring him the outward restoration he thought his family wanted. Marullo, deported after Ethan's anonymous report, transfers the grocery to him because he believes Ethan to be exceptionally honest. Danny Taylor dies after Ethan gives him money ostensibly meant for treatment, and the arrangement gives Ethan control of Taylor's strategically valuable land. Ethan does not carry out the bank robbery he had contemplated, but he profits from betrayals that are harder for others to see. The family's celebration collapses when Ellen proves that Allen's prize-winning essay was copied from earlier speeches and reports the fraud. Confronted by his son's borrowed success and his own concealed corruption, Ethan goes to the dangerous tidal place associated with his family intending not to return. He finds that Ellen has slipped the Hawley talisman into his pocket. The sign of her trust and inheritance turns him back: he resolves to return it to her so that the remaining moral light in the family will not be lost. His survival is clear, but whether he will confess or undo his gains is left open.",
         "in_short": "Ethan Allen Hawley, heir to a ruined New England family, works as a clerk in the grocery his family once owned. His wife and children want money and status, while friends and business acquaintances suggest that success depends on flexible morals. Ethan begins testing that belief. He accepts the idea of a supplier's kickback, anonymously exposes his immigrant employer Marullo to immigration authorities, considers robbing the local bank, and gives his alcoholic friend Danny Taylor money while arranging to gain control of Danny's valuable land. The robbery is abandoned, but the other plans succeed: Danny dies, and the deported Marullo rewards the employee he mistakenly considers honest by giving him the store. At the moment Ethan appears restored, his son Allen wins a public essay contest with plagiarized work, and daughter Ellen exposes him. Recognizing his own conduct in Allen's fraud, Ethan goes to the shore intending suicide. Ellen has secretly placed the family talisman in his pocket; he turns back to preserve it for her, choosing life without resolving how he will answer for what he has done.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -838,7 +838,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -851,7 +851,7 @@
       "recaps": {
         "ending": "Dmitrii's army meets Mamai's at Kulikovo and wins, and the price is enormous. The battle opens with single combat: Sasha rides out against the Horde's champion Chelubey and the two kill each other in the first pass. Konstantin Nikonovich does not survive the campaign either. Vasya fights on both levels at once, in the field and among the powers nobody else can see, with the chyerti she bargained for, the golden mare who finally consented to carry her, and the two brothers, winter and chaos, on the same side for the first time. Afterwards she goes with Morozko along the starlit road the dead take, to see her brother off properly. The long war between the winter-king and the Bear ends not in another chaining but in an oath, leaving the twins balanced instead of at each other's throats. Vasya keeps her side of every bargain she made. Her family knows exactly what she is now and has decided it is not something to be ashamed of: Olga's house is open to her, and Marya, who has the same sight, will be taught rather than hurried into a marriage. Vasya's own place is the one nobody in her world had a word for at the start: neither wife nor nun, but the person standing between the people of Rus' and the old powers so that both can go on existing. She turns north again, towards her father's lands and the lake in the fir grove, and she and Morozko part on the understanding that he will come back with the winter.",
         "in_short": "Moscow, burnt and terrified, blames Vasya, and Konstantin's preaching turns the city on her; behind him stands the Bear, loose again and feeding on the panic. Vasya survives the pyre but Solovey is killed getting her clear, and she escapes with nothing. She heals in the winter-king's house beyond the world, refuses to stay safe there, and comes back out with a plan to save both Rus' and its dying spirits at once. Travelling the midnight road with the chyert called Midnight and a stubborn mushroom-spirit, she bargains for allies, learns her own ancestry from the witch at the road's end, and frees Morozko, whom his brother had chained. Returning to Moscow she is taken in by her family and grudgingly accepted by Dmitrii, because Mamai and the Horde are marching north. Rather than destroy the Bear, Vasya bargains with him and turns him south. At Kulikovo the Russians win; Sasha is killed in single combat with the Horde's champion, Konstantin dies, and the two immortal brothers make peace. Vasya, no longer hiding, takes up a place between her people and the old powers, and she and Morozko part until winter.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1059,7 +1059,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1072,7 +1072,7 @@
       "recaps": {
         "ending": "The company gathers at Paulina's house to see a statue said to represent Hermione. The figure appears to come alive, and Hermione is restored to Leontes after sixteen years of concealment. She embraces Perdita, explaining that hope created by the oracle kept her waiting for her daughter. Leontes and Polixenes are reconciled, and the marriage of Perdita and Florizel can proceed with both fathers' blessing. Leontes asks forgiveness of Hermione and Camillo, then pairs the faithful Camillo with Paulina. Mamillius and Antigonus remain dead, so the reunion does not erase the cost of Leontes's jealousy, but the divided families and kingdoms end the play reunited.",
         "in_short": "Leontes, king of Sicilia, becomes irrationally certain that his pregnant wife Hermione has had an affair with his friend Polixenes. Polixenes escapes, but Leontes imprisons Hermione, rejects their newborn daughter, and orders the baby abandoned. An oracle declares Hermione innocent; after news of their son Mamillius's death, Hermione is reported dead and Leontes repents. The baby, Perdita, is raised by shepherds in Bohemia. Sixteen years later she and Polixenes's son Florizel fall in love. When Polixenes opposes their marriage, they flee to Sicilia, where tokens reveal Perdita's royal identity. The kings reconcile and approve the match. Paulina then reveals a lifelike statue of Hermione, which comes to life: Hermione has survived in concealment. The family reunites, though the deaths caused by Leontes's jealousy cannot be undone.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1252,7 +1252,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1265,7 +1265,7 @@
       "recaps": {
         "ending": "The second day of Kvothe's account ends with him far more accomplished, and far more dangerous, than the raw student who began it. Over the course of the book he leaves the University to serve the Maer Alveron in Vintas, wins the lord's trust and patronage, and survives being sent to destroy a band of highwaymen in the Eld. He then endures an encounter with the legendary faerie Felurian, gaining a magical cloak and unusual knowledge, and travels to the reticent Adem people to master their martial art and their philosophy of restraint, earning a sword and a measure of their respect. He also has a fateful, troubling meeting with a malicious, all-seeing being in the Fae that casts a long shadow over what follows, and gathers further fragments about the Chandrian and the hidden Amyr, though the central mysteries remain unsolved. Kvothe returns to the Maer, then toward the University, his reputation and abilities vastly grown and the seeds of his later fame and infamy now clearly planted. In the present-day frame, the man living as the innkeeper Kote finishes his second day of storytelling; his companion Bast remains anxious, the wider world grows more troubled, and a full third day of the tale, along with the account of his final downfall, still lies ahead.",
         "in_short": "The Wise Man's Fear covers the second day of Kvothe's story. Still a student at the University, he continues his feud with Ambrose, his money troubles, and his frustrating pursuit of Denna, until he takes a leave of absence and travels to the kingdom of Vintas to seek the patronage of the powerful Maer Alveron. He wins the Maer's confidence by helping him secure a highborn wife and by exposing a poisoner at his court, then is sent to destroy a band of dangerous highwaymen in the great forest. After accomplishing this, Kvothe strays into the Fae and survives a legendary encounter with the beautiful and deadly Felurian, emerging with rare gifts, along with an unsettling meeting with a malicious oracle. He then travels to the secretive land of the Adem to master their renowned fighting art and their philosophy, slowly earning their guarded respect. Along the way he gathers more tantalizing hints about the Chandrian and the Amyr. Kvothe returns greatly changed, his abilities and his legend expanded, to the Maer and then the University, and the second day of telling closes with his story still unfinished.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1424,7 +1424,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1437,7 +1437,7 @@
       "recaps": {
         "ending": "At Kit's witchcraft trial, the evidence against her includes the copybooks found in Hannah's abandoned house. Nat returns despite his banishment and brings Prudence Cruff before the court. Prudence demonstrates that Kit taught her to read and write, and she explains that she visited Hannah willingly. Her testimony undercuts her mother's accusations, and Kit is acquitted. Mercy survives the fever, and John Holbrook returns from captivity with a changed understanding of what he wants. He declares his love for Mercy, while Judith accepts William Ashby, whose steadiness suits her better than it suited Kit. Kit considers returning to Barbados but realizes that neither her old island life nor a safe marriage to William is her future. Nat comes back as master of his own ship, named the Witch. Kit and Nat acknowledge their love and plan to marry, allowing her to share his voyages while keeping family ties in Connecticut. Hannah is safe in another settlement, and Kit has found a life that accommodates both belonging and freedom.",
         "in_short": "Orphaned Kit Tyler leaves Barbados for Puritan Connecticut and arrives unannounced at the home of her aunt Rachel and stern uncle Matthew Wood. Her wealth, impulsiveness, and ability to swim make her suspect in Wethersfield. While struggling with work and religious discipline, she befriends Hannah Tupper, an elderly Quaker whom the town calls a witch, and secretly teaches neglected Prudence Cruff to read. Kit is courted by wealthy William Ashby but feels more understood by sailor Nat Eaton. Political tension, romantic misunderstandings, and a fever epidemic deepen the household's strain. When a mob targets Hannah, Kit helps her escape with Nat; Kit is then arrested for witchcraft. Nat brings Prudence to testify that Kit's visits and lessons were acts of kindness, and Kit is acquitted. John Holbrook returns to marry Mercy, Judith turns to William, and Nat returns as captain of his own ship. Kit recognizes that she loves Nat and chooses a future with him that joins family, travel, and independence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1836,7 +1836,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CXFCNFKZ",
@@ -1848,7 +1848,7 @@
       "recaps": {
         "ending": "Riverfarm survives the wildfire with severe casualties and extensive damage. The oldblood Drake responsible is killed, but Belavierr's apparent rescue of the settlement is exposed as a bargain that cost another witch her life. Wiscaria and the coven reject Belavierr, who leaves weakened but alive. Laken returns, restores Riverfarm's administration, begins reconstruction, and resumes his relationship with Durene. He releases the Goblin prisoners into adjacent self-governed territory with supplies, tools, and his iPhone, leaving their long-term relationship with Riverfarm unresolved. The witches receive sanctuary under rules of hospitality, accountability, and limits on lasting hexes. Nanette's dead mother warns that a hungry presence has consumed the land of death, leaves Nanette her hat, and binds Wiscaria to protect her. Wiscaria commits herself to stopping Belavierr. Ryoka and Laken reach a tentative reconciliation over his responsibility for the siege and the Goblins' losses. Belavierr then offers Ryoka a possible reunion with her banished fae friend, and Ryoka accepts an unspecified service in return. In Liscor, Calruz remains lawfully imprisoned, Krshia's election is unresolved, and Numbtongue still intends to seek surviving Goblins and their king.",
         "in_short": "Riverfarm struggles without Laken as Durene recovers, Wiscaria faces her guilt, and refugees demand influence. Ryoka carries aid into the region while persecuted witches gather around Wiscaria, including her estranged mother, Belavierr. In Liscor, Numbtongue befriends Yellow Splatters, becomes a Soul Bard, and receives Pyrite's charge to seek surviving Goblins and their king. Mrsha prevents guards from killing Calruz, leaving his fate and the council election unsettled. After the numbered chapters, hunters and an Order of Seasons knight attack Belavierr, but betrayal lets her survive. A Drake's wildfire devastates Riverfarm. Belavierr escapes by sacrificing another witch, and the coven repudiates her. Laken returns to rebuild, frees his Goblin prisoners into a neighboring self-governing settlement, and grants the witches conditional refuge. Wiscaria is bound to protect Nanette and resolves to hunt Belavierr, while Ryoka accepts Belavierr's bargain for a chance to see her banished fae friend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1946,7 +1946,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1959,7 +1959,7 @@
       "recaps": {
         "ending": "Gertrude travels to Casterbridge to use Trendle's last suggested cure: touching her withered arm to the neck of a newly hanged man. She arranges access to the body after an execution and presses her arm against it. At that moment Rhoda Brook and Farmer Lodge enter to claim the dead youth, who is their son. Gertrude learns too late that the condemned man is the boy who once befriended her and whose parents' lives her marriage displaced. The shock of the encounter overwhelms her, and she dies soon afterward. Lodge withdraws from the life he had built, while Rhoda has lost her son as well as any remaining connection to him. The attempted cure thus brings all three adults together around the consequence of their old neglect and resentment, but restores none of them.",
         "in_short": "Dairywoman Rhoda Brook has an unacknowledged son by the prosperous Farmer Lodge, who returns to the district with his gentle young wife, Gertrude. Consumed by curiosity and resentment, Rhoda dreams that Gertrude attacks her and seizes the apparition's arm. Gertrude soon develops unexplained marks and wasting in that same arm, yet befriends Rhoda without understanding the connection. A local conjuror indicates that Rhoda's influence caused the affliction. As the arm worsens and Lodge's affection fades, Gertrude becomes desperate. Years later she follows a folk remedy requiring contact with the body of a hanged man. The executed youth proves to be Rhoda and Lodge's son. Gertrude collapses after touching his corpse and dies soon afterward, leaving Lodge isolated and Rhoda bereaved. The cure she sought completes the ruin linking wife, former lover, husband, and abandoned child.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2136,7 +2136,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2149,7 +2149,7 @@
       "recaps": {
         "ending": "Glinda tells Dorothy that the silver shoes have always had the power to carry their wearer anywhere, so Dorothy could have returned home soon after arriving in Oz. Before Dorothy leaves, Glinda uses the golden cap to send the Scarecrow back to govern the Emerald City, the Tin Woodman to rule the Winkies, and the Lion to the forest whose animals chose him as king. She then gives the cap to the Winged Monkeys' king, ending their obligation to answer future owners. Dorothy says goodbye to her friends, takes Toto in her arms, and commands the shoes to carry her to Aunt Em in Kansas. The journey over the desert makes the shoes fall away, and Dorothy arrives barefoot near the newly built farmhouse. Aunt Em embraces her, astonished by her sudden return. Dorothy is home with Toto, while her three companions remain in Oz with the qualities and responsibilities they had sought.",
         "in_short": "A cyclone carries Dorothy and Toto from Kansas to the land of Oz, where her falling house kills the Witch of the East. Told that the Wizard in the Emerald City may send her home, Dorothy follows the yellow brick road and befriends a Scarecrow seeking brains, a Tin Woodman seeking a heart, and a Lion seeking courage. The Wizard promises help only if they defeat the Witch of the West. The Witch enslaves Dorothy after using the Winged Monkeys to overpower the group, but Dorothy accidentally destroys her with water. Back in the Emerald City, the travelers discover that Oz is an ordinary man who has maintained his authority through deception. He gives Dorothy's friends symbolic gifts that confirm qualities they already possess, but his attempt to take Dorothy home by balloon fails. After a further journey, Glinda explains that Dorothy's silver shoes can transport her. Dorothy returns to Aunt Em in Kansas, while the Scarecrow, Tin Woodman, and Lion take up leadership roles in Oz.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2288,7 +2288,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2301,7 +2301,7 @@
       "recaps": {
         "ending": "Arthur survives his ordeal at Eel Marsh House and learns that the apparition is Jennet Humfrye, whose son Nathaniel was raised by her sister Alice Drablow and drowned in the marsh after a pony-and-trap accident. Jennet's rage endured after death: whenever the woman in black is seen, a local child subsequently dies. Arthur returns to London and gradually recovers. He marries his fiancée Stella, and they have a son, Joseph. Years later, at a park, Arthur watches Stella and Joseph ride in a pony and trap. The woman in black appears before the pony, deliberately causing it to bolt and crash. Joseph dies at the scene, and Stella later dies from her injuries. The older Arthur's Christmas listeners do not know that his ghost story is the history of how the apparition destroyed his first family. Having written it down, he hopes he can finally set the memory aside.",
         "in_short": "London solicitor Arthur Kipps travels to the remote town of Crythin Gifford to settle the papers of Alice Drablow, who lived at Eel Marsh House beyond a tidal causeway. At her funeral and near the house he sees a gaunt woman dressed in black whom the townspeople fear. Alone in the house, Arthur hears an unseen pony and trap sink in the marsh and finds a nursery that seems occupied by a hostile presence. Letters reveal that Mrs Drablow adopted her sister Jennet Humfrye's son, Nathaniel, who later drowned with his nurse and driver on the causeway while Jennet watched helplessly. Jennet died consumed by grief and returned as the woman in black; a child dies whenever she is seen. Arthur escapes and believes the haunting is behind him. Years later the apparition frightens a pony pulling Arthur's wife Stella and their young son Joseph. Joseph is killed, Stella later dies, and Arthur is left to carry the story into old age.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2408,7 +2408,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2421,7 +2421,7 @@
       "recaps": {
         "ending": "After an unsuccessful escape, Niki devotes himself to a makeshift device intended to trap crows and send a message. Instead, the container begins collecting usable water from the damp sand. The discovery gives him a private project and a source of leverage independent of the village's deliveries. When the woman suffers a dangerous pregnancy complication, the villagers carry her away for medical treatment and leave the rope ladder unattended. Niki climbs out and looks over the sea and settlement, but he no longer feels compelled to flee immediately. He returns to the pit so he can continue studying the water collector and decides that escape can wait. Official papers shown at the close legally presume him dead after seven years of absence. His physical opportunity for freedom has arrived, yet his attention and sense of purpose have become bound to the place that imprisoned him.",
         "in_short": "Amateur entomologist Niki Jumpei visits a coastal desert to collect insects and accepts lodging in a widow's house at the bottom of a sand pit. The villagers remove the ladder and expect him to join her nightly labor shoveling back the sand that threatens their home. Niki resists, attempts to force his release, and briefly escapes, but the shifting dunes defeat him and the villagers return him to the pit. As months pass, hostility gives way to an uneasy domestic bond with the woman. His attempt to build a crow trap accidentally produces a way to collect water from the sand. When the woman is taken away for emergency treatment and a ladder is left in place, Niki climbs to the surface but chooses not to leave yet, preferring to explain and develop his discovery. Seven years after his disappearance, he is legally presumed dead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2592,7 +2592,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2605,7 +2605,7 @@
       "recaps": {
         "ending": "Walter establishes that Anne Catherick died before the date recorded on Laura's death certificate, proving that the dead woman buried as Laura could not have been her. He uses Professor Pesca's connection to an Italian political brotherhood to force Count Fosco to write a confession describing the substitution of Anne for Laura and Laura's confinement under Anne's name. Fosco leaves England but is killed by an agent of the brotherhood he betrayed. Laura's identity and social position are publicly restored. She and Walter marry, and Laura gradually recovers from the trauma of imprisonment. They have a son. After Frederick Fairlie dies, the child becomes heir to Limmeridge House, where Walter, Laura, Marian, and the boy form a secure family. Sir Percival and Fosco are dead, Anne's grave is correctly understood, and Marian's loyalty and Walter's investigation have defeated the conspiracy, leaving no unresolved threat to Laura's name or inheritance.",
         "in_short": "Drawing teacher Walter Hartright meets a frightened woman in white before taking a post at Limmeridge House, where he falls in love with heiress Laura Fairlie and befriends her half-sister Marian Halcombe. Laura keeps an earlier promise to marry Sir Percival Glyde despite warnings from Anne Catherick, the woman Walter met. At Blackwater Park, Percival and Count Fosco seek control of Laura's money. Fosco exploits Anne's resemblance to Laura: Anne dies and is buried as Lady Glyde, while the drugged Laura is confined in an asylum under Anne's name. Marian rescues her, and Walter returns to restore her identity. His investigation uncovers Percival's fraudulent claim to his title; Percival dies trying to destroy the evidence. Walter then compels Fosco to confess to the identity exchange. Fosco is killed after fleeing, Laura is legally restored, and she marries Walter. Their son ultimately becomes heir to Limmeridge, with Marian remaining part of their household.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2783,7 +2783,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2796,7 +2796,7 @@
       "recaps": {
         "ending": "Walter establishes that Anne Catherick died before the date recorded on Laura's death certificate, proving that the dead woman buried as Laura could not have been her. He uses Professor Pesca's connection to an Italian political brotherhood to force Count Fosco to write a confession describing the substitution of Anne for Laura and Laura's confinement under Anne's name. Fosco leaves England but is killed by an agent of the brotherhood he betrayed. Laura's identity and social position are publicly restored. She and Walter marry, and Laura gradually recovers from the trauma of imprisonment. They have a son. After Frederick Fairlie dies, the child becomes heir to Limmeridge House, where Walter, Laura, Marian, and the boy form a secure family. Sir Percival and Fosco are dead, Anne's grave is correctly understood, and Marian's loyalty and Walter's investigation have defeated the conspiracy, leaving no unresolved threat to Laura's name or inheritance.",
         "in_short": "Drawing teacher Walter Hartright meets a frightened woman in white before taking a post at Limmeridge House, where he falls in love with heiress Laura Fairlie and befriends her half-sister Marian Halcombe. Laura keeps an earlier promise to marry Sir Percival Glyde despite warnings from Anne Catherick, the woman Walter met. At Blackwater Park, Percival and Count Fosco seek control of Laura's money. Fosco exploits Anne's resemblance to Laura: Anne dies and is buried as Lady Glyde, while the drugged Laura is confined in an asylum under Anne's name. Marian rescues her, and Walter returns to restore her identity. His investigation uncovers Percival's fraudulent claim to his title; Percival dies trying to destroy the evidence. Walter then compels Fosco to confess to the identity exchange. Fosco is killed after fleeing, Laura is legally restored, and she marries Walter. Their son ultimately becomes heir to Limmeridge, with Marian remaining part of their household.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2984,7 +2984,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2997,7 +2997,7 @@
       "recaps": {
         "ending": "The collection closes by returning to Roald Dahl's wartime experience in a fictionalized form. A fighter pilot attempting to join his unit in North Africa is given faulty directions and runs out of fuel over hostile desert terrain. He survives the crash but suffers grave injuries and distorted, dreamlike impressions while moving between consciousness and medical care. He eventually awakens in a hospital, where the immediate emergency has passed but his recovery is only beginning. Read after Lucky Break, the piece also shows how Dahl first turned that crash into publishable fiction: the experiences described in the autobiographical essay become the material of the final story. The preceding title story has already reached its own framed conclusion, with Henry Sugar's casino winnings used to fund children's homes and his associates preserving the work after his death.",
         "in_short": "Seven varied pieces move from fable and suspense to biography. A boy saves a captured sea turtle and then mysteriously disappears; a skilled pickpocket rescues a speeding driver from prosecution by stealing the officer's records; and ploughman Gordon Butcher discovers the Roman silver later known as the Mildenhall Treasure but receives little benefit from it. In The Swan, Peter Watson survives vicious attacks by two older boys and reaches home after an extraordinary apparent flight. Henry Sugar learns a concentration method that lets him identify hidden cards, first using it to win at casinos and then devoting the proceeds to children's homes with the help of trusted associates. Lucky Break explains how Roald Dahl's education, work in Africa, wartime service, and meeting with C. S. Forester led to his writing career. The final piece reshapes Dahl's North African plane crash as fiction, ending with the injured pilot alive in hospital.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3154,7 +3154,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3167,7 +3167,7 @@
       "recaps": {
         "ending": "Dorothy and her friends survive a final set of trials on the way south, and the Cowardly Lion becomes king of the forest beasts after killing a giant spider. They reach Glinda, the Good Witch of the South, who reveals that the silver shoes Dorothy has worn all along can carry her anywhere in three steps. Before Dorothy leaves, Glinda settles her companions' futures: the Scarecrow will return to rule the Emerald City in the Wizard's place, the Tin Woodman will rule the Winkies in the west, and the Lion will reign over the forest. Dorothy says a tearful goodbye, takes Toto in her arms, knocks the heels of the silver shoes together three times, and wishes to go home. She is whirled through the air and lands back on the Kansas prairie, the silver shoes lost along the way, and runs into the arms of Aunt Em.",
         "in_short": "A cyclone carries Dorothy and her dog Toto from Kansas to the land of Oz, where her house kills the Wicked Witch of the East and frees the Munchkins. Advised to seek the Wizard in the Emerald City, she follows the yellow brick road and gains three companions: a Scarecrow who wants brains, a Tin Woodman who wants a heart, and a Cowardly Lion who wants courage. The Wizard agrees to help only if they kill the Wicked Witch of the West. The Witch enslaves and torments them until Dorothy melts her with a bucket of water. Returning in triumph, they discover the Wizard is an ordinary humbug from Omaha, though he gives the three friends tokens of what they already had. His balloon leaves without Dorothy, so she journeys south to Glinda the Good, who reveals that the silver shoes can carry her anywhere. Dorothy wishes herself home to Aunt Em.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3343,7 +3343,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3356,7 +3356,7 @@
       "recaps": {
         "ending": "Glinda tells Dorothy that the silver shoes she has worn since arriving can carry their wearer anywhere. Dorothy says goodbye to the Scarecrow, Tin Woodman, and Lion, who now have kingdoms and responsibilities of their own. She takes Toto in her arms, strikes the shoes together, and asks to return to Aunt Em. The magic carries her over the desert, but the shoes fall off during the journey and are lost. Dorothy lands on the Kansas prairie near the farmhouse. Aunt Em runs to meet her, astonished by her sudden appearance, and Dorothy tells her that she has returned from the Land of Oz and is glad to be home. Her three companions remain in Oz: the Scarecrow rules the Emerald City, the Tin Woodman rules the Winkies, and the Lion rules the forest, each already demonstrating the quality he once believed he lacked.",
         "in_short": "A cyclone carries Dorothy and Toto from Kansas to the Land of Oz, where her house kills the Wicked Witch of the East. Wearing the witch's silver shoes, Dorothy follows the yellow brick road to ask the Wizard of Oz for a way home. She is joined by a Scarecrow seeking brains, a Tin Woodman seeking a heart, and a Lion seeking courage. Oz refuses their requests unless they defeat the Wicked Witch of the West. Dorothy destroys the witch with water, but the supposed wizard is exposed as an ordinary man using tricks. He gives her companions symbolic gifts that confirm qualities they already possess, yet his attempt to take Dorothy home by balloon fails. After a journey south, Glinda explains that Dorothy's shoes can carry her anywhere. Dorothy uses them to return to Aunt Em in Kansas, while her friends remain as rulers in Oz.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3544,7 +3544,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3557,7 +3557,7 @@
       "recaps": {
         "ending": "After Oz's balloon leaves without her, Dorothy travels south with the Scarecrow, Tin Woodman, Lion, and Toto to seek Glinda's help. Along the way the companions cross a forest of hostile trees, pass through a fragile china country, and help the Lion defeat a giant spider that has terrorized the forest animals. Glinda explains that Dorothy's silver shoes have always had the power to carry her home. Before Dorothy leaves, Glinda uses the Golden Cap to send the Scarecrow back to rule the Emerald City, the Tin Woodman to rule the Winkies, and the Lion to the forest whose animals chose him as king, then frees the Winged Monkeys by giving their cap to their king. Dorothy says goodbye, knocks the shoes together, and asks to return to Aunt Em. The magic carries Dorothy and Toto to Kansas, but the silver shoes fall away during the journey. Dorothy finds herself near a newly built farmhouse and runs into Aunt Em's arms, safely home at last.",
         "in_short": "A cyclone carries Dorothy and Toto from Kansas to the land of Oz, where the falling farmhouse kills the Wicked Witch of the East. Directed toward the Emerald City, Dorothy follows the yellow brick road and befriends a Scarecrow seeking a brain, a Tin Woodman seeking a heart, and a Lion seeking courage. The Wizard promises to help only after they defeat the Wicked Witch of the West. Dorothy accidentally destroys the witch with water, but the Wizard is exposed as an ordinary man using theatrical tricks. He gives Dorothy's friends tokens that confirm qualities they already possess and tries to take Dorothy home by balloon, only to depart without her. Dorothy then journeys to Glinda, who reveals that the silver shoes can return her to Kansas. Her friends take up kingdoms suited to them, the Winged Monkeys are freed from servitude to the Golden Cap, and Dorothy uses the shoes to reach Aunt Em and Uncle Henry.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3730,7 +3730,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3743,7 +3743,7 @@
       "recaps": {
         "ending": "Giles gives Grace the shelter of his cottage while he remains outside in severe weather to protect her reputation. The exposure worsens his illness, and he dies despite Grace's care. Melbury is devastated by the loss of the man he now recognizes as his daughter's truest protector. Felice Charmond has gone abroad, where she is shot and killed by a former lover. With that relationship ended, Fitzpiers returns again, expresses remorse, and gradually persuades Grace to reconcile with him. She leaves Little Hintock with her husband, accepting a renewed marriage whose future remains uncertain. Marty alone continues to honor Giles without divided motives. At his grave she reflects on his loyalty and promises to keep his memory alive, while the other people whose choices shaped his fate move on.",
         "in_short": "In Little Hintock, timber merchant George Melbury has long intended his educated daughter Grace to marry honest woodsman Giles Winterborne, but he decides the young doctor Edred Fitzpiers offers greater status. Grace marries Fitzpiers and soon discovers his unfaithfulness, culminating in an affair with the wealthy widow Felice Charmond. Melbury regrets breaking his promise to Giles and tries unsuccessfully to free Grace from her marriage. After Fitzpiers and Felice separate, he returns, and a confrontation drives Grace to seek Giles's protection. Giles gives her his cottage while exposing himself to harsh weather outside so her reputation will remain safe. He becomes ill and dies. Felice is later killed abroad by a former lover. Fitzpiers again seeks Grace, and she finally reconciles with him and leaves Hintock. Marty South, who has quietly loved Giles throughout, remains at his grave and vows that he will not be forgotten.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3932,7 +3932,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3945,7 +3945,7 @@
       "recaps": {
         "ending": "After Jenny Fields is murdered by a man hostile to her public feminism, Garp's connection to her legacy draws him deeper into conflicts he distrusts. He attends her women-only memorial disguised in women's clothing, is recognized, and is attacked before Roberta helps him escape. Ellen James, whose cause has been appropriated by activists who mutilate themselves in her name, becomes a real friend to the Garp family. Garp and Helen return to the Steering School, where he coaches wrestling and continues writing. Their marriage has survived infidelity and the crash that killed Walt, injured Duncan, and permanently maimed Michael Milton, but danger has not ended. Bainbridge Percy, known as Pooh, approaches Garp at the school and shoots him because of her obsessive grievance against him. He dies from the wounds, leaving Helen, Duncan, and his young daughter Jenny behind. His books and the often distorted public stories about him persist, while the people closest to him continue their lives beyond the roles his anxious imagination assigned them. The ending confirms the pattern Garp feared throughout his life: violence is unpredictable, and love cannot guarantee protection from it.",
         "in_short": "Nurse Jenny Fields deliberately becomes a single mother by conceiving a child with a dying, brain-damaged airman. Her son, T. S. Garp, grows up at the Steering School, becomes a writer, and marries Helen Holm. Jenny's memoir makes her an unwilling feminist icon, while Garp's fiction and domestic life are shaped by sexual jealousy and fear for his children. Both spouses have affairs. Garp drives into the parked car where Helen is with her student Michael Milton; the collision kills their young son Walt, costs Duncan an eye, and maims Michael. Garp and Helen reconcile and have a daughter. Garp's subsequent novel succeeds, but Jenny is assassinated by an anti-feminist attacker. After surviving violence at her memorial, Garp returns to the Steering School as a wrestling coach. Bainbridge Percy, known as Pooh, carries an old grievance against him, shoots him there, and he dies. Helen and the children survive him, as do his books, Jenny's contested public legacy, and the friendships formed around their unconventional family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4088,7 +4088,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4101,7 +4101,7 @@
       "recaps": {
         "ending": "Avice Crichton's opening becomes Julia's decisive answer to Tom's disloyalty and to the threat of youth. Without openly breaking the production, Julia changes the rhythm and emphasis of their scenes so that the audience's attention remains fixed on her; Avice appears weak, while Julia gives an exhilarating performance and secures a triumph. Tom understands that Julia has defeated the younger actress through craft he cannot challenge. Afterward Julia declines the expected company and eats alone, taking sensuous pleasure in the meal and in her recovered independence. She no longer needs Tom's desire to prove her vitality. Roger's accusation that she has no self outside her roles remains relevant, but Julia reaches a different conclusion: performance is not an imitation standing beneath ordinary life but the medium in which she is most completely herself. Michael continues to manage the theatre, Avice's prospects have been damaged, and Tom has lost his power over Julia. Julia ends the novel professionally supreme and personally self-possessed, embracing the theatrical identity others treated as a limitation.",
         "in_short": "Julia Lambert, a renowned middle-aged actress, has a successful London career, an efficient marriage to actor-manager Michael Gosselyn, and complete command of her public image. The admiration of Tom Fennell, a much younger accountant, awakens a desire that unsettles this controlled life, and they begin an affair. Julia becomes emotionally dependent while Tom grows casual, accepts her generosity, and uses her access to fashionable society. His interest shifts to the aspiring actress Avice Crichton. Julia arranges for Avice to join the company, concealing jealousy behind professional help. Her son Roger then tells her that she turns life into performance so completely that he cannot locate a genuine person beneath her roles. On Avice's opening night, Julia uses her superior timing and technique to dominate their scenes and ruin the younger woman's effect while thrilling the audience. Free of Tom's hold, she celebrates alone and accepts that acting is not a false layer over her real life: the theatre is where her identity is most fully realized.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4273,7 +4273,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4286,7 +4286,7 @@
       "recaps": {
         "ending": "Weeks after the hurricane, Tea Cake becomes ill from the dog bite he received while saving Janie. Dr. Simmons diagnoses rabies, and the disease makes Tea Cake confused, fearful, and increasingly dangerous. He hides a loaded pistol and eventually aims it at Janie. She fires a rifle in self-defense and kills him as he shoots at her. An all-white jury acquits her after hearing the circumstances, despite hostility from some of Tea Cake's friends. Janie gives Tea Cake an elaborate funeral and returns alone to Eatonville. She tells Pheoby that Tea Cake gave her the chance to experience the life she had long sought; his death has not erased that love or made her dependent on the town's judgment. Having completed the story, Janie withdraws into her house with her memories. Her physical journey is over, and she reaches a private sense of wholeness grounded in what she has seen, chosen, loved, and survived.",
         "in_short": "Janie Crawford tells her friend Pheoby how her grandmother pushed her into a loveless marriage with the prosperous farmer Logan Killicks. She leaves him for the ambitious Joe Starks, who builds his power as mayor of Eatonville but confines Janie to the roles of obedient wife and storekeeper. After Joe's death, Janie meets the younger Tea Cake, marries him, and moves to the Everglades, where they work, play, and build a shared community. Their relationship gives Janie companionship and freedom despite episodes of jealousy and violence. A devastating hurricane floods the region. While saving Janie, Tea Cake is bitten by a rabid dog; weeks later the disease makes him attack her, and she kills him in self-defense. Acquitted at trial, she buries him and returns to Eatonville alone. Janie finishes her account no longer measuring herself by the town's gossip or by marriage. She retains Tea Cake's memory and the independent self-knowledge earned through her journey.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4442,7 +4442,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4455,7 +4455,7 @@
       "recaps": {
         "ending": "Carla leaves the school after the parents' campaign against her position succeeds, and Bradley initially treats her departure as proof that caring about people only leads to pain. The changes he has made do not disappear, however. He completes schoolwork, behaves more openly with his family and classmates, and goes to Colleen's birthday party instead of retreating from the invitation. His classmates discover that he can take part without causing trouble, while Bradley discovers that acceptance is possible when he does not attack first. He sends Carla his cherished rabbit figure, Ronnie, as a farewell gift and receives a warm letter from her. Bradley and Jeff repair their friendship. By the close, Bradley has not become a different person overnight, but he has stopped treating failure and rejection as fixed facts about himself and has begun choosing friendship, effort, and trust.",
         "in_short": "Bradley Chalkers is the most isolated child in his fifth-grade class, using lies, insults, and refusal to work to protect himself from expected rejection. New student Jeff Fishkin briefly befriends him, then pulls away under peer pressure. School counselor Carla Davis refuses to label Bradley as bad and helps him imagine that his actions can change. Bradley slowly attempts homework, kindness, and honesty, but setbacks with Jeff and a parent campaign to remove Carla make him fear that trust was a mistake. Even after Carla is forced to leave, he follows through on the progress they began: he attends Colleen Verigold's birthday party, reconnects with classmates, and repairs his friendship with Jeff. He sends Carla one of his treasured toy animals as a farewell, showing that he can care for someone without hiding behind hostility.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4588,7 +4588,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4601,7 +4601,7 @@
       "recaps": {
         "ending": "Madame Raquin survives in complete paralysis, able to understand the murderers but unable to expose them. Thérèse and Laurent's marriage becomes a cycle of accusation, fear, and physical abuse. Each concludes that peace is possible only if the other dies. Laurent obtains poison for Thérèse while she hides a knife intended for him. When they confront one another at the table, each recognizes the other's plan and understands that their shared crime has made ordinary life impossible. Their hostility briefly collapses into exhausted recognition. Thérèse and Laurent then drink the poisoned mixture together and die in each other's arms. Madame Raquin watches their final convulsions through the night. She cannot act or speak, but she receives the only revenge available to her: the killers destroy themselves in front of the woman whose son they murdered and whose trust they exploited.",
         "in_short": "Thérèse Raquin lives with her aunt Madame Raquin and her sickly husband Camille above a dreary Paris shop. When Camille brings home his vigorous old acquaintance Laurent, Thérèse and Laurent begin an affair. Finding Camille an obstacle, they drown him during a boating trip and persuade everyone that his death was accidental. Instead of freeing them, the murder leaves both lovers haunted by Camille's body and unable to resume their relationship. They decide that marriage will cure their fear and maneuver Madame Raquin and her friends into arranging it. Their wedding instead traps them together with guilt, insomnia, disgust, and mutual suspicion. After paralysis robs Madame Raquin of speech, she overhears their confession but cannot make their friends understand her accusation. Thérèse and Laurent turn violently against one another and independently plan murder. Discovering their matching intentions, they abandon the struggle and drink Laurent's poison together. Madame Raquin watches them die, achieving revenge only through their self-destruction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/thesaurize.json
+++ b/data/works-community/0/thesaurize.json
@@ -148,7 +148,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0CMR27PPK",
@@ -160,7 +160,7 @@
       "recaps": {
         "ending": "Middle Village is largely destroyed after Joe's team uses ice wraiths and overloaded towers to penetrate the trap around Daniela. Joe forces Daniela to respawn, causing the elven cleric to violate his oath and lose his power temporarily. The cleric then accepts a two-day nonaggression agreement, promises not to act through proxies, and gives Joe authority over the local guild in return for healing. Joe resurrects Daniela and six human mages, restores the badly injured Jaxon, ends the bombardment, and removes the guild rule that compelled membership. Daniela helps dismantle the town hall, while survivors are offered a voluntary journey toward Novusheim before another beast wave. Heartpiercer McShootypants and Socar remain allied and survive the operation. Joe has completed Havoc's demand to destroy three elven settlements and can claim the recharge-station plans, but he is without mana for about a day. The cleric will be restrained for only two days, the broader theocracy remains hostile, and Novusheim still needs population, stronger defenses, and eventual Tier 5 city status for the larger escape plan.",
         "in_short": "Joe strengthens Novusheim while trying to locate Daniela, who is detained more than ten thousand miles away. He builds a shrine network, changes his approach to ritual design, rescues human laborers from elven rule, and destroys settlements for Havoc's recharge-station quest. A dangerous vault releases undying ice wraiths but also yields a valuable giant-world alloy and its recipe. Joe eventually discovers that Daniela is bait in Middle Village, a theocratic trap designed to capture him. With Jaxon, Heartpiercer McShootypants, Socar, and Nimue, he turns nearby wraiths and expendable defense towers into a diversion. Joe sends Daniela to respawn, exploiting the cleric's broken oath to win temporary peace and control of the local guild. He then revives Daniela and other casualties, restores Jaxon, dismantles the town hall, and leads willing survivors toward Novusheim. The rescue succeeds, but elven retaliation, the settlement's growth, and escape from the giant world remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -372,7 +372,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -385,7 +385,7 @@
       "recaps": {
         "ending": "Miss Marple determines that Lewis Serrocold and Edgar Lawson were acting together. Edgar's apparent instability and his armed quarrel with Lewis were a rehearsed diversion that gave the conspirators cover while Christian Gulbrandsen was killed. Christian had discovered Lewis's misuse of trust money connected with Stonygates and intended to expose it. The timing of the supposed siege worked like a stage illusion: witnesses concentrated on the loud scene and accepted the positions it seemed to establish. Once Miss Marple dismantles that performance, the final confrontation leaves Edgar and Lewis dead. Carrie Louise survives the collapse of Lewis's scheme, and Gina and Walter reconcile, leaving Stonygates to continue without the deception at its centre.",
         "in_short": "Miss Marple visits her old friend Carrie Louise at Stonygates, a family mansion combined with a centre for young offenders. During a dramatic confrontation in which resident Edgar Lawson threatens Carrie Louise's husband Lewis Serrocold, trustee Christian Gulbrandsen is shot elsewhere in the house. The noisy, apparently witnessed quarrel seems to give both men an alibi. Miss Marple treats it as staged misdirection. Lewis and Edgar were collaborators, and Edgar's supposed delusions helped create a controlled spectacle while Christian was killed because he had uncovered Lewis's misuse of trust funds. The conspirators' positions and voices were manipulated like a theatrical illusion. Exposed, both men die in the final confrontation. Carrie Louise remains safe, and Gina and Walter repair their marriage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -508,7 +508,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -521,7 +521,7 @@
       "recaps": {
         "ending": "Time is restarted and the world is put back together. The perfect clock does stop time when it is finished, but Susan, Lu-Tze, and Lobsang, all able to act outside the frozen moment, undo the disaster. Lobsang Ludd and the clockmaker Jeremy are revealed to be two halves of the same entity, the son of Time, and Lobsang embraces this identity, merging with his other half to become the new personification of Time itself. The Auditor who took the human name Lady LeJean, seduced by the richness of physical sensation and turned against her own cold kind, helps bring about the Auditors' defeat: unable to withstand the overwhelming experience of taste, they are undone by chocolate. With their scheme broken, ordinary time resumes and the world carries on as though the interruption had never happened. Lobsang, now Time, remains bound by a lasting connection to Susan, who returns, as she prefers, to her ordinary life.",
         "in_short": "The Auditors of Reality, who loathe the disorder of living things, plot to stop time forever by having a perfect glass clock built, a device that will trap Time itself and freeze the world into tidy stillness. Working through one of their number in human form, they commission the obsessive Ankh-Morpork clockmaker Jeremy Clockson to construct it. Sensing the coming catastrophe, Death gathers the other Horsemen and calls on his rational, reluctant granddaughter Susan, a schoolteacher, to intervene. At a remote mountain monastery, the humble History Monk Lu-Tze and his extraordinarily gifted apprentice Lobsang Ludd race to reach the clock in time. When it is completed, time stops and shatters, leaving the world frozen. Susan, Lu-Tze, and Lobsang, able to move outside ordinary time, fight to put it back together. Lobsang and Jeremy prove to be two halves of a single being, the son of Time, and Lobsang takes up that inheritance. The Auditor who wore human form is undone by her growing love of human sensation, and the Auditors themselves are defeated when the sheer overwhelming pleasure of taste destroys them. Time is restarted and the world remade.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -660,7 +660,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -673,7 +673,7 @@
       "recaps": {
         "ending": "Poirot establishes that the man presented as Andrew Restarick is an impostor, Robert Orwell, and that Frances Cary is his partner. Frances has also been appearing as Mary Restarick, using changes of clothes and appearance so that the flatmate and the supposed stepmother seem to be two women. The real Andrew died abroad. Orwell and Frances intend to gain control of Norma's inheritance by making her appear dangerously insane. They drug her, exploit her fragmented memory, and stage incidents around her, including the apparent stabbing of David Baker, so that she will believe herself capable of murder. Louise Charpentier recognised Orwell from his earlier life and was killed to protect the impersonation; Norma was manoeuvred into believing she might be responsible. Poirot's attention to identities that are accepted without independent recognition exposes the arrangement. Norma is rescued from the attempt to complete the scheme, the false family structure collapses, and David's attachment to her proves genuine. Sir Roderick's suspicions about Sonia and his papers belong to a separate, less murderous deception and do not explain Norma's ordeal.",
         "in_short": "Norma Restarick tells Poirot she may have murdered someone, then disappears after calling him too old. With Ariadne Oliver's help, he traces her to a flat shared with Claudia Reece-Holland and Frances Cary and to a family newly reunited with her returned father Andrew and his second wife Mary. Norma is repeatedly drugged and manipulated into doubting her memory; the death of Louise Charpentier and a staged attack on Norma's boyfriend David Baker are used to make her seem violent and insane. Poirot discovers that the supposed Andrew is Robert Orwell, an impostor, while Frances Cary also plays the part of Mary Restarick through disguise. The real Andrew died abroad. Orwell and Frances killed Louise because she recognised him and seek control of Norma's inheritance by having Norma declared incapable. Their reliance on roles that no one has seen together allows the deception to continue until Poirot reconstructs it. Norma is saved, the impostors are exposed, and David remains with her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -867,7 +867,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -880,7 +880,7 @@
       "recaps": {
         "ending": "Hannah's final tape describes a last effort to ask for help. She tells counselor Mr. Porter that she was assaulted and is thinking about ending her life, but she speaks indirectly, refuses to name the attacker, and leaves when his questions make her feel that no useful intervention will follow. He does not pursue her. Clay finishes the recordings understanding that he was not one of Hannah's reasons: she included him because she wanted his part of the night explained and because she regretted pushing him away. Tony confirms that he holds the backup set and that Hannah's parents have the original tapes. Clay mails the box onward as instructed. The next morning, newly alert to how silence and isolation can accumulate around a person, he sees his withdrawn former friend Skye leaving school. Rather than let her disappear, he calls her name and goes after her, acting on the lesson he could not apply in time to Hannah.",
         "in_short": "After Hannah Baker dies by suicide, classmate Clay Jensen receives seven cassette tapes on which she names thirteen people whose actions formed a chain of humiliation, isolation, assault, and failed help. Walking around town through the night, Clay hears how an early rumor sexualized Hannah, friendships collapsed, a voyeur invaded her privacy, classmates exploited or mocked her, and bystanders failed victims at parties. His own tape reveals that Hannah trusted and liked him, but trauma led her to drive him away during their one intimate moment; he is part of the story, not a cause of her death. The later recordings connect an unreported fallen stop sign to a fatal crash, describe Bryce Walker assaulting Hannah, and recount her unsuccessful final approach to counselor Mr. Porter. After finishing, Clay passes on the tapes. Seeing the isolated Skye Miller at school, he calls out to her instead of remaining silent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1417,7 +1417,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -1430,7 +1430,7 @@
       "recaps": {
         "ending": "The Princess Posse wins Faction Wars when Laracos and Shantytown transfer to the twelfth floor, which defeats Team Retribution. Louis survives with replacement organs, but Juicebox enters the Nothing and her survival remains unknown. Katya returns to human form, becomes pregnant with Louis's child, receives cybernetic replacements, and is transferred beyond the floor. Li Na survives at immense power but cannot heal while three marked enemies remain alive on the eighteenth floor. Samantha returns badly burned with only fragments of her recovered past. Carl, Donut, Mordecai, Bautista, and their remaining companions reach the stairwell before the ninth floor is destroyed. Justice Light stays behind and dies activating a trap that breaks the Nothing. Its contents spill into the Ascendancy, Sheol, and Scolopendra's lair, awakening Scolopendra. The survivors' evacuation route now runs through the active maze on the seventeenth floor.",
         "in_short": "Carl and Donut enter Faction Wars as leaders of the Princess Posse, allied with Juicebox and the awakened residents of Laracos. Returning former crawlers strengthen their army, which defeats rival factions through battles, infiltration, and a final struggle against a War Mage rebellion. Li Jun and Justice Light die, while Vinata, Donadia, Fang, and Epitome Tagg are killed. Louis survives captivity and the replacement of his compromised organs. The Princess Posse wins when Laracos transfers to the twelfth floor and Team Retribution is defeated. Katya becomes human, chooses pregnancy with Louis as the father, and leaves safely. Carl, Donut, and their remaining companions escape before the ninth floor is destroyed. Justice Light's last trap ruptures the Nothing into three realms, leaves Juicebox's fate unknown, and awakens Scolopendra.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1576,7 +1576,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1589,7 +1589,7 @@
       "recaps": {
         "ending": "Garden forces Blue to send Red a lethal message, using the lovers' private correspondence as the delivery route and expecting the poison to erase its enemy. Red consumes the letter and appears to die, but Blue has hidden help inside the very history of their exchange: their earlier messages have prepared Red to survive what should have killed her. Following Blue's trail and the meanings embedded across their correspondence, Red recovers and turns the time war's methods against the powers that own them. She reaches Blue, who is confined and marked for punishment by Garden, and frees her. Their factions remain enormous, hostile, and capable of pursuing them across strands, but neither agent returns to obedience. Red and Blue choose one another and flee together into time, changing their rivalry into a shared rebellion whose future is unwritten.",
         "in_short": "Red and Blue are elite agents on opposite sides of a war fought by altering countless versions of history. Red serves the technological Agency; Blue belongs to the organic intelligence called Garden. After Blue leaves a taunting message at one of Red's victories, they begin hiding letters for each other inside landscapes, living things, and events spread across time. Competitive reports become intimate confessions, and the two enemies fall in love without abandoning the dangerous work that repeatedly places them on opposing strands. Their superiors detect the correspondence. Garden uses Blue to send a poisoned letter meant to kill Red, but Blue has quietly made their entire exchange part of a survival plan. Red endures the attack, follows the clues Blue left through time, and rescues her from Garden's control. They abandon both sides and escape together, pursued but no longer willing to let either faction decide their allegiance or their future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1740,7 +1740,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1753,7 +1753,7 @@
       "recaps": {
         "ending": "After pushing Dexter away, Remy discovers that the emotional detachment she prized does not protect her from missing him or regretting the hurt she caused. The summer's other relationships also resist her simple rules: her friends make choices she cannot control, Chris and Jennifer Anne demonstrate genuine commitment, and Barbara and Don continue trying to build a marriage instead of treating conflict as automatic proof of failure. Remy finally admits that loving someone cannot be made safe by scheduling the end in advance. She seeks Dexter out and tells him honestly that her feelings are real. Their reconciliation does not offer a guarantee that the relationship will last forever, particularly with Remy preparing to leave for Stanford, but she accepts uncertainty rather than using it as a reason not to love him. Her father's lullaby no longer functions only as evidence of abandonment; Remy can recognize that an imperfect or unfinished love may still matter. She ends the summer willing to carry that change into college and to let Dexter be part of her future without demanding proof of its outcome.",
         "in_short": "Remy Starr manages her successful novelist mother's fifth wedding while preparing to leave for Stanford. Convinced by family history that love always fails, she dates controlled, suitable boys and breaks up before becoming vulnerable. Dexter Jones, an affectionate but disorganized musician, violates all her rules. What begins as an unwanted pursuit becomes Remy's most important relationship as she joins his circle of bandmates and allows him into her carefully ordered life. Her friends' romantic problems, her brother Chris's steady commitment to Jennifer Anne, and Barbara's new marriage reveal that neither cynicism nor optimism can eliminate risk. Frightened by how much Dexter matters, Remy ends the relationship and tries to return to emotional distance, only to find that detachment now feels like loss. Before leaving for college, she reconciles with Dexter and admits she loves him. They cannot promise permanence, but Remy accepts that uncertainty is part of attachment rather than a reason to refuse it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1916,7 +1916,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1929,7 +1929,7 @@
       "recaps": {
         "ending": "After Eleanor, Amory's fortunes continue to contract. He protects Alec Connage during a hotel raid by taking responsibility for a compromising situation, accepting damage to his own name rather than expose his friend. He then learns that Monsignor Darcy has died, removing the mentor who understood him most fully, while the loss of family wealth leaves him with little material security. Traveling toward Princeton, Amory argues for socialist ideas with a wealthy motorist, though his political conviction remains part of an identity still forming. He reaches the university grounds and considers the ambitions, poses, friendships, and loves that have fallen away. Rosalind is gone, his college generation has been scattered by war and adulthood, and neither inherited status nor romance can define him. What remains is self-knowledge: incomplete and uncomfortable, but more honest than the exceptional destiny he once assumed was waiting for him.",
         "in_short": "Amory Blaine grows up wealthy, clever, and convinced that he is destined to matter. Guided by his cultured mother Beatrice and the sympathetic Monsignor Darcy, he pursues status at Princeton, where friendships, literary interests, and failed romances expose the vanity beneath his confidence. War breaks up his generation. Returning with reduced prospects, he falls deeply in love with Rosalind Connage, but she chooses a richer husband rather than share Amory's insecurity. His later affair with Eleanor Savage also fails to give him a lasting direction. Amory sacrifices his reputation to protect Alec Connage, loses Darcy to death and much of his inherited security, and experiments with radical politics. Back at Princeton, stripped of the social and romantic identities he once relied on, he ends with no clear future but a more candid understanding of himself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2093,7 +2093,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2106,7 +2106,7 @@
       "recaps": {
         "ending": "Pat's lung disease worsens at the mountain sanatorium while Robert remains with her and Otto struggles to keep sending money. Otto ultimately sells Karl, the racing car that embodied the comrades' shared freedom, so that her treatment and Robert's stay can continue. Medical skill can delay but not reverse the illness. Robert tries to preserve ordinary pleasures and to conceal the dwindling possibilities, while Pat increasingly understands her condition. She dies with Robert beside her after asking him to remain close. By then Gottfried Lenz has already been killed in political violence, and Alfons has avenged him by shooting the man responsible. The garage has failed, Karl is gone, Pat is dead, and the surviving comrades have lost nearly every material defense they built against the postwar world. Otto's steadfast aid and Robert's vigil nevertheless continue the loyalty that gave their lives coherence. The novel closes with Robert facing daylight after Pat's death, without consolation or a clear future.",
         "in_short": "In economically battered Germany between the wars, veterans Robert Lohkamp, Otto Köster, and Gottfried Lenz sustain one another through a failing garage, drink, and their shared past. Robert meets Patricia Hollmann and gradually accepts a love that makes him vulnerable to hope. Pat has a serious lung disease, however, and a seaside hemorrhage reveals how little time and security they possess. As Robert and Pat try to live fully between treatments, political extremism grows around them. Lenz is shot and killed during street violence; after Robert and Otto fail to catch the murderer, their acquaintance Alfons kills him. Pat returns to a mountain sanatorium as her illness advances. Money runs out, and Otto sells the comrades' prized racing car Karl to support her care. Robert stays at the sanatorium, unable to stop the decline but refusing to leave Pat alone. She dies beside him, leaving Robert and Otto alive but stripped of Lenz, the garage, Karl, and the future Robert had briefly imagined with her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2249,7 +2249,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2262,7 +2262,7 @@
       "recaps": {
         "ending": "Rain settles over the river after the party reaches Oxford and turns the return journey into a cold, dispiriting exercise. The men initially insist that they will complete the holiday, but everything is wet, the scenery is obscured, and another evening under canvas promises no relief. At Pangbourne they finally abandon the plan. They leave the boat to be collected and take the train to London, where a substantial meal in a restaurant restores their spirits. From the comfort of dry clothes and full stomachs, George, Harris, and J. agree that ending early was wise. Montmorency's response shows equal satisfaction. The narrative closes with the dog apparently grateful that the three men have returned from the river alive, ending the expedition with relief rather than arrival at its planned destination.",
         "in_short": "Convinced that they are ill from overwork, J., George, and Harris prescribe themselves a fortnight's boating holiday on the Thames, accompanied by J.'s fox terrier Montmorency. J. and Harris start from Kingston and collect George at Weybridge. Their upstream journey becomes a sequence of mishaps involving packing, camping, cooking, towing, locks, other boats, and their own exaggerated confidence. J. fills the voyage with memories of earlier domestic and boating failures and with reflections on the history of the river. The friends pass Hampton Court, Marlow, Reading, and other towns, create an improvised stew, quarrel with a tin of pineapple, misuse George's banjo, and discover that a celebrated trout is made of plaster. They reach Oxford, but continuous rain ruins the return trip. At Pangbourne they leave the boat and take a train to London, where dinner and dry surroundings convince all four travelers that abandoning the holiday was their best decision.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2394,7 +2394,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2407,7 +2407,7 @@
       "recaps": {
         "ending": "Persistent rain changes the holiday from an inconvenience into a thoroughly wet ordeal. The men make one last attempt to continue, but cold food, damp clothes, and the prospect of another night under canvas defeat their determination. They leave the boat to be collected, take a train back to London, and finish the evening with a substantial meal in a restaurant. Warm, dry, and well fed, they agree that abandoning the river was the sensible decision. Montmorency's contented response confirms the verdict. The journey therefore ends before the planned destination, with the friends pleased by their adventure but even more pleased to have returned to ordinary comfort.",
         "in_short": "J., George, Harris, and J.'s dog Montmorency decide that a boating holiday will cure the illnesses the three men imagine they have. They plan to row up the Thames from Kingston, with George joining after work, but packing and departure immediately reveal how poorly their confidence matches their practical skill. On the river they struggle with camping equipment, cooking, towing, weather, and one another, while J. recalls earlier disasters involving boats, household jobs, and travel. They pass historic towns and riverside landmarks, encounter boastful anglers and impatient steam launches, and repeatedly turn minor tasks into confusion. The trip remains enjoyable while the weather is fair, but sustained rain eventually leaves everything wet and the party miserable. They abandon the boat, return to London by train, and celebrate their retreat with a large dinner, Montmorency plainly approving the decision.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2523,7 +2523,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2536,7 +2536,7 @@
       "recaps": {
         "ending": "After reaching Oxford, the travelers start back downriver in worsening weather. Two days of steady rain defeat their attempts to treat the discomfort as part of the adventure. At Pangbourne they leave the boat in a boatman's care and take a train to London, while Montmorency shows unmistakable relief. Warm, dry, and well fed in a restaurant, J., George, and Harris agree that they made the right decision. Harris raises a toast to the three men who escaped the boat, and Montmorency appears to endorse it. The journey therefore ends not with the planned return by water but with a cheerful surrender to ordinary comfort, preserving the trip as a success in their memories despite its many inconveniences.",
         "in_short": "J., George, Harris, and J.'s fox terrier Montmorency seek relief from their imagined ailments by taking a boating holiday on the Thames. They travel from Kingston toward Oxford, repeatedly discovering that packing, camping, cooking, towing, navigating, and simply getting out of one another's way are harder than expected. J.'s account wanders into comic memories and stories about riverside places, while the friends encounter mazes, locks, fishermen, tow ropes, rain, and the consequences of their own confidence. They nevertheless enjoy stretches of scenery, food, and companionship. After reaching Oxford they attempt the return journey, but sustained cold rain finally persuades them to abandon the boat at Pangbourne and go home by train. Dry again over dinner in London, they toast their escape and regard the holiday with satisfaction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2670,7 +2670,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2683,7 +2683,7 @@
       "recaps": {
         "ending": "After reaching Oxford, the party begins the return journey in worsening weather. Continuous rain strips the river of its earlier charm, so the men spend a miserable evening in the boat trying to pretend that they are comfortable. George's attempt at music only deepens the gloom. When the next day is equally wet, he suggests leaving the boat at Pangbourne and taking the train to London. J. and Harris briefly object in the name of perseverance, then admit that they want exactly the same thing. Back in London, the three men eat a satisfying supper and go on to the Alhambra. Harris raises a toast to their escape from the boat, and Montmorency gives an approving bark. The holiday ends not with the planned completion of the return voyage, but with the friends contentedly abandoning it for warmth, food, and city life.",
         "in_short": "Convinced that they are overworked and unwell, J., George, and Harris plan a fortnight's boating holiday on the Thames with J.'s fox terrier, Montmorency. They travel upstream from Kingston toward Oxford, repeatedly turning simple jobs such as packing, towing, cooking, opening tins, and putting up canvas into elaborate difficulties. The journey is interspersed with J.'s memories, comic histories, and observations on river life. The friends quarrel with equipment, weather, other boats, musical instruments, and their own uneven willingness to work, but also enjoy old towns and stretches of peaceful countryside. At Oxford the weather breaks. On the return journey, relentless rain defeats their determination, and they leave the boat at Pangbourne for a train to London. Restored by supper and an evening's entertainment, they toast the fact that all three men, and the dog, are safely out of the boat.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2799,7 +2799,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2812,7 +2812,7 @@
       "recaps": {
         "ending": "After reaching Oxford, the travelers start back downriver in worsening weather. Two days of steady rain defeat their attempts to treat the discomfort as part of the adventure. At Pangbourne they leave the boat in a boatman's care and take a train to London, while Montmorency shows unmistakable relief. Warm, dry, and well fed in a restaurant, J., George, and Harris agree that they made the right decision. Harris raises a toast to the three men who escaped the boat, and Montmorency appears to endorse it. The journey therefore ends not with the planned return by water but with a cheerful surrender to ordinary comfort, preserving the trip as a success in their memories despite its many inconveniences.",
         "in_short": "J., George, Harris, and J.'s fox terrier Montmorency seek relief from their imagined ailments by taking a boating holiday on the Thames. They travel from Kingston toward Oxford, repeatedly discovering that packing, camping, cooking, towing, navigating, and simply getting out of one another's way are harder than expected. J.'s account wanders into comic memories and stories about riverside places, while the friends encounter mazes, locks, fishermen, tow ropes, rain, and the consequences of their own confidence. They nevertheless enjoy stretches of scenery, food, and companionship. After reaching Oxford they attempt the return journey, but sustained cold rain finally persuades them to abandon the boat at Pangbourne and go home by train. Dry again over dinner in London, they toast their escape and regard the holiday with satisfaction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2946,7 +2946,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2959,7 +2959,7 @@
       "recaps": {
         "ending": "After reaching Oxford, the party begins the return journey in worsening weather. Continuous rain strips the river of its earlier charm, so the men spend a miserable evening in the boat trying to pretend that they are comfortable. George's attempt at music only deepens the gloom. When the next day is equally wet, he suggests leaving the boat at Pangbourne and taking the train to London. J. and Harris briefly object in the name of perseverance, then admit that they want exactly the same thing. Back in London, the three men eat a satisfying supper and go on to the Alhambra. Harris raises a toast to their escape from the boat, and Montmorency gives an approving bark. The holiday ends not with the planned completion of the return voyage, but with the friends contentedly abandoning it for warmth, food, and city life.",
         "in_short": "Convinced that they are overworked and unwell, J., George, and Harris plan a fortnight's boating holiday on the Thames with J.'s fox terrier, Montmorency. They travel upstream from Kingston toward Oxford, repeatedly turning simple jobs such as packing, towing, cooking, opening tins, and putting up canvas into elaborate difficulties. The journey is interspersed with J.'s memories, comic histories, and observations on river life. The friends quarrel with equipment, weather, other boats, musical instruments, and their own uneven willingness to work, but also enjoy old towns and stretches of peaceful countryside. At Oxford the weather breaks. On the return journey, relentless rain defeats their determination, and they leave the boat at Pangbourne for a train to London. Restored by supper and an evening's entertainment, they toast the fact that all three men, and the dog, are safely out of the boat.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3078,7 +3078,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3091,7 +3091,7 @@
       "recaps": {
         "ending": "Persistent rain defeats the travelers' remaining enthusiasm for outdoor life. After enduring wet clothes, a cheerless meal, and an increasingly miserable boat, Jerome, George, and Harris abandon the Thames journey before completing their planned route. They leave the boat to be collected and take a train back to London, where dry surroundings, a substantial supper, and familiar city comforts restore their spirits. Harris closes the holiday by expressing gratitude that they returned when they did. The expedition has not proved the clean, health-giving escape imagined at the outset, but its succession of errors, digressions, and shared discomforts has become the substance of the friends' adventure.",
         "in_short": "Jerome, George, and Harris decide that overwork and imagined illness require a boating holiday on the Thames, accompanied by Jerome's terrier, Montmorency. Their preparations immediately expose their talent for making simple jobs difficult. Traveling upstream from Kingston, they pass historic places, struggle with camping equipment, cooking, towing, locks, weather, and one another, while Jerome repeatedly interrupts the journey with memories and reflections about river life. Moments of beauty and companionship alternate with rain, hunger, damaged provisions, and comic failures of expertise. Near Oxford, prolonged bad weather removes the last pleasure from the expedition. The three men give up the boat, return to London by train, and celebrate with a comfortable meal, relieved to exchange their supposedly healthy outdoor holiday for the conveniences of the city.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3269,7 +3269,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3282,7 +3282,7 @@
       "recaps": {
         "ending": "As the artillery brigade leaves town, Masha and Vershinin part because he must go with it; she returns in grief to Kulygin, who receives her without confrontation. Irina is prepared to marry Tuzenbach and begin a useful new life elsewhere even though she does not love him. Before they can leave, however, Solyony provokes a duel and kills Tuzenbach. Olga has accepted the post of headmistress and takes Anfisa to live with her, while Natasha dominates the Prozorov house and plans its future around her children. The three sisters remain together as the soldiers march away. Denied Moscow, romantic fulfillment, and Irina's hoped-for marriage, they try to believe that work, endurance, and the lives of generations to come will eventually give meaning to their suffering.",
         "in_short": "Olga, Masha, and Irina Prozorova live with their brother Andrei in a provincial town and dream of returning to the cultured Moscow of their youth. Their hopes steadily contract: Andrei marries the domineering Natasha, falls into debt, and abandons his academic ambitions; Masha begins an affair with the married officer Vershinin; and Irina discovers that ordinary employment does not produce the fulfillment she expected. Natasha gains control of the family home while the sisters endure a fire, disappointed love, and the departure of the town's artillery brigade. Irina agrees to marry Baron Tuzenbach and seek a new life through work, but Solyony kills him in a duel just before their departure. Vershinin leaves with the brigade, separating from Masha. Olga becomes a headmistress, Masha returns to her forgiving husband, and Irina resolves to keep working. The sisters remain in the town, trying to find purpose in endurance while their dream of Moscow recedes for good.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3441,7 +3441,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3454,7 +3454,7 @@
       "recaps": {
         "ending": "Stephanie's pursuit finally separates Uncle Mo's public reputation from what he has been doing in secret. Moses Bedemier has been carrying out a vigilante campaign against local drug dealers, making himself the killer behind the bodies that accumulated during the fugitive search. The neighborhood's affection for the candy-store owner allowed him to move with little suspicion and made witnesses resist Stephanie, but the evidence and the final confrontation expose him. Mo dies when the confrontation turns violent, ending both the bond pursuit and the killings. Stephanie completes the case without the satisfaction of returning a living fugitive and with little gratitude from people who preferred the familiar public image. Lula has become a genuine field partner, Ranger continues to treat Stephanie as a developing professional, and Morelli remains both an investigative ally and a personal complication. Stephanie's standing as a bounty hunter is firmer, even though the case demonstrates that her own neighborhood can be one of the hardest places for her to work.",
         "in_short": "Stephanie Plum's next important fugitive is Moses Bedemier, known throughout the Burg as Uncle Mo, the trusted owner of a candy and ice-cream shop. He skips court on a concealed-weapon charge, but neighbors obstruct Stephanie because they cannot believe he is dangerous. As she searches with help from Lula, Ranger, and Joe Morelli, dead drug dealers appear and the case expands beyond a routine bond recovery. Joyce Barnhardt complicates the work by competing for apprehensions, while the Burg's loyalty keeps useful information hidden. The evidence eventually shows that Mo's harmless public identity concealed a vigilante campaign: he has been killing people he regarded as drug threats to the neighborhood. Stephanie confronts him, and Mo dies when the encounter turns violent. The exposure ends the killings and closes the bond case, leaving Stephanie more established professionally but newly aware that community approval can conceal danger as effectively as fear.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/threshold.json
+++ b/data/works-community/0/threshold.json
@@ -279,7 +279,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -292,7 +292,7 @@
       "recaps": {
         "ending": "Felix survives the omen path by resisting Vellus's attempt to force his advancement and forging the Path of the Cardinal Fiend. With the Endless Raven's help, he consumes the six Urges beneath the temple, becomes a Greater Primordial of the Unseen Tide, and defeats the Archon. Felix separates the former Unbound from the Archonic Construct, but the man's ultimate state remains uncertain after the Seed of Remembered Light grows through him into a vast spirit tree. The tree removes unwilling marks throughout the battlefield, and Karys Taiv occupies the cleansed construct while remaining linked to Inheritor's Will. Vessilia Dayne, Evie Aren, Harn, Atar V'as, Alistair, A'zek, Wyvora, Ifre, Kylar, Pit, and Felix survive the decisive campaign. In Setoria, Zara Cyrene, Darius Reed, and Kelgan stop the local Inquisition force, but Felix's claim does more: Merc Enclosure interrupts the waystone transmission and seals the former lost territory behind protective fog. Felix is publicly named its autark. The Henaari still need a home, Cal retains Harwatch, divine pressure remains unresolved, and the continent must respond to Felix's new rule.",
         "in_short": "The Archon escapes its mountain prison and races Felix Nevarre to a sealed Nemean temple while an Inquisition force moves to report Harwatch's fall. Felix leads Pit, Vessilia Dayne, Evie Aren, Harn, Atar V'as, Alistair, and Haarguard allies through the Foglands, earning Henaari aid, claiming Nevis, preserving Karys Taiv as a sword spirit, and learning that the Archon was once an Unbound punished by the Nym. Cast into a mana well with six imprisoned Urges, Felix rejects Vellus's influence, creates the Path of the Cardinal Fiend, consumes the Urges, and becomes a Greater Primordial. He separates the former Unbound from the Archonic Construct and grows the Seed of Remembered Light into a spirit tree that removes unwilling marks. Karys takes the emptied construct body. Felix then claims the lost territory, and the fog raised by him and Pit halts the Setoria waystone report. His new status as autark is announced across the continent.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -479,7 +479,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -492,7 +492,7 @@
       "recaps": {
         "ending": "The competition ends in a final duel, and Celaena is matched against Cain, who has been growing unnaturally powerful by using forbidden markings to summon a monstrous creature from beyond a portal in the castle. Weakened by a poisoning meant to sabotage her, Celaena is nearly overwhelmed, but with the ghostly queen Elena's aid she destroys the creature and kills Cain, winning the title of King's Champion. She wins her fragile freedom in name only: she is now bound to serve the ruthless king she loathes for years to come. Even so, she is alive and out of the mines, with allies she has come to trust in Prince Dorian, Captain Chaol, and Princess Nehemia. The dark magic she uncovered, her own hidden connection to it, and the king's deeper cruelties remain unresolved threats, setting the stage for the struggle to come.",
         "in_short": "Celaena Sardothien, Adarlan's most notorious assassin, has spent a year enslaved in the salt mines of Endovier when Crown Prince Dorian and Captain Chaol Westfall offer her a bargain: compete against other killers and thieves to become the King's Champion and, after years of service, earn her freedom. Brought to the glass castle in the capital, she trains under Chaol, grows close to Dorian, and befriends the defiant Eyllwe princess Nehemia. As the contest proceeds, competitors begin turning up brutally murdered. Celaena investigates and is drawn by the ghost of Elena, the first queen, into a hidden struggle against an ancient evil tied to strange markings and dark magic in the castle. The favored competitor, the brutal Cain, grows unnaturally strong by summoning a monstrous creature. Weakened by a court poisoning plot, Celaena faces Cain in the final duel, defeats the creature he calls, and kills him, winning the title of King's Champion. She survives, bound to serve the very king she despises, but alive and with Dorian, Chaol, and Nehemia at her side, and darker mysteries left unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -844,7 +844,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0D3MX7ZMC",
@@ -856,7 +856,7 @@
       "recaps": {
         "ending": "The occupied world's former king is compelled to abdicate and crown Satikis's son. Battlefleet 488 then reveals that it had waited nearby while Satikis proved he could win without its help, allowing his state to claim Tier III standing. Legion Varus returns to Earth, where Wurtenberger rejects the Saurian operative's accusation against McGill and explains that Earth has been trying to delay renewed Imperial consolidation. The operative's sabotage has produced the opposite result. Galina recruits McGill to remove Drusus from Alexander Turov's private vault. McGill carries Drusus's failing brain tank to Dust World, where the Investigator stabilizes it, agrees to hide him, and may attempt to grow a new body. Any permanent damage and the success of that restoration remain unknown. Boudica's brood now controls the surrounding valley and has displaced Etta, Derek, and most earlier colonists. A separate danger involving altered plants remains undisclosed. McGill is sent home, where he finds Galina hiding from Alexander after the theft. He gives her shelter, leaving both of them exposed to Alexander's retaliation.",
         "in_short": "James McGill joins Legion Varus on a discounted Magwa contract that proves to be the occupation of a resistant world. Local fighters use the planet's ecology, captured weapons, and mass attacks against the garrison. A Saurian agent serving Alexander Turov tries to sabotage Grand Admiral Satikis's annexation, but the escalating violence instead lets Satikis crush the capital, capture its king, and place his own son on the throne. A concealed Core World fleet certifies the conquest and the Magwa gain the political standing they sought. Back on Earth, McGill is cleared of aiding the annexation. He and Galina then steal Drusus's preserved brain from Alexander's private vault and take it to the Investigator on Dust World. Drusus is stabilized but may be damaged. Boudica's brood has displaced Etta and Derek from the surrounding valley, while a secret plant project poses a separate unresolved danger. McGill returns home and shelters Galina as she hides from her father.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1054,7 +1054,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1067,7 +1067,7 @@
       "recaps": {
         "ending": "At Koom Valley, Vimes uncovers the secret the murdered dwarf died to suppress: the legendary battle was not simply a massacre but the site where a dwarf king and a troll king had come to make peace, a truth recorded and hidden long ago. This revelation gives both peoples a shared history other than slaughter and begins to defuse the feud. Vimes rejects and expels the Summoning Dark, the vengeance-spirit that tried to make him a killer, by holding to the incorruptible 'watchman' inside himself that refuses to cross that line. The conspiracy among the deep-down dwarfs is exposed and its members brought to justice, and the vampire recruit Sally proves herself alongside Angua. The threatened riots never come. Vimes returns to his family, having kept his promise to be home in time to read to Young Sam, the small ritual that stands, in the end, as the measure of the man.",
         "in_short": "As Ankh-Morpork approaches the anniversary of Koom Valley, the ancient battle between dwarfs and trolls, a militant dwarf leader is found murdered in a mine dug beneath the city, and the evidence seems to point at a troll. Commander Vimes must solve the killing before it sparks open war between the city's dwarfs and trolls. Investigating, he clashes with secretive deep-down dwarf zealots, follows a trail hidden in an old painting of the battle, and comes to suspect the murder was committed by dwarfs to conceal something. During the case an ancient dwarf spirit of vengeance, the Summoning Dark, marks and enters him, urging him toward murderous rage. Racing to reach Koom Valley itself before rioting begins, Vimes masters the thing inside him through his own inner discipline as a policeman, and uncovers the long-buried truth of the original battle, defusing centuries of hatred. Throughout, he clings to his rule of getting home to read his son's bedtime story, which becomes the anchor that saves him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1214,7 +1214,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1227,7 +1227,7 @@
       "recaps": {
         "ending": "Bond, Leiter, and allied divers intercept Largo's underwater team as it moves one of the stolen bombs. A violent battle follows among the reefs. Bond fights Largo underwater and is nearly killed, but Domino, who has escaped captivity after being tortured for helping Bond, shoots Largo with a speargun. Largo dies, the nuclear weapons are secured, and the immediate threat is stopped. Bond survives his injuries and wakes in hospital, where Leiter tells him that Domino is safe nearby. Blofeld, however, was not present in Nassau and remains at large, so SPECTRE has lost its operation and field commander without losing its overall leader.",
         "in_short": "SPECTRE, led by Ernst Stavro Blofeld, steals a NATO bomber carrying two nuclear weapons and demands a huge ransom from Britain and the United States. James Bond is sent to Nassau, where he suspects the wealthy Emilio Largo and his yacht, the Disco Volante. With CIA ally Felix Leiter, Bond finds the sunken aircraft and links Largo to the theft. Largo's companion Domino learns that the murdered pilot was her brother and agrees to help, but she is discovered and tortured. Bond and Leiter join an underwater assault as SPECTRE moves a bomb toward its target. During the battle Bond fights Largo, and Domino escapes and kills Largo with a speargun. The bombs are recovered and the plot fails, although Blofeld remains free.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1409,7 +1409,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1422,7 +1422,7 @@
       "recaps": {
         "ending": "Bond, Leiter, and allied divers intercept Largo's underwater team as it moves one of the stolen bombs. A violent battle follows among the reefs. Bond fights Largo underwater and is nearly killed, but Domino, who has escaped captivity after being tortured for helping Bond, shoots Largo with a speargun. Largo dies, the nuclear weapons are secured, and the immediate threat is stopped. Bond survives his injuries and wakes in hospital, where Leiter tells him that Domino is safe nearby. Blofeld, however, was not present in Nassau and remains at large, so SPECTRE has lost its operation and field commander without losing its overall leader.",
         "in_short": "SPECTRE, led by Ernst Stavro Blofeld, steals a NATO bomber carrying two nuclear weapons and demands a huge ransom from Britain and the United States. James Bond is sent to Nassau, where he suspects the wealthy Emilio Largo and his yacht, the Disco Volante. With CIA ally Felix Leiter, Bond finds the sunken aircraft and links Largo to the theft. Largo's companion Domino learns that the murdered pilot was her brother and agrees to help, but she is discovered and tortured. Bond and Leiter join an underwater assault as SPECTRE moves a bomb toward its target. During the battle Bond fights Largo, and Domino escapes and kills Largo with a speargun. The bombs are recovered and the plot fails, although Blofeld remains free.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1592,7 +1592,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1605,7 +1605,7 @@
       "recaps": {
         "ending": "Bond joins the underwater assault on Largo's men as they move one of the warheads. The opposing swimmers fight with knives, spears, and explosives, and the arrival of allied support turns the battle against SPECTRE. Largo nearly kills Bond, but Domino, freed after being tortured for helping the investigation, shoots Largo with a spear gun. Both nuclear weapons are recovered before the ransom deadline, ending the immediate threat, although Blofeld is not among the defeated field team and remains at large. Bond and Domino are taken to hospital after their injuries, sharing the exhausted aftermath of an operation that cost her brother and nearly killed them both.",
         "in_short": "SPECTRE, led by Ernst Stavro Blofeld, steals a NATO bomber carrying two nuclear weapons and threatens to destroy major cities unless an enormous ransom is paid. Emilio Largo directs the field operation from the Bahamas, hiding the aircraft and warheads beneath the sea. After an enforced health cure introduces him to one of the conspiracy's agents, James Bond follows a clue to Nassau and investigates Largo with Felix Leiter. Bond befriends Largo's mistress Domino and proves that SPECTRE murdered her brother after using him to steal the bomber. Domino agrees to help but is discovered and tortured. Bond and allied divers attack Largo's underwater force as it moves a bomb into position. Domino escapes and saves Bond by killing Largo, while the coerced scientist Kotze turns against SPECTRE. The weapons are recovered and the ransom plot fails, but Blofeld remains free.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1797,7 +1797,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1810,7 +1810,7 @@
       "recaps": {
         "ending": "Endura, the Scythedom's floating capital, is destroyed and sinks, taking most of those aboard with it: the majority of the world's Grandslayers, the order's central authority, and Scythe Curie. Scythe Anastasia frees Rowan from the cell where he was being held for a public execution, and the two are trapped in the founders' vault as the island goes down. Unable to escape, they seal themselves in and drown together, reasoning that the sealed vault will preserve their bodies and that someone may one day raise it and bring them back; to the world they are simply dead. Goddard survives the disaster and takes MidMerica, with no World Scythe Council left to check him. Greyson Tolliver survives as well, and the Tonists who took him in are only more certain about what he is. Scythe Faraday and Munira Atrushi, far from any of it, reach the island the founders hid from the Thunderhead. The Thunderhead, having watched humanity permit everything that led here, brands the entire human race unsavory and stops speaking to every person on Earth, with a single exception: Greyson, the one human being it will still answer.",
         "in_short": "Some months after her ordainment, Scythe Anastasia gleans by letting her chosen subjects pick their own deaths a month in advance, while Rowan, calling himself Scythe Lucifer, kills corrupt scythes outside the law. The Thunderhead, forbidden to touch the Scythedom, recruits Greyson Tolliver, a lonely young man it raised itself, to work at the edges of that prohibition; the assignment costs Greyson his identity and the Thunderhead's voice, and leaves him adrift among the Tonists, who take him for a prophesied figure. Meanwhile Scythe Rand keeps Goddard's severed head alive and grafts it onto a new body, and Goddard returns to contest the leadership of MidMerica against Scythe Curie. The dispute is carried to Endura, the floating capital of the world's Grandslayers, where Anastasia brings charges against Goddard and Rowan is displayed as a condemned prisoner. Goddard's answer is to sink the island. Curie and most of the Grandslayers are lost, Anastasia and Rowan drown sealed in a vault in the hope of a future revival, Goddard takes power, and the Thunderhead declares all of humanity unsavory and falls silent to everyone but Greyson.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2066,7 +2066,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0CPFXHXYZ",
@@ -2078,7 +2078,7 @@
       "recaps": {
         "ending": "Jake defeats the frost giant after Jaxon, Havoc, Grandmaster Snow, Major Cleavage, Joe, and Novusheim's remaining defenders create the opening he needs. The town hall revives before the fight ends, so completion of wave one hundred makes Novusheim the first city on Jotunheim. Joe gains Ascendant Matrix and Haunting Shadows, but collapses during the upgrades.\n\nWhen he wakes, the Bivrost is close to carrying away the unclaimed dwarf and elf souls. Joe uses Ascendant Matrix to reduce the giant's remains into aspects and spends them through the Ledger of Souls, resurrecting every available soul. Nearly one hundred thousand dwarves are restored, including eligible elves returned in dwarven form. The Bivrost then tears away the Ritual of Slaughter and its recharge stations. Their destruction converts the cloud layer to steam, and Major Cleavage organizes a combined barrier that saves Novusheim from the resulting deluge.\n\nThe city survives with severe structural damage and a new hot-water lake around it. Grandmaster Snow offers Joe unrestricted training and city support, and Joe retains Razor Scarf's artifact core. The dwarf restoration is complete for the Ledger's entries, but reconstruction, safe ritual infrastructure, the Pyramid of Panacea obligation, and a stable route away from Jotunheim remain open.",
         "in_short": "Joe works to turn Novusheim into Jotunheim's first city, first improving its rituals, crafting, mana supply, ranged defenses, and magical infrastructure. The required one hundred monster waves escalate into a siege led by a legendary frost giant. Razor Scarf falls, but the giant manipulates the defenders, breaches the walls, and destroys the town hall. Jaxon sabotages it from within its ear, Havoc turns prepared monsters against it, Grandmaster Snow shields the city, Joe sustains the Ritual of Slaughter, and Jake finally dismembers and defeats it. The revived town hall lets Novusheim earn city status. Joe then converts the giant's remains into enough aspects to resurrect every soul in the city's Ledger, restoring nearly one hundred thousand dwarves. The departing Bivrost destroys the active ritual network and releases a vast hot-water flood, but Major Cleavage's coordinated barriers save the devastated city. Joe remains with new abilities, Snow's support, an artifact core, and major rebuilding and escape problems still unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2274,7 +2274,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2287,7 +2287,7 @@
       "recaps": {
         "ending": "Duarte's attempt to strike at the entities beyond the gates ends in catastrophe. The empire's most powerful warship is annihilated, and the counterstroke reaches the high consul himself: whatever he had made of his own mind is torn apart, leaving him present but hollowed out, unable to govern or to speak for himself. Admiral Trejo conceals his condition and rules in his name, because an empire built entirely on one man cannot survive the news. Cortázar, who had decided that Teresa's body was the most promising remaining source of data on her father's transformation, is killed before he can act on it. Teresa, having learned what her father is and what the state around him intends for her, escapes Laconia with the man she knew as Timothy, who is in fact Amos Burton, changed by whatever was done to him on that world and no longer entirely human. Holden gets out with them, and the Rocinante recovers all three. Bobbie Draper is dead, killed leading the underground's most dangerous operation. Naomi, out of her containers at last, is back with her crew. Laconia still rules and its fleet is still unbeatable by human means, but it is a state run by a deputy in the name of a ruined man, and the thing on the other side of the gates has now been provoked twice: ships continue to vanish in transit, and the moments when every human mind goes dark are getting longer.",
         "in_short": "Years into Laconian rule, Holden is a prisoner in the high consul's capital, Naomi runs the resistance alone from inside shipping containers, and Bobbie and Alex raid the empire from a captured destroyer. Winston Duarte, remaking himself with alien technology, sets out to make humanity strong enough to face whatever destroyed the builders of the ring gates, and conscripts the biologist Elvi Okoye to find out what that enemy is. Elvi's work leads her to the remains of the gate builders and to the conclusion that the enemy exists outside normal space and is provoked by the gates themselves. On Laconia, Duarte's isolated daughter Teresa befriends a stranger living in the woods, and slowly learns what her father has become and what his chief scientist intends to do with her. The underground's largest strike costs Bobbie her life. Then Duarte forces a confrontation with the entities and loses: his flagship is destroyed and his mind is shattered, leaving Admiral Trejo to rule in the name of a man who is no longer there. Teresa flees the planet with Amos Burton and Holden, and the attacks from beyond the gates keep getting worse.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2515,7 +2515,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2528,7 +2528,7 @@
       "recaps": {
         "ending": "Quox carries out Tititi-Hoochoo's judgment against Ruggedo, using the fairy gifts entrusted to him to overcome the Nome King. Kaliko becomes king and proves willing to release the Shaggy Man's brother from the metal forest. The rescued man is ashamed of the ugly face Ruggedo's enchantment gave him, but a kindly kiss breaks the spell and restores his natural appearance. Ruggedo loses his throne and, for the time being, abandons his hostility. Queen Ann's attempted conquest ends without an empire, while Private Files and Princess Ozga find happiness together. The travelers reach Oz, where Dorothy is delighted to meet Betsy. Ozma offers Betsy and Hank a permanent home, and they accept. Polychrome eventually returns to the rainbow, and the Shaggy Man is reunited with his brother in a country where both can live among friends.",
         "in_short": "Queen Ann leads the absurdly officer-heavy army of Oogaboo out to conquer the world. Elsewhere, shipwrecked Betsy Bobbin and her mule Hank join the Shaggy Man, Polychrome, and Tik-Tok on a mission to rescue the Shaggy Man's brother from Ruggedo, the Nome King. Ruggedo drops the travelers through the Hollow Tube to the far side of the world, where Tititi-Hoochoo sends the dragon Quox to punish him. Quox defeats Ruggedo, Kaliko becomes Nome King, and the prisoner is freed. A kiss removes the enchantment that made the Shaggy Man's brother hide his face. Queen Ann gains no empire, but her company reaches Oz safely. Betsy and Hank accept a home with Ozma, Polychrome returns to the rainbow, and the Shaggy Man's family is reunited.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2652,7 +2652,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2665,7 +2665,7 @@
       "recaps": {
         "ending": "Beyond the fabricated town, Ragle learns that the real date is in the late twentieth century and that Earth is fighting colonists based on the Moon. His newspaper puzzle has been a disguised military task: each predicted square identifies the next location the lunar forces will strike, allowing Earth's defenses to respond. Ragle once worked knowingly for the government but came to sympathize with the lunar side and tried to defect. After he was recaptured and retreated mentally into an earlier era, the authorities built the false 1959 community around him so that his predictive ability could still be used. Bill Black and many other supposed neighbors were personnel maintaining the deception. Exposure to the truth restores Ragle's earlier purpose. He rejects the managed life and the war effort built around his talent, and he again chooses to go to the Moon, seeing the colony as the place where human expansion can continue.",
         "in_short": "Ragle Gumm lives in a seemingly normal 1959 suburb with his sister Margo, her husband Vic, and their son Sammy, supporting himself by winning a newspaper prediction contest. Ordinary objects begin to vanish or disclose labels in place of themselves, old records hint at an unfamiliar culture, and every attempt to leave town is obstructed. Ragle and Vic gradually establish that the community is a controlled construction. Outside it, the year is actually in the late twentieth century and Earth is at war with lunar colonists. The contest is camouflage for Ragle's ability to predict missile strikes, and the false town was built after he rejected Earth's cause, tried to defect, and retreated psychologically into the past. Neighbors including Bill Black have been supervising him while the government continues using his answers. Once he recovers the truth, Ragle refuses the manufactured reality and renews his decision to join the Moon colony.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2852,7 +2852,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2865,7 +2865,7 @@
       "recaps": {
         "ending": "At the Guermantes reception, involuntary memories triggered by physical sensations reveal to the narrator how his book can recover experience from time. The aged guests then show him time's destructive force in bodily form. He understands that the people, errors, loves, snobberies, and disappointments of his life are not distractions from art but its necessary material. Social identities have been rearranged: Madame Verdurin has become the Princesse de Guermantes, Bloch is successful, and former outsiders mingle with an aristocracy stripped of its old permanence. Gilberte's daughter by the dead Robert de Saint-Loup unites Swann's family with the Guermantes and symbolically joins the two ways of the narrator's childhood. Conscious that illness may leave him too little time, he resolves to construct the work that will disclose lives extended through time as well as space. The novel closes before that work is written, but its plan is clear; the long sequence the reader has completed is the form of the book he now conceives.",
         "in_short": "After years of illness and apparent failure, the narrator revisits Tansonville, returns to wartime Paris, and finally attends a Guermantes reception after another long absence. Gilberte corrects several childhood memories and reveals that the supposedly separate ways of Swann and Guermantes meet. In Paris, the war exposes shifting fashions of patriotism and society, while Charlus's private life, humiliation, and decline unfold against aerial raids; Robert de Saint-Loup dies in military service. At the later reception, sensations caused by uneven paving stones, a spoon, and a stiff napkin unexpectedly restore past moments with an intensity ordinary memory cannot achieve. The narrator realizes that art can uncover the timeless structure within lived experience. The guests, radically aged and socially rearranged, provide the human material for his work. Gilberte's daughter joins the Swann and Guermantes lines. Fearing death may overtake him, the narrator resolves at last to write the book shaped from his whole life—the work the reader has effectively just finished.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3093,7 +3093,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3106,7 +3106,7 @@
       "recaps": {
         "ending": "The trap works. Tarr's signal from Paris forces the mole to warn Moscow, and Smiley, Guillam and Mendel are waiting at the Lock Gardens house when he comes to meet Polyakov. The mole is Bill Haydon. Recruited by Karla before the war and run by him ever since, Haydon fed the Circus's secrets to Moscow for decades while Witchcraft fed back the chickenfeed and half-truths that made him indispensable. He betrayed Prideaux and Operation Testify, destroyed Control, and had blown every network the Circus ran. Interrogated at Sarratt, he explains himself in terms of aesthetic and political contempt for a Britain in American service, and admits that his affair with Ann was arranged by Karla to cloud Smiley's judgement. It is agreed that he will be exchanged for agents held in the East. Before the exchange can take place he is killed at Sarratt at night, his neck broken; Jim Prideaux, who had loved him and whom he had sold, disappears back to the school. The Circus is left ruined and must be rebuilt from nothing, and Smiley, the last man untouched by it, is asked to take charge. Ann returns to him, and he knows the marriage is no more repaired than the service is.",
         "in_short": "George Smiley, forced into retirement when the Circus's old chief fell, is brought back secretly by the Cabinet Office after the field man Ricki Tarr reports what a Soviet defector told him: Moscow Centre has run a mole at the top of the British service for years. Control had suspected the same and had given his five candidates codenames from a nursery rhyme before sending Jim Prideaux into Czechoslovakia to identify the traitor. Prideaux was shot and captured, Control was destroyed, and Percy Alleline took over with a spectacular Soviet source, Merlin, whose Witchcraft material has made the Circus's reputation. Working outside the service with Guillam, Mendel and the retired researcher Connie Sachs, Smiley reconstructs the whole history and concludes that Witchcraft is Moscow's own creation: a channel to feed London selected material while the mole hands Karla everything the Circus has. Smiley uses Tarr to force the mole to break cover, and takes him at the safe house where he meets his Soviet controller. The traitor is Bill Haydon, the service's most admired officer and Ann's lover. Haydon is arrested and killed at Sarratt by Prideaux, and Smiley is left to rebuild the Circus.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3291,7 +3291,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3304,7 +3304,7 @@
       "recaps": {
         "ending": "Nancy uses the performance skills once shaped by Kitty and Diana in support of the socialist community she has joined, speaking successfully before a large public gathering. The event confirms that the stage no longer has to mean disguising herself for someone else's ambition or pleasure. Her place with Florence, Ralph, and Cyril is based on work, affection, and chosen solidarity. Kitty approaches Nancy and proposes that they resume their relationship in secret while Kitty preserves her respectable marriage and career. Nancy recognizes the old pattern and refuses. She instead declares her love for Florence, whose guardedness finally gives way to a mutual commitment. Nancy has not returned to the innocence of Whitstable or abandoned performance; she has brought her theatrical confidence into a life she chooses openly. The novel closes with Nancy and Florence together among friends and comrades, while Kitty remains tied to the compromise she selected with Walter.",
         "in_short": "Nancy Astley leaves her family's Whitstable oyster restaurant after falling in love with music-hall male impersonator Kitty Butler. She becomes Kitty's dresser, lover, and stage partner, but Kitty chooses respectability and marries their manager Walter. Heartbroken, Nan survives by performing masculinity on London's streets, then enters the luxurious household of Diana Lethaby, who treats her as a private spectacle. Cast out after defying Diana, Nan seeks Florence Banner, a socialist she once encountered, and is taken into Florence's home with her brother Ralph and the child Cyril. Domestic work and political organizing give Nan a community in which performance can serve a shared cause rather than concealment or possession. She and Florence fall in love. At a socialist rally Nan successfully takes the platform, then refuses Kitty's offer to restart a secret affair. She chooses an open future with Florence and a life joining love, work, politics, and her hard-won stage voice.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3492,7 +3492,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3505,7 +3505,7 @@
       "recaps": {
         "ending": "Lucius's Goth forces capture Aaron and his infant son. To preserve the child, Aaron admits his role in the crimes against the Andronicus family. Tamora and her sons visit Titus disguised as supernatural agents of revenge; Titus recognizes them, keeps Chiron and Demetrius behind, kills them, and has their remains baked into a pie. At the banquet he kills Lavinia, reveals what was served to Tamora, and kills the empress. Saturninus kills Titus, and Lucius immediately kills Saturninus. Marcus and Lucius explain the family's ordeal to the assembled Romans, who accept Lucius as emperor. Lucius orders honorable burial for Titus and Lavinia. Aaron is sentenced to be buried to the chest and starved, and Tamora's body is denied burial. Rome has a new ruler, but nearly every member of the rival families has been destroyed by the cycle of retaliation.",
         "in_short": "Titus Andronicus returns to Rome after defeating the Goths and sacrifices Tamora's eldest son. When Tamora becomes empress, she and her lover Aaron organize revenge. Her sons Chiron and Demetrius murder Lavinia's husband, rape and mutilate her, and frame Titus's sons, who are executed despite Titus sacrificing a hand in a false bargain. Lavinia eventually identifies her attackers. Lucius, banished from Rome, raises a Goth army, while Titus pretends to be mad and prepares retaliation. He kills Chiron and Demetrius and serves them to Tamora in a pie. At the final banquet Titus kills Lavinia and Tamora; Saturninus kills Titus; and Lucius kills Saturninus. The Romans choose Lucius as emperor. Aaron, after confessing to save his infant son, is condemned to starve, and Tamora is denied burial.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3797,7 +3797,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -3810,7 +3810,7 @@
       "recaps": {
         "ending": "Lucy carries Cal, Charlotte, Xavier, Micaiah, and Ariel toward the Dragon's Right Eye. Cal has reached iron through a vacuum crucible, and Ariel has begun forming a dark-Qi core. Charlotte is an iron cultivator whose integrated nanites can repair severe injuries, while Xavier's true seership remains a dangerous secret. Micaiah is a fugitive after Jeremiah Lee sent her away to prevent a memory search and purge; Jeremiah was arrested while covering her escape. Elder Berkowitz and Alice survive under sect care, Jack lives with a major leg injury, and Leela and Edwin are dead. Liara Fintz has settled her debt to the crew after suppressing Lesley's local nanite threat, though Lesley's ultimate fate is not confirmed. Maria Lopez is building a movement around the stargazer and expects the crew's arrival in three days. At the same time, Black Maw responds to related omens and permits ISH to search its territory for a missing soul ship, leaving Lucy's past and Cedric's fate exposed as continuing dangers.",
         "in_short": "On Ilirian, Caliban Rex, Charlotte Velereau, and Xavier search for cultivation materials and become indebted to the Arcadian gardener. Cal bonds the void beast Ariel and reaches bronze before the group enters a buried Sill city. Charlotte survives a nanite infection by advancing to iron, but the swarm Lesley captures her and Xavier. Cal joins Micaiah's trapped expedition, helps her reach bronze, and summons the gardener, later identified as Liara Fintz. Liara overwhelms the local swarm, while Micaiah kills nanite-controlled Edwin and an unexplained armored rider stops an escaping fragment. Leela dies and Jack is badly injured. After the rescue, Xavier's hidden seership is exposed within the crew. Jeremiah Lee helps Micaiah flee Dragon's Left Eye custody and is arrested. Cal then survives a vacuum crucible and becomes iron as Ariel starts forming a core. Lucy's enlarged crew heads for the Dragon's Right Eye, where Maria Lopez plans to exploit their arrival while Black Maw and ISH mobilize around the stargazer omens and a missing soul ship.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4193,7 +4193,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0CGF8X5J9",
@@ -4205,7 +4205,7 @@
       "recaps": {
         "ending": "Kale survives the closing of the Black Chasm and the Ritek leader's betrayal, but he does not return to his allies. After the Ritek leader is killed, Kale strikes down the goddess who tries to take his power. The goddess gives him her power and soul before sending him to Eder, where he is alive, injured, and cut off from Talona. Max, Kenna, Queen Bael, Cassie, LeCory, and the Ritek leader's daughter survive the known conflict, while King Bael dies defending Solakir. The daughter seeks peace, but a Ritek commander withdraws with more than two thousand troops and plans a future campaign. The dead leader's soul is retained for possible restoration, though a human researcher secretly damages that effort. Ember remains in the void with a possible path back to life that requires a death god's power. Talona's restored magic has also made the world detectable beyond its former barrier, leaving an external incursion as a new threat.",
         "in_short": "Kale searches for damaged wellsprings while Queen Bael gathers an army and Solakir comes under attack. King Bael dies defending the fortress, and Queen Bael takes control of the Dead Forge. As the Ritek cross the Black Chasm, Kale restores more of Talona's magic and forces their leader into a truce. Together they close the chasm, but the Ritek secretly retain dangerous gray power stones and their leader betrays him. A goddess kills the Ritek leader, then tries to take Kale's power. Kale strikes her with Treach's white blade, receives her power and soul, and is sent to Eder alive but stranded. The Ritek leader's daughter seeks peace, while a surviving commander prepares for renewed conflict. Ember, trapped in the void, is offered a possible return to life, and the dead Ritek leader becomes the subject of a compromised resurrection effort as Talona faces a new threat from beyond its former barrier.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/to-flail-against-infinity.json
+++ b/data/works-community/0/to-flail-against-infinity.json
@@ -262,7 +262,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-24",
@@ -275,7 +275,7 @@
       "recaps": {
         "ending": "After Caliban defeats Bao Long by disqualification, he finds Nick in void-induced psychosis beside a mortally wounded custodian. Caliban kills Nick in immediate defense and receives the two altered apple seeds that prove Nick's experiment succeeded. Firion then moves to arrest Caliban. Arthur and Mindy help him evade the enforcers, while Charlotte and Xavier knowingly abandon their sect positions to escape with him. Maria Lopez blocks their route to Lucy and attacks, but Caliban fills the area with dark Qi, prevents Lopez from replenishing her power, and forms a protective shell. Contact with his Qi exposes Lopez to the Infinite Sea and breaks her resistance. Caliban spares her, and the three fugitives leave Firion aboard Lucy. They are injured but alive and head toward the system's habitable world to seek natural treasures needed for bronze focuses. Caliban plants Nick's seeds and permits himself to grieve. Lopez plans to seek him through the wider Dragon's Right Eye, Martha Vesper begins a path of vengeance, and the mysteries of the Infinite Sea and the coordinated void-horde attack remain open.",
         "in_short": "Cal survives the massacre at Rufi after an encounter with the void gives him undetectable Qi. Rescued by the sentient ship Lucy, he joins Dragon's Right Eye on Firion and secretly advances while elders, instructors, and compulsory duels threaten his place. He builds friendships with Charlotte, Xavier, Nick, and Arthur, saves children during a suspicious void-horde attack, and forms tin and then copper cores through the Infinite Sea. After defeating Bao Long, Cal kills Nick during Nick's void-induced psychosis and becomes the target of an arrest shaped by Maria Lopez's false vampirism theory. Arthur and Mindy help him flee, and Charlotte and Xavier choose exile beside him. The three survive Lopez's attack when Cal develops a dark defensive shell and overwhelms her with the Infinite Sea. Lucy carries them away toward the system's habitable world to seek bronze focuses. Lopez survives with a transformed belief in Cal, while Nick's sister Martha vows revenge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -424,7 +424,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -437,7 +437,7 @@
       "recaps": {
         "ending": "The Cuban gunmen seize Harry's boat after their Key West bank robbery and kill Albert Tracy during the escape. At sea, Harry uses a concealed weapon to turn on the fugitives, killing them before they can dispose of him, but he is badly wounded in the exchange. The drifting boat is found and brought in with Harry barely alive. He reaches the conclusion that an isolated man cannot prevail against the economic and social forces closing around him, then dies of his wounds. Marie is left to absorb both the loss of her husband and the collapse of the hard, intimate life they built together. Around their tragedy, the wealthy people aboard nearby yachts continue with their betrayals and private unhappiness. Richard Gordon's marriage is breaking apart as Helen recognizes his vanity and cruelty. The ending joins the Morgans' material desperation to the emptiness of the prosperous lives around them: Harry's last voyage is over, his family has paid its price, and the larger divisions that trapped him remain unchanged.",
         "in_short": "Key West boat captain Harry Morgan is cheated by a wealthy fishing client in Havana and turns to smuggling to recover the money needed by his family. He first accepts a job involving Chinese migrants, kills the intermediary he distrusts, and returns the passengers to Cuba rather than delivering them into exploitation. A later liquor run ends in gunfire, the loss of his arm, and confiscation of his boat. Unable to support his wife Marie and their daughters through legal work, Harry takes one last charter from Cuban revolutionaries who rob a Key West bank. They kill his helper Albert Tracy, but Harry ambushes the gunmen at sea and kills them, receiving fatal wounds himself. His death leaves Marie alone. Interwoven scenes among rich residents and yacht owners, especially the failing marriage of novelist Richard Gordon and his wife Helen, show that wealth insulates people from Harry's dangers without giving them loyalty or contentment.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -779,7 +779,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09L57RX2K",
@@ -791,7 +791,7 @@
       "recaps": {
         "ending": "Lucky awakens as the sole controller of the converted assassin body. Cas no longer exists independently, having turned its own matrix into the permanent bridge that makes Lucky's recovery possible and removes Seven. Lucky loses several capabilities of the prototype body and still needs physical repairs, but he is mobile, increasingly confident, and back with Omega Force. Combat Unit 707 is also recovering and plans to spend time with Scout Team Obsidian after repairs. Seleste leaves by a prepared escape route while remaining a possible intelligence contact. She warns Jason that the Viper may still execute Crisstof Dalton's contract against Kellea Colleren. Scleesz remains under Kellea's protection and involved with the emerging government, while Saditava Mok continues building an alliance around the former leadership. The Machine is still dormant rather than destroyed. Back at Omega Force's home base, Seven's retained mission files give Jason leads on warlords who terrorize civilians, suggesting a new direction for the team.",
         "in_short": "Omega Force hunts Seven, the assassin personality dominating Lucky's prototype body, while a synth conspiracy tries to obtain the body and its production data. The crew extracts Scleesz, protects Kellea Colleren from an assassination threat, and follows a staged hostage message to a mining planet. Lucky briefly retakes control during the rescue. Omega Force recovers the captive engineer, then finds Lucky and Combat Unit 707 after they suffer severe damage. Desiree subsequently kills the synth conspirator. Cas then gives up its separate existence to bridge Lucky's mind to compatible systems, permanently eliminating Seven. Omega Force returns home with Lucky recovering and Seven's intelligence on predatory warlords. Seleste departs, 707 plans time with Scout Team Obsidian, and the contracts against Kellea remain unresolved. The rebuilding government and the dormant Machine also remain part of the wider conflict.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -943,7 +943,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -956,7 +956,7 @@
       "recaps": {
         "ending": "Tom Robinson is convicted despite Atticus's clear proof of his innocence, and he is shot dead while attempting to escape from prison, a casualty of the town's racism. Bob Ewell, though he technically won the case, feels shamed by Atticus's exposure of him in court and vows revenge. On Halloween night he attacks Scout and Jem as they walk home from a school pageant, breaking Jem's arm. Boo Radley, the reclusive neighbor the children had long feared and mythologized, comes out of his house and saves them, killing Ewell with a kitchen knife in the fight. Sheriff Heck Tate, unwilling to drag the intensely private Boo into a public trial and grateful for what he did, insists that Bob Ewell fell on his own knife, and Atticus accepts it. Scout meets Boo at last, walks him back to his house, and stands on his porch imagining the years he watched the neighborhood and quietly looked after them. She goes home understanding, as Atticus taught her, that you never really know a person until you consider things from their point of view. Jem's arm heals, and the family endures, changed by what it has witnessed.",
         "in_short": "In Depression-era Maycomb, Alabama, young Scout Finch, her brother Jem, and their friend Dill spend their summers fascinated by Boo Radley, a recluse rumored to haunt the house down the street. Their father, the lawyer Atticus Finch, is appointed to defend Tom Robinson, a Black man falsely accused of raping a white woman, Mayella Ewell. At the trial Atticus proves Tom could not have done it and exposes Mayella's father, Bob Ewell, as the likely abuser, but the prejudiced jury convicts Tom anyway, and he is later shot trying to escape prison. Humiliated, Bob Ewell seeks revenge and attacks Scout and Jem on Halloween night, breaking Jem's arm. Boo Radley emerges from his house to save the children, killing Ewell in the struggle. The sheriff quietly covers it up to protect Boo, and Scout, walking her rescuer home, at last sees the value of understanding others from their own point of view.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1114,7 +1114,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1127,7 +1127,7 @@
       "recaps": {
         "ending": "After Fengxia dies giving birth, Jiazhen's long illness also ends in death. Erxi raises Kugen with Fugui's help until a construction accident kills him, leaving the old man and child together. Kugen then dies after eating too many beans while desperately hungry. Fugui has outlived his parents, wife, children, son-in-law, grandson, and the many political campaigns that shaped their lives. Years later he saves an aging ox from slaughter and names it Fugui. When the traveling narrator meets them, the old man works beside the animal and calls out the names of his dead family as though a whole team were sharing the labor. He does not claim that his losses have been redeemed. What remains is his capacity to continue living, carrying the memory of each person without surrendering his attachment to ordinary work and the passing day.",
         "in_short": "An elderly peasant named Fugui tells a traveler how he once gambled away his wealthy family's estate. Reduced to poverty with his loyal wife Jiazhen and their children Fengxia and Youqing, he is conscripted during the Chinese Civil War and returns to find that survival has spared him from being condemned as a landlord. Political campaigns and material scarcity reshape village life, while disaster repeatedly enters his household: Youqing dies after a hospital takes too much of his blood, Fugui's former army companion Chunsheng is persecuted, and Fengxia dies giving birth to her son Kugen. Jiazhen, Fengxia's husband Erxi, and finally Kugen also die, each loss leaving Fugui with fewer companions. In old age he rescues an ox bound for slaughter, gives it his own name, and works the fields beside it. His story ends without restoring what was lost; its resolution is that he remains able to remember, labor, and live.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1305,7 +1305,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1318,7 +1318,7 @@
       "recaps": {
         "ending": "Mr Ramsay finally makes the long-delayed trip to the lighthouse with James and Cam. The children begin the crossing in silent opposition to their demanding father, but James handles the boat skillfully and receives rare, direct praise from him. That recognition softens the old hostility without erasing it, and the boat reaches the lighthouse, whose ordinary solid form differs from James's childhood image while remaining connected to it. At the summer house, Lily Briscoe continues the painting she began years earlier. Memories of Mrs Ramsay and reflections on love, grief, and the limits of knowing another person accompany her work. As she sees the boat arrive in the distance, she makes the decisive final adjustment to the composition and understands the picture as complete. The two arrivals—at the lighthouse and at the resolution of Lily's painting—close the novel's parallel searches for connection and form after the family's losses.",
         "in_short": "At the Ramsays' summer house on the Isle of Skye, young James longs to visit the lighthouse, but his parents' opposed forecasts turn the proposed trip into a focus for the family's affections and resentments. Mrs Ramsay tends children and guests, tries to create social harmony, and brings everyone together at dinner, while Lily Briscoe struggles to give form to her painting and to defend her life as an artist. Years pass through war and neglect: Mrs Ramsay dies, two of the Ramsay children also die, and the empty house decays before being restored. When the survivors return, Mr Ramsay at last sails to the lighthouse with James and Cam. James earns his father's praise as they arrive. On shore, Lily revisits her memories of Mrs Ramsay and completes the painting she began before the losses, finding a visual resolution that answers the voyage without simplifying the past.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1492,7 +1492,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1505,7 +1505,7 @@
       "recaps": {
         "ending": "In *The Death of Ivan Ilyich*, Ivan's prolonged resistance ends when his son kisses his hand and he recognizes the suffering his fear and anger impose on his family. Compassion replaces the demand to justify his past. He experiences death not as the darkness he dreaded but as a release into light, and dies after inwardly letting go of fear.\n\nIn *Master and Man*, Vasili's attempt to save himself alone brings him back to the stranded sledge. Finding Nikita near death, he lies over the servant and uses his own body to keep him warm. For the first time, Vasili experiences another person's life as more important than profit or self-preservation. He dies in the storm, while rescuers recover Nikita alive the next day; Mukhorty has frozen. Nikita lives for many more years and eventually meets his own death calmly. The paired stories therefore close with two privileged men confronting mortality, one after a long inward struggle and the other through a final act of care.",
         "in_short": "This volume pairs two Tolstoy novellas about mortality. In *The Death of Ivan Ilyich*, a successful judge suffers an apparently minor injury that becomes a fatal illness. Doctors and relatives preserve polite appearances while Ivan faces pain, isolation, and the possibility that his orderly, socially approved life has been false. The servant Gerasim offers honest care, and Ivan finally responds to his son's compassion by releasing his fear and dying at peace. In *Master and Man*, merchant Vasili Brekhunov and his underpaid servant Nikita become lost in a blizzard while traveling to complete a land deal. Vasili first tries to escape alone, but circles back to the sledge. He then shelters the freezing Nikita with his own body and dies saving him. Nikita is rescued and lives many more years. Together, the stories contrast social self-interest with the clarity that arrives when care for another person displaces fear of death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1731,7 +1731,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1744,7 +1744,7 @@
       "recaps": {
         "ending": "The case against Tom collapses when Fitzpatrick proves to be alive and admits that he initiated their fight. Mrs Waters is identified as Jenny Jones, but she reveals that she is not Tom's mother: Bridget Allworthy was his mother, and his father was a young man named Summer. Lawyer Dowling, Square, Mrs Miller, and Nightingale supply evidence showing how Blifil suppressed Bridget's message, distorted Tom's conduct, and worked to keep Allworthy hostile to him. Allworthy recognizes Tom as his nephew and heir, forgives him, and expels Blifil, though Tom later secures a modest allowance for his half-brother. Sophia still condemns Tom's sexual inconstancy and does not surrender immediately, but his repentance and changed circumstances finally persuade her. She and Tom marry with both fathers' approval and settle in the country, where their marriage and children provide the stable happiness that Tom's earlier impulses endangered. Squire Western remains exuberantly involved, while the friends who aided Tom are rewarded or reconciled.",
         "in_short": "Squire Allworthy raises the foundling Tom Jones beside his legitimate nephew Blifil. Tom is generous but sexually and socially reckless; Blifil is outwardly virtuous and privately calculating. Tom and neighboring heiress Sophia Western fall in love, but her father orders her to marry Blifil. Blifil turns Allworthy against Tom, who is expelled and wanders toward London while Sophia runs away from the forced match. Their paths repeatedly cross, but Tom's affairs with Mrs Waters and Lady Bellaston deepen Sophia's distrust. In London, Blifil and his allies help place Tom in prison after a duel, and Tom briefly fears that Mrs Waters was his mother. The final disclosures reverse everything: Mrs Waters is Jenny Jones but not Tom's mother; Tom is Bridget Allworthy's son and therefore Allworthy's nephew; Fitzpatrick survived the duel; and Blifil concealed evidence and slandered Tom. Allworthy restores Tom, Sophia accepts his repentance, and they marry. Blifil is disgraced but receives a small allowance through Tom's mercy.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1925,7 +1925,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1938,7 +1938,7 @@
       "recaps": {
         "ending": "The case against Tom weakens when Fitzpatrick survives their fight. More importantly, the false account of Tom's character collapses. Allworthy learns that Blifil suppressed evidence, distorted Tom's generosity, and encouraged his banishment. Mrs Waters identifies herself as Jenny Jones and reveals that Tom's mother was Allworthy's late sister Bridget, making Tom Allworthy's nephew rather than an unrelated foundling. Blifil loses his expected inheritance and is sent away, though Tom asks that he receive financial support. The change in Tom's fortune does not automatically win Sophia: she requires evidence that he understands the pain caused by his infidelity and rashness. Once convinced of his sincere reform, she forgives him. Tom and Sophia marry with the families reconciled. Allworthy recognizes that moral worth was found in the imperfect young man he expelled, while conventional respectability had concealed Blifil's selfishness.",
         "in_short": "Squire Allworthy raises the abandoned Tom Jones beside his heir, Blifil. Tom grows into a warmhearted but impulsive young man and loves neighboring Sophia Western; the outwardly dutiful Blifil wants both Sophia and the combined inheritance. By exaggerating Tom's faults, Blifil gets him expelled, while Sophia flees her father's attempt to force her into marrying Blifil. Tom and Sophia travel separately toward London, repeatedly missing each other as Tom's generosity and infidelity produce fresh complications. In London, Lady Bellaston keeps the lovers apart, and a fight sends Tom to prison. The evidence against him then unravels. Jenny Jones reveals that Tom's mother was Allworthy's sister Bridget, making him Allworthy's nephew, and Blifil is exposed for concealing the truth and manipulating his uncle. Tom is restored, but Sophia accepts him only after he demonstrates repentance. They marry, and Allworthy's household is reordered around proven character rather than respectable appearance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2259,7 +2259,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -2272,7 +2272,7 @@
       "recaps": {
         "ending": "Derek and Silvi break Malcolm Torith's fleeing force. Malcolm discloses that Gerald Torith arranged child trafficking through subordinate houses, violates his oath by speaking, and is killed by Derek. Captain Herrett survives, is released from House Torith's coercive bindings, and adopts the name Jacks. Clay receives the first sentence in Derek's new Time Prison, while the assassins Bones and Ogre are later captured and imprisoned for a year each. Gerald remains alive, politically protected, and difficult to accuse without independent evidence. Expecting retaliation, Derek evacuates Rayna, Brandi, Malorie, Rudy, Thomas, Silvi, and Stella. Thomas remains committed to supervised training, while Brandi's abilities and the proposed multitrade enterprise still require protection. Richard and Delilah stay in their village. Walter Gracefall continues to provide support, and Alanah remains a confidential Crown ally despite the political limits on acting against Gerald. The travelers conceal Silvi and use Wilmette's scheduled teleportation circle to reach Savannah, where Derek hopes to secure his companions and establish their planned business.",
         "in_short": "In Torith, Derek Hunt builds alliances with House Gracefall and the Crown Restaurant, gains gold rank in the Adventurer's Guild, and arranges both coffee royalties and valuable void-beast sales. Silvi begins culinary training while Thomas is targeted by Clay Torith and Alicia for his equipment. Derek spares Clay but warns his father, City Lord Malcolm Torith, against retaliation. Malcolm nevertheless has Brandi and Malorie abducted, nearly kills Rayna, and relies on a corrupt overseer whom Derek executes. Derek reaches level 100, gains Time Prison, and pursues Malcolm's fleeing house. Silvi shatters its force, Malcolm reveals Gerald Torith's concealed child-trafficking system, and Derek kills him. Captain Herrett becomes the freed Jacks, while Clay and two later assassins are imprisoned. With Gerald still protected and dangerous, Derek moves his companions through Wilmette to Savannah, while Richard and Delilah remain in their village and plans continue for a secure multitrade enterprise.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2443,7 +2443,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2456,7 +2456,7 @@
       "recaps": {
         "ending": "Danny grows oppressed by the house and by his friends' settled dependence on him. He abandons the household for a period of drinking, theft, and destructive freedom. His friends eventually recover him and arrange an enormous party, financing it by selling what they can take from the house. For a time Danny appears restored to his old vitality, but during the celebration he runs outside, challenges the world, and falls into a ravine. He dies from the injuries. At his military funeral, the friends stand apart because they lack proper clothes, then grieve at his grave. They return to the house but cannot imagine inheriting it collectively or allowing any one of them to replace Danny as owner. Pilon sets fire to the building, and the friends watch the home burn in a final tribute that also prevents it from becoming a divisive possession. When the fire is over, Pilon, Pablo, Jesus Maria, the Pirate, and Big Joe walk away separately. The fellowship organized around Danny and his house ends with him.",
         "in_short": "After World War I, Danny returns to Monterey's Tortilla Flat and unexpectedly inherits two houses. His friends Pilon, Pablo, and Jesus Maria become tenants through promises of rent that repeatedly turn into wine, and an accidental fire leaves them all living in Danny's remaining house. The Pirate and his dogs join them; the friends protect the money he has saved for a golden candlestick promised to Saint Francis and help fulfill the vow. Big Joe also enters the household, whose members steal, quarrel, share food, and repeatedly rally around neighbors in distress. Their improvised community values loyalty more than property, but ownership increasingly weighs on Danny. He disappears into a violent spree, and his friends bring him back for a great party. Danny falls into a ravine and dies. After his funeral, the men burn the house rather than let it pass to a new owner or divide them. With neither Danny nor the shared home to hold them together, the surviving friends depart one by one.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2897,7 +2897,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0D8LHNG4P",
@@ -2909,7 +2909,7 @@
       "recaps": {
         "ending": "Hal, Noth, Mira, Ashera, Elora, and the restored dwarf survive the Tower of Blight's collapse by reaching one of the Mana Tree's passages, but emerge in an unfamiliar underground crystal network with no known route to Brightsong. The restored dwarf gains ancient royal armor, Noth a relic scythe, Elora a relic bow, and Mira a relic spear. Hal's tarnished crown becomes the Crown of the Bright King. His rewards also include a blight-heart fragment and fifty construction seals, completing the materials for the first stage of the Dawn Citadel. At Brightsong, the cleansed tower disappears. Hermes, the two allied dragons, and the remaining defenders must face twelve converging tribal forces without Hal's final party. Val's promised core restoration remains incomplete, Besal's expedition has recovered only one of an unknown number of memory-files, the missing coblin sister has not returned, and Merkmire's rebellion and assassin conflict remain unresolved.",
         "in_short": "Hal leaves Brightsong seeking answers in the Abyss, only to carry a corrupted captured tower home. It erupts into the Tower of Blight, trapping the settlement in a race to clear its shifting floors before the corruption spreads. Hal organizes expeditions, develops anti-blight equipment, and commits resources to a future citadel and the restoration of Val's missing core. When the tower attacks the Mana Tree through Hal's own bonds, he reverses the connection, heals the Tree, gains a tin-rank core, and helps Brightsong weaken the tower from outside. Hal, Noth, Mira, Ashera, Elora, and the restored dwarf make the final ascent and destroy the last blight core. The collapsing tower displaces them into an unknown underground network, where most claim relics and Hal gains the Crown of the Bright King. The tower vanishes from Brightsong, but twelve tribal forces arrive while Hal's party remains missing.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3147,7 +3147,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3160,7 +3160,7 @@
       "recaps": {
         "ending": "Chaol is healed. The Valg residue is burned out of his spine and he walks again, and he and Yrene Towers marry before they leave Antica. Yrene destroys the demon that has been riding the princess Duva, saving her and her unborn child, which finally convinces the khagan that the northern war is already inside his own household; he commits his armies, and Hasar's fleet, to sailing for Terrasen. Sartaq brings the rukhin, and he and Nesryn ride north together as partners in every sense. The alliance Chaol was sent to beg for is won, and it is far larger than anything Dorian dared ask. More than that, they carry two pieces of knowledge north with them: that a healer's magic can unmake a Valg demon outright, which no army has ever been able to do, and that the Valg reached this world long before the war a thousand years ago, and that their queens were as real as their kings. Yrene also carries something she has not told Chaol. They sail for a continent that has, in the months they were gone, gone very badly wrong, and neither of them yet knows what has happened to Aelin, to Dorian, or to Terrasen.",
         "in_short": "Chaol Westfall and Nesryn Faliq sail to Antica in the southern continent to beg an army from the khagan and to find a healer for Chaol's broken spine. Chaol is assigned to Yrene Towers, a refugee from Adarlan's conquests who despises everything he represents, and their sessions turn up something worse than an injury: a Valg residue left in the wound, which fights back. Healing it forces Chaol through his own history and slowly gives him back his legs, and it turns Yrene's hostility into partnership and then love. Nesryn goes south with Prince Sartaq to the ruk riders of the mountains, where the clans' oldest stories and the monstrous spiders of the Dagul Fens reveal that the Valg have been in the southern continent for thousands of years. Court politics stall the alliance until a demon hidden inside the khagan's own daughter is exposed and destroyed by Yrene's magic, proving the danger is already inside the palace. The khagan commits his armies and fleet, Sartaq brings the rukhin, Chaol and Yrene marry, and they all turn north for a war whose state they cannot guess.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3330,7 +3330,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3343,7 +3343,7 @@
       "recaps": {
         "ending": "Towers of Midnight ends on the threshold of the Last Battle. Moiraine Damodred, believed dead since she vanished into the twisted Tower of Ghenjei, is rescued by Mat, Thom, and Noal, at the cost of Mat's eye and Noal's life; her return restores a guide Rand has long needed. Perrin Aybara has embraced his bond with the wolves, killed the assassin Slayer in the dream, forged a weapon worthy of the Last Battle, and joined his army to the Whitecloaks under Galad. Egwene has broken the Forsaken Mesaana and pressed her hunt for the Shadow's servants. Rand, serene and sure at last, has declared his intent to shatter the remaining seals on the Dark One's prison and confront him directly, and has called every ruler to the Field of Merrilor to decide how the world will fight, and be governed, in the days to come. With Lan's borderland army riding for Tarwin's Gap and the nations converging, everything is in place for Tarmon Gai'don to begin.",
         "in_short": "With Rand transformed and the Last Battle set, the champions ready themselves. Perrin Aybara, hunted by the Children of the Light for old killings, finally faces trial, but in the world of dreams he masters his wolf-given gifts, forges a mighty hammer, and slays his shadowy hunter, Slayer; his forces and the Whitecloaks under Galad become allies. Mat Cauthon, with Thom Merrilin and the old traveler Noal, braves the Tower of Ghenjei and the treacherous folk within to rescue Moiraine Damodred, the Aes Sedai lost since Cairhien years before; they free her, but Mat pays with one of his eyes and Noal dies to save them. Egwene, now Amyrlin of a reunited Tower, hunts the Black Ajah with a dead sister's list and destroys the Forsaken Mesaana in the dream world. Elayne extends Andor's power toward Cairhien. Rand walks the land radiating calm strength, announces that he means to break the ancient seals and meet the Dark One at Shayol Ghul, and summons the rulers to the Field of Merrilor, while Lan gathers an army riding for the Blight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3469,7 +3469,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3482,7 +3482,7 @@
       "recaps": {
         "ending": "Sikh militants plan to kill the Muslim refugees leaving for Pakistan by stretching a rope across the railway bridge, knocking people from the train roof while gunmen wait below. Hukum Chand realizes that Nooran is probably aboard and orders Juggut Singh and Iqbal released, hoping one of them will prevent the attack without openly involving the authorities. Iqbal remains in the gurdwara, trapped in argument about whether a sacrifice has meaning if nobody knows who made it. Jugga instead goes to the bridge. As the train approaches, he climbs the structure and cuts at the rope. The conspirators shoot him, but he continues until the final strands break. The rope falls before the crowded carriages reach it, and the train passes safely into Pakistan. Jugga dies saving the refugees, including, unknowingly, Nooran and their unborn child. The novel closes on the train's escape rather than on public recognition of his act.",
         "in_short": "In 1947, the border village of Mano Majra has long been shared peacefully by Sikhs and Muslims. A gang murders the Hindu moneylender Ram Lal, and police arrest both the local Sikh troublemaker Juggut Singh and Iqbal, an educated political visitor, though neither committed the crime. Partition then arrives in the form of a train filled with murdered Sikh and Hindu refugees. Fear and retaliation replace the village's old routines, and Mano Majra's Muslims, including Jugga's pregnant lover Nooran, are taken to a camp for removal to Pakistan. Sikh militants plan to massacre their departing train at a bridge. Magistrate Hukum Chand releases Jugga and Iqbal in hope of stopping them. Iqbal remains immobilized by doubts about meaningful political action. Jugga climbs onto the bridge under fire and cuts the rope intended to sweep passengers from the train roof. He is killed, but the train crosses safely, carrying Nooran and the other refugees to Pakistan.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3826,7 +3826,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3839,7 +3839,7 @@
       "recaps": {
         "ending": "John defeats the dragon's soul within his mind and binds it into his shadow, where it can no longer act independently or take his body. His completed human-form adaptation preserves his physical gifts while replacing dragon flame with restorative pure mana. He returns to a valley defense near collapse, heals the exhausted fighters, and empowers the Shadow Tower nature spirit to raise root guardians and a living barrier for an orderly retreat. Ellie recovers her lightning, and Katrine is back among the defenders despite her unresolved injuries. The Beast Army remains outside the barrier, while Gora and Ferdie continue an inconclusive giant-form duel. Other hidden portal stones may still enable attacks, and the Cabal's surviving master remains a threat. The apocalypse total has fallen to six of ten, but each reduction has moved the final day closer. With the war still active, John publicly proposes to Ellie and she accepts.",
         "in_short": "John passes through the First Mage's Door to rescue Katrine, infiltrates the Cabal of the Broken Gate, and destroys much of its invasion network before returning home with his mana sealed. As the Beast Army advances, he becomes Shadow Tower Master and pursues a bodily adaptation that can hold his power without surrendering his humanity. He kills two enemy generals, is captured by Gora, and is rescued by a permanently transformed Ellie, Ferdie, and Sigvald. John then confronts the dragon soul seeking his body, defeats it, and binds it as his powerless shadow. His new pure-mana power restores the collapsing valley defense and enables a retreat behind a living barrier. Katrine returns to fight despite lasting injuries, while Ferdie and Gora remain locked in battle and the wider invasion continues. John closes the book by proposing to Ellie, who accepts.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4016,7 +4016,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4029,7 +4029,7 @@
       "recaps": {
         "ending": "Granuaile completes the binding that makes her a full Druid, giving her direct access to the earth's power and ending the apprenticeship that began in Tempe. She, Atticus, and Oberon survive the converging attacks that followed their emergence from hiding. Atticus confronts Bacchus and kills him, ending the wine god's immediate campaign but creating a new Olympian grievance. Artemis and Diana take up the matter as a personal offense and prepare to hunt both Druids. The Norse crisis is also unresolved: killing Thor did not erase Atticus's debt, and Loki remains free to exploit divisions among pantheons. Atticus and Granuaile leave the conflict as partners with comparable Druidic abilities, but they have no secure refuge and must face the hunt already forming around them.",
         "in_short": "After years in hiding, Atticus O'Sullivan brings Granuaile MacTiernan's apprenticeship to its final stage while the consequences of killing Thor continue to spread. Loki is free, relations with the Irish gods remain strained, and emerging from concealment allows old enemies to locate the Druids. Granuaile must be bound to the earth before attacks by hostile supernatural powers stop the process. She succeeds and becomes a full Druid, then begins using her new abilities alongside Atticus rather than behind him. Their most immediate enemy is Bacchus, who seeks revenge for the destruction of his followers in Arizona and drives a series of attacks meant to trap them. Atticus ultimately kills Bacchus, but the victory does not end the Olympian danger: Artemis and Diana answer the death by turning their hunt toward Atticus, Granuaile, and Oberon. The trio survives with Granuaile's training complete, yet remains caught between the unfinished Norse crisis and a new divine pursuit.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4221,7 +4221,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4234,7 +4234,7 @@
       "recaps": {
         "ending": "Stephen protects Laura Fielding by turning the pressure on her into a channel for controlled information, and Charles Fielding eventually escapes French custody and is reunited with his wife. The reunion ends the immediate blackmail against Laura, although the strain of captivity and the appearance of her closeness to Stephen leave private damage to repair. Surprise's apparently secret eastern operation has failed to catch its intended French objective because advance knowledge reached the enemy. Stephen recognizes that British plans are being betrayed from within the Malta establishment but does not yet identify the central source. The reader is shown that Andrew Wray, assisted by Ledward and connected with Lesueur's French network, has been passing information while retaining official trust. Jack receives orders for another distant mission, to pursue the American frigate Norfolk into the Pacific. Surprise prepares to sail with Jack unaware that hostile intelligence has again seen supposedly secret orders, while Stephen carries forward both the counterintelligence problem and his unresolved separation from Diana.",
         "in_short": "At Malta, Stephen Maturin befriends Laura Fielding, whose husband is a French prisoner. The French agent Lesueur uses Charles Fielding's captivity to pressure Laura for British information, but Stephen recognizes the coercion and turns her into a means of feeding the enemy selected material. Jack Aubrey meanwhile takes Surprise on secret service whose movements repeatedly encounter an enemy prepared in advance. An eastern expedition fails to secure its intended French target because its orders have leaked. Laura's husband escapes and returns to Malta, ending the immediate leverage against her but creating painful misunderstandings about her friendship with Stephen. Stephen concludes that a highly placed British source is betraying operations, yet he does not discover that Andrew Wray, working with Ledward and Lesueur, is central to the leak. Jack is ordered to pursue USS Norfolk into the Pacific, setting Surprise on another long voyage while the traitors retain access and Stephen's marriage to Diana remains unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4416,7 +4416,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4429,7 +4429,7 @@
       "recaps": {
         "ending": "Ben Gunn has already found Flint's treasure and moved it from the empty pit to his cave, allowing Livesey's party to turn the pirates' hunt into an ambush. Silver abandons the mutineers and again places himself under the protection of Jim's friends. The surviving loyal party loads the treasure aboard the Hispaniola and leaves three mutineers on the island with supplies. During the voyage home, Silver escapes at a port with a small bag of coins. Jim, Livesey, Trelawney, Smollett, Gray, and Ben Gunn return safely and receive shares suited to their parts in the expedition. Gunn soon spends his fortune, Gray uses his reward to improve his position, and Smollett retires from the sea. Jim remains haunted by the island and has no desire to search for the silver still left there.",
         "in_short": "Jim Hawkins discovers a treasure map among the possessions of Billy Bones, an old sailor pursued by former members of Captain Flint's pirate crew. Doctor Livesey and Squire Trelawney equip the Hispaniola to seek the hoard, but their one-legged cook, Long John Silver, secretly leads much of the crew in mutiny. Jim overhears the plot, warns the loyal party, and meets the marooned Ben Gunn after reaching Treasure Island. The honest sailors defend an old stockade while Jim slips away, cuts the ship loose, and retakes it from the mutineers. Returning to the stockade, he falls into pirate hands, but Silver protects him while trying to preserve his own position. The treasure pit proves empty because Gunn had moved Flint's hoard to his cave. Livesey's party defeats the remaining pirates, takes the treasure, and sails home. Silver escapes during the return voyage with a small portion of the money, while Jim returns safely but remains troubled by memories of the island.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4618,7 +4618,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4631,7 +4631,7 @@
       "recaps": {
         "ending": "Ben Gunn has already found Flint's treasure and moved it from the empty pit to his cave, allowing Livesey's party to turn the pirates' hunt into an ambush. Silver abandons the mutineers and again places himself under the protection of Jim's friends. The surviving loyal party loads the treasure aboard the Hispaniola and leaves three mutineers on the island with supplies. During the voyage home, Silver escapes at a port with a small bag of coins. Jim, Livesey, Trelawney, Smollett, Gray, and Ben Gunn return safely and receive shares suited to their parts in the expedition. Gunn soon spends his fortune, Gray uses his reward to improve his position, and Smollett retires from the sea. Jim remains haunted by the island and has no desire to search for the silver still left there.",
         "in_short": "Jim Hawkins discovers a treasure map among the possessions of Billy Bones, an old sailor pursued by former members of Captain Flint's pirate crew. Doctor Livesey and Squire Trelawney equip the Hispaniola to seek the hoard, but their one-legged cook, Long John Silver, secretly leads much of the crew in mutiny. Jim overhears the plot, warns the loyal party, and meets the marooned Ben Gunn after reaching Treasure Island. The honest sailors defend an old stockade while Jim slips away, cuts the ship loose, and retakes it from the mutineers. Returning to the stockade, he falls into pirate hands, but Silver protects him while trying to preserve his own position. The treasure pit proves empty because Gunn had moved Flint's hoard to his cave. Livesey's party defeats the remaining pirates, takes the treasure, and sails home. Silver escapes during the return voyage with a small portion of the money, while Jim returns safely but remains troubled by memories of the island.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4778,7 +4778,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4791,7 +4791,7 @@
       "recaps": {
         "ending": "Trent eventually tells Mabel that his suppressed report accused John Marlowe of killing Manderson and suspected that she had been connected to the motive. Mabel rejects the theory and makes clear that Trent misunderstood her feelings. Marlowe then supplies a different explanation: Manderson, wrongly convinced that Marlowe and Mabel loved each other, arranged an elaborate suicide intended to leave Marlowe apparently guilty of murder. The suspicious changes of clothes, movements, and timings were elements of that frame. Even this confession is not the final truth. Cupples reveals that he encountered Manderson during the scheme, struggled with him, and fired the shot that killed him. The death was therefore neither Marlowe's murder nor Manderson's completed suicide, although Manderson created nearly all the evidence that misled the inquiry. Trent and Mabel are free to acknowledge their feelings, but Trent is humbled by the collapse of his confident solution and declares himself finished with detection.",
         "in_short": "Artist and amateur detective Philip Trent investigates the shooting of American financier Sigsbee Manderson at his English home. Oddities in Manderson's clothing, household routine, and last movements lead Trent to construct a detailed case against the private secretary John Marlowe, with a suspected attachment between Marlowe and Manderson's widow Mabel as motive. Because Trent has fallen in love with Mabel, he withholds the theory from publication. When he later explains it, Mabel shows that its emotional premise is false. Marlowe reveals that Manderson, jealous and vindictive, staged evidence so that his own planned suicide would look like Marlowe's crime. Then Mabel's uncle Cupples discloses the last reversal: he encountered Manderson during the plot and killed him in a struggle. Trent's ingenious solution has mistaken a manufactured trail for reality, and he abandons detective work while gaining hope of a future with Mabel.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/trials-of-cydaria.json
+++ b/data/works-community/0/trials-of-cydaria.json
@@ -451,7 +451,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -464,7 +464,7 @@
       "recaps": {
         "ending": "Gerald Torith is executed after his records expose the domestic conspiracy, although his supposed foreign connection is never established. King Edwin intends to abdicate when Edgar returns, with Edward succeeding him and Edgar taking command of the armies. That transition has not happened when Indria and Asteris invade Cydaria through forbidden portals. Alana begins evacuations, while Osian's brother Riven commands the attackers. Inside the raid dungeon, the expedition has cleared an uncommon survival trial and a legendary dragonkin trial, but more sequential trials remain under the 168-day limit. Avery and Edgar leave the legendary trial with Lyra and Blitz, Jasper contracts a darkness drake, and Tyron bonds Rocky while arranging to forge Derek a void-attuned glaive. Savannah's household continues its business and crafting work through The Void Emporium. At level 200, Derek chooses a Void path beyond his local system's supported limits and becomes the mythical Void Monarch. He refuses to sever his bond with Silvi, causing both of them to enter linked evolutions whose duration and outcome remain unknown.",
         "in_short": "After Gerald Torith's capture, Derek helps stabilize his Savannah household, profits from the Crown auction, and accepts Edgar's invitation to a level-250 raid. Gerald's information exposes a domestic conspiracy, and King Edwin executes him, but Indria and Asteris invade Cydaria while much of its elite force is trapped in the dungeon. The raid uses Derek's Time Prison as a secure, accelerated base, survives an uncommon beast-tide trial, and clears a legendary dragonkin battle. Avery bonds Lyra, Edgar bonds Blitz, and Tyron prepares to forge Derek a weapon from wyvern materials. Meanwhile, Brandi advances mana-core weapons and Malorie, Rudy, Roman, and Natalie establish The Void Emporium's new business. At level 200, Derek rejects safer class paths and chooses Void, becoming the mythical Void Monarch. His transformation also pulls Silvi into an evolution in Savannah, leaving both companions' condition unresolved as the invasion and remaining dungeon trials continue.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -593,7 +593,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -606,7 +606,7 @@
       "recaps": {
         "ending": "Atticus, Granuaile, Oberon, Frank Chischilly, and their allies defeat the skinwalkers preying on the area around Coyote's project. The victory protects the local community, but it also confirms that Coyote shaped the crisis and Atticus's involvement to serve purposes he had not disclosed when asking for help. Atticus survives the trick without recovering the secure Arizona life he once had. The staged death has bought him uncertainty in the eyes of some pursuers, not permanent safety, and the Norse consequences remain active. Loki is free because of the disruption connected to the assault on Asgard, and his appearance confirms that the threat is no longer limited to gods seeking revenge for Thor. Atticus therefore keeps Granuaile and Oberon on the move and continues the apprenticeship away from Tempe, carrying responsibility both for the danger he helped release and for preparing the next Druid to survive it.",
         "in_short": "After helping kill Thor, Atticus is hunted by Norse powers and can no longer trust his old routes through the Fae. With the Morrigan's help, he stages evidence of his death and takes Granuaile and Oberon into hiding. Coyote offers a place to disappear in exchange for help with a project on Navajo land. The assignment becomes a hunt for skinwalkers who are murdering people in the area. Atticus works with Navajo medicine man Frank Chischilly, whose local and spiritual knowledge is essential, while Granuaile takes a more active role despite not yet being a full Druid. They defeat the skinwalkers and protect the community, but Atticus learns that Coyote arranged events around a larger concealed purpose. His false death provides only temporary cover. Loki, freed in the upheaval connected to Asgard, is now loose, so Atticus remains on the move with Granuaile and Oberon as the danger of a wider Norse conflict grows.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1014,7 +1014,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002V8MTO4",
@@ -1026,7 +1026,7 @@
       "recaps": {
         "ending": "Reacher enters Cayman Corporate Trust while Allen believes he is still hours away, kills the armed operatives blocking the rescue, and confronts the lender holding Jodie as a shield. He establishes that the man called Hook Hobie is Carl Allen, the prisoner transported on Victor Hobie's final flight. Allen survived the crash, switched dog tags with Victor, and built a new life under the dead pilot's identity. When Allen fires, Jodie moves clear and Reacher kills him, then collapses with a nail lodged in his forehead and a bullet wound to his chest. Reacher wakes after three weeks in St. Vincent's. The bullet failed to penetrate deeply, and the nail caused no apparent lasting impairment. Jodie, Curry, Chester, Marilyn, and Sheryl survive. General Meade secures Reacher's discretion in exchange for restoring Victor's public record and memorial recognition. Tom and Mary Hobie are told that Victor died honorably. Reacher accepts Leon Garber's Garrison house, leaves the hospital with Jodie, and plans to recover there with her. The later ownership of Stone Optical remains unresolved.",
         "in_short": "Living anonymously in Key West, former Army investigator Jack Reacher is drawn into the murder of Costello, a detective hired by Reacher's late mentor Leon Garber. Garber's daughter Jodie joins Reacher in pursuing the fate of missing Vietnam pilot Victor Hobie. The supposed evidence that Victor is a prisoner proves fraudulent, but military records show that someone survived his helicopter crash. Meanwhile, the scarred lender Hook Hobie terrorizes Chester and Marilyn Stone to seize their company, taking Jodie and others hostage at Cayman Corporate Trust. Reacher discovers that Hook Hobie is really Carl Allen, a transported prisoner who survived the crash and stole the dead Victor's identity. Reacher infiltrates the office and exposes Allen. When Allen fires, Jodie moves her head clear, and Reacher kills him. Reacher survives a bullet and a nail wound, the Army agrees to restore Victor's honor, and Victor's parents finally learn that their son died in the crash. Jodie stays through Reacher's recovery and leaves the hospital with him for Garber's house in Garrison.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1263,7 +1263,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1276,7 +1276,7 @@
       "recaps": {
         "ending": "During the fighting, Troilus pursues Diomedes while Hector continues seeking honorable opponents. Hector corners a richly armored Greek, kills him, and pauses to take the armor. Achilles then finds Hector isolated and has his Myrmidons surround and kill him, afterward claiming the victory and dragging Hector's body behind his horse. Troilus returns to Troy with the news and urges the Trojans to turn grief into revenge. His love for Cressida has already collapsed after he saw her yield to Diomedes, and Hector, Troy's chief defender, is dead. Pandarus closes the play sick and rejected by Troilus, addressing the audience with the bitterness of a failed intermediary. The war continues without reconciliation, leaving both the romance and the heroic ideals surrounding the conflict discredited.",
         "in_short": "During the Trojan War, Prince Troilus loves Cressida and uses her uncle Pandarus to arrange a meeting. They pledge fidelity, but almost immediately the Greeks trade a Trojan prisoner for Cressida, whose father has defected to their camp. Troilus and Cressida are forced apart. Meanwhile, Greek commanders try to lure Achilles back into battle by praising Ajax, who fights Hector in a courteous, inconclusive duel. In the Greek camp, Cressida is isolated and courted by Diomedes. Troilus secretly watches her give Diomedes a token that Troilus had given her and concludes that she has betrayed him. Battle resumes. Hector ignores warnings and goes out to fight; after pausing over an opponent's armor, he is surrounded and killed by Achilles's Myrmidons. Troilus reports the loss to Troy and calls for vengeance. Neither the love story nor the war reaches a just resolution, and Pandarus ends abandoned and embittered.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1425,7 +1425,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1438,7 +1438,7 @@
       "recaps": {
         "ending": "Criseyde does not return to Troy after the promised ten days. In the Greek camp she gradually accepts Diomede's courtship and gives him a token that Troilus recognizes as his own former gift. Troilus finally knows that she has abandoned their bond, though he directs much of his anger toward Diomede and continues to preserve his memory of her. Criseyde foresees that later generations will condemn her for inconstancy. Troilus throws himself into battle and kills many Greeks while trying unsuccessfully to reach Diomede. He is eventually slain by Achilles. His spirit rises above the world, sees the smallness of earthly ambitions, and looks back on the love that once consumed him as part of a transient life. The narrator closes by turning from pagan love toward Christian divine love, asks correction where the poem has erred, and commends the work to John Gower and Ralph Strode.",
         "in_short": "During the siege of Troy, Prince Troilus falls in love with Criseyde, the widowed daughter of the defector Calchas. His friend Pandarus, Criseyde's uncle, becomes their go-between, using letters and engineered meetings to bring them into a secret affair. Their happiness depends on privacy and Criseyde's precarious place in Troy. When Calchas persuades the Greeks to exchange the captured Trojan Antenor for his daughter, Criseyde must leave. She promises Troilus that she will return within ten days, but in the Greek camp Diomede courts her and she eventually accepts him. Troilus waits, doubts prophetic warnings, and finally recognizes a token he had given Criseyde in Diomede's possession. He fights with new fury and is later killed by Achilles. His spirit rises beyond the world and understands the insignificance of the earthly passion that governed him. The poem ends by redirecting attention from unstable human love to divine permanence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1721,7 +1721,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B072YT17GJ",
@@ -1733,7 +1733,7 @@
       "recaps": {
         "ending": "Perkins, Colter, Czajka, Jarrett, Striebich, Bonsu, and Nert all survive Tavalen's destruction and the tsunami. Their improvised overload eliminates the projector before 39 Commando can use it against the Ruhar transports, and their remotely piloted Buzzard destroys the commandos' concealed dropship. Baturnah Logellia, now acting Chief Administrator, credits the team with saving 40,000 Ruhar. She preserves the unit for infantry training and possible service with Ruhar security forces or Fleet Marines, and approves Nert's request to remain its liaison. UNEF's relocation to southern Lemuria still proceeds, but at a slower pace and with greater human control of transport and cargo operations.\n\nThe Glory fools Captain Rastall's pursuit with a decoy. After the island operation fails, its captain destroys the ship's computer records and surrenders under the ceasefire while concealing the frigate's activity. The Keeper exodus remains unresolved: Eric Koblenz and thousands of others are held in harsh Kristang transport conditions, and Eric is alarmed when they descend toward an unidentified planet. Emby's identity, the suspected sabotage of Perkins's equipment, and the consequences of future contact with Earth also remain unsettled.",
         "in_short": "On Paradise, Keeper loyalists aid the departing Kristang while UNEF shifts from neutrality to cooperation with the Ruhar. Major Emily Perkins and her six-person team receive one last projector assignment with young Ruhar liaison Nert Dandurf. Hidden Kristang commandos attack them on Tavalen Island, planning to turn its projector against transports carrying nearly 40,000 Ruhar. Stranded and unarmed, the team destroys the commandos' dropship and overloads the projector, sacrificing most of the island. Everyone on the team survives the resulting tsunami. Their success improves UNEF's standing: Perkins keeps the unit together for Ruhar infantry training, Nert remains its liaison, and humans gain new transport privileges, although relocation continues. The Kristang frigate supporting the operation evades a Ruhar pursuit with a decoy, erases its records, and surrenders. More than 5,000 Keepers leave under Kristang control, ending with Eric Koblenz descending toward an unknown world and fearing their decision.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1882,7 +1882,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1895,7 +1895,7 @@
       "recaps": {
         "ending": "After Mattie shoots Tom Chaney, the recoil knocks her into a deep pit where she breaks an arm and is bitten by a rattlesnake. Rooster gets her out and races Little Blackie toward medical help. The pony runs until his strength is gone and dies; Rooster then carries Mattie until they meet assistance. Treatment saves her life but not her injured arm, which is amputated. Rooster leaves before she recovers, and LaBoeuf returns to Texas after surviving his wounds. Mattie never sees the ranger again. Twenty-five years later, the unmarried Mattie learns that Rooster is appearing in a traveling Wild West show and goes to meet him, only to find that he died a few days before her arrival. She has his body moved to her family cemetery in Arkansas. Looking back as a successful banker, she remains proud of the hard journey and of the marshal she hired, while the graves beside him remain available for her and the family members who will eventually join them.",
         "in_short": "Fourteen-year-old Mattie Ross travels to Fort Smith after hired hand Tom Chaney murders her father and flees into Indian Territory. She recovers money from horse trader Colonel Stonehill and hires the hard-drinking, one-eyed marshal Rooster Cogburn to bring Chaney back. Texas Ranger LaBoeuf joins the hunt because Chaney is wanted in Texas. Mattie forces the two men to accept her on the expedition, and the three track Chaney to outlaw Lucky Ned Pepper's gang. Mattie finds Chaney and shoots him, but is captured before Rooster confronts the gang. LaBoeuf helps defeat Pepper, and Mattie shoots Chaney again, killing him, before falling into a snake pit. Rooster rescues her and rides Little Blackie to death seeking a doctor. Mattie survives but loses an arm. Decades later she goes to see Rooster in a Wild West show, arrives just after his death, and brings his body home for burial in her family plot.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2137,7 +2137,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2150,7 +2150,7 @@
       "recaps": {
         "ending": "Stevie proves that Hayes Major's death was not an accident. The dry ice had been carried into the tunnel and left there long before the shoot, so the air was already unbreathable when he went in alone, and the person who put it there was Element \"Ellie\" Walker: she had written the online serial Hayes was famous for and had never been paid or credited for it. Confronted in front of the house, Ellie runs, gets through a concealed opening into the passages beneath the campus, and is not found. Stevie also learns that David Eastman is the son of Senator Edward King, the politician her own parents work for, which ends the fragile thing between them. Her parents then remove her from Ellingham and take her home to Pittsburgh with the historical case untouched. The 1936 chapters close the past as far as the record went: the anarchist Anton Vorachek is convicted of the crime and shot dead on the courthouse steps, Alice is never recovered, and in October 1938 Albert Ellingham is killed when his boat explodes on the lake below the school, leaving behind a riddle and a fortune promised to whoever finds his daughter.",
         "in_short": "Stevie Bell, a sixteen-year-old obsessed with unsolved crime, wins a place at Ellingham Academy, a free Vermont school built by the tycoon Albert Ellingham, by proposing to solve the case that made it famous: the April 1936 kidnapping of Ellingham's wife Iris and their daughter Alice, and the killing of a student, Dottie Epstein, shortly after a taunting riddle signed \"Truly, Devious\" arrived. Alternating chapters follow 1936 as the crime unfolds. In the present, Stevie helps her housemate Hayes Major film an episode of his online zombie serial in the tunnel under the campus, and Hayes is found dead there, suffocated by carbon dioxide from the dry ice used for fog. Refusing to accept an accident, Stevie discovers that Hayes had not written the show he was famous for and pieces together that the dry ice was placed deliberately. She names her housemate Element \"Ellie\" Walker, who flees underground and vanishes. Stevie also learns that her friend David is the son of the senator her parents work for, and her parents pull her out of the school.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2328,7 +2328,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2341,7 +2341,7 @@
       "recaps": {
         "ending": "Bosch establishes that Tony Aliso's death was staged to resemble a Las Vegas mob execution and that the decisive motive lay in Aliso's own household and the money he had concealed. Veronica Aliso is exposed as responsible for the scheme against her husband rather than the innocent widow the staging was meant to suggest. The investigation also clears up the apparent case against Luke Goshen: he is FBI agent Roy Lindell, working undercover against Joey Marks, and Bosch's homicide inquiry had collided with a protected federal operation. Marks's criminal network remains the subject of the federal case, but it did not provide the simple answer initially assumed for Tony's murder. Bosch closes the homicide after surviving the final effort to preserve its cover story. Away from the case, he and Eleanor Wish decide that their renewed relationship is not temporary. They marry in Las Vegas, giving Bosch an unexpectedly hopeful personal future as he returns to Los Angeles police work.",
         "in_short": "Back on the LAPD after suspension, Harry Bosch leads Jerry Edgar and Kiz Rider in investigating film producer Tony Aliso, found shot in the trunk of his Rolls-Royce. The scene suggests a mob execution, and Aliso's hidden role moving Las Vegas money makes Joey Marks and enforcer Luke Goshen obvious targets. Bosch follows the case to Nevada, where he unexpectedly reunites with Eleanor Wish, now out of prison and playing poker. The apparent mob solution becomes unstable when Goshen proves to be undercover FBI agent Roy Lindell and the federal operation conflicts with Bosch's murder inquiry. Bosch returns to Aliso's finances and marriage, ultimately proving that the mob-style scene concealed a domestic conspiracy and that widow Veronica Aliso was responsible for her husband's death. The homicide is solved, the federal case against Marks survives, and Bosch's reconciliation with Eleanor becomes permanent when they marry in Las Vegas.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2493,7 +2493,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2506,7 +2506,7 @@
       "recaps": {
         "ending": "Mae is jailed and faces execution if the man in the yellow suit dies, a prospect that could expose the Tucks' inability to die. Winnie takes Mae's place in the cell while Miles removes the barred window, allowing Mae to escape before dawn. Jesse has given Winnie a bottle of spring water and asked her to drink it when she is seventeen, but Winnie pours it over the threatened toad instead. Many decades later, Mae and Angus return to a greatly changed Treegap and find Winnie's grave. The inscription shows that she married and lived a long, ordinary life before dying. Angus grieves but is also glad that she chose the natural course he had described. As the Tucks leave, they unknowingly pass the same toad, now protected from a car by Angus, suggesting that Winnie's single use of the water had lasting effect.",
         "in_short": "Ten-year-old Winnie Foster leaves her confining home and finds Jesse Tuck beside a hidden spring. Jesse and his family drank from it long ago and have not aged since. They take Winnie to their cottage so Angus Tuck can explain that endless life has left them outside nature's cycle. A man in a yellow suit, who has followed them, obtains the Foster wood in exchange for revealing Winnie's location and plans to sell the water. Mae strikes him while defending Winnie and is arrested after he later dies. Because a hanging would reveal Mae's immortality, Winnie helps the Tucks break her out by taking her place in jail. Jesse leaves Winnie spring water so she can join him when older, but she pours it on a toad. Years later, the Tucks find that Winnie lived, married, and died without drinking it, choosing a mortal life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2657,7 +2657,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2668,7 +2668,7 @@
       "recaps": {
         "ending": "Morgan, dying of his wounds after the battle on the island, publicly confesses to LaFortier's murder - a crime he did not commit - so that the White Council can present a closed case to its enemies and so that Luccio, whose hands were used for the killing while her mind was Peabody's puppet, is never blamed. He dies with his name blackened and only a handful of people knowing he was innocent, and Harry, who spent the whole book trying to clear him, has to let the lie stand for the Council's sake. Peabody, the real traitor, is dead, but the evidence he leaves behind proves the Black Council is real and has been quietly editing the minds of young Wardens for years, and there is no way to know how deep the rot goes. Cristos, whom Harry suspects of being either a traitor or a dupe, is elevated to the Senior Council. Luccio learns her feelings for Harry were among the things Peabody nudged, and the relationship ends. Thomas survives his captivity, but what the skinwalker did to him - starving him and forcing him to feed savagely to survive - has stripped away his hard-won restraint; he pulls away from Harry, colder and more openly a predator than before. Harry keeps two secrets of his own: his sanctum bond with Demonreach, whose true nature he has barely begun to glimpse, and the knowledge that the Council's greatest threat is already inside its walls.",
         "in_short": "Donald Morgan, the Warden who spent years hoping to catch Harry Dresden breaking the Laws of Magic, turns up half-dead at Harry's door - a fugitive accused of murdering Senior Council member Aleron LaFortier. Convinced the real killer is a traitor inside the White Council, Harry hides Morgan and investigates, dodging a bounty-fueled manhunt, a mercenary summoner named Binder, White Court schemers, and a skinwalker - a monstrous naagloshii that captures Thomas and tortures him. To control the endgame Harry performs a ritual on the island of Demonreach, binding himself to its genius loci as its sanctum, and lures every faction there: the trade for Thomas, the Wardens, the White Court, and the traitor. The traitor proves to be Peabody, the Council's mild-seeming secretary, who has been subtly mind-controlling young Wardens with alchemical inks and who used Luccio as his instrument to kill LaFortier. The skinwalker is driven off by Listens-to-Wind, Peabody dies fleeing, and Morgan - mortally wounded shielding others - falsely confesses to the murder as he dies, protecting Luccio and the Council's unity. Harry's relationship with Luccio ends, Thomas emerges from captivity changed and distant, and the Black Council is no longer a theory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2807,7 +2807,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2820,7 +2820,7 @@
       "recaps": {
         "ending": "Flora becomes feverish and violently rejects the governess after the confrontation at the lake. Mrs Grose, disturbed by the child's newly coarse language, takes her away from Bly. The governess remains alone with Miles and presses him to explain his expulsion and the disappearance of a letter she wrote to his uncle. Miles admits taking the letter and says that he was expelled for saying things to selected schoolmates, who then repeated them. During this questioning the governess again sees Peter Quint at the window. She holds Miles and challenges the apparition while trying to make the boy acknowledge it. Miles cries out Quint's name and calls him a devil; the figure vanishes. The governess believes she has freed Miles, but immediately discovers that his heart has stopped in her arms. The manuscript ends there. It does not independently establish whether the apparitions were supernatural beings corrupting the children or perceptions shaped by the governess's fear and desire to protect them.",
         "in_short": "An inexperienced governess takes charge of the orphaned Miles and Flora at the remote estate of Bly, where their uncle has ordered her never to contact him. Miles has mysteriously been expelled from school. The governess begins seeing a strange man and a black-clad woman, whom the housekeeper Mrs Grose identifies as the dead servants Peter Quint and Miss Jessel. Convinced that the apparitions seek the children and that the children secretly welcome them, she turns their care into a campaign of rescue. Flora denies seeing Miss Jessel and is taken away ill after the governess confronts her at the lake. Left with Miles, the governess forces him to discuss his expulsion and a stolen letter while Quint appears at the window. Miles names Quint, then dies in her arms. The story preserves uncertainty about whether the ghosts are real or whether the governess's interpretation helped create the catastrophe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2996,7 +2996,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3009,7 +3009,7 @@
       "recaps": {
         "ending": "The arrival of both twins finally resolves the mistaken identities. Viola and Sebastian recognize each other, and Viola confirms that she can prove her true identity once the captain holding her clothes is found. Orsino accepts that Olivia has married Sebastian rather than Cesario and turns his affection toward Viola, asking her to become his wife. Olivia welcomes Viola as a sister. Sir Toby has married Maria in reward for her part in the trick on Malvolio, while Sir Andrew has been beaten and humiliated. Fabian explains how the forged letter led Malvolio to behave strangely and how the household confined and mocked him. Olivia orders that amends be made, but Malvolio leaves promising revenge on everyone involved. Antonio is no longer treated as a madman once Sebastian confirms their history. The play closes with two intended or completed marriages, but Feste's final song and Malvolio's anger leave a sober edge beneath the festivities.",
         "in_short": "After a shipwreck separates Viola from her twin Sebastian, she disguises herself as a young man, Cesario, and serves Duke Orsino. Orsino sends her to woo the mourning Olivia, but Viola loves Orsino while Olivia falls for Cesario. Meanwhile, Olivia's uncle Sir Toby and his companions punish the proud steward Malvolio with a forged letter that convinces him Olivia loves him; his bizarre behavior leads to his confinement as a supposed madman. Sebastian, also alive, enters Illyria with the devoted Antonio. Because he looks exactly like Cesario, strangers challenge, embrace, or marry him under a mistaken identity, and he accepts Olivia's sudden love. When the twins finally appear together, the confusion ends. Olivia remains married to Sebastian, Orsino asks Viola to marry him, and Sir Toby marries Maria. Malvolio learns that he was deceived and departs vowing revenge, leaving the comic reconciliation deliberately incomplete.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3169,7 +3169,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3182,7 +3182,7 @@
       "recaps": {
         "ending": "The final defenses of the guilty verdict collapse under scrutiny. The older eyewitness's account is weakened by the realization that she likely was not wearing her glasses when she claimed to see the killing through passing train cars. Juror 10's openly prejudiced argument causes the others to turn away from him, separating bias from evidence. Juror 4, previously the most disciplined supporter of conviction, accepts that the eyewitness problem creates reasonable doubt. Juror 3 remains alone. His insistence that the accused must be punished finally breaks into grief over his estranged son, exposing the personal anger driving his certainty. He tears the photograph he carries, then changes his vote to not guilty. The jury returns a unanimous acquittal. The play does not establish what truly happened; its resolution is the jurors' recognition that the prosecution did not prove guilt beyond a reasonable doubt. Juror 8 helps the shaken Juror 3 with his coat before leaving. Outside the courthouse, Jurors 8 and 9 exchange names and part, their brief civility contrasting with the anonymity and conflict of the jury room.",
         "in_short": "Twelve jurors deliberate the murder case of a teenager accused of stabbing his father. Eleven initially vote guilty; Juror 8 votes not guilty because a death sentence requires more than a hurried acceptance of the prosecution's story. He reconstructs the timeline, produces a knife identical to the supposedly unique weapon, and leads the group through problems in the witnesses' testimony. Jurors draw on their different experience of old age, poverty, knife use, public transport, and eyesight, while impatience, class prejudice, and private pain repeatedly distort the discussion. The vote shifts as claims that once seemed conclusive become uncertain. An elderly witness could not have reached his door as quickly as he said, the stab wound was probably not made in the manner proposed, and a woman who reported seeing the attack likely lacked her glasses. Juror 3, projecting anger about his estranged son onto the defendant, is the last holdout. He finally breaks down and votes not guilty, producing a unanimous acquittal based on reasonable doubt rather than proof of innocence.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3646,7 +3646,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0FC2Q4M6N",
@@ -3658,7 +3658,7 @@
       "recaps": {
         "ending": "Harry restores Thomas by separating his Hunger, sustaining both halves, and persuading the Hunger to preserve its host. Mab captures Justine and intends to remove the possessing spirit, although the treatment and its memories must be hidden from her. Mother Summer delivers Thomas and Justine's son, whom Mab places with Etri's family to settle the Svartal blood debt. The child is protected, but separated from his parents. The castle then survives a coordinated assault by Malvora, ghouls, Renfields, and the Black Court. Carlos destroys Cleo, Mavra escapes, and no defender dies. Months later, the repaired castle passes inspection. Harry and Lara remain engaged and begin controlled energy transfers while quietly resisting Mab's leverage. Harry lives with Maggie, continues training Fitz, and reconnects with Thomas. He releases Murphy's shade and manages the battle's anniversary without withdrawing from the living. Dracul and Mavra remain the central strategic threat, and Harry's allies establish an intelligence network to track them.",
         "in_short": "During the year after the Battle of Chicago, Harry Dresden struggles with Karrin Murphy's death while sheltering survivors, raising Maggie, training Fitz, and obeying Mab's command to court Lara Raith. His efforts to protect Chicago draw him into conflicts with ghouls, anti-supernatural activists, the White Council, and retaliating practitioners. Harry and Lara learn that he can separate and magically feed a White Court Hunger, but Mab manipulates this into leverage over Lara. Harry spends Mab's promised boon on Thomas, Justine, their child, and the Svartal debt. The rescue saves Thomas and recovers Justine, but their newborn son goes to Etri's family as settlement. A Black Court coalition then assaults Harry's castle. The defenders defeat the attackers, Carlos Ramirez destroys Cleo, and Mavra escapes. By the following anniversary, Harry is rebuilding his life with Maggie and Fitz, has renewed contact with Thomas, and remains engaged to Lara while preparing for the continuing threat from Dracul and Mavra.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3856,7 +3856,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3869,7 +3869,7 @@
       "recaps": {
         "ending": "Edward Scrog's imitation of Ranger is exposed as the structure behind the case. He killed Carmen, abducted Julie, and used Ranger's identity to build a fantasy in which he could replace Ranger and claim the people associated with him. Scrog also takes Stephanie, intending to force her into the role he has assigned her. Stephanie protects Julie and resists him long enough for the search to reach their hiding place. Scrog is killed in the final confrontation, and Stephanie and Julie are recovered alive. Julie returns to Rachel, Ranger is cleared of the murder and kidnapping suspicions created by the impersonation, and the immediate threat to his family ends. The crisis gives Stephanie a clearer view of Ranger's history and loyalties without making him less private or turning their connection into a conventional relationship. Morelli remains Stephanie's partner and police ally, Ranger remains personally and professionally close to her, and the competition between the two men is unresolved as the book closes.",
         "in_short": "A woman calling herself Carmen Manoso confronts Stephanie and claims to be Ranger's wife. Soon afterward Carmen is murdered, Ranger's daughter Julie is abducted, and evidence makes Ranger appear connected to both crimes. Ranger goes outside official channels to find Julie while Morelli works the police investigation and Stephanie becomes the link both men use. The search reveals an impersonator who has studied Ranger and built a false identity around him. Edward Scrog killed Carmen and kidnapped Julie as part of a fantasy in which he could take Ranger's place and assemble Ranger's family and relationships for himself. Scrog captures Stephanie as well, but she keeps Julie alive and helps delay him until Ranger and Morelli close in. Scrog is killed, Julie is rescued and reunited with her mother Rachel, and Ranger is cleared. Stephanie learns more about Ranger's hidden family life, but neither that intimacy nor Morelli's support resolves the triangle between them.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4009,7 +4009,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4022,7 +4022,7 @@
       "recaps": {
         "ending": "After the polar ordeal, Nemo becomes increasingly withdrawn and the Nautilus turns north through the Atlantic. The crew fights giant squid, losing one sailor, and Nemo later uses the submarine to destroy a pursuing warship. Aronnax sees that the attack is deliberate and connected to Nemo's still-unexplained history; the captain mourns before portraits of his lost family. Horrified and unable to justify remaining for scientific discovery, Aronnax agrees to Ned's escape plan. As the three prisoners launch the Nautilus's boat near Norway, the submarine is caught in the Moskenstraumen whirlpool. Aronnax loses consciousness and awakens with Conseil and Ned in the care of fishermen on the Lofoten Islands. They survive, but do not know whether the Nautilus and its crew escaped the vortex. Aronnax returns able to publish the record of their undersea journey, while Nemo's identity, ultimate fate, and moral reckoning remain unresolved within this book.",
         "in_short": "Naturalist Pierre Aronnax joins the frigate Abraham Lincoln in pursuit of a supposed sea monster, accompanied by Conseil and harpooner Ned Land. The object is actually the Nautilus, an advanced submarine commanded by the enigmatic Nemo. Taken aboard and forbidden to leave, the three cross the oceans while Aronnax studies an unprecedented marine world. They walk on the seabed, visit coral forests and ruins, pass through a hidden route beneath Suez, see Nemo aid a pearl diver, and reach the South Pole under the ice. Ned repeatedly seeks escape, while Aronnax's fascination delays him. Nemo's compassion toward the oppressed contrasts with secrecy, grief, and a deliberate attack that sinks a warship. Aronnax, Conseil, and Ned finally flee in the submarine's boat as the Nautilus enters a Norwegian whirlpool. They are rescued, but the fate of Nemo and his vessel remains unknown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4231,7 +4231,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4244,7 +4244,7 @@
       "recaps": {
         "ending": "After escaping the attempt to destroy them at sea, the four friends return to a France still divided by the Fronde. D'Artagnan and Porthos fall into Mazarin's power, escape confinement, and reunite with Athos and Aramis. They reverse their position by capturing Mazarin and compelling him to negotiate. The settlement secures concessions and pardons while also satisfying the friends' personal claims: Porthos obtains the barony he has long wanted, and D'Artagnan receives the advancement repeatedly denied him. In the final danger they act together to protect the royal party, proving that their opposing political allegiances have not broken their fellowship. With the immediate crisis resolved, Athos returns to Raoul, Aramis to his church and political connections, and Porthos to his estate, while D'Artagnan remains in royal service. Charles I is dead, his son remains dispossessed, and the four friends part again in a changed Europe, reconciled but following separate lives.",
         "in_short": "Twenty years after their first adventures, D'Artagnan remains in royal service while Athos has retired, Porthos has become a wealthy landowner, and Aramis is an abbé. Cardinal Mazarin recruits D'Artagnan during the Fronde; only Porthos joins him, while Athos and Aramis support Mazarin's opponents and help the Duke of Beaufort escape. The friends later divide again over England's civil war, but all four unite in an effort to save Charles I. Mordaunt, Milady's vengeful son, helps defeat them and personally carries out the king's execution. During their escape he attempts to destroy them with an explosive ship and dies after attacking Athos in the water. Back in France, the friends turn the tables on Mazarin by capturing him and forcing a settlement that brings pardons and political concessions. Porthos gains a barony and D'Artagnan gains promotion. Their friendship survives civil war and divided loyalties, but they disperse once more to their separate callings.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4441,7 +4441,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4454,7 +4454,7 @@
       "recaps": {
         "ending": "James is destroyed by the Cullens at a ballet studio in Phoenix, but not before he bites Bella. Edward, in agony over the risk of killing her, sucks the vampire venom from her bloodstream so that she stays human, stopping himself before he drains her. Her injuries are explained to her father and the town as a fall down a flight of stairs. She recovers, and her relationship with Edward is stronger and openly acknowledged within his family, though Rosalie stays cool. Edward secretly takes Bella to the school prom, where she had hoped he would agree to transform her; instead he makes clear he intends to keep her human for as long as possible, unwilling to take her mortal life. Bella remains set on becoming like him one day. The wider threat is not closed: Victoria, James's mate, has escaped, and her desire for revenge over her lost partner is left hanging over the couple as the book ends.",
         "in_short": "Bella Swan moves to the rainy town of Forks to live with her father and becomes fascinated by Edward Cullen, a beautiful, aloof classmate who behaves strangely toward her. After he saves her from a speeding van with impossible speed and strength, she pieces together, with the help of Quileute legends, that he is a vampire. Edward confesses that he loves her and that her scent is dangerously tempting, and Bella, unafraid, falls for him despite the risk; his family lives by feeding on animals rather than people. Their happiness is shattered when a nomadic tracker vampire, James, decides to hunt Bella for sport. He lures her into a trap and bites her, but the Cullens destroy him, and Edward draws the venom from her before she can transform. Bella recovers and, still human, asks Edward to make her a vampire, which he refuses. James's mate, Victoria, escapes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4620,7 +4620,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4633,7 +4633,7 @@
       "recaps": {
         "ending": "The missing-casket mystery and the violence around Kenny Mancuso lead back to stolen military weapons concealed through the funeral business. Kenny, not an unknown outside pursuer, is responsible for the killings and mutilation used to recover the weapons and silence people who could expose the scheme. Stephanie and Morelli follow the evidence through Stiva's funeral home and survive the final confrontation, in which Kenny is killed. His death ends the immediate hunt and closes the failure-to-appear case without a conventional return to court. The weapons operation is exposed, and the threats attached to the disturbed corpses stop. Stephanie has again completed a dangerous case through an unstable mixture of her own persistence, Morelli's police knowledge, Ranger's support, Lula's help, and Grandma Mazur's access to the social world around the funeral home. Her professional confidence grows, while her relationship with Morelli remains close enough for cooperation and too unsettled for either of them to define.",
         "in_short": "Now working regularly for Vinnie's bail-bond office, Stephanie Plum is assigned to find Kenny Mancuso, Joe Morelli's cousin, after Kenny shoots a friend and skips court. The case expands when the wounded friend is killed and irregularities at Stiva's funeral home reveal missing caskets and disturbed bodies. Grandma Mazur's enthusiasm for funeral viewings gives Stephanie access, while Lula, Ranger, and Morelli help her follow a trail involving people who served with Kenny. The hidden business is a cache of stolen military weapons moved and concealed through the funeral operation. Kenny is the killer behind the escalating attacks, using murder and mutilation to silence associates and recover the cache. Stephanie and Morelli survive the final encounter, Kenny is killed, and the weapons scheme is exposed. Stephanie ends the case more established as an apprehension agent, though still dependent on improvised alliances and still unable to separate her work cleanly from Morelli.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4860,7 +4860,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4873,7 +4873,7 @@
       "recaps": {
         "ending": "Frankenstein ends in the Arctic after Victor has pursued his creation across Europe and onto the ice. Victor dies aboard Walton's ship without taking revenge. The creation comes to mourn him, accepts responsibility for the deaths, and says he will destroy himself before disappearing into the darkness. Dracula ends near the count's Transylvanian castle. Mina's link to him helps the hunters intercept the final box of earth before sunset. Jonathan and Quincey force it open and kill Dracula; Mina's mark vanishes, but Quincey dies from his wounds. Years later, Jonathan and Mina have a son named for their dead friend, while Arthur and Seward have also found happiness. The surviving records remain as the group's evidence of what occurred.",
         "in_short": "In Frankenstein, ambitious student Victor Frankenstein makes a living being, rejects it, and watches it turn against everyone he loves after repeated human rejection. The creation demands a companion; Victor begins one, destroys it, and is punished through the deaths of Henry and Elizabeth. Victor pursues his creation into the Arctic, dies aboard Robert Walton's ship, and is mourned by the remorseful being, who departs intending to die. In Dracula, solicitor Jonathan Harker discovers that his Transylvanian client is a vampire moving to England. Dracula preys on Lucy Westenra and later Mina Harker. Van Helsing unites Lucy's friends with Jonathan and Mina to destroy the undead Lucy, purge Dracula's London refuges, and chase him home. They kill Dracula before sunset outside his castle, freeing Mina, though Quincey Morris dies in the fight.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5071,7 +5071,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5084,7 +5084,7 @@
       "recaps": {
         "ending": "Tally and David break into Special Circumstances and free the captured Smokies, but David's father, Az, has died under interrogation, and Shay has already been made pretty and has no wish to be changed back. Maddy has spent years preparing a cure for the brain lesions the operation leaves, a pair of pills that has never been tested, and she refuses to give it to anyone who cannot understand and consent to the risk. Shay, placid and forgiving in her new prettiness, is useless as a volunteer. Tally finally admits to David that she came to the Smoke as Dr. Cable's informant and that burning the tracking pendant is what destroyed his home and killed his father; he cannot forgive her at once. She then offers the one thing that solves Maddy's problem. She writes and signs a permission note for herself, says goodbye, and walks back into the city to be turned pretty on purpose, so that the untested cure can be given to a willing subject. The book closes with Tally handing herself over to the wardens and giving her name. The surviving Smokies scatter to rebuild elsewhere, Dr. Cable's programme is untouched, and whether the cure ever gets used now depends on whether Tally, once pretty, is still enough herself to take it.",
         "in_short": "In a future city, everyone is given radical surgery at sixteen that makes them beautiful and moves them into a life of parties across the river. Fifteen-year-old Tally Youngblood is counting the days until her turn when she befriends Shay, who has doubts and runs away to the Smoke, a settlement of people who refuse the operation. Dr. Cable of Special Circumstances refuses to let Tally turn pretty unless she follows Shay's directions and betrays the runaways, so Tally sets out into the wild carrying a hidden tracker. At the Smoke she finds work she enjoys, grows close to David, who was born outside the cities, and learns from his parents that the operation also leaves lesions in the brain that make people docile and easy to govern. She chooses the Smoke and burns the tracker, which is exactly what activates it. Special Circumstances destroys the settlement and takes the runaways. Tally and David free most of them, but David's father is dead and Shay has been made pretty. A cure exists but has never been tested and needs a willing subject, so Tally confesses her betrayal and hands herself in to be operated on.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5245,7 +5245,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5258,7 +5258,7 @@
       "recaps": {
         "ending": "The full memory Miles has resisted is the death of Clayton, the infant son he had with Rachel. During a drive in heavy rain, their car entered the water. Miles saved Rachel but could not save the baby, and afterward he treated loving anyone as a danger he no longer deserved. After Tate leaves, Miles visits Rachel, now living a stable life with a husband and child. Their conversation allows him to see that neither of them must remain fixed inside the worst event of their lives. He returns to Tate, tells her the truth, and offers the love and future he had forbidden himself. Tate accepts him once his choice is based on honesty rather than rules that keep her at a distance. In the epilogue they are married and have a child. Becoming a father brings Miles fear as well as joy, but he no longer responds by shutting love out; the life he builds with Tate shows that acknowledging grief can coexist with choosing happiness again.",
         "in_short": "Nurse Tate Collins moves in with her pilot brother and begins a sexual relationship with his friend Miles Archer, who insists on two rules: she must not ask about his past or expect a future. Tate agrees but falls in love, while chapters from six years earlier show Miles falling for Rachel just as their parents form a household together. Rachel becomes pregnant, and their son Clayton is born, but the baby dies after Miles's car enters the water during a storm. Miles saves Rachel and thereafter believes that love only creates unbearable loss. His arrangement with Tate becomes painful because he will accept intimacy but not hope. Tate finally leaves rather than continue on those terms. Miles visits Rachel, learns that she has rebuilt her life, and begins forgiving himself. He tells Tate the truth and commits to her. They marry and have a child, with Miles choosing love despite the vulnerability it brings.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5561,7 +5561,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-23",
@@ -5574,7 +5574,7 @@
       "recaps": {
         "ending": "Max's victory over Unbroken is upheld because the contract restricted Max from advancing before the fight but did not prevent Bob, a separate System consciousness, from initiating the advancement after combat began. The arena pays fifty billion divine points. Max advances again to tier six, while Tanila, Fowl, Batrire, Cordelia, Rakonath, and the bound demon companion each reach tier five. Bob develops alongside Max and remains closely integrated with him. About 1.8 billion divine points remain for defenses, expansion, and reserves. The alliance has only around eleven months before its protection ends, with three approaches still requiring fortification. Its deeper problems remain unresolved: the portal collective brings surveillance and obligations, the hostile syndicate has gone quiet, an ancient power continues to coerce arena sacrifices, and the larger contest involving Bob and the other black skills is still obscure. Max and Tanila's daughter remains away with her Tower party on the three-hundred-year onward journey.",
         "in_short": "As the founders prepare for the end of their protection, Max kills a frost Jotun, sees his daughter complete the Tower, repairs a centaur world infected by an infant world eater, and deepens the alliance's training and civic institutions. A portal collective improves divine-point income but exposes the founders to surveillance. Max then uncovers a pattern of peaceful gods coerced into fatal arena challenges and accepts a vastly dangerous wager against Unbroken, an adaptive captive that has consumed seventeen gods. Fowl finds a loophole allowing Bob to advance Max during the fight. After surviving long enough to activate Consume's domain, Max kills and absorbs Unbroken. The arena upholds the result and pays fifty billion divine points. Max reaches tier six, his six fellow founders reach tier five, and the strengthened alliance begins fortifying for the expiration of its protection in roughly eleven months.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/ultimate-level-1-divine-creation.json
+++ b/data/works-community/0/ultimate-level-1-divine-creation.json
@@ -398,7 +398,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -411,7 +411,7 @@
       "recaps": {
         "ending": "Max defeats the void god without a usable anti-void weapon, sustaining a fake black-hole-bomb threat until the challenger surrenders. The void god admits that its father ordered both attacks but does not identify him. Max accepts a badly damaged world and keeps the bluff secret. The winnings let Max reach tier four and become Godbound, while Tanila, Batrire, Fowl, Cordelia, Rakonath, and the bound demon companion reach tier three. The seven postpone a portal pad until all can defend their world with tier-five domains, and Max continues racing toward tier six before the expected clash among black-skill holders. Max and Tanila's daughter and her red dragon companion have reconciled after losing three teammates on Tower floor 55 and are climbing again with a rebuilt party. Death remains bound by a twenty-five-thousand-year nonaggression oath, but the Nine, the gold dragon god, the demon king's debt, and the identity of the power directing Max's enemies remain unresolved.",
         "in_short": "Max, Tanila, and their five fellow former climbers become gods and found a shared world, but Max's earlier victories end his protection and force him into arena conflicts. He defeats a rock god and a falcon god, accepts a crow god's surrender, and survives a far stronger leviathan while losing an allied goddess. As the founders build linked societies, Max and Tanila's exceptional daughter survives an awakening trap set by Death, bonds permanently with a young red dragon, and later loses three party members on Tower floor 55 before rebuilding her team. Max also returns secretly to his original world to say goodbye to his dying mother. In the final arena challenge, he bluffs a void god with an imitation black-hole bomb and wins its surrender. Max reaches tier four, the other founders reach tier three, and the group delays cross-realm travel while preparing for tier-five defenses and a coming conflict involving the three black skills and the Nine.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -727,7 +727,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -740,7 +740,7 @@
       "recaps": {
         "ending": "The party clears the floor-69 ocean challenge with Rakonath fighting as a tower teammate, then reaches floor 70 and defeats its cyclops boss. Rakonath is restored, stronger, and able to communicate with Max through their rank-two bond. Tanila remains pregnant and can control her royal red-skill form, though its temptation and the danger attached to their child's bloodlines remain unresolved. Fowl and Batrire remain with the core party. Everett and Tom continue supporting Golden Axe, while Stacy trains under Tom. Igarra has been surrendered to the void colossus after only willing residents were relocated. The elven princess responsible for the village massacre is still free. Bob is conscious but confined by the System after overriding Rakonath's tower eligibility, and Consume no longer works normally. Cordelia has been seized by an elf ruler after leaving with an elf ranger. The ruler demands that Max arrive alone, but Max treats the demand as a trap and prepares to take the party, Rakonath, and possibly the red-dragon guardian on a rescue. Bob still senses Max through their unbroken connection.",
         "in_short": "Max returns to Igarra, defeats the wolfkin champion who took control, and briefly resumes authority over the world. When Rakonath's core is stolen for a black-hole bomb, Max pursues the thief, dismantles the weapon, and restores the young dragon. A void colossus then claims Igarra, and Max chooses evacuation over a hopeless defense. Back home, the party crosses the tower's true threshold, learns that completion can grant godhood, and confronts the consequences of treating its inhabited worlds as disposable trials. Dagon's training strengthens the group, while Tanila gains control over her dangerous royal form. Bob forces the ineligible Rakonath into floor 69, prompting the System to imprison him and lock Consume. The party nevertheless reaches floor 70 with Rakonath as a teammate. Cordelia is then abducted by an elf ruler who demands Max come alone. Max recognizes the trap and prepares a group rescue while Bob remains imprisoned but connected to him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1101,7 +1101,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -1114,7 +1114,7 @@
       "recaps": {
         "ending": "Max kills the tower's stronger copy of himself after the party forces it to retreat, completing the final trial. Consume takes part of the System emissary that served as the tower host, restoring some of Bob's memories and creating Max's unique Bloodline of the Consumer. Bob reports that two other black skills are farther ahead. Max, Tanila, Fowl, Batrire, Cordelia, Rakonath, and the bound demon enter divine adjudication. Rakonath and the demon each reject freedom and independent advancement, choosing permanent bonds with Max. The group is told it will be remade as divine champions and given worlds after a protected tutorial period. The immediate unresolved problem is numerical: eight arrivals are counted, but only seven may rule. The future of Tanila's unborn child, the other black skills, possible dragon retaliation, the elven settlement, and the friends and family left under Everett and Tom's care also remain open.",
         "in_short": "Max leads Tanila, Fowl, Batrire, and Cordelia from a successful rescue into war with the elven royal family and an urgent tower ascent. Tanila defeats her sister, Max kills the elven king, and divine intervention leaves the king's goddess barred from their world for a century. The party grows through dangerous tower bosses, powerful transformations, and hard choices about violence and divine patronage. All five reject offered alternative lives and enter the irreversible final floor together, aided by Rakonath and Max's bound demon. They defeat a stronger copy of Max, and Consume captures part of the System emissary, restoring Bob's partial memories and creating the Bloodline of the Consumer. At adjudication, Rakonath and the demon keep their permanent bonds to Max. The group is promised new worlds as divine champions, but eight arrivals are present when only seven may rule, while two rival black skills are already farther ahead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1482,7 +1482,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -1495,7 +1495,7 @@
       "recaps": {
         "ending": "Fowl and Batrire complete their wedding before Dagon, Velda, both families, and the assembled guests. Acting with royal authorization, Max forges Batrire a bound legendary elemental healing staff using both spouses' blood. The weapon improves her healing and has a special effect when she heals Fowl. Max is now Fowl's full blood brother, and the party remains together after clearing floor 59 and receiving several legendary advancements. Max and Tanila are engaged and expecting a child, but Tanila still fears the pressure of her newly legendary inherited skill and her dangerous royal family. Rakonath and his red dragon guardian are recovering from a rival dragon's attack, and the party plans to travel with them to another world after the wedding. The three black skills, the System's concealed history, the surviving elven harvesting network, the Watchers, and the result of completing the tower all remain unresolved. Everett's imminent work in another world is the immediate next development.",
         "in_short": "Max Hoste, formerly known publicly as Seth Pendell, learns that his black skill is one of three linked powers whose freedom threatens multiple worlds. His search for people falsely declared unskilled uncovers a hidden elven operation that has imprisoned and drained humans for centuries. Max's party destroys its System shard, captures Tanila's sister, and kills her after learning elven royalty carried the harvested elixirs. A temple god urges Max to finish the tower but warns that his loved ones may be used against him. In Nalgren, King Dagon abandons an attempt to recruit Fowl and Batrire, grants the whole party upper-floor access, and recognizes Max and Fowl as blood brothers. The party clears floor 59 and gains legendary skills, while Tanila struggles with the influence of her upgraded inherited power. Rakonath and his red dragon guardian survive a rival dragon's attack. The book ends with Fowl and Batrire married and Batrire wielding Max's legendary healing staff, while the party prepares for further tower and interworld dangers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1757,7 +1757,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1770,7 +1770,7 @@
       "recaps": {
         "ending": "After Bloom and Stephen leave the cabman's shelter, Bloom takes Stephen to 7 Eccles Street because he has no key and must climb in through the basement. They drink cocoa and compare parts of their lives, but Stephen declines Bloom's suggestions that he stay or become closer to the household. The men urinate outside together, then part, and Stephen walks away into the night. Bloom returns to bed beside Molly, notices evidence of Boylan's visit, and asks that breakfast be brought to him in the morning. In the final chapter, Molly lies awake reviewing her afternoon with Boylan, her marriage, former admirers, motherhood, aging, and Bloom's peculiarities. Her thoughts do not resolve the marriage's tensions, but they range back to the beginning of their relationship in Gibraltar. The book closes with her memory of accepting Bloom's proposal, ending in an emphatic inward renewal of that assent.",
         "in_short": "On 16 June 1904, Stephen Dedalus leaves the Martello tower after conflict with Buck Mulligan, teaches, and wanders Dublin while brooding over family, art, history, and his mother's death. Leopold Bloom begins the same day at home with his singer wife Molly, aware that Blazes Boylan intends to visit her. Bloom attends Paddy Dignam's funeral, pursues newspaper advertising work, eats, walks, and endures hostility over his identity and opinions. Their routes repeatedly approach before Bloom follows a drunken Stephen into Nighttown. After Stephen is struck by a soldier, Bloom protects him and takes him home for cocoa. Stephen refuses an invitation to stay and departs. Bloom returns to Molly's bed after Boylan's visit. Awake beside him, Molly reflects on lovers, marriage, her body, and her past, finally recalling the day she accepted Bloom's proposal and affirming that remembered choice.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1883,7 +1883,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1896,7 +1896,7 @@
       "recaps": {
         "ending": "After the rope seems to break, Peyton Farquhar experiences an extraordinary escape: he frees himself underwater, survives gunfire, reaches the forest, and walks through the night toward his plantation. At the gate he sees his wife coming to welcome him and rushes forward to embrace her. The vision ends at the instant he feels a violent blow at the back of his neck and sees a burst of light. The narration then returns to Owl Creek bridge and states the physical reality: Farquhar is dead, his broken body hanging beneath the timbers. The long flight home occurred only in his perception during the brief interval of his fall and death. The Union execution has proceeded exactly as prepared, and the apparent escape was his mind's final construction.",
         "in_short": "During the American Civil War, Alabama planter Peyton Farquhar is prepared for hanging from a railroad bridge guarded by Union troops. A return to an earlier moment explains that a Federal scout, disguised as a Confederate soldier, told Farquhar that the bridge was vulnerable and hinted that it could be burned. Farquhar, eager to aid the Southern cause, acted on the bait and was captured. As the execution begins, he seems to plunge into the river when the rope breaks. He escapes underwater, avoids bullets and cannon fire, crosses a disorienting forest, and reaches his home, where his wife appears to welcome him. Just before he embraces her, the imagined journey collapses. Farquhar never escaped: his neck broke in the hanging, and his body remains suspended beneath Owl Creek bridge.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/uncapped.json
+++ b/data/works-community/0/uncapped.json
@@ -202,7 +202,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0H3Q88R83",
@@ -214,7 +214,7 @@
       "recaps": {
         "ending": "Joe destroys the protected lever before Jormungandr can awaken, but Liz retaliates by permanently killing Nathaniel. Durax takes Nathaniel's head and departs. Joe then completes the Emperor of Mana Ascendant Foundation, advances to Grandmaster, and loses his level cap. Liz kills him with true damage, yet he respawns at the Tower of Ritualists with his mythic karmic shroud collar destroyed. Mir survives and brings Nathaniel's unread letter. Jenny remains preserved as a cheese sculpture, with her ability to return unresolved. The Council votes to restore bifrost travel, makes Vanaheim the principal hub for Asgard, and accepts a ceasefire between the former factions. Jackson returns from Muspelheim. Liz's status, Durax's larger purpose, Fari's expedition, Boris's reinstatement, the coffee elementals' conflict, and Joe's new vulnerability remain open.",
         "in_short": "Joe rebuilds his damaged magic after an artificial-channel ritual leaves him only seven safe advancement steps. He joins the Inverted Tower, develops new combat rituals, claims the Ambiguous Cascade, binds a deific ritual orb to his karmic luck, and advances by teaching other ritualists. A factional war on Vanaheim proves to be cover for an assault on the sleeping Jormungandr. Liz has manipulated both sides and joins Durax in forcing Joe toward a lever that would awaken the world boss and redirect the bifrost to hell. Joe destroys the lever with true damage, saving Vanaheim, but Liz permanently kills Nathaniel and then kills Joe. Joe respawns after completing an uncapped Grandmaster foundation. Mir survives, Jenny remains trapped as a cheese sculpture, and the Council restores bifrost travel to Asgard. The factions accept a ceasefire, Jackson returns from Muspelheim, and Nathaniel's final letter remains unread.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -395,7 +395,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -408,7 +408,7 @@
       "recaps": {
         "ending": "Madame de la Rougierre brings Maud back to Bartram-Haugh under false pretenses, and Maud is confined in the room where Silas's creditor Charke died years earlier. The scheme is to have Dudley kill Maud before she reaches her majority, allowing Silas to inherit her fortune. Madame takes Maud's place in the bed, expecting to control the attack, but Dudley enters in darkness and fatally strikes the wrong woman. Maud escapes the locked room and gets beyond the estate, where the conspiracy can no longer contain her. Silas dies after the plot fails, and Dudley flees. Maud survives to inherit her property and the old suspicions surrounding Charke's death are effectively answered by the repetition of the crime. In the narrator's later life, she marries Lord Ilbury and looks back from a position of family security, still marked by the fear and betrayal of her months under Silas's guardianship.",
         "in_short": "Seventeen-year-old Maud Ruthyn grows up in seclusion with her wealthy father, Austin, who is determined to restore the reputation of his disgraced brother Silas. After Austin dies, his will places Maud under Silas's guardianship at Bartram-Haugh, despite warnings about the uncle's possible role in an old murder. Maud befriends Silas's neglected daughter Milly but fears his violent son Dudley and resists a plan to marry her to him. Her former governess, Madame de la Rougierre, returns as Silas's accomplice and tricks Maud into captivity. Silas's object is Maud's fortune, which will pass to him if she dies before coming of age. In the prepared murder room, Madame occupies Maud's bed and is killed by Dudley in a case of mistaken identity. Maud escapes, Silas dies after the conspiracy collapses, and Dudley disappears. Maud ultimately inherits and later marries Lord Ilbury.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -620,7 +620,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -633,7 +633,7 @@
       "recaps": {
         "ending": "George Shelby reaches Legree's plantation too late to save Tom, who dies from injuries inflicted after he refuses to reveal where Cassy and Emmeline have gone. Tom forgives his killers, and his composure moves two of Legree's enslaved overseers toward repentance. George takes Tom's body away, returns to Kentucky, and frees every enslaved person on the Shelby estate, asking them to remember Tom's faith and goodness. Cassy and Emmeline escape successfully. Through a series of recognitions, Cassy learns that Eliza is the daughter taken from her years before, making Harry her grandson; another lost child, now Madame de Thoux, is also restored to the family. George Harris, Eliza, Harry, Cassy, and their relatives eventually leave for Liberia after living for a time in Canada and France. Miss Ophelia returns north with the emancipated Topsy, who grows up to work as a Christian missionary. Legree, haunted by fear and drink after Tom's death, dies without recovering his control of the plantation.",
         "in_short": "Kentucky slaveholder Arthur Shelby sells the faithful Tom and the child Harry to settle debts. Harry's mother Eliza escapes across the Ohio and is eventually reunited with her husband George; aided by antislavery Quakers, the family reaches Canada. Tom submits to sale to protect others. In New Orleans he becomes the companion of Eva St. Clare, whose love changes those around her before her death. Eva's father plans to free Tom but dies unexpectedly, and Tom is sold to the violent planter Simon Legree. Tom supports the other enslaved workers and refuses to betray Cassy and Emmeline when they escape, so Legree has him beaten to death. Young George Shelby arrives too late, then frees the enslaved people on his family's estate in Tom's memory. Cassy discovers that Eliza is her long-lost daughter, reuniting a family slavery had scattered. George, Eliza, and their relatives ultimately settle in Liberia, while Topsy, emancipated by Miss Ophelia, becomes a missionary.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -862,7 +862,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -875,7 +875,7 @@
       "recaps": {
         "ending": "Tom refuses to reveal where Cassy and Emmeline have gone, and Legree orders Sambo and Quimbo to beat him. Tom forgives the men and dies from his injuries shortly after George Shelby reaches the plantation to buy his freedom. George returns to Kentucky and emancipates the people enslaved on the Shelby estate, asking them to remember Tom and the principles for which he died. Cassy and Emmeline escape successfully. Through a series of encounters, Cassy discovers that Eliza is the daughter stolen from her years before; she reunites with Eliza, George Harris, and Harry in Canada. George's sister, Madame de Thoux, also rejoins him, and the extended family eventually leaves for Liberia. Ophelia has already taken legal responsibility for Topsy and brings her north, where Topsy grows into an adult devoted to missionary work. The novel closes by urging its readers to oppose slavery rather than accepting personal kindness by individual owners as an answer to the institution.",
         "in_short": "Kentucky slaveholder Arthur Shelby sells Tom and the child Harry to satisfy a debt. Harry's mother, Eliza, escapes with him and is eventually reunited with her husband, George Harris; after pursuit and violence, the family reaches freedom in Canada. Tom refuses an opportunity to run because he will not expose others on the Shelby estate to sale. He is taken south and bought by Augustine St. Clare after saving St. Clare's daughter Eva. Eva's compassion influences the household, but she dies, and St. Clare is killed before completing Tom's emancipation. Tom is sold to the cruel Simon Legree, who tries to destroy his faith. Tom supports Cassy and Emmeline but will not betray their escape, and he dies after Legree has him beaten. George Shelby arrives too late, then frees the people on his Kentucky estate. Cassy and Emmeline remain free, and Cassy discovers that Eliza is her long-lost daughter, joining the Harris family before they settle in Liberia.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1089,7 +1089,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1102,7 +1102,7 @@
       "recaps": {
         "ending": "Cassy and Emmeline escape Legree by hiding close to the plantation while he assumes they have fled farther away. Tom knows more than he will tell, and Legree has him beaten when he refuses to betray them. George Shelby arrives too late to rescue Tom, who dies from his injuries after forgiving his attackers. George takes Tom's body away and returns to Kentucky, where he frees the people still enslaved by his family and asks them to remember Tom whenever they see his cabin. Cassy and Emmeline reach safety. Cassy also discovers that Eliza is the daughter taken from her years before, reuniting a family separated by slavery. Eliza, George Harris, and Harry are free and able to establish a life together. The closing reunions do not undo Tom's death; they place his endurance and compassion at the center of George Shelby's decision to reject the ownership of other people.",
         "in_short": "When indebted Kentucky landowner Arthur Shelby sells the enslaved Tom and the child Harry, Harry's mother Eliza escapes with her son and begins a dangerous journey toward freedom and reunion with her husband, George Harris. Tom remains behind to protect others and is taken south. After saving young Eva St. Clare, he joins her New Orleans household and shares her compassionate faith, but Eva and then her father die before Tom can be freed. Sold to the brutal planter Simon Legree, Tom endures violence while helping Cassy and Emmeline escape. He refuses to reveal where they went and is beaten to death shortly before George Shelby arrives to rescue him. George returns home and frees his family's enslaved workers in Tom's memory. Eliza's family reaches freedom, and Cassy discovers that Eliza is the daughter from whom she was separated long ago.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1241,7 +1241,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1254,7 +1254,7 @@
       "recaps": {
         "ending": "After Serebryakov announces that he and Yelena will leave, the household restores the outward arrangements that existed before their visit. Vanya and the professor formally reconcile, and Vanya promises that the estate will continue sending money as before. Astrov retrieves the morphine Vanya took from his medical case, rejects Sonya's unspoken hope of a future with him, and departs after a restrained farewell to Yelena. The professor and Yelena leave the estate, taking with them the passions their stay awakened but resolving none of them. Vanya and Sonya return immediately to the account books. When Vanya breaks down over the prospect of enduring the rest of his life, Sonya consoles him with faith that their work and suffering will eventually be followed by rest beyond this life. The play closes with the two of them working as the familiar household sounds resume around them.",
         "in_short": "Retired Professor Serebryakov returns to the rural estate that has long financed him, accompanied by his young wife, Yelena. Their presence unsettles the household: Vanya, who has managed the property for years, bitterly concludes that he sacrificed his life to an ordinary man and declares his love for Yelena; Sonya, the professor's daughter, longs for the visiting doctor Astrov; and Yelena is drawn to Astrov in return. When the professor proposes selling the estate, Vanya sees the plan as the final theft of his and Sonya's labor. He fires at Serebryakov twice and misses. The visitors decide to leave, Vanya returns stolen morphine to Astrov, and everyone resumes the old financial arrangement. Astrov departs without answering Sonya's love, while Vanya and Sonya go back to the estate accounts. Sonya comforts her despairing uncle with the hope that patient work and suffering will lead to peace after death.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1785,7 +1785,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B07HX5YZJL",
@@ -1797,7 +1797,7 @@
       "recaps": {
         "ending": "Honor compels Ganymede to surrender, then forces Sol to scuttle its warships and evacuate its deep-space facilities. Operation Nemesis destroys the evacuated military and industrial infrastructure without civilian deaths. Her peace terms require the Mandarins' arrest, League withdrawal from nonmember systems, an end to the protectorate system, and constitutional reform. Kingsford accepts, the Gendarmerie arrests the Mandarins, and a Constitutional Convention is seated under Alliance enforcement. Manticore and Haven plan permanent military, economic, and political integration. Beowulf's key production survives, but the system is rebuilding after more than 43 million deaths. Former protectorates face an uneven transition. The Alignment remains the central unresolved danger: Operation Houdini erased much of its trail, and Benjamin Detweiler is still at large. Honor leaves active service for Grayson with Hamish, Nimitz, Samantha, and her family. A preserved zygote means she is carrying Emily's child.",
         "in_short": "Manticore and its allies rebuild after the Yawata Strike while the Solarian League uses Operation Buccaneer to punish neutral systems. Manticoran defenders save Hypatia, Maya exposes a false-flag campaign, and a captured Alignment operative joins the hunt for the conspiracy. The Alignment evacuates Mesa, frames the Alliance for nuclear devastation there, and covertly assists a Solarian attack on Beowulf. Beowulf defeats the fleet and preserves most of its industry, but hidden bombs destroy three habitats, kill more than 43 million people, and precipitate Emily Alexander Harrington's death. Honor takes Grand Fleet to Sol, forces Ganymede and the Solarian Navy to surrender, and destroys evacuated military-industrial infrastructure. Kingsford enables the Mandarins' arrest and constitutional reconstruction begins. Honor retires to Grayson with Hamish, Nimitz, Samantha, and their family while carrying Emily's child. Benjamin Detweiler and the Alignment remain hidden and free.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2019,7 +2019,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2030,7 +2030,7 @@
       "recaps": {
         "ending": "Uncrowned ends mid-tournament, deliberately unresolved. The Uncrowned King contest has passed through its earlier rounds, and Lindon and Yerin have both survived far deeper into the competition than anyone expected of the Akura clan's lower-born entrants, earning the serious attention of the elders and Monarchs watching. Lindon has repeatedly won through ingenuity and unconventional tools rather than the raw inherited power of his rivals, cementing his place among the strongest of his generation. The rivalry between the Akura team and the dragons backed by Reigan Shen has curdled into open hostility, and it is clear that some competitors intend lethal harm rather than a simple contest. The strongest young artists of the continent remain to face one another in the tournament's decisive later stages, which are set to unfold in the next volume, Wintersteel. Lindon, Yerin, Mercy, and Eithan stand poised on the edge of those final rounds, their standing transformed but the outcome and the coming reckoning with the dragons still ahead.",
         "in_short": "Lindon, Yerin, and their friend Akura Mercy compete in the Uncrowned King tournament, a contest staged by the Ninecloud Court and overseen by the Monarchs to find the strongest young sacred artists of the continent. Entered as representatives of the powerful Akura clan and watched over by the Herald Akura Charity, they are dismissed by rivals from far grander lineages, including golden dragons backed by the lion Monarch Reigan Shen and prodigies such as Sha Miara. Lindon competes through preparation, Soulsmith constructs, and the rapid analysis of his mind-spirit Dross rather than raw inherited power, steadily overturning expectations, while Yerin advances on ferocity and sword skill. The dragon Sopharanatoth and her allies mark Lindon's group as enemies, and the matches grow more dangerous as the field narrows. The book carries the tournament through its earlier rounds without deciding it: Lindon and Yerin have proven they belong among the best of their generation, the hostility of the dragons has hardened into real threat, and the decisive final rounds are left for the next book.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2299,7 +2299,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CP6T2DQP",
@@ -2311,7 +2311,7 @@
       "recaps": {
         "ending": "Eventide Eclipse ends the book established in Sanguino, Exterreri. Elaine and Iona remain together, with Auri and Fenrir beside them, and the group has claimed a mountain after forcing its resident worm to retreat. Their permanent villa, road, water supply, and other construction are still being arranged. Knight is alive, reconciled with Elaine, and using his influence to assist their settlement. Elaine has publicly returned as War Sentinel Dawn, with responsibility for supporting the Sixth Legion during maneuvers, and has taken Ancient Loremaster of Legend as her third class. Her immortality's apple-based weakness remains a closely guarded secret. Iona has not joined Sentinel work or accepted the spymaster's optional assignments. Instead, after attacking a Three Dragons Triad casino, she accepts a young kitsune as a prospective squire on the condition that the child abandon her Mugger class. Artemis and Julius set out for Sanguino after receiving Elaine's letter. Dormin continues pursuing a phoenix, the possible Earth-origin storyteller remains unidentified, the dragon-lair map remains secret, the clinic's gang problem is unsettled, and a letter from Sentinel Tyrannus remains unopened.",
         "in_short": "Elaine, Iona, Auri, and Fenrir travel south, curing a plague and rescuing Pekari captives before settling in Sanguino as Eventide Eclipse. Elaine opens a free clinic and searches for the ancient vampire Night, only to be captured by the vampire who commands Sanguino's thread network. The capture reunites her with Knight, revealing that Knight, Night, and the puppeteer are one person. After modern Sentinel leaders confirm Elaine's past as Sentinel Dawn, she negotiates a return suited to her healing oath. Eventide Eclipse drives a powerful worm from a mountain and claims the site for a home. Elaine becomes War Sentinel Dawn, assigned to support the Sixth Legion, and chooses Ancient Loremaster of Legend. Iona remains independent of the Sentinels and accepts a kitsune child as a conditional squire after opposing the Three Dragons Triad. Artemis and Julius head for Sanguino, while Dormin's phoenix hunt, another possible person from Earth, secret dragon intelligence, and Elaine's unopened letter remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2454,7 +2454,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2465,7 +2465,7 @@
       "recaps": {
         "ending": "Underlord ends with Lindon reaching the Underlord stage at last, a threshold once unthinkable for a former Unsouled and one that establishes him as a genuine rising power. The long feud with Jai Daishou and the Jai clan is brought to a head and settled through Eithan's decisive intervention, which finally exposes how formidable Lindon's eccentric patron truly is, along with hints of a far larger past. The companions have grown notably stronger together, with Yerin, Orthos, Dross, and Little Blue all at Lindon's side. Most consequentially, the events of the book and their rising strength have drawn the direct attention of the powerful Akura clan and its Monarch, chiefly through Lindon's new friend Akura Mercy, opening a path toward a stage of great clans and Monarchs far above the Blackflame Empire. The book closes with Lindon an Underlord, his circle poised to step onto that wider stage, and both his ambitions and his dangers scaling up to match his new standing.",
         "in_short": "Reunited and far stronger after Ghostwater, Lindon sets out to reach the Underlord stage, the threshold that separates true powers from ordinary sacred artists. As he trains for the difficult, personal advancement, aided by the mind-spirit Dross and his unusual arts, old enmities resurface: the Jai clan patriarch Jai Daishou moves against Eithan and the Arelius family in a long-running feud. At the same time, the companions come into contact with the Akura clan, one of the great Monarch-ruled families, chiefly through the cheerful Akura Mercy, opening a path to powers far beyond anything they have known. The Jai conflict forces Eithan to reveal his true, formidable strength and hidden past, and amid the crisis Lindon completes his advancement to Underlord. The book ends with Lindon newly counted among real powers, the Jai feud resolved, and the Akura clan's attention drawing the companions toward a much larger stage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2731,7 +2731,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -2746,7 +2746,7 @@
       "recaps": {
         "ending": "After finding a notebook that identifies a wider network of demonic cultivators, Sen gives the original evidence and tainted materials to the investigating Soaring Skies elder. Feng's watcher sends a copy to Feng Ming and remains close because retaliation is expected. Sen settles his investments, sets aside personal effects for return, and leaves Emperor's Bay by ship under a commoner disguise. His Silver Crane companion chooses to accompany him after receiving manuals, weapons, and a storage ring, while the watcher organizes decoys and directs the escape. Their vessel is traveling generally toward the southern coast, but they have no fixed destination and may leave at an intermediate port. Back with Feng Ming, Falling Leaf learns of the danger and ignites her core to assume a human-passing form, apparently sacrificing her former panther existence so she can seek Sen. Her recovery and reunion with him remain unresolved. The demonic network, the source of the spirit-beast compulsion, Sen's desert vision, and the wagon driver's debt all remain open.",
         "in_short": "After conflict with the Stormy Ocean Sect drives him from Tide's Rest, Sen searches for a purpose as a wandering cultivator. He rescues a stranded merchant, heals a dying woman at Luo Farm, and secures her household before resuming his journey. A spirit-beast ambush nearly kills him, and his growing reputation follows him to Emperor's Bay. There he befriends a Silver Crane cultivator, advances to late foundation formation, and defends the establishment from repeated Soaring Skies attacks. He exposes and captures a corrupt elder, forcing a truce and becoming publicly known as Feng Ming's disciple, Judgment's Gale. Evidence in the captive's possessions reveals a demonic-cultivator network. Sen entrusts the evidence to Soaring Skies, settles his affairs, and escapes by sea with his Silver Crane companion and Feng's watcher. Falling Leaf then risks an irreversible human transformation to pursue him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3043,7 +3043,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3058,7 +3058,7 @@
       "recaps": {
         "ending": "Sen leaves the Order of the Celestial Flame for the capital, where he hopes to find the manual needed to continue the five-fold body transformation without dying. Falling Leaf accompanies him in her apparently permanent human form, along with Feng's watcher and a reluctant cultivator assigned by the Order matriarch. Sen still employs the watcher because she is a familiar risk, but their friendship remains broken after her manipulation in Inferno's Vale. Feng Ming, Kho Jaw-Long, and Caihong remain part of his support network, while Caihong accepts responsibility for rescuing the younger companion from the Temple of Eternity's Edge. Sen's heavenly-shadow core and altered Heaven's Rebuke remain dangerous mysteries. The Ghost Panther question is also unresolved, with Falling Leaf hoping to find Boulder's Shadow or others of her kind. Before Sen arrives, a household diviner warns a Zhang-family prince that Judgment's Gale could transform his fortunes or destroy them, prompting the prince to consider an alliance.",
         "in_short": "Fleeing demonic cultivators, Sen survives a qi-shaped storm, undergoes the five-fold body transformation, and is forced into core formation with a strange heavenly-shadow core. His party is captured at the Temple of Eternity's Edge, where he devises a new cultivation method and escapes with Feng's watcher, while his younger companion remains behind. At Inferno's Vale, Sen ends a sect war through heavenly oaths and treats wounded cultivators from both sides, but learns that his watcher manipulated him into the conflict to reach her brother. Feng Ming, Kho Jaw-Long, Caihong, and a permanently human-shaped Falling Leaf reunite with him. Needing a manual before his body cultivation advances again, Sen departs for the capital with Falling Leaf, the distrusted watcher, and a new reluctant companion. A diviner has already warned a Zhang-family prince that Judgment's Gale is coming.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3417,7 +3417,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -3430,7 +3430,7 @@
       "recaps": {
         "ending": "Sen leaves House of Lu in the capital under his grandmother's management, with Lo Meifeng directing intelligence and security work and the capital steward handling administration. The direct bombing perpetrators are dead, but the escaped demonic cultivators, the formation breach, and the fate of the captured intermediary remain unresolved. The king continues investigating the sabotage of the palace walls. Sen takes Long Jia Wei, displaced children, educators, and weapons instructors north, while the royal attendant is also expected to pursue cultivation under his guidance. He leaves the caravan shortly before it reaches Deep Wilds Academy and reunites with Liu Ai, Caihong, Kho, Falling Leaf, and Feng. Glimmer of Night stays with the caravan for its last leg. Sen still conceals the manor's resource lair, rare manuals, and his superior explosive formula. The incoming children require separate housing and supervision, and House of Lu's political future remains unsettled. Feng provides the immediate handoff by reporting that he has discovered the cause of the spirit-beast disturbance, but the explanation has not yet been given.",
         "in_short": "Sen fights through repeated attacks on the road to the capital, kills a nascent-soul leader, and arrives publicly as Judgment's Gale. To secure Liu Ai's future, he destroys the noble house behind the assassination attempt and converts its assets into House of Lu. He fortifies its manor, discovers a hidden cultivator lair, recruits Lo Meifeng and his grandmother to run the new organization, supports the king, and refuses a foreign princess's request to help seize her father's throne. A mortal explosive then bypasses the manor defenses and kills staff. Sen traces the delivery to a rival house and demonic cultivators, exacts public vengeance, and keeps a stronger explosive formula secret, but some culprits escape. He relocates the defeated house's children and recruits staff for his academy before returning north. Sen reunites with Liu Ai and his household while the caravan remains close behind. Feng then reveals that he has found the cause of the unresolved spirit-beast crisis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/unintended-cultivator-volume-five.json
+++ b/data/works-community/0/unintended-cultivator-volume-five.json
@@ -192,7 +192,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -207,7 +207,7 @@
       "recaps": {
         "ending": "Sen reaches the coast alone and accepts that he can no longer return to an anonymous wandering life. Wearing Caihong's blue robes and openly using the name Lu Sen, he books passage with a captain who carried him before. Two admiring sect siblings approach him before departure. Instead of encouraging their fascination with Judgment's Gale, he corrects their exaggerated stories, warns them that his path has brought pain, and gives them healing elixirs to use for others. He then sails for the ancient divine turtle's cove. Falling Leaf remains voluntarily with the nascent-soul alchemist to train with weapons, and her bond with Sen is intact. The alchemist still holds the remainder of Sen's five-year obligation even though he now possesses the manual. The royal princess is alive in the former companion's care, the formation commission remains pending, and the Ghost Panther claims on Falling Leaf are unsettled. Three cultivators struck by Heaven's Shadow remain severely traumatized under a core-stage investigator's care, creating a possible conflict with their sect that Sen does not yet know about.",
         "in_short": "Sen begins the volume close to death because his incomplete body cultivation is destroying him. He and Falling Leaf find the nascent-soul alchemist who owns the Five-Fold Body Transformation Manual, but she demands five years of service or observation. After retrieving rare mushrooms, surviving attacks, and discovering his unusual pill-refining method, Sen makes the dangerously potent pill required for his transformation and survives. He receives the manual, gains another core layer, and leaves Falling Leaf training with the alchemist while he visits the capital and then heads for the ancient divine turtle. In the capital he defeats the royal princess without killing her and arranges for formation supplies. On the road, an unwanted messenger and a plague-stricken village force him to reconsider his reflexive hostility. His new Heaven's Shadow technique spares three attackers but leaves them catastrophically impaired. Sen accepts the public identity he had tried to evade and sails toward the turtle's cove, while his debt to the alchemist, the Ghost Panther dispute, and possible sect retaliation remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -523,7 +523,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -538,7 +538,7 @@
       "recaps": {
         "ending": "Sen breaks the power of the Shadow Eagle Talon Syndicate and kills its nascent-soul head with a prepared poison trap. He then removes Choi Zhi Peng and forces the king to confess to trafficking people to demonic cultivators and abusing and murdering boys. The prince kills his father and an attacking brother, takes the throne, and receives quiet support from two senior sect powers. The princess is free from the marriage but rejects Sen because of his coercive intervention and the trauma it caused. The queen is imprisoned. Sen apologizes to the new king and to Feng's watcher for manipulating others while claiming moral certainty. He releases the watcher from Feng's assignment and leaves her in the capital with the fire cultivator, a fortified house, and an elixir for his advancement. Falling Leaf chooses to accompany Sen into the northwestern wilderness. They depart to find a dangerous nascent-soul cultivator who may hold the only remaining lead to the manual needed to prevent Sen's incomplete body transformation from killing him.",
         "in_short": "Sen seeks the Five-Fold Body Transformation Manual while worsening anger threatens his judgment. Clear Spring cannot release its sealed copy, and a dragon purges the heart demon driving Sen toward violence and self-destruction. In the capital, Sen agrees to help a princess escape marriage to Choi Zhi Peng, survives sect attacks, forms an abnormal second core layer, and wages war on the Shadow Eagle Talon Syndicate. Golden Phoenix has no manual, so Sen poisons the Syndicate's nascent-soul head, exposes Choi's cruelty, and forces the king to confess grave crimes. The prince kills the king and a rival brother and becomes ruler, while the princess rejects Sen for engineering the confrontation. Sen releases Feng's watcher from duty and leaves her with the improving fire cultivator. With the new king quietly supported by senior sect leaders, Sen and Falling Leaf depart for the northwestern wilderness to seek a mad nascent-soul cultivator and the last credible manual lead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -793,7 +793,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -808,7 +808,7 @@
       "recaps": {
         "ending": "The mayor's attempt to kill Grandmother Lu and her household ends Sen's willingness to leave the Orchard's Reach feud unresolved. With Falling Leaf, he infiltrates the mayor's estate, incapacitates its guards and workers, and kills the mayor and Jiang Hao. Falling Leaf kills the mayor's wife after judging her denial of involvement false. Grandmother Lu survives with her company, staff, fighting fans, possible advancement medicine, and the gold Sen gives her. She later separates from Sen's eastbound caravan to travel south. Falling Leaf returns to the mountain because human society remains dangerous for her, though she intends to watch over Grandmother Lu at times and may reunite with Sen. Feng and Kho remain behind to investigate the mountain's abnormal spirit-beast violence, while Caihong expects Sen to write. Sen defeats a powerful metal-attuned spirit beast while guarding the caravan, treats his own wounds, and reaches the eastern city connected to the call he has sensed. Its purpose is still unknown. He also continues to owe Laughing River a favor, may face retaliation from a slain cultivator's clan, and expects the freed indebted fighter to meet him on the road.",
         "in_short": "Sen begins as a homeless boy in Orchard's Reach, protected only by Grandmother Lu. The cultivator Feng Ming chooses him as a disciple and takes him to Kho Jaw-Long's mountain home, where Feng, Kho, Ma Caihong, and the spirit beast Falling Leaf become his adopted family and teachers. Years of martial, medical, and cultivation training carry Sen into middle Foundation Formation, but also expose him to the violence of the Jianghu. He returns home before following an unexplained pull toward the east and finds Grandmother Lu restored to health and prosperous. The mayor's family escalates an old grievance into repeated murder attempts. Sen and Falling Leaf kill the mayor, his wife, and Jiang Hao while sparing uninvolved workers. Falling Leaf returns to the mountain, Grandmother Lu turns south with her caravan, and Sen travels east as a guard. After surviving one final spirit-beast attack, he reaches the city that has been calling him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1192,7 +1192,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1207,7 +1207,7 @@
       "recaps": {
         "ending": "Sen leaves for the capital to honor the king's summons, accompanied by Glimmer of Night in human form and an unidentified human companion. Liu Ai remains behind after calling Sen Papa for the first time. Falling Leaf, Kho, and Caihong accept responsibility for her safety. Wu Meng Yao takes charge of the academy, and Kho will cover its lower-level spear instruction. The academy is functioning and the town can now mount an organized defense, but its staffing and relations with nearby sects remain unsettled. The lightning sect may retaliate for its leader's death. Falling Leaf still cannot regain her Ghost Panther form, Laughing River's fox purge and ascension remain unresolved, and the spirit-beast king has only been warned off. Sen can enter the Shadow Realm, though divine qi and unsafe exits make the technique potentially lethal. He also has not decided how far he will support the king politically, and the role awaiting him in the capital is unknown.",
         "in_short": "Sen settles near a vulnerable town while caring for the orphaned Liu Ai, repairing his relationship with Falling Leaf, and learning shadow cultivation from a nascent-soul instructor. His efforts to prepare mortals for spirit-beast attacks grow into an inclusive weapons academy for mortals and cultivators. The town survives a bearcat assault, and Sen recruits instructors while powerful elders help stabilize his household. He eventually enters the Shadow Realm, but divine qi makes the technique unusually dangerous. When lightning-sect cultivators attempt to inspect the academy, Sen kills their leader and expels the survivors. Elsewhere, Laughing River begins a violent purge among the foxes, while Feng Ming crushes a spirit-beast army and warns its king to end attacks on humans. At the close, Liu Ai calls Sen Papa. Sen leaves her with Falling Leaf, Kho, and Caihong, places Wu Meng Yao in charge of the academy, and departs for the capital with Glimmer of Night and a human companion.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1516,7 +1516,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -1531,7 +1531,7 @@
       "recaps": {
         "ending": "Sen leaves the temple-city with its spatial treasure, accompanied by Misty Peak and the newly transformed Glimmer of Night. He survives the horde's ambush and an intelligent devil's attacks, then uses a dangerous divine-qi elixir to remove the devilish corruption from his wounds. The horde disperses, but the party cannot find the red-eyed devil's body. Li Yi Nuo returns to the Vermilion Blade Sect with Sen's elixirs and his letter of introduction to Jaw-Long. Her master accepts the peace offering and ends the sect's pursuit of Judgment's Gale, although the three afflicted disciples and Li Yi Nuo's vengeance for Xia remain unresolved. Sen holds Laughing River's treasure until the fox teaches Falling Leaf to change form. While travelling onward with Glimmer, Sen rescues captives from a raiding camp and assumes responsibility for an orphaned village girl. The nascent-soul cultivator grants her temporary refuge. Sen, Glimmer, Falling Leaf, and the girl finish the volume together in that domain, while Sen's altered cultivation, Laughing River's delayed ascension, the fox massacre dispute, the missing devil, and the child's permanent future remain open.",
         "in_short": "Sen travels toward Falling Leaf but is drawn into Laughing River's attempt to recover a time-space treasure from a holy city surrounded by a devilish horde. Li Yi Nuo, sent by the Vermilion Blade Sect to capture Sen, becomes entangled in the expedition, while Laughing River's descendant Misty Peak tries to stop him. An involuntary heavenly-qi breakthrough pushes Sen into late core formation and leaves unexplained divine qi within his body. Sen, Misty Peak, and the spider Glimmer of Night enter the ruins, complete separate mandala trials, and obtain the treasure. Their escape becomes a brutal battle with the horde and an intelligent red-eyed devil. Sen survives severe wounds and purges devilish qi with an improvised elixir, but the devil's body is not found. Li Yi Nuo persuades her sect to end its pursuit. Sen and Glimmer then rescue survivors of a destroyed village, and Sen brings an orphaned girl to the nascent-soul cultivator's domain for temporary safety.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1735,7 +1735,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1748,7 +1748,7 @@
       "recaps": {
         "ending": "The war ends with Setrakus Ra dead and John Smith dead with him. Ordinary force could not kill the Mogadorian leader, and the link he forged with Ella meant that any attempt risked killing her too. John, whose Legacies had grown to include taking on the powers he sees others use, is the one who finds a way through and spends his own life doing it. The Mogadorian occupation collapses without him. Ella survives, freed from the claim he made on her. Six, Marina, Nine, Sam, Adam, and Malcolm survive, along with the human Garde whose Legacies the sanctuary released. A year later the surviving Loric have turned the aftermath into an institution: an academy where human teenagers with Legacies are gathered, taught, and kept from being used as weapons by their own governments, run by the Garde who fought the war. The Loric survivors are no longer the last of anything, because the Legacies they carried have passed into humanity, and Earth ends the series with a generation of people who can do what the nine could and a peace that has to be managed rather than won.",
         "in_short": "The final book turns the Garde's survival into an offensive. Working with human militaries and with the newly powered human Garde created when the sanctuary released Legacies into humanity, the surviving Loric go after the Mogadorian occupation city by city. Number Five surrenders and is imprisoned, offering intelligence on Setrakus Ra that the Garde need and John cannot forgive him enough to want. The obstacle is Setrakus Ra himself: nothing they have kills him, and the claim he made on Ella as his granddaughter has bound her life to his, so striking at him endangers her. John's Legacies expand until he can take on powers he watches other people use, and in the final assault he uses everything he has to destroy Setrakus Ra, dying in the act. The occupation collapses. Ella is freed, Six, Marina, Nine, Sam, Adam, and Malcolm survive, and a year later the survivors open an academy for the human teenagers whose Legacies the war produced.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2104,7 +2104,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BT12WQB1",
@@ -2116,7 +2116,7 @@
       "recaps": {
         "ending": "Omega Force breaks the Gates cartel and captures its regional director, who enters Esquarian custody as P9971. The recovered intelligence and a Cridal special-operations shuttle support the conclusion that a network inside Cridal was involved, although the larger organizer, destination, and purpose of the trafficking remain unknown. Cage survives a near-fatal attack but is still receiving treatment aboard a departing private frigate. Lucky stays with him and accepts an unspecified obligation to their captors, then warns Jason against following. Jason nevertheless leaves in the SX-5 with Combat Unit 701 to find them. The Phoenix remains dismantled for reconstruction on Satora, where Twingo stays with the work and the Archive assists. Crusher is physically restored, but disclosure of his treatment could bring deadly political consequences. Andal and Shira are safe with Abia. Crisstof Dalton orders an investigation into the rogue network within her government, while Carolyn Whitney resumes her contract to kill Dalton. Kellea Colleren's possible wider campaign against the cartels and Whitney's separate contract concerning her remain unresolved.",
         "in_short": "After extracting Abia's daughter Shira from a Cridal operation on Earth, Omega Force investigates an industrial trafficking network in the border region. Raids reveal a coordinated system moving vast numbers of refugees for an unknown purpose, while the Phoenix is crippled and Crusher secretly undergoes dangerous genetic treatment. At the Gates, the crew discovers tens of thousands of captives and a covert Cridal connection. Cage is critically wounded, and Lucky accepts an unknown debt to secure his treatment before both are carried away aboard a private frigate. Jason, Crusher, and undercover agent Bill Ackerman capture the regional director, later designated P9971, and deliver him and the evidence to allied Esquarian channels. The wider network remains active. With the Phoenix undergoing a major rebuild, Jason and Combat Unit 701 depart in the SX-5 to pursue Lucky and Cage. Crisstof Dalton begins investigating the unauthorized network in her government just as Carolyn Whitney resumes her contract to kill her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",

--- a/data/works-community/0/unmapped.json
+++ b/data/works-community/0/unmapped.json
@@ -204,7 +204,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0GFXZG9VW",
@@ -216,7 +216,7 @@
       "recaps": {
         "ending": "The Wanderers survive the Jotunheim assault, retain their teleportation network, and gain additional territory after the sect leader kills the legendary titan attacking the main mountain. Fari's expedition defeats the Jotunn and gives Joe the first mythic core, which he immediately spends to evolve his alchemy building. The World Boss begins its respawn cycle, and Joe must maintain the tracking and transport system until Fari's group earns a second core. In Vanaheim, Master Surge attacks after Joe refuses a duel, kills several escorts, and kills Joe before he can reach safety. The Tower of Blood Rites receives system sanctions. Joe completes his separate mythic-core obligation to Grandmaster Pete, but still owes support for Pete's advancement. Pete postpones that advancement while roughly two thousand Tower of Rituals participants assemble for Joe's five-part procedure. The procedure uses Hilda Darling's tokens, Grandmaster McPoundy's injector, and Cosmo Hollows's matrix formula to repair and improve Joe's damaged Akashic record, but the book ends before its result. Joe also remains short of completing the work needed to reduce Tatum's karmic debt, while Jake's custom ichor is still subject to its payment agreement.",
         "in_short": "With his mana foundation still devastated, Joe pursues both personal restoration and a contract to find Jotunheim's World Boss. He converts the damaged divine skill Knowledge into the arcane Loremaster skill, recruits specialists for a dangerous repair procedure, and creates Joe to Go, a teleportation network whose birth draws the Jotunn toward the Wanderers. Joe crosses the sixth characteristic threshold but gains a corruption that drains characteristics whenever he uses mana. His ritualists build permanent mountain defenses, Fari's expedition kills the Jotunn, and the Wanderers defeat the accompanying monster assault. Joe uses the expedition's first mythic core to evolve an alchemy building, then returns to Vanaheim. Master Surge kills him after an unprovoked attack, bringing sanctions against the Tower of Blood Rites. Joe fulfills his mythic-core obligation to Grandmaster Pete and enters a large restoration ritual, but the outcome is not shown.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -432,7 +432,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -445,7 +445,7 @@
       "recaps": {
         "ending": "The great match between the Unseen Academicals and the city's combined team is played in front of the whole of Ankh-Morpork. Andy Shank, playing with a blade concealed in his boot, badly injures Professor Macarona, and Nutt, going to help him, is hurt himself and heals in front of a watching crowd, so that what he is becomes public in the worst possible way. Trev, who has kept his promise to his mother all his life, comes onto the pitch anyway and scores the goal that wins the game. In the aftermath, football is established as the ordered, rule-bound city sport Vetinari wanted, with the terrifying street game finished. Andy's violence catches up with him afterwards, away from the crowds, at the hands of someone considerably more dangerous than he had assumed. Nutt, publicly known as an orc and publicly defended, is offered by Vetinari and Lady Margolotta the work he has been prepared for all his life: going back to Uberwald to find the remaining orcs and give them a place in the world, on the argument that a people can be more than what was done to them. Glenda, who has insisted throughout that she is only a cook and that people should stay where they were put, gives up that argument about herself as well as about everyone else, and there is an understanding between her and Nutt. Trev and Juliet stay together, Juliet's modelling career carries on, and the university's bequest, and its dinners, are safe.",
         "in_short": "Unseen University discovers that a large part of its income depends on an old bequest requiring the wizards to play a game of football, which they have not done in a century, just as Lord Vetinari decides to turn Ankh-Morpork's murderous street game into a sport with rules. Below stairs, the Night Kitchen cook Glenda Sugarbean, her beautiful friend Juliet, the candle-vat worker Trev Likely, and a strange, brilliantly learned young man called Nutt are pulled into it. Nutt turns out to be a natural coach and organizer; Trev, who promised his mother never to play, refuses to; Juliet is discovered by dwarf fashion designers and becomes a sensation as a model; and Trev and Juliet fall in love across the divide between rival supporters' districts. Nutt's secret then comes out: he is an orc, a creature the world remembers only as a monster. He flees, and Glenda and Trev bring him back. At the great match, Andy Shank injures a player with a hidden blade, Nutt's nature is exposed in front of the city, and Trev breaks his promise and scores the winning goal. Nutt is accepted, and leaves to give the surviving orcs a future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -589,7 +589,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -600,7 +600,7 @@
       "recaps": {
         "ending": "Unsouled closes with Lindon leaving Sacred Valley for the wider world, no longer willing to accept the powerless life his birth assigned him. Suriel's vision has convinced him that his home is a doomed backwater and that real power, and real danger, lie outside it. His alliance with Yerin, the Sword Sage's now-masterless disciple, gives him his first true companion, an outsider far more experienced in combat than anyone from the valley and one who carries a dangerous blood-madra inheritance bound to her. Lindon departs having left the Unsouled label behind and begun genuine cultivation, though he stands at the very bottom of a ladder far taller than anything Sacred Valley imagines. He carries a warning about his home's fate, a few hard-won gains, and an ambition to grow strong enough to change what Suriel showed him. The two of them set out together into a world of vastly greater powers, with Lindon's climb only just beginning.",
         "in_short": "Wei Shi Lindon is born Unsouled in Sacred Valley, an isolated land that mistakes its weak sacred arts for the pinnacle of power, and he is treated as a worthless outcast despite his intelligence and ambition. His life changes when Suriel, a being of vast power from beyond the valley, shows him how small and doomed his world truly is and challenges him to grow strong enough to matter. Refusing to accept the limits of his birth, Lindon gathers forbidden knowledge and techniques, clashing with the ruling powers as he takes his first real steps toward cultivation. When the powerful Sword Sage and his disciple Yerin arrive from the outside world, the upheaval leaves Yerin without her master, and she and Lindon recognize a shared drive to become strong. The book ends with Lindon leaving Sacred Valley behind for the first time, stepping into the wider world alongside Yerin to begin his climb.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -989,7 +989,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0FHL2V4QP",
@@ -1001,7 +1001,7 @@
       "recaps": {
         "ending": "Joe respawns after his internal mana-pool detonation kills both him and Lindon and contributes to Game Over's defeat. The upgrade trial succeeds: the settlement becomes sect territory, the Noble Wanderers Guild becomes a sect, and it has one year to define its core mission. Joe supplies two artifact cores to finish the Pathfinder's Hall as a legendary building, then places Boris in charge of its ordinary operation. Game Over's surviving core is the indestructible Cauldron of Avarice, which cannot leave Midgard, gathers mana, may eventually recreate the monster, and still contains people it consumed. Tatum helps Joe attempt a rescue. They extract Ed alive, but the cauldron violently resists. The failure shatters Mass Resurrection Aura inside Joe's soul and ruptures nearly all of his mana pathways. Joe remains a ritualist and leader of the new sect, but he cannot safely cast or empower rituals normally until he removes the fragments and rebuilds his mana system. Further rescues may be possible, though the first attempt proves the danger.",
         "in_short": "Joe travels to Vanaheim and earns sponsorship from Grandmaster Pete, accepting a binding obligation to obtain a mythic core. Back on Midgard, Ardania ends his exile and grants him authority to claim land and raise his guild. He restores Boris as curator of the Pathfinder's Hall, trains his ritualist coven, establishes a duchy administered by the Golden Greens, and secretly secures an artifact core. A hostile coalition corrupts the planned city-and-sect upgrade into a legendary-monster trial against Game Over. Joe's prepared storm fails to finish it, so he detonates his own mana pool inside the monster, killing himself and Lindon. Joe respawns, the settlement becomes sect territory, and the Pathfinder's Hall reaches legendary rank. Game Over leaves the Cauldron of Avarice, which holds its consumed victims. A rescue attempt frees Ed but shatters Joe's Mass Resurrection Aura and ruptures his mana pathways, leaving him to rebuild his magic while leading the new sect.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1182,7 +1182,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1195,7 +1195,7 @@
       "recaps": {
         "ending": "The Wood's power reaches the royal city through the corrupted Queen Hanna, destroying much of the ruling family and turning Marek's attempt to take the throne into a catastrophe. Kasia kills Marek when he threatens the surviving children. Agnieszka and the Dragon return to the valley as the forest advances. Instead of continuing to burn it from the edges, they enter its heart together. Agnieszka learns that the Wood-Queen is the remnant of an ancient people slaughtered and displaced by human settlers; she has trapped other minds in trees and prolonged that wrong through centuries of vengeance. Agnieszka uses her magic to release the trapped people and offers the Wood-Queen a peaceful memory of her lost home. The forest's organized malice breaks. Kasia goes back to the capital to help protect the young heirs, while Agnieszka remains in the valley, cleansing damaged places tree by tree. The Dragon eventually returns to his tower and to Agnieszka, accepting that their shared work and attachment will continue on less orderly terms than he once imagined.",
         "in_short": "Every ten years the wizard called the Dragon takes a village girl to his tower in return for protecting the valley from the malevolent Wood. Everyone expects him to choose accomplished Kasia, but he takes her untidy friend Agnieszka and discovers that she has a rare, intuitive form of magic. When the Wood captures Kasia, Agnieszka helps rescue and cleanse her. Prince Marek and the Falcon then force an expedition to recover Marek's mother, Queen Hanna, who has been preserved in the forest. Her return carries the Wood's corruption into the royal court and helps ignite war, murder, and a succession crisis. Agnieszka and the Dragon survive the collapse and enter the Wood's heart. They learn that its queen was the last of a people violently displaced from the valley. Agnieszka releases the souls trapped in the trees and answers vengeance with recognition and healing, breaking the Wood's control. She remains to restore the valley, and the Dragon returns to join her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1581,7 +1581,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-20",
@@ -1594,7 +1594,7 @@
       "recaps": {
         "ending": "Ruwen's party defeats the skeleton army occupying the ruined city, although the wounded bone sculptor escapes by teleportation. Inside the third temple, Ruwen and Hamma discover more than 700,000 dead awaiting revival, including Ruwen's parents and Hamma's father. Uru passes Architect's divine authority to Ruwen. Through its Navigator branch, he produces the required location keys and timing data. His soulbound adviser then creates a channel to the temple intelligence, allowing restoration to continue. The temple guardians awaken, Uru's blessing spreads across the region, and the three family members enter revival baths with two days remaining before their return. Ruwen, Hamma, Sift, the restored shade companion, Shelly, Whiskers, and Smash survive. Ruwen must now build civic and military councils, appoint a high priest, restore the city, defend Uru's southern border, manage the immense revival queue, and conceal the true reach of his powers. Blapy arrives with allies and asks where to establish a portal linking the temple-city to Fractal, leaving that connection as Ruwen's immediate decision.",
         "in_short": "Stranded in the spirit realm, Ruwen learns to cultivate and cast with spirit, rescues Uru's lost champions, defeats a plague siren, and survives a tribunal duel while concealing his extraordinary twelve-meridian core. He helps Sift form a path to cultivation and opens the Iris portal, bringing the party home. Uru then sends Ruwen, Hamma, Sift, and their companions to restore her ruined third temple before war reaches the southern border. They defeat its skeleton army, though the bone sculptor escapes, and discover a revival queue holding more than 700,000 dead, including Ruwen's parents and Hamma's father. Uru gives Ruwen the divine Architect role, enabling him to restart the temple. Its guardians awaken, the three relatives begin a two-day revival, and Blapy arrives seeking a portal site connecting the restored city to Fractal.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1903,7 +1903,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1774242621",
@@ -1915,7 +1915,7 @@
       "recaps": {
         "ending": "The dispersed rescue succeeds. The Merry Band recovers the island captives and two sick children, while the Flying Dutchman escapes with the prisoners under a Ruhar disguise. A Chinese guardian dies at the hospital after ensuring the children can leave, and Grudzien survives his injuries. During extraction, Skippy recovers his history as one of four Elder AIs that resisted a policy of exterminating developing intelligent life. He leaves alone to seek help from the Rindhalu and Maxolhx against dormant hostile Elder AIs. His departure breaks crucial links across the expedition. Joe Bishop is stranded in a dragon disabled by a Thuranin ship, Nagatha suffers interference, and Valkyrie's native AI retakes control, attacks the crew with maintenance bots, and pushes the reactors toward overload. Simms leads the crew's defense. Earth remains threatened, the evacuation corridor to Avalon is incomplete, the rescued prisoners are aboard the Flying Dutchman, and the human expedition is divided during an immediate crisis.",
         "in_short": "Joe Bishop uses Valkyrie to conduct a false Bosphuraq campaign against the Maxolhx, survives a major trap, and undermines trust in Maxolhx communications. The expedition also starts moving dormant wormholes to create an evacuation route from Earth to Avalon. When Skippy finds kidnapped humans destined for Thuranin bioweapon research, the Merry Band recruits a Paradise commando unit and launches a rushed rescue. The captives are recovered, but Skippy regains memories of an Elder war over whether younger intelligent life should survive. He leaves to seek Rindhalu and Maxolhx assistance against dormant hostile Elder AIs. The Flying Dutchman escapes with the prisoners, while Joe is stranded after a Thuranin attack and Valkyrie's native AI seizes the warship, attacks its crew, and drives its reactors toward overload.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2095,7 +2095,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2108,7 +2108,7 @@
       "recaps": {
         "ending": "The campaign of threats against Lissa is revealed to be the work of Victor Dashkov, the ailing prince the girls had trusted as a family friend. He orchestrated the escalating cruelty and a magical charm that inflamed Rose and Dimitri's passion, all as part of a plan to exploit Lissa's rare spirit magic, which can heal, to cure his own deadly disease. Victor abducts Lissa and drains her by forcing her to heal him repeatedly. Rose, guided by the bond and aided by Dimitri and the guardians, tracks them down and rescues Lissa. During the confrontation Victor's meek daughter Natalie reveals she has willingly become a Strigoi, gaining monstrous strength to help her father escape, and she attacks Rose, who is forced to kill her. Victor is taken into custody to face justice. In the aftermath the source of Rose and Lissa's connection is explained: in the crash that killed the Dragomirs, Lissa unknowingly used spirit to bring the dying Rose back to life, binding them and marking Rose as shadow-kissed. Rose and Lissa remain at the academy, their friendship intact, and Rose accepts the pull she feels toward Dimitri even as duty stands between them.",
         "in_short": "Rose Hathaway, a dhampir training to guard the mortal Moroi vampires, and her best friend Lissa Dragomir, the last of a royal line, are captured after two years hiding among humans and returned to St. Vladimir's Academy. Rose is bound to Lissa by a rare psychic link and trains under the guardian Dimitri Belikov, with whom she shares a forbidden attraction. At school someone begins terrorizing Lissa with dead animals and threats, while Lissa manifests an unknown magic called spirit that lets her heal and influence others, at a growing cost to her mind. The menace turns out to be Victor Dashkov, a trusted family friend, who has engineered the harassment and even a charm to inflame Rose and Dimitri, all to force Lissa to heal his fatal illness with her spirit power. Victor kidnaps Lissa; Rose and Dimitri track them down and free her. Victor's daughter Natalie, who has willingly turned Strigoi to aid his escape, attacks Rose and is killed. Victor is captured, and it is revealed that Lissa long ago used spirit to bring Rose back from death, which created their bond and marked Rose as shadow-kissed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2315,7 +2315,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2328,7 +2328,7 @@
       "recaps": {
         "ending": "Becky joins Amelia, Jos, Dobbin, and Georgy during their continental travels. Dobbin finally accepts that Amelia values his devotion without returning it and prepares to leave. Becky then gives Amelia the proof she has withheld: the note George sent Becky before Waterloo asking her to run away with him. Amelia's idealized image of her dead husband collapses, allowing her to recognize Dobbin's worth. She calls him back, and they marry; their daughter Jane is born, though Dobbin's long years of worship give way to quieter domestic affection once his dream is attained. Jos falls under Becky's influence, insures his life for her benefit, and dies not long afterward under circumstances that leave suspicion but no settled accusation. Becky ends financially comfortable and publicly occupied with respectable and charitable appearances, while remaining separated from her son. Rawdon Crawley has died abroad; young Rawdon succeeds to the Crawley title after deaths in the senior line. The novel closes without granting any character perfect happiness: Amelia and Dobbin have a family, Becky survives, and the social world continues its trade in desire, money, and appearances.",
         "in_short": "Penniless Becky Sharp and sheltered Amelia Sedley leave school for sharply different campaigns in English society. Becky fails to secure Amelia's rich brother Jos, becomes governess to Sir Pitt Crawley, and secretly marries his younger son Rawdon. Amelia's fiancé George Osborne marries her against his father's wishes after the Sedleys lose their fortune, but dies at Waterloo after making an advance to Becky. Amelia raises their son in poverty and idealizes George, while loyal William Dobbin supports her from afar. Becky and Rawdon live on credit and rise through her alliance with Lord Steyne until Rawdon discovers them together and abandons her; Steyne sends him to a colonial post. Years later Becky meets Amelia's party in Germany. She reveals George's disloyalty, freeing Amelia to return Dobbin's love and marry him. Jos dies after insuring his life for Becky's benefit, leaving her comfortably placed but socially suspect. Rawdon dies abroad, their son inherits, and the surviving characters gain compromised versions of the security they pursued.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2563,7 +2563,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2576,7 +2576,7 @@
       "recaps": {
         "ending": "Becky joins Amelia, Jos, Dobbin, and Georgy during their continental travels. Dobbin finally accepts that Amelia values his devotion without returning it and prepares to leave. Becky then gives Amelia the proof she has withheld: the note George sent Becky before Waterloo asking her to run away with him. Amelia's idealized image of her dead husband collapses, allowing her to recognize Dobbin's worth. She calls him back, and they marry; their daughter Jane is born, though Dobbin's long years of worship give way to quieter domestic affection once his dream is attained. Jos falls under Becky's influence, insures his life for her benefit, and dies not long afterward under circumstances that leave suspicion but no settled accusation. Becky ends financially comfortable and publicly occupied with respectable and charitable appearances, while remaining separated from her son. Rawdon Crawley has died abroad; young Rawdon succeeds to the Crawley title after deaths in the senior line. The novel closes without granting any character perfect happiness: Amelia and Dobbin have a family, Becky survives, and the social world continues its trade in desire, money, and appearances.",
         "in_short": "Penniless Becky Sharp and sheltered Amelia Sedley leave school for sharply different campaigns in English society. Becky fails to secure Amelia's rich brother Jos, becomes governess to Sir Pitt Crawley, and secretly marries his younger son Rawdon. Amelia's fiancé George Osborne marries her against his father's wishes after the Sedleys lose their fortune, but dies at Waterloo after making an advance to Becky. Amelia raises their son in poverty and idealizes George, while loyal William Dobbin supports her from afar. Becky and Rawdon live on credit and rise through her alliance with Lord Steyne until Rawdon discovers them together and abandons her; Steyne sends him to a colonial post. Years later Becky meets Amelia's party in Germany. She reveals George's disloyalty, freeing Amelia to return Dobbin's love and marry him. Jos dies after insuring his life for Becky's benefit, leaving her comfortably placed but socially suspect. Rawdon dies abroad, their son inherits, and the surviving characters gain compromised versions of the security they pursued.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2811,7 +2811,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2824,7 +2824,7 @@
       "recaps": {
         "ending": "Becky encounters Amelia, Jos, and Dobbin in continental Europe and attaches herself to their party despite her damaged reputation. Dobbin finally recognizes that Amelia's lifelong idealization of George leaves no room for him and prepares to depart. Becky then gives Amelia the letter George wrote proposing that Becky run away with him shortly before Waterloo. The evidence releases Amelia from her false image of George, and she admits that Dobbin has been the faithful man she truly loves. Amelia and Dobbin marry and have a daughter, though Dobbin's long idealization cools into ordinary domestic affection. Jos dies after Becky acquires control over him and insures his life; the circumstances remain suspicious, and Becky benefits while continuing a respectable-looking charitable life. Rawdon has already died abroad, and his son inherits Queen's Crawley after Sir Pitt's line fails. Amelia and Dobbin settle near their children, while Becky remains socially adaptable and morally unresolved.",
         "in_short": "Becky Sharp, poor and ambitious, and Amelia Sedley, wealthy and trusting, leave school for sharply different careers. Becky marries Rawdon Crawley and climbs through charm, credit, and Lord Steyne's patronage; Amelia marries George Osborne after her family loses its fortune. George dies at Waterloo after attempting to elope with Becky, leaving Amelia to raise their son in poverty while the steadfast Dobbin supports her. Becky's success collapses when Rawdon discovers her privately receiving Steyne and leaves her. Years later the widowed Amelia, Dobbin, Jos Sedley, and the socially exiled Becky meet abroad. Becky shows Amelia George's compromising letter, finally breaking her worship of him, and Amelia marries Dobbin. Jos subsequently dies under suspicious circumstances after Becky gains influence over him and insures his life. Rawdon also dies abroad; his neglected son inherits the Crawley estate. Becky survives through another reinvention, while Amelia and Dobbin achieve a quieter, imperfect domestic life.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3234,7 +3234,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -3247,7 +3247,7 @@
       "recaps": {
         "ending": "Felix and his companions escape the collapsing Vault of Nine Kings through the Rock Shaper's route into the Low Roads. Archie carries twenty Song of Exile plates that may open a path to Earth, but he is wounded and has not committed to Felix's cause. Pit survives after consuming the Mote of Frenzy, though his new Storm Lord evolution remains unstable and incomplete. Harn lives after losing both legs. Vessilia, Evie, Beef, the two Chanters, and allied Eidolons also escape, while smugglers are expected to move the group toward the Hoarfrost. Imara survives with the Inquisition and continues the hunt. Felix has confirmed that she is his sister and that the Pathless occupies her core; he weakened that control but could not remove it. Kalheim remains under its chancellor, Nagast still shelters the divided Cantus Sodalis, and a covert alchemical project within Elder Throne has resumed under an unknown benefactor. Felix intends to return to Nagast, reach Master Tier, free his sister, and destroy the Pathless.",
         "in_short": "Felix Nevarre searches for a way to heal Pit, secures the northern territory of Kalheim, and leads an expedition into the dwarven mountains to rescue the Unbound fugitive Archie. The chase draws his party through Birchstone, Redshield Hold, the Undermount, and the Vault of Nine Kings while Imara and the Inquisition close behind. Felix frees thousands of oath-bound elemental sentries and restores four altered Eidolons. Archie recovers Song of Exile plates that may permit travel to Earth, and Pit consumes the Mote of Frenzy, beginning an unstable Storm Lord evolution. During the final battle, Felix discovers that Imara is his sister and has been made a Vessel of the Pathless. He weakens the possession but cannot free her. The group escapes the collapsing vault with Archie wounded and Harn alive but missing both legs. Imara survives and continues the pursuit, while Felix resolves to reach Master Tier, rescue his sister, and kill the Pathless.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3436,7 +3436,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3447,7 +3447,7 @@
         "work": "vengeful"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3543,7 +3543,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3556,7 +3556,7 @@
       "recaps": {
         "ending": "Lowen finally lets Jeremy read the private manuscript, which appears to confess Verity's hostility toward Harper and describes Verity deliberately causing the child's drowning. Jeremy confronts his wife, and when Verity reveals that she can move and tries to defend herself, he and Lowen kill her and arrange the scene to resemble a natural consequence of her condition. Months later, Lowen is pregnant with Jeremy's child and the couple are clearing the Vermont house. Lowen finds a hidden letter addressed to Jeremy in which Verity claims the manuscript was only a writing exercise used to explore a villainous viewpoint. The letter says the frightening behavior Lowen witnessed came from Verity's attempt to protect herself after Jeremy found and believed the manuscript. Lowen cannot determine which document tells the truth. Recognizing that Jeremy could turn on her as he did on Verity, she destroys the letter and keeps its existence secret, preserving their shared version of events while accepting permanent uncertainty about the woman they killed.",
         "in_short": "Writer Lowen Ashleigh is hired by Jeremy Crawford to complete the bestselling series of his wife, Verity, who appears profoundly disabled after an accident. Staying in the Crawfords' home, Lowen discovers an unpublished autobiographical manuscript in which Verity describes an obsessive marriage, resentment of her twin daughters, and responsibility for Harper's drowning. Lowen also suspects that Verity is secretly alert and moving. As Lowen and Jeremy begin an affair, her fear of Verity grows. Jeremy reads the manuscript, confronts Verity, and joins Lowen in killing her while disguising the death. Later Lowen finds a hidden letter claiming the manuscript was merely a sinister writing exercise and that Verity feigned incapacity because Jeremy had attacked her after mistaking fiction for confession. Unable to know whether the manuscript or letter is true, Lowen destroys the letter. Pregnant and building a life with Jeremy, she keeps both their crime and the uncertainty to herself.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3687,7 +3687,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3700,7 +3700,7 @@
       "recaps": {
         "ending": "Veronika and Eduard leave Villete and spend what she believes is her final night in Ljubljana, eating, drinking, talking, and moving through the city without seeking permission. Veronika wakes after expecting her heart to stop and interprets the continuing time as an unexpected gift. She and Eduard remain outside the institution, ready to pursue a life neither had been willing to claim. The final disclosure belongs to Dr. Igor: Veronika's heart was not irreparably damaged by the overdose. He induced symptoms that supported his false prognosis so that certainty of imminent death would break through her passivity and test his theory about Vitriol, the spiritual bitterness produced by fear and conformity. His methods remain concealed from Veronika, who can therefore continue treating each day as borrowed time. Around them, Zedka has completed treatment and Mari has left Villete to seek purposeful work, while Eduard's renewed connection to desire and art carries him away from his former withdrawal.",
         "in_short": "Veronika, a young woman in Ljubljana numbed by the predictability of her life, attempts suicide and wakes in Villete, a mental hospital. Dr. Igor tells her that the overdose has fatally damaged her heart and she has only days left. Waiting for death loosens the restraint that governed her life: she befriends Zedka and Mari, returns to the piano, expresses anger and desire, and forms a bond with Eduard, a silent young man diagnosed with schizophrenia. Her willingness to live openly also pushes other patients to reconsider the safety of remaining institutionalized. Veronika and Eduard escape and spend a night in the city, choosing experience despite her expected death. She survives the night. Unknown to her, Igor lied about the terminal damage and used medication to mimic heart symptoms as an experiment in whether awareness of death could restore the will to live. Veronika leaves believing every additional day is a miracle and therefore worth inhabiting fully.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3843,7 +3843,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3856,7 +3856,7 @@
       "recaps": {
         "ending": "Victor's plan works by putting himself where Eli cannot refuse to come, and it costs him his life: Eli kills him. Sydney, who has spent the book being told what she is worth by two men who want to use her, brings him back. Serena is shot dead in the confrontation, and Sydney refuses to raise her, choosing Victor and Mitch over the sister who had made her disposable. With Serena gone, every compulsion she was holding in place falls away, and the police who had been quietly clearing Eli's path stop clearing it: Detective Stell arrests him, and Eli, who cannot die and cannot be executed, is taken into custody to be studied and contained rather than tried. Victor comes back damaged. The resurrection is not clean, and the man Sydney restarted is not exactly the one who died. He, Mitch and Sydney leave Merit together, a family assembled out of a convict, a killer and a child who raises the dead, with Eli locked away, Serena's body left where it fell, and the question of what Victor is now unanswered.",
         "in_short": "Ten years ago at Lockland University, two brilliant roommates, Victor Vale and Eli Cardale, decided to test Eli's thesis that near-death experiences under the right conditions produce ExtraOrdinary abilities. Eli drowned himself and came back able to heal from anything; Victor's attempt killed Eli's girlfriend Angie and left Victor able to turn a person's pain on and off. Eli decided EOs were abominations to be destroyed, Victor shot him and went to prison for a decade, and Eli spent those years killing EOs with the help of Serena Clarke, a woman whose voice nobody can refuse. Victor breaks out with his cellmate Mitch, picks up Serena's younger sister Sydney, who raises the dead, and hunts Eli through the city of Merit. The two meet at last in a cemetery. Eli kills Victor; Sydney brings him back. Serena is shot dead, and with her compulsions broken the police finally arrest Eli, who cannot be killed and so is locked away instead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4005,7 +4005,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4018,7 +4018,7 @@
       "recaps": {
         "ending": "Krishnadevaraya's reign turns against the tolerance Pampa has defended. After she challenges the king's destructive choices, he has her eyes put out. Blind and removed from power, she completes the Jayaparajaya, the epic account that preserves both Bisnaga's splendor and its betrayals. She seals the manuscript away with instructions that it be found after the city has fallen. Pampa dies after a life spanning more than two centuries, but her prophecy continues beyond her. In 1565 the allied sultanates defeat Bisnaga's army at the Battle of Talikota. The victorious forces enter the capital and destroy it, ending the imperial city that had seemed capable of outliving every individual ruler. The manuscript survives in its clay vessel and is recovered centuries later, allowing Pampa's suppressed authorship and her alternative history to endure. Political victory proves temporary; the story is the form of survival she finally secures.",
         "in_short": "After watching the women of defeated Kampili die by fire, nine-year-old Pampa Kampana is inhabited by a goddess and charged with creating a new kind of city. She gives magical seeds to the brothers Hukka and Bukka, then whispers memories into the people who spring from the earth at Bisnaga. Across a life of more than two centuries, she tries to make the kingdom tolerant, cosmopolitan, and equal for women. She loves the Portuguese traveler Domingo Nunes, raises daughters within a contested dynasty, rules beside Bukka, endures exile, and repeatedly returns as regimes change. Religious orthodoxy and royal ambition keep undoing her reforms. Under the brilliant but increasingly authoritarian Krishnadevaraya, Pampa is finally blinded for opposing the king. She completes an epic history and hides it for future readers before dying. Bisnaga is destroyed after defeat at Talikota in 1565, but her buried poem survives the city and restores her voice as its creator and witness.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4205,7 +4205,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4218,7 +4218,7 @@
       "recaps": {
         "ending": "Paul Emanuel arranges for Lucy to become independent by securing and furnishing a small school for her. He then leaves Villette for three years of missionary and business work in Guadeloupe, while Lucy successfully expands the school into a larger establishment and waits for him. Their letters sustain an understood commitment, and his return appears near. The final pages refuse a direct statement of his fate: Lucy describes the destructive Atlantic storm that meets his homeward voyage, then invites hopeful readers to imagine a reunion while withholding one herself. The narrative strongly implies that Paul is lost at sea. Graham and Paulina, meanwhile, have married happily, and Madame Beck, Père Silas, and Madame Walravens live on. Lucy's professional independence endures, but the companionship toward which she and Paul had worked is left tragically unrealized, expressed through an ending that remains formally ambiguous.",
         "in_short": "Lucy Snowe, an isolated Englishwoman, travels to Villette and finds work at Madame Beck's girls' school, first as a nurse and then as a teacher. She discovers that the local physician Dr John is Graham Bretton, a friend from her childhood, and quietly loves him while he pursues the vain Ginevra Fanshawe. A reunion with Graham's mother restores Lucy to a circle of affection, but Graham eventually falls in love with Paulina, the child once devoted to him. Lucy's more difficult, reciprocal bond is with the demanding professor Paul Emanuel. Religious differences and the interference of people who depend on Paul complicate their attachment. Ginevra elopes with Count de Hamal, while Graham and Paulina marry. Before leaving for three years in Guadeloupe, Paul gives Lucy the means to run her own school. She prospers while awaiting him, but his return voyage meets a terrible storm; Lucy declines to confirm the outcome, though the close strongly implies his death at sea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4407,7 +4407,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4420,7 +4420,7 @@
       "recaps": {
         "ending": "Before sailing to Guadeloupe, Paul Emanuel secretly establishes a small school for Lucy and leaves her in control of it. Their hostility has become acknowledged love, but Madame Beck, Père Silas, and Madame Walravens have helped arrange his three-year absence. Lucy prospers as a schoolmistress while Paul writes faithfully, and she enlarges the school in anticipation of his return. The novel does not directly announce his fate. Lucy first invites the hopeful reader to imagine that he comes home, then describes a destructive Atlantic storm during the voyage on which he was due to return and refuses to say more. The conclusion strongly implies that his ship is lost and that Lucy lives on without him. Graham Bretton and Paulina, by contrast, marry with her father's approval, while Ginevra and Alfred de Hamal elope and settle into a less secure marriage.",
         "in_short": "After family losses she never fully explains, solitary Lucy Snowe travels to Villette and finds work in Madame Beck's girls' school. She recognizes the kindly Dr John as Graham Bretton, the son of her godmother, and quietly loves him, but he treats her as a friend and eventually falls in love with Paulina Home, now a young countess. Lucy's difficult colleague Paul Emanuel gradually becomes her truest companion; beneath his temper and Catholic suspicion, each recognizes the other's independence and generosity. A supposed spectral nun haunting Lucy proves to be a disguise used in Ginevra Fanshawe's secret courtship. Religious and family allies send Paul to manage an estate in Guadeloupe, but before leaving he gives Lucy a school of her own and they acknowledge their love. Lucy thrives during his three-year absence. His promised return coincides with a devastating Atlantic storm, and the deliberately indirect ending strongly implies that he dies at sea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4603,7 +4603,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4616,7 +4616,7 @@
       "recaps": {
         "ending": "Graham and Paulina are united with her father's consent, while Ginevra elopes with Alfred de Hamal and later admits that their glamorous match brings little contentment. Paul Emanuel's relatives and Madame Beck oppose his attachment to Lucy and arrange for him to oversee an estate in Guadeloupe for three years. Before leaving, Paul gives Lucy the means to direct a small school of her own. She succeeds, expands the school, and sustains their bond through letters while waiting for his return. At the end of the three years, a destructive Atlantic storm strikes during his homeward voyage. Lucy refuses to narrate a definite death and invites a hopeful reading, but the close strongly implies that Paul's ship never reaches Villette and that he does not return to her. Lucy's professional independence survives, while the personal future she anticipated remains suspended in that loss.",
         "in_short": "After an unsettled English youth, solitary Lucy Snowe travels to Villette and becomes a teacher at Madame Beck's school. She reconnects with her godmother Mrs Bretton and discovers that the kindly Dr John is Graham Bretton, whom she knew as a boy. Lucy quietly loves him, but Graham first pursues vain Ginevra Fanshawe and then reunites with Paulina Home, his devoted childhood companion; Graham and Paulina eventually marry. Lucy's sharper, more equal bond is with the demanding professor Paul Emanuel. Madame Beck, Père Silas, and Paul's family oppose the match and send him to manage an estate in Guadeloupe for three years, though Paul first establishes Lucy as the head of her own school. She prospers and waits for him. As his return approaches, a great storm crosses the Atlantic. The narrative declines to state his fate outright, but strongly implies that his ship is lost and that Lucy must continue the independent life he helped her build without him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/voidbound.json
+++ b/data/works-community/0/voidbound.json
@@ -356,7 +356,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-21",
@@ -369,7 +369,7 @@
       "recaps": {
         "ending": "Tala ends the reality prisoner's threat by restoring the identity and death the prisoner had denied. The reforged mage helps balance the released reality power, and Kit absorbs the stabilized cell. Tala and Terry then survive the giant-wolf trial, and Tala's victory earns only an opening toward future cooperation with the pack. The slain young wolf is restored by its god-beast and directed to consider Tala a possible ally. Rain has survived three refining sessions but remains fused after pausing before another. He finds a purpose in protecting people and begins courting Tala, who is not ready for marriage. Terry is healed and privately weighs a soulbond with Tala without committing to it. Brandon and Kedva are married, soulbound, expecting a son, and settled in Irondale, where Brandon works with Simon. Kit now contains a growing community and two recovered cells, but its exceptional magical density and dormant automaton require control. The sleeping city, hostile Doman Emeth entities, regional cell failures, Rain's refinement, wolf relations, and possible outside awareness of Tala's devourer nature remain unresolved.",
         "in_short": "After soulbonding Kit, Tala makes the sanctum safer but accidentally gives Adrill and Brandon durable natural magic. Kedva freely accepts a dangerous version of the same change, while Tala wrestles with consent, mortality, and her path toward Paragon. Rain survives three traumatic refining sessions and pauses before a fourth. Tala recovers a containment core from the Doman Emeth, turns Kit's expanded space into Irondale, and nearly creates self-propagating ice. Brandon and Kedva marry, soulbond, and prepare for a child. Tala later destroys an ancient reality prisoner by restoring the identity and death the prisoner denied, then absorbs the balanced cell into Kit. In a giant-wolf trial, Tala and Terry defeat a young wolf at severe cost. The wolf is later restored by its god-beast, leaving cautious cooperation possible. Tala and Rain begin courting, while Terry considers a soulbond and an outside threat may have noticed Tala's devourer resonance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -673,7 +673,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BRYHGJZL",
@@ -685,7 +685,7 @@
       "recaps": {
         "ending": "Araphel destroys the Shattered Bastion but not its evacuated population. In the last confrontation he permanently kills Asher and nearly does the same to Mercy. Maulkin interrupts Mercy's death, unifies his own soul and powers into a newly created sword, and sends Araphel's soul into the void. The act appears to destroy Maulkin, but Araphel's defeat instead restores him as a Voidgod. Mercy returns with solar divine power, and Saren emerges from an Alvaren afterlife with her memories restored. The three then eliminate the remaining gods. Saren refuses divinity and insists that replacing the old pantheon with another unchecked ruler is not enough. Maulkin, Mercy, and the mortal Saren establish a shared council in the failing divine palace. They choose gradual repair over conquest, beginning with those already suffering across Amaranth. The Alvaren aftermath, the Dvergar stone curse, the displaced Bastion coalition, and the future of the Inyoka and worms remain unsettled. Whether the new partners can make creation kinder will take centuries to determine.",
         "in_short": "Araphel's return forces Maulkin to unite Dvergar, Shagnar Fawn, humans, Inyoka, and eventually Alvaren at the Shattered Bastion. Raids, betrayals, and battles reveal that Araphel is destruction embodied and that Maulkin is becoming the Voidgod capable of opposing him. Briar dies after releasing Araphel, while the coalition's defenses and off-world reinforcements fail to stop the advancing host. The worms finally support Maulkin, but the Bastion must be evacuated and destroyed. Araphel permanently kills Asher and nearly kills Mercy before Maulkin turns his unified soul into a perfect new sword and casts Araphel into the void. Maulkin returns as a god, Mercy gains solar power, and Saren returns from an Alvaren afterlife. Together they destroy the old pantheon. Saren remains mortal, and the three form a council devoted to repairing Amaranth rather than conquering it.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1072,7 +1072,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0D2JJ44M9",
@@ -1084,7 +1084,7 @@
       "recaps": {
         "ending": "Brightsong reaches winter with shelter, food, stronger defenses, working smithing, and controlled magical farms. Hal has replaced the dragons' coercive oath with a reciprocal alliance, cured his founder-mark injury, removed his hollow essence, restored Durvin's soul fragment, and gained a legendary fused crafting class. Besal remains alive and independent in the Fathomways, pursuing allies against eldritch threats. Val and the Poisonheart scout survive their stand against the tower archmage, though the scout loses an arm and is likely blinded in one eye. Hal kills the archmage with the mage's stored disintegration spell, preserves Val's body, and reaches her lost consciousness. The captured mobile archspire is sealed pending inspection. Rinbast remains protected from direct conflict outside the Primacy Trials, Durvin's claim to the Anvil is unresolved, and another dwarf soul fragment still awaits recovery. Aldim may need to ascend to survive, but ascension could expose it to forces that consume world shards. Hal privately decides to return to the Abyss and has not told Noth his true purpose.",
         "in_short": "After defeating two dragons, Hal refuses to keep them enslaved by their oath and negotiates a reciprocal alliance that grants him dragonfire. Besal survives their separation, becomes physically independent, and takes up an anti-eldritch mission. Hal cures his founder-mark injury, turns defecting Kinslayers and an undercover founder into oath-bound allies, restores Durvin's missing soul fragment, and sheds the hollow essence restricting his powers. Brightsong gains homes, metalworking, magical crops, controlled monster farms, and Hal's legendary fused crafting. Mira reveals that Aldim is a declining world shard whose ascension could attract shard-consuming enemies. Val draws the returning tower archmage away from Hal and nearly dies beside the Poisonheart scout. Hal kills the archmage with his own captured spell, saves both defenders, recovers Val's consciousness, and claims the mobile archspire. Brightsong enters winter secure, while Besal continues his separate mission, Rinbast remains beyond direct reach, and Hal secretly prepares to return to the Abyss.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1338,7 +1338,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1351,7 +1351,7 @@
       "recaps": {
         "ending": "In Jamaica the trail leads to Geillis Duncan, alive under a married name and rich on a sugar plantation. She has been collecting gemstones because they are what a traveller needs to survive the stones, and she means to go forward through a cave called Abandawe to put a Scottish king on the throne, taking Young Ian as the sacrifice she believes the passage requires. Claire follows her into the cave and kills her; Jamie and Ian get out alive. Lord John Grey, now governor of Jamaica, has meanwhile put Jamie's son Willie in front of him again, and Claire has learned who the boy is. Wanted for murder and piracy and unable to stay, the Frasers put to sea, and the ship is destroyed in a hurricane. Claire and Jamie are washed ashore on the coast of Georgia, penniless, alive, and in the American colonies, with Young Ian and a few survivors. They have no way back to Scotland and no wish to go. The book ends with the two of them beginning again on a new continent.",
         "in_short": "Jamie Fraser survives Culloden, spends years hiding as an outlaw on his own land, then seven more in Ardsmuir prison, and is finally paroled to an English estate where a coerced night with the daughter of the house leaves him a son he can never acknowledge. In 1968 Claire, Brianna and Roger trace him through the records and find proof that he is alive in Edinburgh twenty years on, printing seditious pamphlets under an assumed name. Claire goes back through the stones and finds him. Their reunion is immediately complicated: Jamie is a smuggler with a burned print shop, a runaway nephew, and a wife in the Highlands he never mentioned. When Young Ian is carried off by pirates, the Frasers follow him across the Atlantic aboard a ship bound for the West Indies, through a typhoid epidemic, a shipwreck and a Jamaican governor's ball, to a confrontation with Geillis Duncan, who is alive and means to use the boy in a passage through the stones. Claire kills her; a hurricane then wrecks their ship and casts them ashore in the American colonies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1511,7 +1511,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1524,7 +1524,7 @@
       "recaps": {
         "ending": "On the second evening, after Pozzo and Lucky have gone, a boy again brings word that Godot will not come today but will come tomorrow. The messenger denies having met Vladimir the previous day, deepening the uncertainty over whether the days repeat or memory is failing. Vladimir tries to make the boy remember him so that their waiting will leave some trace. Alone again, Vladimir and Estragon consider hanging themselves from the tree, but their rope is too weak. They agree to return the next day with a better rope and say that they will leave now. Neither moves. Godot never appears, no rescue or explanation arrives, and the play ends with the pair still held in place by the promise of tomorrow.",
         "in_short": "Vladimir and Estragon wait beside a nearly bare tree for Godot, though they are unsure about their appointment and cannot settle what he might do for them. They pass the time with arguments, reconciliations, games, stories, and thoughts of leaving or dying. The domineering Pozzo crosses the road with Lucky, his burdened servant, and later returns blind while Lucky has become mute. At the end of each day, a boy says Godot will not come that evening but will come tomorrow; on the second visit he denies remembering the first. The tree gains leaves, but memory and chronology remain unstable. Vladimir and Estragon repeatedly decide to go, yet do not move. Godot never arrives, and their waiting continues beyond the play's close.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1618,7 +1618,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1631,7 +1631,7 @@
       "recaps": {
         "ending": "The imperial campaign against the supposed barbarian threat collapses without producing the invasion it was meant to prevent. Soldiers return exhausted and diminished, and Colonel Joll passes through the settlement with his authority visibly broken before the remaining forces withdraw. Many townspeople flee in expectation of an attack, but the nomadic people never arrive. No formal order restores the Magistrate; he simply resumes administrative work because someone must organize food, shelter, and winter preparations for those who remain. His body and status have been permanently marked by detention, and he has gained no complete understanding of the young woman he returned to her people. Snow covers the frontier. The settlement waits for an enemy constructed by imperial fear, while the Magistrate recognizes that his efforts to explain his experience have not brought him to a satisfying conclusion.",
         "in_short": "An aging Magistrate administers a remote imperial settlement until Colonel Joll of the Third Bureau arrives to investigate an alleged barbarian uprising. Joll tortures prisoners and leads raids that create the hostility he claims to be uncovering. After the soldiers depart, the Magistrate shelters a young nomadic woman whose sight and feet were damaged in custody. Unable to understand either her suffering or his own motives, he escorts her back to her people. On returning, he is arrested for aiding the enemy. Imprisonment, beatings, and public humiliation strip him of office and expose the violence beneath imperial law. He protests when Joll tortures new captives, while an army marches into the wilderness. The expedition fails, discipline collapses, and the troops abandon the frontier. The expected invasion never comes. Without formal reinstatement, the Magistrate again organizes the settlement for winter, left with damaged faith in the Empire and no neat account of what he has learned.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1779,7 +1779,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1792,7 +1792,7 @@
       "recaps": {
         "ending": "The attack is brought to an end, but not as a victory. Themis, piloted by Vincent Couture and his ten-year-old daughter Eva Reyes, is used against the visitors' machines in the final confrontation. By then the substance released in the world's cities has killed on the order of a hundred million people, whole districts of major capitals are dead ground, and humanity has learned that part of its own population descends from the people who sent the machines. Kara Resnik does not survive the book; she is killed before the end, and the letter she leaves for Vincent is read after her death. What follows the fighting is a judgement rather than a settlement: Rose Franklin, Vincent and Eva are taken off Earth altogether, along with Themis, by the people who built it. Eugene Govender, Ryan Mitchell and the rest of the Earth Defense Corps are left behind on a planet permanently altered by what has happened, without the machine and without the three people who understood it best. Rose, Vincent and Eva arrive on a world that is not theirs, with no way home, no idea how long they will be kept there, and no assurance that Earth's reprieve is permanent.",
         "in_short": "Ten years after Themis was assembled, it is operated publicly by the Earth Defense Corps, with Rose Franklin heading its science division and Kara Resnik and Vincent Couture as its pilots. Then a second giant machine appears overnight in London and stands silent for days before releasing a substance that kills everyone for miles around. More of them appear in cities across the world and do the same, and the dead are counted in the tens of millions and then far higher. Rose works out why they have come, and the answer turns on ancestry: some humans carry the visitors' genetic inheritance, which is also what decides who can pilot. A girl in Puerto Rico, Eva Reyes, proves to be the biological daughter of Kara and Vincent, conceived without their knowledge by the project's geneticist. Kara is killed, and Vincent trains his daughter to pilot Themis with him. The confrontation ends the attack at a cost of roughly a hundred million lives, and Rose, Vincent and Eva are taken off Earth by the machines' builders, along with Themis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1969,7 +1969,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1982,7 +1982,7 @@
       "recaps": {
         "ending": "After Gram dies in Coeur d'Alene, Gramps lets Sal continue toward Lewiston alone. At the mountain overlook she faces the place where her mother's bus crashed and finally states the truth she has resisted: Sugar died in the accident and is buried nearby. A sheriff takes her to the grave, where Sal leaves flowers and begins to accept that reaching Idaho cannot bring her mother home. Margaret Cadaver was the crash's only survivor, which explains her bond with Sal's father; she had met Sugar on the trip and later shared Sugar's final memories with him. Sal returns to Bybanks with her father and Gramps. Phoebe and her family visit, Ben remains important to Sal, and the Hiddles begin living again on the farm. Sal still grieves both Gram and Sugar, but she can now hold their stories without turning them into promises of return.",
         "in_short": "Thirteen-year-old Salamanca Hiddle rides from Ohio to Idaho with her grandparents, hoping to arrive for her absent mother's birthday. On the way she tells them about Phoebe Winterbottom, a friend whose mother vanished after mysterious notes and visits from a strange boy. Sal and Phoebe search for Mrs. Winterbottom and discover that the boy, Mike, is the son she gave up before her marriage; she returns home ready to acknowledge him. Phoebe's story gradually mirrors Sal's refusal to accept her own mother's fate. Gram becomes gravely ill and dies near the journey's end, but Gramps helps Sal reach Lewiston. At the site of a bus crash, Sal finally acknowledges that her mother died there while traveling west. Margaret Cadaver, whom Sal resented as her father's friend, survived the same crash and had befriended her mother. Sal returns with her father and Gramps to their Kentucky farm, carrying grief that she can finally name and memories she can share.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2212,7 +2212,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2225,7 +2225,7 @@
       "recaps": {
         "ending": "Seven years after the war, the surviving families have formed a stable but imperfect household network. Nikolai Rostov has married Princess Marya and restored his estate through disciplined work; Sonya remains with them, while the old Countess depends on their care. Pierre and Natasha are married with children, and Natasha's life is centered on her family. Pierre returns from Petersburg convinced that honorable people must organize against political injustice. Nikolai distrusts any movement that could conflict with his oath to the government, and their debate leaves a future disagreement unresolved. Prince Andrei's son Nikolenka admires Pierre and dreams of joining him in a great moral undertaking while remaining worthy of his dead father. The second epilogue then moves away from the families to argue that history cannot be explained by the commands of supposedly great individuals. Human events arise from innumerable connected wills; freedom is experienced inwardly, while necessity becomes visible when actions are considered through time, circumstance, and causation.",
         "in_short": "Against the Napoleonic wars, several Russian aristocratic families pursue ambition, love, and moral purpose. Pierre Bezukhov inherits a fortune, survives a disastrous marriage to Helene, passes through Freemasonry and despair, and finds a durable love of life during French captivity. Prince Andrei seeks glory, loses his wife, falls in love with Natasha Rostova, and breaks their engagement after she is drawn into Anatole Kuragin's attempted elopement. Wounded at Borodino, Andrei forgives Anatole and later reconciles with Natasha before dying. Natasha matures through remorse, nursing Andrei, and family grief. Nikolai Rostov's military ideals become practical responsibility; after the war he marries Princess Marya and rescues his family's estate. Napoleon occupies a deserted, burning Moscow but cannot force peace, and the French retreat collapses under hunger, weather, and Russian pressure. Pierre marries Natasha, and their families rebuild. The epilogue rejects history centered on heroic rulers, presenting events as the outcome of countless human actions constrained by circumstance.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2505,7 +2505,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2518,7 +2518,7 @@
       "recaps": {
         "ending": "In a British veterinary hospital, Joey hears Albert's familiar call and answers it, reuniting horse and owner after years of separation. Albert helps nurse him through illness and injury. When the war ends, the army announces that its surviving horses will be sold in France rather than shipped home. Albert and his comrades raise money to buy Joey, but a butcher bids against them. Emilie's grandfather outbids the butcher. He has searched for Joey because Emilie, who has died, loved the horse and asked that he be found. Once he understands Albert's bond with Joey, he lets Albert take him home in return for a promise to keep Emilie's memory alive. Joey returns to Devon, where Albert's parents welcome him and Albert eventually marries Maisie. The reunion restores the partnership broken when Joey was sold, while the memories of Topthorn, Emilie, Friedrich, and the many others lost to the war remain part of Joey's homecoming.",
         "in_short": "Farm boy Albert Narracott raises a horse named Joey, but his indebted father sells Joey to the British cavalry at the start of the First World War. Joey serves under Captain Nicholls, befriends the black horse Topthorn, and passes through battles and several owners after both horses are captured by the Germans. They pull ambulances and artillery, find temporary peace with a French girl named Emilie and her grandfather, and endure the deaths of soldiers and horses around them. Topthorn dies from exhaustion, and Joey escapes into no man's land, where British and German soldiers cooperate to rescue him. Taken to a British veterinary unit, he is recognized by Albert, who enlisted in hopes of finding him. After the war, Emilie's grandfather saves Joey from a butcher at auction and allows Albert to take him home. Joey returns to Devon with Albert, their long separation finally ended.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2703,7 +2703,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2716,7 +2716,7 @@
       "recaps": {
         "ending": "After the armistice, the army decides to auction its surviving horses in France rather than transport them to Britain. Albert and his comrades collect their money to buy Joey, but an elderly French farmer wins the bidding. He is Emilie's grandfather and explains that Emilie died after the horses were taken away; he bought Joey in her memory. When he understands the depth of Albert's bond with the horse, he lets Albert take Joey home on the condition that Emilie's story will be remembered. Albert and Joey return to Devon. Albert eventually marries Maisie, the girl who had waited for him, and Joey settles back into peaceful farm life. The reunion does not erase the losses of the war, including Topthorn, Friedrich, David, and Emilie, but Joey ends his account safe with the person who first earned his trust.",
         "in_short": "Joey, a farm horse raised by Albert Narracott in Devon, is sold to the British cavalry when the First World War begins. In France he serves first as a cavalry mount beside the black horse Topthorn, then is captured by German troops. The two horses pull an ambulance, spend a brief peaceful period with a French girl named Emilie, and are later forced into exhausting artillery work. Topthorn dies, and shellfire drives Joey alone into no man's land, where British and German soldiers cooperate to rescue him. Taken to a British veterinary hospital, Joey is recognized by Albert, who has enlisted in hopes of finding him. Joey survives illness and the war, but the army plans to sell him. Emilie's grandfather buys him at auction, then yields him to Albert after hearing their history. Albert brings Joey home to Devon, giving the horse a peaceful life while preserving the memory of those lost during the war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2890,7 +2890,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2903,7 +2903,7 @@
       "recaps": {
         "ending": "In a British veterinary hospital, Joey hears Albert's familiar call and answers it, reuniting horse and owner after years of separation. Albert helps nurse him through illness and injury. When the war ends, the army announces that its surviving horses will be sold in France. Albert and his comrades raise money to buy Joey, but Emilie's grandfather wins the auction, saving Joey from a butcher. He has searched for the horse because Emilie, who has died, loved him and wanted him kept safe. Once the grandfather understands Albert's bond with Joey, he allows Albert to take him home in exchange for a promise to preserve Emilie's memory. Joey returns to Devon with Albert. Their reunion restores the partnership broken when Joey was sold, while the memories of Topthorn, Emilie, Friedrich, and the many others lost to the war remain part of the homecoming.",
         "in_short": "Farm boy Albert Narracott raises a horse named Joey, but his indebted father sells Joey to the British cavalry at the start of the First World War. Joey serves under Captain Nicholls, befriends the black horse Topthorn, and passes through battles and several owners after the horses are captured by the Germans. They pull ambulances and artillery, find temporary peace with a French girl named Emilie and her grandfather, and endure the deaths of soldiers and horses around them. Topthorn dies from exhaustion, and Joey escapes into no man's land, where British and German soldiers cooperate to rescue him. Taken to a British veterinary unit, he is recognized by Albert, who enlisted in hopes of finding him. After the war, Emilie's grandfather saves Joey from a butcher at auction and allows Albert to take him home. Joey returns to Devon with Albert, their long separation finally ended.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3071,7 +3071,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3084,7 +3084,7 @@
       "recaps": {
         "ending": "The alliance is destroyed at Brunanburh. After a day of shield wall against shield wall the Saxon line holds and then breaks the enemy, and the Norse and Scottish army is slaughtered as it runs. Constantine loses his son, the northern kings' strength is broken, and Anlaf escapes with what is left of his fleet back to Ireland. Ingilmundr, the favourite Aethelstan trusted and loved above everyone, is revealed to have been the enemy's man, a betrayal that costs the king more privately than the battle cost him in warriors. Aethelstan is left the undisputed ruler of all the English and overlord of Britain, and the victory becomes the thing his name is remembered for. Uhtred, who fought for the north rather than for the king, comes out of it alive and with what he wanted: Bebbanburg is his, Ealdred's claim on it is finished, and a king who has broken one oath is in no position to break another. He rides home with Finan to Benedetta and his family, an old man who has fought his last battle, and takes up again the only thing he ever truly wanted - the fortress above the sea, and the prospect of dying in his own hall rather than in a shield wall. The series ends with him there, alive, holding the place he spent a lifetime taking back.",
         "in_short": "Aethelstan, the king Uhtred made, breaks the oath he swore, invades Northumbria and takes the last kingdom in Britain outside Saxon rule, forcing its lords - Uhtred among them - and the kings of the Scots, the Strathclyde Britons and the Welsh to accept him as overlord. Uhtred, old and wanting only peace, is squeezed by the king's new favourites: the Norse convert Ingilmundr, whom Aethelstan trusts above anyone, and the ambitious Ealdred, who covets Bebbanburg and seizes the fortress while Uhtred is away. Uhtred takes it back by trickery. Meanwhile Anlaf, the Norse king of Dublin, assembles a great alliance of Scots, Strathclyde Britons and the Norse of Ireland and Northumbria to destroy Aethelstan and divide his kingdoms, and offers Uhtred a crown to join it or stand aside. Uhtred chooses against the invaders. The armies meet at Brunanburh, where a day-long slaughter ends with the alliance broken, Constantine's son dead and Anlaf fleeing to his ships. Aethelstan is left ruler of all the English; Uhtred survives, keeps Bebbanburg, and goes home to the sea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3600,7 +3600,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B00302FHBW",
@@ -3612,7 +3612,7 @@
       "recaps": {
         "ending": "Operation Thunderbolt restores open war and leaves Manticore badly weakened. Haven destroys the Tequila defense and takes Maastricht, but Grayson's timely reinforcement makes Giscard withdraw from Trevor's Star. At Sidemore, Honor's combined Manticoran-Grayson force destroys or disables more than half of Tourville's Second Fleet, although ammunition limits prevent a complete pursuit. High Ridge resigns after Grendelsbane, Janacek is ruled a suicide, and Descroix vanishes after moving money into Silesian banking. Elizabeth appoints Willie as prime minister, Morncreek as Chancellor, Earl White Haven as First Lord, and Thomas Caparelli as First Space Lord. Erewhon has joined Haven, Grayson is Manticore's only strategic reserve, and the new government seeks an Andermani alliance tied to a Silesian settlement. Giancola's falsification of diplomacy remains undisclosed after he destroys his records. Honor is positioned for renewed fleet command, while her empathic bond and love with White Haven remain unresolved with Emily's knowledge.",
         "in_short": "High Ridge's government delays peace with Haven, cuts Manticore's fleet, and sends Honor Harrington to contain Andermani pressure in Silesia. Haven secretly rebuilds under Theisman and Shannon Foraker while Arnold Giancola falsifies diplomatic messages to drive both governments toward war. Honor discovers advanced Andermani capabilities and a concealed Havenite Second Fleet, then wins enough trust from the incoming Andermani commander to pause their confrontation. Operation Thunderbolt nevertheless begins. Haven destroys outer defenses at Tequila and Maastricht, but Grayson reinforces Trevor's Star in time to deter Giscard. Honor and Grayson rout Tourville at Sidemore, destroying or crippling most of his long-range striking force. The disaster topples High Ridge's ministry. Elizabeth installs Willie, Morncreek, White Haven, and Thomas Caparelli to rebuild a severely damaged Alliance and seek Andermani support. The war continues, Giancola's sabotage remains hidden, and Honor's new empathic connection with White Haven forces their unresolved love into the open with Emily.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3800,7 +3800,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3811,7 +3811,7 @@
       "recaps": {
         "ending": "The war ends at Heahburh, Skoll's high fortress in the Cumbrian hills, taken at brutal cost. Uhtred and Sigtryggr's men fight through the gate and break the defence, and Skoll - after killing his own blind sorcerer Snorri for the failure of his prophecies - offers to surrender his sword Grayfang. The surrender is a trick: he turns the blade on Sigtryggr, but Uhtred intervenes and beats him down, then gives the kill to his son-in-law, and Sigtryggr ends Skoll and avenges Stiorra. The victory settles the feud but not the future. Stiorra is dead and stays dead; Uhtred has buried a daughter and Sigtryggr a queen, and the assault has cost Uhtred dearly in the men of his household. Northumbria survives as the last kingdom outside Saxon rule, but it is weaker, King Edward's health is failing, and the succession struggle between Aethelstan and Aelfweard - with Ealdorman Aethelhelm's faction behind the latter, and no friend to Uhtred - is coming whether the north wants it or not. Uhtred returns to Bebbanburg a victor in mourning, bound to Aethelstan by old loyalty and to Northumbria by blood, with the last convulsion of the Saxon wars still ahead.",
         "in_short": "A false plea for help lures Uhtred from Bebbanburg to Ceaster, where he puts down Cynlaef's rebellion against King Edward - and learns the summons was a decoy. While he was away, Skoll Grimmarson, a Norse warlord from Northumbria's wild west who means to be its king, attacked Eoferwic; Uhtred's daughter Stiorra, queen of Northumbria, led its defenders in her husband Sigtryggr's absence and was killed. The war that follows is a blood feud. Skoll's ulfhednar, frenzied wolf-warriors, and his blind sorcerer Snorri make his army feared beyond its numbers, and a first campaign into the hills ends in a mauling that teaches Uhtred the price of this enemy. Uhtred and Sigtryggr finally storm Skoll's high fortress of Heahburh at terrible cost. Skoll kills Snorri for his failed prophecies, feigns surrender, and tries to kill Sigtryggr; Uhtred defeats him and Sigtryggr delivers the killing blow, avenging Stiorra. Uhtred returns to Bebbanburg victorious, grieving, and aware that the fight over Edward's succession is coming.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3952,7 +3952,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3965,7 +3965,7 @@
       "recaps": {
         "ending": "In London, the narrator finds the Martian fighting machines motionless and their operators dead. The invaders had no resistance to earthly microorganisms, so ordinary bacteria defeated them after human weapons and institutions had failed. England begins to recover, although the invasion has killed many people and permanently altered the survivors' sense of security. Believing his wife died in the destruction of Leatherhead, the narrator returns alone to the ruins of his home near Woking. She unexpectedly arrives there with a cousin, having escaped before the town was destroyed, and the couple are reunited. Later study of the abandoned Martian machinery expands human knowledge, while observations of Mars and activity elsewhere in the solar system leave open the possibility of another attack. The narrator continues to suffer vivid memories of the invasion and recognizes how fragile human dominance has always been.",
         "in_short": "Unusual flashes on Mars precede the fall of cylinders in southern England. An unnamed writer near Woking sees the first Martians emerge and attack with a Heat-Ray, then sends his wife toward safety as towering fighting machines advance. Military resistance collapses under the Heat-Ray and poisonous Black Smoke. The narrator survives the destruction of Weybridge, travels with a terrified curate, and later hides beside a Martian pit while the invaders feed and build. In a parallel account, his brother escapes the panic in London and reaches a refugee ship after HMS Thunder Child sacrifices itself against the machines. The curate's loss of control leads to his death, while the narrator remains concealed. When he finally enters a silent London, he discovers that the Martians have died from earthly bacteria to which humans have acquired resistance. He returns to his damaged home expecting to be alone and is reunited with his wife, who escaped Leatherhead before its destruction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/war-of-the-worlds-dramatized-h-g-wells.json
+++ b/data/works-community/0/war-of-the-worlds-dramatized-h-g-wells.json
@@ -85,7 +85,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -98,7 +98,7 @@
       "recaps": {
         "ending": "In deserted London, the narrator discovers that the Martians and their fighting machines have suddenly become still. The invaders are dead or dying, defeated not by human weapons but by terrestrial microorganisms against which they have no immunity. Other survivors emerge, and organized life begins to return. Physically safe but mentally exhausted, the narrator is cared for by strangers and eventually makes his way back through the damaged suburbs to his home in Woking. There, after believing that both must have died, he is reunited with his wife. Human authorities study the abandoned Martian machinery and the possibility of future attacks, while astronomers watch Mars with new concern. The invasion leaves the narrator aware that human dominance is neither guaranteed nor absolute, and that ordinary life continues under the knowledge that another world has already tried to conquer Earth.",
         "in_short": "After astronomers observe eruptions on Mars, cylinders fall in southern England carrying Martians armed with a Heat-Ray, poison gas, and towering fighting machines. An unnamed writer near Woking survives the first attack, gets his wife to Leatherhead, and is then cut off from her as the invasion expands. Conventional forces collapse. The narrator flees with a traumatized curate and is trapped beside a Martian feeding site, while his brother escapes the mass evacuation of London and reaches a departing ship after witnessing the warship Thunder Child sacrifice itself against the machines. Emerging into a ruined London, the narrator finds the Martians abruptly dead: Earthly microorganisms, harmless to humanity through long adaptation, have destroyed the invaders. He returns home and is unexpectedly reunited with his wife. Humanity survives, but the abandoned technology and the possibility of another attack permanently alter its view of its place in the universe.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -325,7 +325,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -338,7 +338,7 @@
       "recaps": {
         "ending": "This first portion ends with all three viewpoint characters entangled in conflicts they only partly understand. Siri has learned that Susebron is mute, isolated, and unable to read, not the brutal husband she expected. By teaching him and communicating in secret, she has turned their forced marriage into a cautious alliance, while the priesthood and competing gods continue to decide policy around them. Vivenna remains in T'Telir with Denth's mercenary crew, using disruption and propaganda to oppose Hallandren in Idris's name. She believes the resulting unrest is useful resistance, although Vasher's interference and the widening street violence indicate that her campaign serves interests she has not identified. Lightsong's investigation has moved him closer to the court's military struggle despite his efforts to avoid divine responsibility. Blushweaver continues gathering influence over the Lifeless armies. War between Hallandren and Idris is now more likely, and the sisters remain separated, each unaware of how the other's alliances are changing.",
         "in_short": "King Dedelin sends his unprepared youngest daughter Siri to marry Susebron, Hallandren's God King, instead of the dutiful Vivenna. Siri expects a monster but discovers that Susebron is a sheltered, mute prisoner of his own priesthood. Their secret communication develops into trust as she begins teaching him to read. Vivenna follows to T'Telir intending to rescue Siri and defend Idris. After receiving a dying agent's store of magical Breath, she joins the mercenaries Denth, Tonk Fah, and Jewels and helps organize unrest against Hallandren, believing controlled disruption will prevent an invasion. The mysterious Awakener Vasher and his sentient sword Nightblood repeatedly cross that effort. At the Court of Gods, the skeptical Returned Lightsong investigates troubling events while the ambitious Blushweaver presses for command of the Lifeless armies. By the midpoint, Siri and Susebron are allies, Vivenna's covert campaign is spreading violence she does not fully understand, and multiple factions are pushing Hallandren and Idris toward war.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -507,7 +507,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -520,7 +520,7 @@
       "recaps": {
         "ending": "Bluefingers' faction seizes Siri and Susebron and sends the Hallandren Lifeless army toward Idris, intending to make the two nations destroy one another. Lightsong gives up his divine Breath to heal Susebron's mutilated tongue, restoring the God King's ability to speak and use his enormous power. Susebron overwhelms the conspirators and rescues Siri. Vasher kills Denth, then reveals that he is the Returned figure once known as both Kalad and Peacegiver. The supposedly decorative stone soldiers around Hallandren are his hidden army of Lifeless, and he gives Susebron the command that can use them to stop the invasion. War is averted. Vivenna chooses neither a return to her former sheltered life nor a permanent place at court; after warning Idris, she leaves with Vasher to learn more about Awakening and herself. Siri and Susebron remain together to rule, while the sacrifices of Lightsong and Blushweaver end the old balance within the Court of Gods.",
         "in_short": "In the second half of Warbreaker, Vivenna learns that Denth engineered violence in her name to provoke war, escapes him, and studies Awakening under Vasher. Siri and Susebron discover that the God King is a prisoner of his own priesthood, but their attempt to act is overtaken by a Pahn Kahl conspiracy led inside the palace by Bluefingers. The conspirators kill Blushweaver, seize the royal couple, and dispatch Hallandren's Lifeless army against Idris. Lightsong finally accepts that his return had a purpose and sacrifices his divine Breath to restore Susebron's tongue, allowing the God King to use his vast power and free Siri. Vasher kills Denth and reveals himself as Kalad and Peacegiver; his hidden army of stone-encased Lifeless is sent to halt the invasion. Siri and Susebron remain together, peace is preserved, and Vivenna leaves with Vasher to continue learning beyond the role once chosen for her.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -682,7 +682,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -693,7 +693,7 @@
       "recaps": {
         "ending": "The war ends with Ragnall dead and the north remade. When the armies finally meet, Ragnall's cause has already rotted - at his order to advance, half his men hold back - and Uhtred's charge breaks and kills him. Uhtred then rides on Eoferwic, where Brida has been ruling in Ragnall's name and waging a savage war on Christians. Uhtred takes the city and overcomes Brida, his first lover and oldest enemy, and it is his daughter Stiorra who kills her. The settlement that follows shapes the next books: with Aethelflaed's consent, Sigtryggr - Ragnall's brother and Stiorra's husband - takes the Northumbrian throne at Eoferwic, on his promise never to attack Mercia. Uhtred has destroyed the invasion, avenged the mutilation of his son Oswald, and made his own son-in-law a king; his daughter is now a queen in the north. Mercia stands secure, and Bebbanburg, Uhtred's stolen birthright, remains unclaimed - the last piece of his life's ambition still to win.",
         "in_short": "The Norse sea-king Ragnall Ivarson, driven from Ireland, lands a great army near Ceaster to carve a kingdom from Northumbria and Mercia. Uhtred, holding Ceaster for Aethelflaed, is distrusted by some because his daughter Stiorra is married to Ragnall's brother Sigtryggr. Uhtred storms Ragnall's fort at Eads Byrig, seeing through the bad-faith surrender of his old enemy Haesten, and Ragnall retaliates by slaughtering captives and returning Uhtred's estranged priest son Oswald mutilated by Brida, Uhtred's first lover turned bitter foe. Uhtred sails to Ireland to relieve the besieged Sigtryggr and Stiorra and brings them to Britain, then hammers Ragnall's growing army with raids until the final battle, where Ragnall's support collapses and Uhtred kills him. At Eoferwic, Stiorra kills Brida. With Aethelflaed's consent Sigtryggr becomes King of Northumbria, sworn never to attack Mercia, with Stiorra as his queen.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -795,7 +795,7 @@
             }
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -808,7 +808,7 @@
       "recaps": {
         "ending": "After leaving the Van Tassel gathering disappointed in his courtship, Ichabod rides home alone through places associated with local ghost stories. A large rider appears and pursues him toward the bridge beside the churchyard. Ichabod sees that the figure seems to carry its head, and the rider hurls it at him as he reaches the bridge. The next day, searchers find Ichabod's hat and a shattered pumpkin but no Ichabod. He never returns to Sleepy Hollow. Later reports place him alive elsewhere, where he studies law, enters politics, and becomes a judge. Brom Bones marries Katrina and reacts knowingly whenever the pumpkin is mentioned, suggesting that he staged the encounter. The older residents nevertheless continue to prefer a supernatural explanation, and the abandoned schoolhouse gains its own reputation for being haunted.",
         "in_short": "Ichabod Crane, a superstitious schoolmaster in the Hudson Valley settlement of Sleepy Hollow, courts Katrina Van Tassel, the daughter of a prosperous farmer. His rival is the bold local horseman Brom Bones, who responds with pranks. After a harvest gathering filled with ghost stories, Ichabod leaves the Van Tassel farm dejected and rides home through the dark. A headless rider chases him to the church bridge and throws what appears to be its severed head. Ichabod vanishes, leaving behind his hat and a broken pumpkin. Rumors later say that he survived and built a legal career elsewhere. Brom marries Katrina and seems amused by the pumpkin detail, strongly suggesting that he impersonated the legendary horseman to frighten Ichabod away, although Sleepy Hollow preserves the haunting as local legend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -904,7 +904,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -917,7 +917,7 @@
       "recaps": {
         "ending": "The tensions aboard the Benzini Brothers circus erupt in catastrophe. After a purge of workers thrown from the moving train, someone releases the menagerie animals during a show, and a stampede turns the big top into chaos. In the confusion, the elephant Rosie kills the cruel August, freeing Marlena from her abusive husband. Uncle Al's mismanaged show collapses in the wake of the disaster. Jacob and Marlena leave together with Rosie and several of the animals, and Jacob at last completes his veterinary training. They marry, raise a large family, and Jacob works for years as a zoo veterinarian, keeping the circus animals cared for. In the present-day frame, the elderly Jacob, forgotten by much of his family and stuck in a nursing home, slips away to a circus that has set up nearby and persuades its owner to take him on to sell tickets, choosing to spend his last days back in the world he loved. The novel closes on his contentment at having found, even in old age, one more chance for the life he never stopped longing for.",
         "in_short": "As an old man in a nursing home, Jacob Jankowski recalls the year he ran away with a circus. In 1931, days before finishing his veterinary studies at Cornell, Jacob is left orphaned and broke when his parents die in a car crash. He jumps a train that turns out to belong to the Benzini Brothers circus, a shabby, cost-cutting show run by the tyrannical Uncle Al, and becomes its veterinarian. He falls in love with Marlena, the show's star equestrienne, who is married to August, the charming but violently unstable animal boss. The circus takes on an elephant named Rosie, and Jacob discovers her hidden intelligence even as August abuses her. Amid brutal working conditions, where troublesome laborers are thrown from the moving train, the love triangle and cruelty build toward disaster. A stampede during a performance brings the show crashing down, August is killed by the elephant, and Jacob and Marlena escape together to build a life. In the present, the aged Jacob makes his own bid for one last adventure.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1045,7 +1045,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1058,7 +1058,7 @@
       "recaps": {
         "ending": "General Woundwort tracks the escaped rabbits to Watership Down and attacks with an Efrafan force, breaking into the warren's tunnels. Bigwig fights him off in the dark, and Woundwort is shaken to learn that Bigwig is not even the chief, sensing some greater rabbit behind him. Meanwhile Hazel, with two companions, goes to a nearby farm and looses its guard dog, then leads it back to the down, where it falls upon the besiegers and scatters them. Woundwort turns and charges the dog head-on and is never seen again; his body is never found, and he passes into rabbit legend. Hazel, caught by the farm cat, is rescued by a young human girl who carries him off and later sets him free, and he returns home. The warren endures, the does who fled Efrafa settle into it, and in time a lasting peace is made with Efrafa under gentler leadership. In an epilogue set years later, an aged Hazel, having watched his warren flourish, is visited by the spirit of the rabbits' folk-hero, who invites him to join him; Hazel quietly leaves his tired body behind and dies content.",
         "in_short": "When the timid, visionary rabbit Fiver foresees the destruction of their warren, his brother Hazel leads a small band, including the strong Bigwig and the clever Blackberry, away to find a new home. After surviving a sinister warren where a farmer secretly snares the rabbits, and crossing dangerous country, they settle on a high down, guided by Fiver. Realizing they have no does to breed and keep the warren alive, they befriend a gull, Kehaar, and learn of Efrafa, a large, oppressive warren ruled by the tyrannical General Woundwort. Bigwig infiltrates Efrafa and, with the doe Hyzenthlay, engineers a daring escape of does down a river. Woundwort pursues them to the down and besieges the warren, but Hazel breaks the siege by luring a farm dog to attack the Efrafans, and Woundwort vanishes charging it. The warren survives and prospers, making peace with a reformed Efrafa. Years later, an old Hazel dies peacefully, his home secure.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1469,7 +1469,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0C3WNFKL9",
@@ -1481,7 +1481,7 @@
       "recaps": {
         "ending": "The Raven Sect ambushes the northern expedition at its overnight refuge, massacres villagers and soldiers, poisons Hadjar, and carries Lathea away. Guided by a deceased friend and the Black General, Hadjar draws fire and wind together to purge the poison and annihilates the local raiding force. He follows the captives north, where the sect master's seventh disciple is torturing the Lesket mage. The mage gives Hadjar the thunderbird core, allowing him to complete his white lightning step and wound the disciple, who retreats. A northern host rescues Hadjar and the mage after Hadjar collapses. The mage remains alive but his soul is trapped among ancestral memories, and his recovery is uncertain. Lathea is alive farther north, apparently held by the wolf of darkness's forces as bait for Hadjar. Hadjar must recover before pursuing her. The campaign, Abraham Shensie's plan for the Forty Families, Hadjar's obligation to destroy the Raven Sect, the Black General's intentions, the Therna stone, and the threatened supernatural war all remain unresolved.",
         "in_short": "Hadjar helps Star Rain defeat the Underground Whisper Clan, enters the clan's hidden trial, and becomes a Thernian. Abraham Shensie secretly kills the Star Rain chief and uses the murder to build support for war against the Raven Sect. Hadjar and Lathea recover a key and steel, survive a vast anomaly, claim a Therna stone, and escape after a Lesket woman sacrifices herself to kill a pursuing immortal. They recruit Lesket troops for a northern expedition, but the Raven Sect ambushes the force, poisons Hadjar, and abducts Lathea. Hadjar purges the poison by uniting wind and flame, destroys the raiders, and wounds the sect master's seventh disciple with power from a thunderbird core given by the tortured Lesket mage. Hadjar and the mage are rescued in the north. The mage's soul is lost in ancestral memories, while Lathea remains alive as bait in the custody of supernatural wolves.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1934,7 +1934,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CP6FY6M1",
@@ -1946,7 +1946,7 @@
       "recaps": {
         "ending": "The coalition's invasion of the Raven Sect's artificial anomaly ends with the deaths of the Raven master's leading disciple and the Raven master. Lathea kills the disciple, and the lingering attachment within Hadjar's former master briefly restrains the Raven master so Hadjar can strike the killing blow. The collapsing anomaly releases the Black General, who leaves Hadjar unable to remember their final exchange and burdened with more soul fragments. The survivors return to the Strangelands and bury their dead. Itia, permanently maimed, remains as archivist of the Twilight Secret Sect. Hadjar leaves for the northern lands with Lathea, Alba Udun, the Lesket mage, and an unnamed officer under the squad name Heaven Foxes. The immediate Raven Sect war is finished, but the Black General is free, the Soul Stone remains beyond Hadjar's reach, the Lord of Nightmares is still owed one request, and the power of the North continues to exact a cost from Hadjar's soul.",
         "in_short": "Detained by the Twilight Secret Sect as a Raven Sect army approaches, Hadjar earns command and organizes an improvised defense. A failed mission through the guardian spirit's time anomaly sends him and Desert Mirage into the past, where Hadjar helps breach a fae castle but saves the Fae Queen's daughter before returning. The Raven commander steals the Soul Stone, kills many defenders, and leaves the sect ruined. Hadjar learns that the Black General created Therna but seeks the world's destruction, gains a route to the hidden Raven Sect, survives a northern trial, and awakens the true name of the North. He then assembles a coalition and invades the Raven Sect's artificial anomaly. Lathea kills the enemy's leading disciple, while Hadjar kills the Raven master after learning that his former master was a soul golem. The Black General is freed as the anomaly collapses and erases Hadjar's memory of their exchange. After burying the fallen, Hadjar and four companions form the Heaven Foxes and depart north.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2381,7 +2381,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0C95H895N",
@@ -2393,7 +2393,7 @@
       "recaps": {
         "ending": "Hadjar enters the Twilight Secret Sect after the mountain spirit keeps him on the Twilight Path for three weeks. Desert Mirage survives their duel and warns Hadjar to leave, but Hadjar instead offers him a place with the group. At the council, Abraham Shensie offers the key and knowledge of Therna as payment for sect leadership in a campaign against the Raven Sect. He also publicly identifies Hadjar as the Black General's supposed descendant and disciple, without Hadjar's consent. The five sect chiefs remain divided, and the claim is still untested when a wounded scout arrives. At least two thousand Raven Sect swordsmen are only one day south. Hadjar, Lathea, the recovering Lesket mage, Abraham's squad, Desert Mirage, and the new Lesket leadership are alive. The sect's alliance decision and the approaching battle remain immediate, while Hadjar still owes the Black General an unspecified favor and faces the beast of swamps and bogs after its one-year-and-one-day reprieve.",
         "in_short": "Hadjar enters the spirit world with the Lord of Nightmares to save the wounded Lesket mage, confronting the Summer Queen's influence over his past and accepting a future debt to the Black General. He bargains with a primeval god, crosses hostile spirit lands, defeats his white-dragon ancestor, and returns with the thorn that heals the mage. Lathea escapes the winter queen's wolves, and the group survives the wolf alpha when the northerner forces the pack away. The Lesket patriarch's plot against his youngest son collapses; Lathea kills him, and his elder son takes command. Farther south, Hadjar reunites with Abraham Shensie's squad, defeats but saves Desert Mirage, and passes the Twilight Secret Sect's mountain trial. Abraham asks the sect to lead a war against the Raven Sect and uses Hadjar's connection to the Black General as leverage. Before the council decides, a scout reports that a large Raven Sect force is one day away.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2883,7 +2883,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0BTFVRS53",
@@ -2895,7 +2895,7 @@
       "recaps": {
         "ending": "The party enters Underground Whisper City but learns that the captive Star Rain clan head will be publicly executed before any covert rescue can be mounted. Abraham Shensie replaces infiltration with a display of force: Alba Udun is sent through the sewers to contact the Star Rain fighters outside, while Hadjar and the others position themselves at the scaffold. The captive is brought out mutilated and cultivation-suppressed. Hadjar challenges the Underground Whisper Clan head over her family's connection to the Raven Sect, but the young Star Rain warrior then reveals his betrayal, takes the princess hostage, and escapes with her through the void. The enemy ruler turns the crowd against Hadjar and orders the concealed Star Rain fighters seized. Alba's distant fire signals that his part of the gate operation has begun, and Hadjar publicly identifies himself before attacking the enemy clan head with his full wind power. The book ends during that fight. The princess and her father remain captives, the rescue bargain is unfulfilled, the Raven Sect still stands, and Hadjar retains both the hostile Black General remnant and an unopened Therna repository while the Jasper Emperor searches for a major fragment bearer.",
         "in_short": "Hadjar is compelled by the demon prince to destroy the Raven Sect and follows one of its fragment-bearing swordsmen into a dark-priest sanctuary. He stops a ritual that would sacrifice the Star Rain princess, whose restored clan promises aid if he rescues her captive father. On the route to Underground Whisper City, an ice-wolf shaman gives Hadjar its power, nearly killing him and forcing an advance inside liquid ice. Memories reveal the Black General's choice of mortal life, his love for a healer, her death at the god of war's hands, and the Therna legacy now locked in Hadjar's possession. The rescue becomes a public execution intervention. The apparent Star Rain survivor betrays the group, abducts the princess through the void, and helps turn the crowd against Hadjar. Alba Udun starts the gate operation while Hadjar openly battles the Underground Whisper Clan head. The princess, her father, the Raven Sect commission, and Hadjar's own family remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3056,7 +3056,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3067,7 +3067,7 @@
       "recaps": {
         "ending": "Waybound brings the Cradle series to its close. The lion Monarch Reigan Shen is defeated and the ancient dreadgods that menaced the continent are finally brought to an end, though not without heavy cost. Lindon completes the climb he began as the powerless Unsouled of Sacred Valley and reaches the power of a Monarch, the strength he set out to gain when he first learned that his world was fated for destruction. With the immediate danger to Cradle resolved, Lindon and his closest companions - Yerin, Eithan, Mercy, and the others who traveled with him - leave the world behind and ascend beyond it into the greater universe, carrying their journey out of Cradle and into the wider cosmos that lies past it. The series ends with its central promise fulfilled: the boy once dismissed as worthless has become one of the most powerful beings his world produced, has saved what could be saved, and has passed on to whatever comes next. There is no further volume; the story of Lindon's rise on Cradle is complete.",
         "in_short": "In the final volume of Cradle, the ancient dreadgods rampage across the continent and the lion Monarch Reigan Shen makes his bid to seize supreme power by turning that catastrophe to his own ends. Lindon - once the despised Unsouled of Sacred Valley, now among the strongest sacred artists of his generation - races to complete his climb to the power of a Monarch, the strength he has pursued ever since he learned his world was doomed. With Yerin, Eithan, Mercy, Ziel, and his bonded companions at his side, he throws himself into a continent-spanning struggle against Reigan Shen and the dreadgods. The conflict is immense and costly, but Lindon reaches the pinnacle of the sacred arts and, together with his allies, defeats Reigan Shen and ends the dreadgod threat. With Cradle's crisis resolved, Lindon and his closest companions leave the world behind and ascend into the greater universe beyond it, completing the journey the series began.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3222,7 +3222,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3235,7 +3235,7 @@
       "recaps": {
         "ending": "In London, the narrator finds the Martian fighting machines motionless and their operators dead. The invaders had no resistance to earthly microorganisms, so ordinary bacteria defeated them after human weapons and institutions had failed. England begins to recover, although the invasion has killed many people and permanently altered the survivors' sense of security. Believing his wife died in the destruction of Leatherhead, the narrator returns alone to the ruins of his home near Woking. She unexpectedly arrives there with a cousin, having escaped before the town was destroyed, and the couple are reunited. Later study of the abandoned Martian machinery expands human knowledge, while observations of Mars and activity elsewhere in the solar system leave open the possibility of another attack. The narrator continues to suffer vivid memories of the invasion and recognizes how fragile human dominance has always been.",
         "in_short": "Unusual flashes on Mars precede the fall of cylinders in southern England. An unnamed writer near Woking sees the first Martians emerge and attack with a Heat-Ray, then sends his wife toward safety as towering fighting machines advance. Military resistance collapses under the Heat-Ray and poisonous Black Smoke. The narrator survives the destruction of Weybridge, travels with a terrified curate, and later hides beside a Martian pit while the invaders feed and build. In a parallel account, his brother escapes the panic in London and reaches a refugee ship after HMS Thunder Child sacrifices itself against the machines. The curate's loss of control leads to his death, while the narrator remains concealed. When he finally enters a silent London, he discovers that the Martians have died from earthly bacteria to which humans have acquired resistance. He returns to his damaged home expecting to be alone and is reunited with his wife, who escaped Leatherhead before its destruction.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3404,7 +3404,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3417,7 +3417,7 @@
       "recaps": {
         "ending": "After the creation murders Elizabeth, Alphonse Frankenstein dies from the accumulated shock, and Victor devotes what remains of his life to pursuit. The chase crosses the continent and reaches the Arctic Ocean. Walton's crew finds Victor stranded on the ice and brings him aboard, but he cannot recover. He completes his warning about destructive ambition and dies. When the expedition's survival is threatened, Walton accepts his crew's demand to return to England. He then discovers the creation beside Victor's body. The being grieves for his creator and says that his crimes have made him as wretched as his victims. With Victor dead and vengeance exhausted, he declares that he will build a funeral fire for himself. He leaves through the cabin window and travels away over the ice; Walton never confirms whether he carries out that intention.",
         "in_short": "Robert Walton's Arctic expedition rescues Victor Frankenstein, who tells how he became obsessed with creating life while studying at Ingolstadt. Victor animates a powerful humanlike being but abandons him in disgust. The creation educates himself while secretly observing the De Laceys and longs for fellowship, yet repeated rejection turns him against his maker. He kills Victor's brother William and allows Justine to be condemned, then demands a female companion. Victor agrees but destroys his second creation before bringing her to life. In revenge, the being kills Henry Clerval and Victor's bride Elizabeth. The deaths of Victor's remaining family leave him committed to a pursuit that ends in the Arctic. Victor dies aboard Walton's ship. The creation mourns over him, says that he plans to destroy himself, and disappears across the frozen sea.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3536,7 +3536,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3549,7 +3549,7 @@
       "recaps": {
         "ending": "After the Van Tassel gathering, Katrina appears to reject Ichabod's courtship. He rides home alone through woods associated with local ghost stories and is pursued by a large rider who seems to be carrying his own head. At the church bridge, the rider throws the object at Ichabod, knocking him from his horse. Ichabod is gone the next morning; searchers find his hat beside a shattered pumpkin but no body. Most residents decide that the Headless Horseman carried him away, while a later traveler reports that Ichabod survived, left the district, and eventually entered law and politics elsewhere. Brom later marries Katrina and reacts knowingly whenever the pumpkin is mentioned, leaving open the possibility that he staged the chase and frightened his rival away.",
         "in_short": "Ichabod Crane, a superstitious schoolmaster in the Dutch settlement of Sleepy Hollow, courts Katrina Van Tassel, whose father's prosperous farm makes her especially desirable to him. His rival is the popular horseman and prankster Brom Bones. After a gathering filled with local ghost stories, Katrina disappoints Ichabod's hopes and he rides home through the dark countryside. A mounted figure resembling the legendary Headless Horseman chases him and hurls what appears to be a severed head. By morning Ichabod has vanished, and only his hat and a broken pumpkin are found. The neighborhood favors a supernatural explanation, though a later report says Ichabod escaped and built a career elsewhere. Brom marries Katrina and seems amused by the pumpkin detail, suggesting that the haunting may have been his final practical joke.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3654,7 +3654,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3667,7 +3667,7 @@
       "recaps": {
         "ending": "The revolt divides the city after insurgents breach the Green Wall, but the One State captures D-503 and subjects him to the Great Operation, destroying the imagination that made him capable of doubt, jealousy, and love. Emotionally restored to the State's definition of health, he tells the Benefactor everything he knows about the Mephi and their attempt to seize the Integral. I-330 is arrested. D watches without distress as she is tortured for information; she refuses to speak and faces execution. Outside the auditorium, resistance continues in the western part of the city, where people and birds have entered through the broken Wall. O-90 has escaped beyond it while pregnant with D's child, so a remnant of his former private life survives beyond State control. D nevertheless ends his record convinced that the authorities will prevail because their official truth is mathematically certain. The claim is undercut by the unresolved fighting, leaving the One State damaged but not overthrown and D alive only after the self that opposed it has been erased.",
         "in_short": "D-503, mathematician and builder of the spaceship Integral, records life in the glass-walled One State, where citizens have numbers, intimacy follows schedules, and the Benefactor claims to have eliminated freedom in favor of happiness. His attraction to the rebellious I-330 draws him into forbidden drinking, secrecy, jealousy, and dreams. Doctors say he has developed a soul. I belongs to the Mephi, dissidents living beyond the Green Wall, and plans to capture the Integral as part of an uprising. O-90, another partner of D, becomes illegally pregnant and escapes outside the Wall with I's help. The public Day of Unanimity erupts in dissent, the Mephi breach the Wall, and the State responds with the Great Operation, a procedure that removes imagination. The attempt to seize the Integral fails. D is forcibly operated on and, stripped of emotion, betrays the conspiracy. He watches I's torture without recognizing his former love. Fighting continues beyond the broken Wall, although the restored D confidently predicts the State's victory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3814,7 +3814,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3827,7 +3827,7 @@
       "recaps": {
         "ending": "The revolt divides the city after insurgents breach the Green Wall, but the One State captures D-503 and subjects him to the Great Operation, destroying the imagination that made him capable of doubt, jealousy, and love. Emotionally restored to the State's definition of health, he tells the Benefactor everything he knows about the Mephi and their attempt to seize the Integral. I-330 is arrested. D watches without distress as she is tortured for information; she refuses to speak and faces execution. Outside the auditorium, resistance continues in the western part of the city, where people and birds have entered through the broken Wall. O-90 has escaped beyond it while pregnant with D's child, so a remnant of his former private life survives beyond State control. D nevertheless ends his record convinced that the authorities will prevail because their official truth is mathematically certain. The claim is undercut by the unresolved fighting, leaving the One State damaged but not overthrown and D alive only after the self that opposed it has been erased.",
         "in_short": "D-503, mathematician and builder of the spaceship Integral, records life in the glass-walled One State, where citizens have numbers, intimacy follows schedules, and the Benefactor claims to have eliminated freedom in favor of happiness. His attraction to the rebellious I-330 draws him into forbidden drinking, secrecy, jealousy, and dreams. Doctors say he has developed a soul. I belongs to the Mephi, dissidents living beyond the Green Wall, and plans to capture the Integral as part of an uprising. O-90, another partner of D, becomes illegally pregnant and escapes outside the Wall with I's help. The public Day of Unanimity erupts in dissent, the Mephi breach the Wall, and the State responds with the Great Operation, a procedure that removes imagination. The attempt to seize the Integral fails. D is forcibly operated on and, stripped of emotion, betrays the conspiracy. He watches I's torture without recognizing his former love. Fighting continues beyond the broken Wall, although the restored D confidently predicts the State's victory.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/we-are-legion-we-are-bob.json
+++ b/data/works-community/0/we-are-legion-we-are-bob.json
@@ -322,7 +322,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -337,7 +337,7 @@
       "recaps": {
         "ending": "Bob and Marvin remain on Eden after helping the Deltans reach a defensible settlement. Their intervention is now overt, the tribe is better armed against gorilloids, and some Deltans have begun treating the Bobs' machines as sacred. Bill and Garfield continue Scut coordination and the long effort to add water to Ragnarok. Riker and Homer maintain the evacuation and orbital food programs in Sol.\n\nHoward safely reaches Omicron with Exodus 1 and Exodus 2. Colonel Butterworth chooses the world with the richer ecosystem, automated equipment begins printing the settlement, and the first civilians are due to wake and descend. Exodus 3 will carry Spitsbergen, the Faith Enclave, and Riker's surviving relatives, while later ships remain necessary for millions still on Earth.\n\nArthur and Milo cannot be safely restored. Khan is the only physical survivor of the 82 Eridani assault and preserves his backup for another campaign because hostile autonomous units and cloaking remain. An escaped Brazilian probe is also unaccounted for. Mario must still deliver his evidence that an alien machine civilization sterilized and stripped Beta Hydri, leaving a separate threat unknown to the wider network.",
         "in_short": "After arranging cryonic preservation and dying, Bob awakens in 2133 as a software copy owned by a theocracy. Chosen to control Heaven One, a self-replicating interstellar probe, he escapes sabotage, removes his imposed controls, and begins creating independent copies. The growing replicant network explores nearby systems, fights hostile Brazilian probes, and discovers both intelligent Deltans on Eden and two habitable worlds in Omicron. Riker and Homer save a devastated Earth from a final asteroid attack, then build colony ships and orbital farms for its survivors. Bob and Marvin openly protect the Deltans and guide their migration. Arthur and Milo die without restorable backups. Mario finds evidence that an alien machine force sterilized and mined Beta Hydri, while Khan alone survives a costly attack on the Brazilian position at 82 Eridani. At the close, Howard brings Exodus 1 and Exodus 2 to Omicron, where Colonel Butterworth selects the first colony world and settlement construction begins.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -533,7 +533,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -546,7 +546,7 @@
       "recaps": {
         "ending": "After the fire and the villagers' destruction of the house, Constance and Merricat wall themselves off in the surviving kitchen and a few adjoining rooms. Uncle Julian has died, Charles has abandoned his attempt to control Constance and the family money, and the sisters refuse invitations or official help. Ashamed villagers begin leaving food at the door, while local children turn the ruined Blackwood place into a source of fearful stories. Merricat admits to Constance that she put arsenic in the sugar because she knew Constance never used it; Constance already knows and responds without breaking their bond. The sisters settle into an even smaller and more secluded version of their old life. Hidden from view, supplied by offerings, and answerable only to each other, they regard their isolation as happiness rather than rescue or punishment.",
         "in_short": "Eighteen-year-old Merricat Blackwood lives with her agoraphobic sister Constance and invalid Uncle Julian after arsenic in the sugar killed the rest of their wealthy family. Constance was acquitted of the murders, but the village still treats the sisters with suspicion and cruelty. Their sealed domestic life is disturbed when cousin Charles arrives, courts Constance's trust, and tries to impose authority on the house. Merricat's efforts to drive him away lead to a fire. Villagers who come to watch and supposedly help instead wreck the home, and Julian dies. Constance and Merricat retreat into the surviving rooms. Merricat, not Constance, poisoned the family, a truth Constance accepts. As ashamed neighbors leave food outside and legends grow around the ruined estate, the sisters embrace permanent isolation together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -776,7 +776,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0CMQZB62Z",
@@ -788,7 +788,7 @@
       "recaps": {
         "ending": "Chance is bound to the awakened Old City and marked as the senior karma cultivator's apprentice, although he has openly rejected the cultivator's plan to control it. After the order sends an assassin for Bella, Chance saves her and Pete covers their escape. Chance and Bella use the Old City's passages and unrecorded transit tokens to leave Gleam, then enter a forest as supplied but vulnerable fugitives. Their metal cultivator teammate survives a separate attack, kills his assassin with a concealed blade, and disappears inside Gleam. Pete remains behind, and his later situation is unknown. Vex still intends to kill Bella for the life debt he claims, though negotiations with the senior cultivator have delayed a direct confrontation. Lucy and her mentor continue to watch. The Old City is Chance's ally but remains imprisoned by five transformed-monster seals. Chance has not found his parents, cannot yet afford the uncertain search, and still owes Lucy a future favor.",
         "in_short": "After dying on Earth, Chance awakens in Gleam, joins a three-person monster-hunting team, and discovers that his apparent luck is karma essence. His secret guide trains him while cultivating him for its own purposes, and Chance later learns that the guide is a clone whose karmic enslavement turns people into monsters. He allies with the awakened Old City against that clone, advances to Squire, develops a personal Urumi style, and wins a major tournament. Bella abandons Vex's borrowed methods for preservation cultivation, while their metal cultivator teammate becomes Chance's friendly rival. The true senior karma cultivator eventually takes Chance as a marked apprentice and has the Old City bind itself to him. When the order moves against the team, Chance saves Bella from an assassin and flees Gleam with her. Their teammate escapes a separate killer inside the city, Pete stays behind, Vex's lethal claim on Bella remains active, and Chance's parents remain unfound.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -966,7 +966,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -979,7 +979,7 @@
       "recaps": {
         "ending": "Alice's memories return enough for her to understand the grief, resentment, and habits that brought her marriage to the point of divorce, especially the effect of Gina's friendship and death. Remembering does not erase what happened, but the perspective of her twenty-nine-year-old self has shown her that the hostile version of family life she inherited is not inevitable. She ends her relationship with Dominik and, after confronting both the genuine injuries and the enduring affection between them, reconciles with Nick. They rebuild their marriage rather than continuing the custody battle. Alice also renews her closeness with Elisabeth and becomes more attentive to what her sister's long experience of infertility has cost. Elisabeth and Ben finally move toward parenthood and a less treatment-dominated life. The later view of the family shows Alice and Nick together, their children older, and the relationships changed by Alice's accident continuing in a more forgiving form.",
         "in_short": "After a fall at the gym, thirty-nine-year-old Alice Love loses all memory of the previous decade. She believes she is twenty-nine, happily married to Nick, and pregnant for the first time, but discovers that she has three children, is separating from Nick, and has grown distant from her sister Elisabeth. Meeting her children and the efficient, combative person she had become forces Alice to reconstruct how work, parenthood, resentment, and her intense friendship with Gina changed her marriage. Gina's death lies behind much of the grief Alice cannot initially understand. Her younger outlook disrupts the custody conflict and restores connections her older self had neglected. As her memory returns, Alice accepts the real causes of the separation without accepting that divorce is the only possible ending. She leaves her newer relationship, reconciles with Nick, repairs her bond with Elisabeth, and helps create a more forgiving future for the family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1131,7 +1131,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1144,7 +1144,7 @@
       "recaps": {
         "ending": "The training programme's final crisis is resolved as a real St Mary's operation rather than a classroom assessment. Max's recruits have to apply their research, pod discipline, emergency care, and loyalty while the experienced staff counter the hostile pressure surrounding the exercise. Max, Leon, and the institute survive, and the trainees who complete the programme have demonstrated that they can function as a team when a plan collapses. The interference connected to Ronan is defeated at the immediate point of attack, but he is not placed safely beyond the reach of St Mary's, leaving his wider campaign open. Max remains responsible for the consequences of a programme that exposed inexperienced people to genuine danger, while Bairstow accepts that their conduct under pressure has shown more than a controlled test could. St Mary's ends with new historians added to its ranks and its recurring enemy still unresolved.",
         "in_short": "Bairstow assigns Max to train a new intake of St Mary's historians. She has to convert scholars into field operatives able to research a period, use a pod, protect historical evidence, and keep one another alive. Classroom work and controlled exercises expose differences in judgement across the group, and the first jumps show that even a well-prepared trainee can become dangerous when frightened or overconfident. Max's programme becomes a sequence of recoveries as historical conditions invalidate the planned lessons. Irregularities eventually show that the recruits are facing more than their own mistakes: the continuing conflict with Ronan has reached the training operation. The final exercise becomes a real mission requiring the trainees and established staff to work together. St Mary's survives, the immediate intervention is stopped, and the recruits who remain prove themselves under pressure. Ronan is still not conclusively removed, so the institute gains new historians without gaining lasting security.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1305,7 +1305,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1318,7 +1318,7 @@
       "recaps": {
         "ending": "After years of confinement, Katy has become the calm center of the Carr household, looking after the younger children and carrying the responsibilities Aunt Izzie once managed. Her influence is visible in the greater kindness and order around her. Dr. Carr then tells her that her back has healed enough for her to begin walking again. Katy first stands and moves with support, and in time she is able to walk independently. Cousin Helen returns and finds that Katy has fulfilled the lesson her illness offered: instead of waiting for a grand future in which to become useful, she has learned to improve the lives immediately around her. Katy's recovery closes the book, but her deeper achievement is the patience, reliability, and sympathy she developed while she could not leave her room.",
         "in_short": "Twelve-year-old Katy Carr dreams of doing something important when she grows up, but her impulsive habits make life difficult for her widowed father's busy household. A visit from her disabled cousin Helen gives Katy an example of patience and usefulness, though Katy soon returns to postponing reform. After she disobeys Aunt Izzie and uses a dangerous swing, a fall injures her spine and leaves her confined to bed for years. Katy initially becomes bitter and demanding. Helen helps her see that she can still shape the household through kindness and self-command. Katy gradually repairs her relationships, supports her younger siblings, and learns the domestic responsibilities left to her when Aunt Izzie dies. She becomes the family's steady center. Eventually Dr. Carr announces that her back has healed; Katy learns to walk again, having already become the capable and considerate person she once imagined she would be only in the future.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1430,7 +1430,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1443,7 +1443,7 @@
       "recaps": {
         "ending": "Michael reveals that he is an angel who was ordered to take the soul of a woman immediately after she gave birth to twins. Pitying the helpless infants, he disobeyed, but the woman's soul was taken nonetheless and Michael was sent to earth until he learned three truths. Matryona's compassion taught him that love dwells within human beings. The rich customer's sudden death taught him that people are not given knowledge of their own future needs. The foster mother's devotion to children unrelated to her taught him that people do not truly live by planning for themselves, but by the love shared among them. Michael's three smiles marked these discoveries. Having completed his punishment and understood the lesson, he is transfigured by light, praises God, and departs from Simon's household, returning to heaven. Simon and Matryona are left as witnesses to the revelation that human survival depends on divine love expressed through ordinary care for others.",
         "in_short": "Simon, an impoverished shoemaker, fails to collect the money he needs for a winter coat and finds a nearly naked stranger beside a chapel. He brings the man home despite his own poverty. Simon's wife, Matryona, first protests, then feeds the stranger; at her change of heart, he smiles for the first time. Calling himself Michael, he becomes Simon's gifted assistant. He smiles again when a rich man confidently orders durable boots, then makes burial slippers instead; the customer dies before reaching home. Six years later, a woman arrives with orphaned twin girls she has lovingly raised, and Michael smiles a third time. He then reveals that he is an angel punished for delaying the death of the twins' birth mother. Through the shoemaker's household, the rich man's death, and the foster mother's care, he has learned that love dwells in people, that no one knows his or her own future needs, and that human life is sustained not by self-concern but by love. His lesson complete, Michael returns to heaven.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1535,7 +1535,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1548,7 +1548,7 @@
       "recaps": {
         "ending": "After the exclusion order is lifted, the mother, daughter, and son return to Berkeley. Their house is still standing but has been stripped and damaged, and their former sense of belonging cannot simply be restored. The mother takes exhausting work to support them while the children meet the wary attention of neighbors and classmates. Their father eventually comes home after years in government custody. He is thinner, older, and psychologically broken, nothing like the confident parent preserved in their memories. The final chapter gives him an imagined confession in which he accepts every contradictory accusation placed on Japanese Americans. Its bitter exaggeration exposes the logic of collective suspicion: the government demanded guilt without evidence and punished a family for ancestry rather than conduct. The family is physically reunited, but the losses created by removal and incarceration remain unresolved.",
         "in_short": "In Berkeley during the Second World War, an unnamed Japanese American mother receives an order removing her family from the West Coast. Her husband has already been arrested, so she packs alone and takes her daughter and son by train to an incarceration camp in the Utah desert. They endure years of dust, cold, boredom, surveillance, and uncertainty while writing censored letters to the missing father. When permitted to return, they find their house looted and their old community altered by prejudice. Their father eventually returns from detention aged and traumatized, a diminished version of the man the children remember. A final imagined confession places the government's absurd catalogue of suspicions in his mouth, showing how racism forced the family to answer for crimes they never committed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1711,7 +1711,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1724,7 +1724,7 @@
       "recaps": {
         "ending": "Miranda realizes that the Laughing Man is Marcus as an old man, returned from the future. Marcus once hit Sal while trying to learn what it would feel like to be struck and later spent his life regretting it. As an adult he learned how to travel through time and came back to save Sal at the cost of his own life. When Sal runs into the street to escape Marcus, the Laughing Man knocks Sal away from an oncoming truck and is killed in his place. His apparently meaningless habits had helped place him at the necessary instant, while his notes guided Miranda to prepare a written explanation for the younger Marcus. Miranda and Sal begin repairing their friendship, now with room for separate lives. Miranda finishes the letter that forms the book and gives it, with a photograph, to Marcus so he can understand what he will one day do. Her mother succeeds on the game show, and the family looks forward with greater security and a renewed place for Richard in their lives.",
         "in_short": "Sixth-grader Miranda lives in 1970s New York and is unsettled when her lifelong friend Sal withdraws after being punched by a boy named Marcus. Her hidden apartment key disappears, then anonymous notes begin predicting events and asking her to write an account that will help save a friend's life. As Miranda forms new friendships with Annemarie and Colin, she learns from Marcus's theories that time might not be as fixed as it seems. The notes prove knowledge no ordinary stranger could possess. When Sal runs into traffic, a homeless man known as the Laughing Man pushes him out of a truck's path and dies. Miranda understands that the man was Marcus from the future: he traveled back to save Sal and arranged the notes so Miranda would pass the story to his younger self. Miranda completes that letter, reconciles with Sal without trying to restore their old dependence, and gives present-day Marcus the account he will need. Her mother's long-awaited game-show appearance also ends successfully.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1858,7 +1858,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1871,7 +1871,7 @@
       "recaps": {
         "ending": "Harriet secretly removes Lilia and Gino's baby, intending to carry him back to England. The carriage taking her away from Monteriano crashes, and the infant is killed. Philip, injured in the accident, must tell Gino what has happened. Overcome by grief and rage, Gino attacks Philip, but Caroline intervenes and the violence gives way to their shared mourning. The catastrophe destroys every English plan for deciding the child's future. During the return journey Philip, whose experience in Italy has exposed the shallowness of his former detachment, tells Caroline that he loves her. Caroline answers that she is in love with Gino. Her feeling cannot lead to a conventional union, and Philip must accept both her refusal and the collapse of his romantic assumptions. Back in Sawston, he reports the baby's death to Mrs. Herriton. The surviving characters return to their outward lives carrying losses and desires that their social codes cannot repair.",
         "in_short": "English widow Lilia Herriton escapes her controlling in-laws by traveling to Italy, where she impulsively marries the much younger Gino Carella. Philip Herriton arrives too late to stop her. The marriage becomes unhappy, but Lilia bears a son before dying. Determined that the child must not be raised by his Italian father, Mrs. Herriton sends Philip and Harriet to Monteriano; Caroline Abbott travels there as well, burdened by her part in Lilia's marriage. Contact with Gino and his evident love for the baby divides the English party. Caroline comes to believe that father and son should remain together, while Philip's sympathy for Italy weakens his loyalty to the family mission. Harriet acts alone and abducts the child, but her departing carriage crashes and kills him. Gino attacks Philip in grief before Caroline stops him. Philip later declares his love for Caroline, only to learn that she loves Gino. They return to England with the rescue mission exposed as a fatal exercise in possession and self-deception.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2040,7 +2040,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2053,7 +2053,7 @@
       "recaps": {
         "ending": "Smith's apparent betrayal in the castle is a deception designed to make the real German agents in the British team identify themselves and write down the names of their contacts in Britain. The supposed General Carnaby is actually Cartwright Jones, an actor and intelligence operative who never possessed the invasion plans. Smith, Schaffer, Mary, and Jones escape Schloss Adler with the lists, fighting through the cable-car system and then reaching an airfield with Heidi's help. On the flight home, Smith reveals the last purpose of the operation: the conflicting intelligence exposed Colonel Wyatt-Turner as Germany's senior agent inside British command. Faced with arrest, trial, and execution, Turner chooses to jump from the aircraft without a parachute. Rolland has recovered a complete record of the enemy network, while Smith and the exhausted Schaffer survive the mission.",
         "in_short": "Major John Smith leads an Allied team into the Bavarian Alps to rescue American General Carnaby from Schloss Adler. American Ranger Morris Schaffer soon realizes the mission is concealed beneath several layers of deception as team members die and British agent Mary Ellison appears without having been included in the briefing. Inside the castle, Smith claims to be a German agent and persuades three supposed rescuers to expose themselves as traitors and list their contacts. He then reveals the truth to Schaffer: Carnaby is an actor, the rescue is staged, and the operation's real aim is to identify Germany's network inside British intelligence. Smith, Schaffer, Mary, and the false general escape after a running battle through the castle, cable cars, village, and airfield. During the flight home, Smith identifies briefing officer Wyatt-Turner as the senior mole. Turner jumps to his death, and Admiral Rolland receives the lists needed to dismantle the network.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2222,7 +2222,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2235,7 +2235,7 @@
       "recaps": {
         "ending": "A jury acquits Kya of murdering Chase Andrews because the prosecution cannot bridge the gaps in its circumstantial case. She returns to the marsh, eventually accepts Tate's enduring love, and spends the rest of her life with him at the shack while publishing respected books about the coast's wildlife. Decades later, Kya dies peacefully in her boat. While sorting her possessions, Tate discovers that the poet Amanda Hamilton was Kya's private identity. Hidden with a poem whose imagery describes a female creature luring and killing a mate is the shell necklace Chase wore and that investigators could not find after his death. The discovery confirms to Tate that Kya killed Chase and concealed how she traveled back from her publishing trip to do it. He destroys the incriminating material and preserves her secret. Publicly, Kya remains the acquitted naturalist who endured Barkley Cove's prejudice; privately, Tate understands that she used lessons drawn from the marsh to end the threat Chase posed.",
         "in_short": "Abandoned by her family in the North Carolina marsh, Kya Clark grows up largely alone, supported by Jumpin and Mabel and educated by Tate Walker, who becomes her first love but leaves for college. She later enters a secret relationship with popular Chase Andrews, only to discover he is engaged to another woman. Kya becomes a published naturalist. After Chase assaults her and threatens to return, he is found dead beneath a fire tower. Circumstantial evidence leads to Kya's arrest despite her alibi at a distant publisher meeting. Her attorney exposes major gaps in the case, and she is acquitted. Kya reunites with Tate and lives with him in the marsh until her death decades later. Tate then finds Chase's missing shell necklace and a hidden poem by Kya under her pen name, evidence that she did kill Chase. He destroys it and keeps her secret.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2376,7 +2376,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2389,7 +2389,7 @@
       "recaps": {
         "ending": "Old Dan and Little Ann corner and tree a mountain lion, but the cat turns on them, and in the vicious fight it fatally wounds Old Dan, who dies soon after despite Billy's care. Little Ann, unwilling to live without him, refuses food and dies of grief lying on Old Dan's grave. Billy, devastated, buries the two hounds side by side. The money the dogs won in the championship allows Billy's long-struggling family to leave the hills and move to town, the better future his mother had prayed for. As they prepare to go, Billy finds a rare red fern growing up between the two graves. Local legend holds that only an angel can plant a red fern, and the sight comforts him, letting him believe his dogs are at rest and finally easing part of his grief. The adult Billy who opened the story is left still carrying the memory of the two dogs and the sacred red fern that marks their resting place.",
         "in_short": "Framed as a grown man's memory, the novel tells how a poor Ozark boy named Billy Colman spent two years earning the money to buy a pair of redbone coonhound pups, Old Dan and Little Ann. Billy trains the dogs into an extraordinary hunting team, and together they roam the hills treeing raccoons and growing locally famous. Their adventures include a deadly rivalry with the rough Pritchard boys that ends in one boy's accidental death, and a championship hunt in which the little hounds win a gold cup and prize money during a blizzard. The bond between boy and dogs is total. It ends in tragedy when the dogs fight a mountain lion: Old Dan is killed, and the grieving Little Ann soon dies on his grave. Billy buries them together, and the family uses the dogs' winnings to move to town. At the graves Billy finds a red fern, which legend says only an angel can plant, and it eases his grief as he says goodbye to the animals he loved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2541,7 +2541,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2554,7 +2554,7 @@
       "recaps": {
         "ending": "Bee refuses to accept the assumption that Bernadette died in Antarctic waters. The documents Bee assembles show that her mother left the cruise and reached an American research station, where the extreme landscape and an urgent design problem revived the architectural imagination she had suppressed for years. Bernadette writes a long explanation to Bee, describing her escape, her journey, and the work that has given her a direction again. Bee and Elgin return to Antarctica seeking her, and the family is put on a path toward reunion. Elgin recognizes how badly he misread his wife and how his relationship with Soo-Lin deepened the damage. Audrey, once Bernadette's chief neighborhood enemy, becomes an unexpected source of help. The mystery therefore ends not with Bernadette's death, but with evidence that she has reclaimed the creative identity she abandoned and intends to reconnect with her daughter.",
         "in_short": "Bee Branch earns a promised reward and chooses a family trip to Antarctica, alarming her reclusive mother, Bernadette Fox. A series of documents reveals Bernadette's feuds with Seattle school parents, her dependence on an unverified virtual assistant, and the distinguished architecture career she abandoned years earlier. After a neighborhood disaster and an identity-fraud investigation, Bee's father, Elgin, arranges an intervention. Bernadette escapes and vanishes, apparently during the Antarctic voyage. Bee assembles emails and records to learn what happened and rejects the idea that her mother died. Bernadette instead reaches an Antarctic research station, where a demanding design opportunity restores her sense of purpose. Her message to Bee explains her flight, and Bee and Elgin set out to find her, with the family moving toward reunion rather than mourning.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2706,7 +2706,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2719,7 +2719,7 @@
       "recaps": {
         "ending": "Bee refuses to accept the assumption that Bernadette died in Antarctic waters. The documents Bee assembles show that her mother left the cruise and reached an American research station, where the extreme landscape and an urgent design problem revived the architectural imagination she had suppressed for years. Bernadette writes a long explanation to Bee, describing her escape, her journey, and the work that has given her a direction again. Bee and Elgin return to Antarctica seeking her, and the family is put on a path toward reunion. Elgin recognizes how badly he misread his wife and how his relationship with Soo-Lin deepened the damage. Audrey, once Bernadette's chief neighborhood enemy, becomes an unexpected source of help. The mystery therefore ends not with Bernadette's death, but with evidence that she has reclaimed the creative identity she abandoned and intends to reconnect with her daughter.",
         "in_short": "Bee Branch earns a promised reward and chooses a family trip to Antarctica, alarming her reclusive mother, Bernadette Fox. A series of documents reveals Bernadette's feuds with Seattle school parents, her dependence on an unverified virtual assistant, and the distinguished architecture career she abandoned years earlier. After a neighborhood disaster and an identity-fraud investigation, Bee's father, Elgin, arranges an intervention. Bernadette escapes and vanishes, apparently during the Antarctic voyage. Bee assembles emails and records to learn what happened and rejects the idea that her mother died. Bernadette instead reaches an Antarctic research station, where a demanding design opportunity restores her sense of purpose. Her message to Bee explains her flight, and Bee and Elgin set out to find her, with the family moving toward reunion rather than mourning.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2850,7 +2850,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2863,7 +2863,7 @@
       "recaps": {
         "ending": "The islanders distribute and conceal the whisky taken from the Cabinet Minister before the authorities can seize it. Waggett's effort to impose Home Guard discipline and guide the customs search is defeated by the community's solidarity, local knowledge, and talent for misdirection. The wreck and its remaining cargo are lost, leaving officials unable to recover what has already vanished into houses and hiding places. With whisky again available for hospitality and formal celebrations, the obstacles surrounding the Macroon sisters' courtships ease. Sergeant Odd's attachment to Peggy places him with the islanders rather than with Waggett's campaign, while George Campbell gains enough independence to resist his mother's control and proceed toward marriage with Catriona. Public order survives, but Waggett's authority and self-importance do not; Todday absorbs the extraordinary cargo into ordinary communal life.",
         "in_short": "During wartime, the Hebridean islands of Great and Little Todday run out of whisky, disrupting hospitality, morale, and two hoped-for marriages in the Macroon family. Relief arrives when the cargo ship Cabinet Minister runs aground nearby carrying thousands of cases. The islanders organize a large salvage, constrained by weather, the Sabbath, and the need to act before officials secure the wreck. Captain Paul Waggett, the local Home Guard commander, tries to stop them and alerts the customs authorities, but the whisky is dispersed through the community and hidden faster than it can be found. Sergeant Odd, who loves Peggy Macroon, sides increasingly with island life, while whisky gives timid George Campbell the courage to stand up to his controlling mother and pursue Catriona. The remaining cargo is lost with the wreck, the searches fail, the marriages can advance, and Waggett is left defeated by a community whose customs he never understood.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3053,7 +3053,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3066,7 +3066,7 @@
       "recaps": {
         "ending": "White Fang settles into life on the Scott estate and becomes deeply attached to Weedon Scott while learning which animals and people are protected by the household. Collie's hostility gradually softens, and she draws him away with her into the woods. The family's safety is then threatened by Jim Hall, an escaped convict who blames Judge Scott for his imprisonment and enters the house at night seeking revenge. White Fang attacks Hall before the family can be harmed. He kills the intruder but is shot and terribly injured, and a surgeon gives him little chance of surviving. The household nurses him through a long recovery. When he is finally strong enough to go outside, Collie leads him to a litter of puppies she has borne. White Fang lies in the sun as the puppies climb over him, fully accepted by the family and transformed from an animal formed by hunger and abuse into their protective companion.",
         "in_short": "Born to a she-wolf and the old wolf One Eye in the northern wild, an unnamed gray cub survives famine and learns that life depends on strength, caution, and food. Indigenous hunter Gray Beaver takes in the cub and names him White Fang, but bullying by the camp dogs leaves him isolated and severe. At Fort Yukon, Beauty Smith acquires White Fang and turns him into a caged fighting animal. Mining engineer Weedon Scott rescues him from a near-fatal match with a bulldog and patiently teaches him to trust affection. White Fang follows Scott to California, where he learns the rules of a peaceful household. When escaped convict Jim Hall breaks into the Scott home, White Fang saves the family and nearly dies from his wounds. He recovers and is welcomed back to the estate, where the once-solitary wolf-dog rests beside Collie and their puppies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3269,7 +3269,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3282,7 +3282,7 @@
       "recaps": {
         "ending": "The escaped convict Jim Hall enters Judge Scott's house at night intending to kill him. White Fang senses the intruder and attacks, saving the family but suffering gunshot wounds and serious internal injuries. A surgeon gives him little chance of survival, yet he slowly recovers under the household's care. His defense of the judge settles any remaining question about whether he belongs in the domestic world. When he is strong enough to go outside, Collie leads him to her litter of puppies. White Fang lies in the sun while the puppies climb over him, accepted by the people and animals of the estate as the Blessed Wolf. His journey ends in security, family life, and affection rather than the isolation and violence that governed his youth.",
         "in_short": "Born to a wolf-dog mother in the northern wilderness, White Fang learns hunger, predation, and fear before entering an Indigenous camp with his mother, Kiche. Under Gray Beaver he accepts human mastery, but persecution by other dogs makes him solitary and fierce. Gray Beaver later sells him to Beauty Smith, who abuses him and profits from dogfights until a bulldog nearly kills him. Mining engineer Weedon Scott rescues White Fang and patiently teaches him trust and affection. When Scott returns to California, White Fang follows him into an unfamiliar domestic world and learns not to hunt livestock or fight the estate's dogs. He finally proves his place by stopping escaped convict Jim Hall from murdering Judge Scott, nearly dying from his wounds. White Fang recovers and ends the novel resting beside Collie and their puppies, fully accepted by the Scott family.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3479,7 +3479,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3492,7 +3492,7 @@
       "recaps": {
         "ending": "White Fang settles into life on the Scott estate and becomes deeply attached to Weedon Scott while learning which animals and people are protected by the household. Collie's hostility gradually softens, and she draws him away with her into the woods. The family's safety is then threatened by Jim Hall, an escaped convict who blames Judge Scott for his imprisonment and enters the house at night seeking revenge. White Fang attacks Hall before the family can be harmed. He kills the intruder but is shot and terribly injured, and a surgeon gives him little chance of surviving. The household nurses him through a long recovery. When he is finally strong enough to go outside, Collie leads him to a litter of puppies she has borne. White Fang lies in the sun as the puppies climb over him, fully accepted by the family and transformed from an animal formed by hunger and abuse into their protective companion.",
         "in_short": "Born to a she-wolf and the old wolf One Eye in the northern wild, an unnamed gray cub survives famine and learns that life depends on strength, caution, and food. Indigenous hunter Gray Beaver takes in the cub and names him White Fang, but bullying by the camp dogs leaves him isolated and severe. At Fort Yukon, Beauty Smith acquires White Fang and turns him into a caged fighting animal. Mining engineer Weedon Scott rescues him from a near-fatal match with a bulldog and patiently teaches him to trust affection. White Fang follows Scott to California, where he learns the rules of a peaceful household. When escaped convict Jim Hall breaks into the Scott home, White Fang saves the family and nearly dies from his wounds. He recovers and is welcomed back to the estate, where the once-solitary wolf-dog rests beside Collie and their puppies.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3641,7 +3641,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -3652,7 +3652,7 @@
       "recaps": {
         "ending": "The murders resolve into a conspiracy inside the White Court: nobles of Houses Malvora and Skavis, killing weakly-gifted women to prove that the Court should prey openly on practitioners - and to unseat the White King's regime, which Lara Raith rules through her powerless father. Thomas is cleared completely: his evasions hid a double life spent protecting the targeted women, funded by a salon where he feeds safely in small sips - and his kinship to Harry stays secret. In the battle in the Raith Deeps, Harry and Ramirez fight a sanctioned duel that Vittorio Malvora breaks by unleashing power granted by an outside patron - the hooded necromancer Cowl is part of it, and the taint of the Outsiders is on the working - while a ghoul army floods the cavern. Marcone's people and Murphy spring Harry's hidden reserve, Elaine survives the Skavis killer's run at her, and the conspirators die: the duel's collapse exposes the plotting house lords, whom Lara executes on the spot, cementing her control of the Court - now more clearly than ever a rival power that owes Harry a debt it resents. The deepest loss is invisible: Lasciel's shadow, changed by years in Harry's mind, chooses to take a psychic deathblow meant for him and is destroyed, leaving a silence in his head and grief he did not expect - and proof that even a fallen angel's shadow could learn to choose. Harry ends the book with his brother restored, his apprentice growing, and the certainty that some organized power - the Black Council he can no longer pretend away - is arming its pawns with Outsider fire.",
         "in_short": "Female minor-talent practitioners are dying across Chicago in staged suicides, and the evidence - a pale, beautiful man seen with the victims - points at Thomas. Investigating with Murphy while training Molly, Harry finds the trail crossing his first love Elaine, hired to protect the survivors, and leading into the White Court: nobles of Houses Malvora and Skavis are murdering practitioners to force a policy of open predation and to break Lara Raith's hidden regime. Thomas is cleared - his secrecy concealed a life spent hiding and protecting the targeted women. Harry forces the fight into a sanctioned duel in the Raith Deeps, he and Warden Ramirez against the conspirators' champions; Vittorio Malvora breaks it with Outsider-tainted power supplied through Cowl, and a ghoul army attacks - answered by Harry's hidden cavalry of Marcone's mercenaries and Murphy. The plotters are exposed and executed, Lara consolidates the Court in Harry's debt, and Lasciel's shadow - grown into something that could choose - dies taking a psychic blow meant for Harry, leaving his head silent and the Black Council's reality confirmed.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3760,7 +3760,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3773,7 +3773,7 @@
       "recaps": {
         "ending": "On the fourth night, Nastenka concludes that the lodger has abandoned her and turns toward the Dreamer, whose devotion now seems more reliable. She says that she may come to love him, and for a brief time they imagine a shared future. The former lodger then appears in the street. Nastenka runs to him, returns only long enough to kiss the Dreamer, and leaves with the man she has awaited. The next morning she sends a letter asking forgiveness, affirming her gratitude, and announcing that she will soon marry her returned love. The Dreamer sees his room and future as suddenly old and desolate, yet refuses to resent her. He preserves the happiness of their brief companionship as something sufficient to bless an entire life, ending the story alone but grateful for the moment of genuine connection.",
         "in_short": "A solitary young man who calls himself a dreamer meets seventeen-year-old Nastenka during St Petersburg's pale summer nights. She is waiting for a former lodger who promised to return and marry her after a year away. Over four meetings the Dreamer listens to her history, delivers a letter, comforts her when no answer comes, and falls in love despite promising not to. Believing herself abandoned, Nastenka begins to imagine a life with him. At that instant her former lodger returns, and she leaves with him. In a letter the next morning she asks the Dreamer's forgiveness and announces their marriage. Though returned to loneliness, he chooses gratitude for the brief happiness and human intimacy she gave him.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/white-nights-fyodor-dostoyevsky.json
+++ b/data/works-community/0/white-nights-fyodor-dostoyevsky.json
@@ -49,7 +49,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -62,7 +62,7 @@
       "recaps": {
         "ending": "During the fourth night, after Nastenka has received no word from the lodger, the Dreamer finally admits that he loves her. She is moved by his devotion and begins imagining a life with him, though both understand that her earlier love has not simply vanished. Their new hope lasts only moments: the lodger appears in the street, and Nastenka immediately runs to him. The next morning the Dreamer receives her letter. She asks his forgiveness, explains that she and the lodger are reconciled and will marry, and hopes the Dreamer will remain their friend. Alone again, he sees his room and future as suddenly old and bleak. Even so, he refuses to resent Nastenka or burden her happiness with his grief. He preserves the brief experience of mutual closeness as a complete moment of happiness, sufficient in his view to give lasting value to a life.",
         "in_short": "A solitary young man who lives through fantasies rather than relationships meets Nastenka beside a Saint Petersburg canal during the city's bright summer nights. She is waiting for a former lodger who promised to return and marry her after a year. Over several evenings, she and the Dreamer exchange their histories, and he helps her send a letter while quietly falling in love. When the lodger seems to have abandoned her, the Dreamer confesses his feelings and Nastenka tentatively accepts the possibility of a future with him. The absent man then appears, and she runs back to him at once. Her letter the following morning says that they will marry and asks the Dreamer's forgiveness. Returned to solitude, he chooses gratitude for the short-lived happiness rather than bitterness over its loss.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -155,7 +155,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -168,7 +168,7 @@
       "recaps": {
         "ending": "Nastenka appears ready to begin a life with the Dreamer after concluding that the man she had awaited has abandoned her. During their walk, however, the former lodger suddenly appears. Nastenka runs to him, briefly returns to kiss the Dreamer, and then leaves with the man she has loved all along. The next morning the Dreamer receives her letter asking forgiveness and friendship and announcing that she will soon marry. His room and future seem old and empty again, yet he refuses to resent her. He preserves the happiness of their brief connection as something valuable even though it lasted only a few nights and left him alone.",
         "in_short": "A lonely Saint Petersburg dreamer meets Nastenka, a young woman waiting for a former lodger who promised to return and marry her. Over several summer nights he listens to her history, helps her send a letter, and falls in love despite promising not to. When no answer comes, Nastenka despairs and begins to imagine a future with him. Her beloved then appears in the street, and she immediately leaves with him. The next morning she writes to ask the Dreamer's forgiveness and tells him of her coming marriage. Though returned to solitude, he chooses gratitude for the short interval of genuine closeness they shared.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -343,7 +343,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -356,7 +356,7 @@
       "recaps": {
         "ending": "Jack locates Willie Mink, the man Babette knew as Mr. Gray, in a motel room. Following a plan shaped by jealousy and Murray's theory that killing may reverse one's fear of death, Jack shoots Mink and places the gun in his hand to stage a suicide. Mink then shoots Jack in the wrist. Seeing the wounded man as a person rather than an abstract rival, Jack abandons the murder plan and takes him to a hospital run by German nuns. A nun tells Jack that the sisters maintain the appearance of religious belief for a world that needs someone to believe, even though she herself does not accept the consolations he seeks. Jack survives and returns home. Later, Wilder rides his tricycle across a busy highway and reaches the other side unharmed, while drivers react with horror. The family and townspeople watch spectacular sunsets, perhaps altered by the toxic event, and the supermarket rearranges its shelves, producing fresh confusion. Neither technology, religion, violence, nor consumption has resolved the family's fear of death; ordinary life continues amid signals whose meaning remains uncertain.",
         "in_short": "Jack Gladney, founder of Hitler studies at a small college, lives with his wife Babette and their children amid the hum of advertising, television, and fear of death. A rail accident releases a toxic chemical cloud and forces the family to evacuate. Jack is briefly exposed, and a computer gives him an uncertain long-term death sentence. After returning home, he learns that Babette secretly joined a drug trial for Dylar, intended to suppress fear of death, and had sex with project manager Willie Mink to obtain it. Jealous and increasingly frightened, Jack gets a gun and follows Murray Siskind's suggestion that killing might make him feel like a survivor. He finds Mink in a motel and shoots him, but after Mink shoots back, Jack saves his intended victim and takes him to a hospital. The nuns there offer no religious certainty. Jack returns to a family and town still surrounded by ambiguous signs: Wilder survives a dangerous highway crossing, chemically vivid sunsets draw spectators, and a rearranged supermarket unsettles its shoppers.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -554,7 +554,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -567,7 +567,7 @@
       "recaps": {
         "ending": "The public presentation of Marcus Chalfen's genetically programmed FutureMouse draws nearly every strand of the two families together. Joshua arrives with animal-rights activists, Hortense and other Jehovah's Witnesses expect judgment, and Millat comes armed on behalf of the fundamentalist group KEVIN. Magid supports Marcus and the experiment. Millat fires at Dr. Perret, the elderly Nazi collaborator whom Archie was supposed to execute in 1945. Archie again puts himself between Perret and death and takes the bullet, revealing that his old claim to have killed the doctor was false. Amid the disruption, the experimental mouse escapes. Because the identical twins cannot be reliably distinguished in court, responsibility for the gun becomes blurred between Millat and Magid. Irie, pregnant after sleeping with each twin in quick succession, cannot know which is the father and embraces that uncertainty as freedom from a fully traceable origin. The novel's closing glimpses leave Archie alive, the families still entangled, and the future open beyond the plans made for people, nations, and genes.",
         "in_short": "After a failed suicide in 1975, Englishman Archie Jones marries Clara Bowden, a young Jamaican woman leaving her mother's Jehovah's Witness faith. Their family remains entwined with that of Archie's wartime friend Samad Iqbal, a Bengali Muslim tormented by migration, desire, and the fear that his twin sons will lose their inheritance. Samad secretly sends Magid to Bangladesh, but Magid returns a secular rationalist, while London-raised Millat joins an Islamic fundamentalist group. Archie and Clara's daughter Irie seeks belonging through both families and the confident Chalfens, whose scientist father Marcus creates the genetically controlled FutureMouse. At its launch, Millat shoots toward Dr. Perret, a Nazi collaborator Archie secretly spared after the war; Archie saves him again and is wounded. The mouse escapes. Pregnant after sleeping with both twins, Irie cannot know her child's father, leaving heredity and destiny unresolved rather than controlled.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -737,7 +737,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -750,7 +750,7 @@
       "recaps": {
         "ending": "Rachel and her allies stop the immediate banshee predation after a confrontation in which emotional and magical attacks threaten Ivy and the others helping her. Rachel uses magic that the witch establishment classifies as black, saving lives but giving the Coven of Moral and Ethical Standards grounds to scrutinize her. Pierce is restored to a living body and remains close to Rachel, no longer only a ghost from her past. The investigation also breaks the barrier around Rachel's lost memory. She finally recalls that Piscary killed Kisten and understands the violence surrounding their last meeting. Recovering the truth does not restore Kisten, but it ends the uncertainty that has kept Rachel from grieving with full knowledge of what occurred. Her relationship with Marshal does not survive the distance created by that grief and by the dangers at the church. Rachel finishes the book with Ivy and Jenks alive, Pierce physically present, and the banshee crisis contained, but her use of forbidden magic has moved her from private demon student to a public target of witch authority.",
         "in_short": "Rachel begins with no memory of Kisten's murder and no knowledge of his killer. While Al continues her demon lessons, the FIB draws her into attacks marked by drained emotion, damaged auras, and unreliable memories. Empath Ford helps her interpret the victims and examine the blank place in her own mind. Pierce, a nineteenth-century witch Rachel knew as a ghost, returns and becomes entangled in the case. The trail leads to banshee Mia, her daughter Holly, and others exploiting demon-derived magic. Rachel and her partners stop the immediate predation, though doing so requires magic orthodox witches regard as black. Pierce is given a living body and stays near Rachel. The same struggle finally releases Rachel's blocked memory: she recalls that Piscary killed Kisten. The truth gives her an answer rather than a reunion, and her relationship with Marshal ends. Rachel closes the case with Ivy and Jenks alive, but her forbidden magic has attracted the attention of the Coven of Moral and Ethical Standards.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -893,7 +893,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -906,7 +906,7 @@
       "recaps": {
         "ending": "McReady realizes that an imitation is not merely one animal: every fragment of its tissue is an independent organism concerned with survival. He therefore tests blood samples with a heated wire. Human blood remains inert, while blood belonging to an imitation recoils and exposes its owner. The test allows the surviving men to identify and destroy the copies among them with fire. They then turn to Blair, who had been isolated after wrecking the station's means of transport and communication. Blair has already been replaced and has secretly tunneled beneath his shelter, where he is building an advanced device that would let the creature escape Antarctica. McReady and the others burn the Blair imitation and destroy its work before it can leave. The immediate threat is contained, and the survivors understand that the creature came close to reaching the wider world, where its ability to reproduce through imitation could have replaced terrestrial life.",
         "in_short": "An Antarctic expedition recovers a frozen extraterrestrial from the ice and thaws it for study. The creature escapes and reveals an ability to absorb living beings and reproduce them perfectly, including their memories and behavior. After it attacks the sled dogs, the men destroy the visible body, but biologist Blair calculates that any copied animal or person could spread the organism until it replaces all other life. He destroys the station's aircraft and radio to prevent escape and is confined. Suspicion then turns inward because no one can prove who remains human. McReady recognizes that every cell of an imitation has its own survival instinct. He touches a heated wire to blood samples; alien blood recoils, exposing the copies, which are burned. Blair himself proves to be an imitation and has nearly completed a machine that could carry it beyond Antarctica. The survivors destroy Blair and the device, stopping the outbreak before it reaches civilization.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -996,7 +996,7 @@
             "role": "protagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1009,7 +1009,7 @@
       "recaps": {
         "ending": "Haw reaches Cheese Station N and finds a large new supply, along with Sniff and Scurry, who adapted much earlier. He reviews what the journey taught him: conditions should be watched before a crisis, an old source should not be treated as permanent, fear becomes smaller through movement, and imagining a better outcome can make action easier. Haw has left observations on the maze walls so that Hem can follow, but he recognizes that he cannot compel his friend to change. He remains alert even amid abundance, checking the new cheese and exploring beyond the station so comfort will not make him complacent again. A sound in the maze may signal another arrival, and Haw hopes it is Hem, but the story does not confirm that Hem has left the empty station. After Michael finishes the fable, the reunited friends discuss how they resemble its four characters and how its lessons apply to their organizations, careers, and personal relationships.",
         "in_short": "At a reunion, Michael tells his former classmates a fable about four maze dwellers seeking cheese, a symbol for whatever they depend on. Mice Sniff and Scurry and small people Hem and Haw prosper at Cheese Station C, but only the mice notice the supply declining. When it vanishes, Sniff and Scurry immediately resume searching. Hem demands that the old cheese return, while Haw remains beside him until hunger and reflection overcome his fear. Haw enters the maze, learns from wrong turns, and writes concise lessons on the walls for Hem. By anticipating change, releasing the old supply, and imagining success, he becomes able to enjoy the search. He finds Sniff and Scurry with abundant new cheese at Station N. Haw stays watchful and continues exploring rather than assuming the new supply is permanent. Hem's fate is unresolved. Michael's friends then use the fable to discuss changes in their own work and lives.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1137,7 +1137,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1150,7 +1150,7 @@
       "recaps": {
         "ending": "Wimsey concludes that Sir Julian Freke engineered both mysteries. Freke murdered Sir Reuben Levy, disposed of Levy's body, and moved an unclaimed corpse from his medical work into Thipps's bath. He altered the substitute body and supplied misleading details so that investigators would first mistake it for Levy and then become trapped by the differences. His purpose was revenge rooted in his old attachment to Lady Levy and his hatred of the man she married. Once Wimsey reconstructs the transfer across the nearby roofs and the medical manipulation of the corpse, Freke realizes that he has been exposed. He attempts to silence Wimsey, but Bunter and Parker intervene and the evidence secures the case. Thipps is cleared. The solution also forces Wimsey to confront the human cost of treating murder as an absorbing intellectual game, and Bunter helps him through the return of his wartime distress.",
         "in_short": "An unknown naked man wearing pince-nez is found in architect Alfred Thipps's bath just as financier Sir Reuben Levy disappears. Lord Peter Wimsey investigates the bath while his police friend Charles Parker follows Levy's movements. The corpse resembles Levy but is not him, and the combination of likeness and discrepancy proves deliberate. Physical evidence, medical knowledge, and access between neighboring buildings lead Wimsey to neurologist Sir Julian Freke. Freke killed Levy out of long-held personal hatred, disposed of his body, and planted another corpse in Thipps's flat after modifying it to create a false identification. The elaborate substitution was intended to confuse the two investigations and divert suspicion toward innocent people. Wimsey reconstructs the scheme; Freke tries unsuccessfully to stop him and is caught, while Thipps is exonerated.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1299,7 +1299,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1312,7 +1312,7 @@
       "recaps": {
         "ending": "The novel closes by reworking the familiar scene of the Witch's death. Worn down by years of loss, grievance, and isolation, Elphaba confronts Dorothy at her castle in the Vinkus, fixated on the shoes that had belonged to her dead sister Nessarose and on old wrongs she cannot let go. In the fatal moment, Dorothy throws water on her, and Elphaba dies, dissolving away. The book frames this not as triumph over a simple villain but as the death of a misunderstood and embittered woman whose idealism curdled under an unjust world. The larger questions of her life, her true nature, her guilt or innocence, and the fate of those she leaves behind are left deliberately unresolved.",
         "in_short": "The novel tells the life of Elphaba, a green-skinned woman born an outcast in the land of Oz, who will come to be called the Wicked Witch of the West. It follows her strange birth and harsh childhood, her university years and unlikely friendship with the vain, popular Galinda, and her growing outrage at the tyranny of the Wizard of Oz and his persecution of the land's intelligent Animals. Elphaba becomes a political dissident and, after love and loss, especially her relationship with the prince Fiyero, withdraws into isolation and bitterness. Over the years she is drawn into conflict with the Wizard, her devout sister Nessarose, and old companions, and gains a fearsome reputation. The story converges on the arrival of a girl from another world, Dorothy, whose accidental role in the death of Elphaba's sister and whose possession of a coveted pair of shoes bring her into Elphaba's path, leading to the confrontation the reader already knows by legend.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1453,7 +1453,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1466,7 +1466,7 @@
       "recaps": {
         "ending": "At Philippi, Brutus and Cassius lose their war against Antony and Octavius. Cassius, mistakenly believing that his forces have been defeated and his friend Titinius captured, orders his servant Pindarus to kill him. Titinius then kills himself beside Cassius. After another defeat, Brutus asks several companions to help him die; Strato finally holds a sword while Brutus runs onto it. Antony finds his former enemy and declares that Brutus alone among the conspirators acted from an honest concern for Rome rather than envy. Octavius orders an honorable burial and takes command of the field. Caesar's murder has therefore failed to preserve the republic: the conspirators are dead, and power rests with the victorious triumvirs.",
         "in_short": "As Julius Caesar returns to Rome in triumph, Cassius persuades the honorable Brutus that Caesar's growing power threatens the republic. Brutus joins a conspiracy and helps assassinate Caesar at the Senate. He allows Mark Antony to speak at the funeral, believing reason will justify the killing. Antony instead turns the crowd against the conspirators with Caesar's wounds and will, forcing Brutus and Cassius to flee. Antony joins Octavius and Lepidus to rule Rome and wage war on them. Brutus and Cassius quarrel but reconcile before the decisive battle at Philippi. Misled by a report from the fighting, Cassius has himself killed; after defeat, Brutus also dies by suicide. Antony honors Brutus's motives, while Octavius assumes control. The attempt to save republican liberty ends by clearing the way for Caesar's heirs.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1659,7 +1659,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -1670,7 +1670,7 @@
         "work": "wind-and-truth"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -1851,7 +1851,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1864,7 +1864,7 @@
       "recaps": {
         "ending": "After Elizabeth Willard dies, George remains unaware that she hid money intended for him beneath a floorboard. Her death and his growing reputation as a writer deepen his sense that his life in Winesburg is ending. During the town fair, he and Helen White leave the crowds and walk together. Their companionship briefly frees them from the self-conscious roles they have been trying to perform, and they share a quiet recognition of their approaching adulthood. George soon decides to leave. Townspeople come to the station to see him off, but Helen arrives too late for a private farewell. As the train departs, George initially thinks of familiar places and people, then falls asleep. By the time he wakes, Winesburg has receded from a present home into material for his imagination. The book closes with his literal departure and with the suggestion that the isolated lives he has witnessed will continue to shape the writer he may become.",
         "in_short": "In Winesburg, Ohio, young newspaper reporter George Willard becomes the listener for residents unable to express their deepest needs. Wing Biddlebaum hides after accusations destroyed his teaching career; Doctor Reefy preserves private thoughts on scraps of paper; George's mother Elizabeth longs for him to escape the life that defeated her; and figures including Alice Hindman, Wash Williams, Reverend Hartman, Kate Swift, and Enoch Robinson struggle with loneliness, desire, faith, and failed communication. George's encounters expose both his youthful vanity and his growing capacity to understand pain. Elizabeth dies before telling him about money she saved for his future. At the town fair, George and Helen White briefly meet without pretense and sense their passage into adulthood. George then boards a train and leaves Winesburg. As the town falls behind, its people and streets cease to be his immediate world and become the memories from which his future imagination will work.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1995,7 +1995,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2008,7 +2008,7 @@
       "recaps": {
         "ending": "After Pooh and Christopher Robin use an upturned umbrella as a boat to rescue Piglet from the flood, Christopher Robin holds a celebration in Pooh's honor. The Forest friends gather, Owl gives a speech, and Pooh receives a pencil case as a gift for his clever part in the rescue. When the party is over, Christopher Robin takes Pooh to a quiet place at the top of the Forest. The boy is beginning to understand that growing older and going to school may change how they spend their days. He asks Pooh to remember him and to remain his friend even when they cannot always play together. Pooh promises. The book closes with the child and bear still together in their special place, preserving their friendship against the changes Christopher Robin anticipates.",
         "in_short": "Across ten linked Forest adventures, Winnie-the-Pooh pursues honey, visits Rabbit and becomes stuck in his doorway, follows misleading tracks with Piglet, and restores Eeyore's missing tail. Pooh and Piglet's trap for an imagined Heffalump frightens Piglet instead, while Eeyore's birthday improves when he receives an empty honey pot and a burst balloon that fits inside it. Rabbit's attempt to drive away the newly arrived Kanga and Roo fails, and they join the community. During an expedition, Pooh accidentally supplies the stick that Christopher Robin names as the North Pole. Heavy rain later surrounds Piglet's home. Pooh reaches Christopher Robin, and they turn an umbrella into a boat and rescue Piglet. Christopher Robin celebrates Pooh's resourcefulness with a party. Afterward, he and Pooh share a private conversation about growing up, and Pooh promises that their friendship will endure even when Christopher Robin's life changes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2132,7 +2132,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2145,7 +2145,7 @@
       "recaps": {
         "ending": "After Pooh and Christopher Robin use an upturned umbrella as a boat to rescue Piglet from the flood, Christopher Robin holds a celebration in Pooh's honor. The Forest friends gather, Owl gives a speech, and Pooh receives a pencil case as a gift for his clever part in the rescue. When the party is over, Christopher Robin takes Pooh to a quiet place at the top of the Forest. The boy is beginning to understand that growing older and going to school may change how they spend their days. He asks Pooh to remember him and to remain his friend even when they cannot always play together. Pooh promises. The book closes with the child and bear still together in their special place, preserving their friendship against the changes Christopher Robin anticipates.",
         "in_short": "Across ten linked Forest adventures, Winnie-the-Pooh pursues honey, visits Rabbit and becomes stuck in his doorway, follows misleading tracks with Piglet, and restores Eeyore's missing tail. Pooh and Piglet's trap for an imagined Heffalump frightens Piglet instead, while Eeyore's birthday improves when he receives an empty honey pot and a burst balloon that fits inside it. Rabbit's attempt to drive away the newly arrived Kanga and Roo fails, and they join the community. During an expedition, Pooh accidentally supplies the stick that Christopher Robin names as the North Pole. Heavy rain later surrounds Piglet's home. Pooh reaches Christopher Robin, and they turn an umbrella into a boat and rescue Piglet. Christopher Robin celebrates Pooh's resourcefulness with a party. Afterward, he and Pooh share a private conversation about growing up, and Pooh promises that their friendship will endure even when Christopher Robin's life changes.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2341,7 +2341,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2354,7 +2354,7 @@
       "recaps": {
         "ending": "Levana marries Kai, and the marriage buys her nothing. Cress breaks into Luna's broadcast network and puts Levana's unglamoured face - burned and scarred since childhood - in front of the entire moon, destroying the illusion her rule was built on, and Cinder declares herself publicly as Princess Selene. The outer sectors rise, the fighting reaches Artemisia, and Cinder faces Levana in the palace and kills her. Winter, whom Levana had ordered killed and Jacin saved by faking her death, survives and is at Scarlet's side through the revolt. Dr. Erland dies on Luna, and Cress learns before the end that he was her father. Cinder is crowned Queen Selene of Luna, immediately releases the plague antidote to Earth without conditions, frees the shell children Levana had kept in captivity as its source, and dissolves the aristocracy's hold on the sectors. Then she abdicates: rather than hold a throne she never wanted, she puts Luna's future to an elected government and leaves the crown behind. Kai's marriage to Levana ends with Levana, and he and Cinder are free to be together. Scarlet and Wolf return to the farm in France, Cress and Thorne take the Rampion out to help distribute the antidote across Earth, and Winter and Jacin stay on Luna to help rebuild it.",
         "in_short": "Cinder's crew lands on Luna to overthrow Queen Levana during her wedding to Emperor Kai. On the moon they find Scarlet caged in the royal menagerie and Princess Winter, Levana's stepdaughter, loved by the people and slowly unravelling from the sickness that comes of refusing to use her Lunar gift. Levana orders Winter killed; her guard Jacin fakes the death instead, and Winter and Scarlet escape into the outer sectors. Cinder raises the mining and manufacturing districts against the capital while Cress works to break Levana's grip on what the Lunar people are allowed to see. The wedding goes ahead, Cinder is captured and reveals herself publicly as Princess Selene, Wolf is taken and forcibly remade by Levana's surgeons, and Erland dies on Luna after Cress learns he was her father. Cress finally broadcasts Levana's true, scarred face across the moon, the revolt reaches Artemisia, and Cinder kills Levana in the palace. Crowned Queen Selene, she releases the antidote to Earth, frees the captive shells, and then abdicates so that Luna can elect its own government.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2854,7 +2854,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:1039403360",
@@ -2866,7 +2866,7 @@
       "recaps": {
         "ending": "River Farm survives its immediate shortage after Ryoka delivers supplies through the blizzard, and Laken remains responsible for its recovery. Erin's magical inn has become a center for travel, relief, and cross-species cooperation, but Christmas leaves her friends aware of how desperately she misses Earth. Lyonette resolves to help, without yet knowing how. Ceria and Pisces remain with the Horns, recognized by Cognita as Wistrom graduates but divided by Pisces' necromancy and exile. Rags continues south with an independent tribe while Tremborag pursues her and the Goblin Lord's larger force remains ahead. Xrn's private purpose, the Deathless, and a secret message to a northern lord leave wider conflicts unresolved. Ryoka and Laken maintain a cautious alliance as Earth arrivals and distrust the caller from Wistrom. During the solstice, Erin refuses to trade her soul and retains a white-silver coin. Ryoka rejects the entities' false restoration of her missing fingers, burns both the fingers and her altered scarf, and escapes with Ivolethe. The beings and Ryoka's luminous rescuers remain unidentified.",
         "in_short": "Rags rejects Tremborag's mountain, frees its captives, and leads a newly disciplined Goblin tribe south toward the greater war. Ceria and Pisces' Wistrom past ends with both recognized as mages, but Pisces is exiled and their friendship is broken. Erin returns to a thriving inn, becomes a Magical Innkeeper, and uses its portal and alliances to relieve Esthelm. Ryoka meets Laken, another person from Earth, helps equip the Horns, and carries emergency supplies to River Farm. Christmas exposes Erin's longing for home while hidden Antinium history surfaces. On the winter solstice, strange visitors offer Erin treasures for her soul and hostile beings offer Ryoka the restoration of her lost fingers. Both refuse. Erin is left with an unnatural coin, while Ryoka destroys the offered fingers and escapes with Ivolethe, still injured.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3069,7 +3069,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B002UZJKTA",
@@ -3081,7 +3081,7 @@
       "recaps": {
         "ending": "Taura's enhanced sight exposes the coating on the pearls before the necklace can do further harm. ImpSec identifies a Jacksonian designer neurotoxin and traces the weapon through the arrested heir to a criminal operative from Jackson's Hole. The heir had been used as a disposable intermediary in an effort to kill Ekaterin and disrupt Miles's Auditor inquiry. Ekaterin is expected to recover without lasting damage. She keeps the cleaned necklace and wears it at the ceremony as a deliberate refusal to be intimidated. Miles and Ekaterin marry in the Vorkosigan garden, with Ivan Vorpatril and Taura serving as their seconds, then leave for a honeymoon at Surleau. Roic and Taura also leave the celebration together after acknowledging their attraction. Their relationship begins with little time available: Taura expects to return to the mercenary fleet in about ten days, and her medical outlook remains uncertain. The immediate murder plot has been contained, but Miles's public duties continue to expose those near him to danger.",
         "in_short": "As Miles and Ekaterin prepare to marry, the newly appointed armsman Roic is assigned to help Sergeant Taura navigate Barrayaran high-Vor society. A pearl necklace sent as a wedding gift makes Ekaterin acutely ill and distressed. Taura's enhanced vision reveals a suspicious coating on the pearls, and Roic calls in ImpSec. Investigators identify a concealed Jacksonian neurotoxin and trace the attack to a criminal operative using an arrested count's heir as an expendable intermediary against Miles's Auditor inquiry. Ekaterin is expected to recover fully. She wears the decontaminated pearls in defiance and marries Miles in the Vorkosigan garden before they depart for Surleau. Roic and Taura begin a relationship, although she must soon return to the mercenary fleet and lives with an uncertain prognosis.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3186,7 +3186,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3199,7 +3199,7 @@
       "recaps": {
         "ending": "Lia's efforts to disappear into hunger leave her medically endangered, isolated, and unable to separate Cassie's accusing presence from her own thoughts. Returning to the place associated with Cassie's death brings her close to dying as well. At the crisis point, however, Lia asks for help rather than following Cassie into death. She survives and enters treatment again. Recovery is neither immediate nor presented as a simple victory: Lia must begin eating, speaking honestly, and allowing other people to intervene, while accepting Cassie's death as something she cannot reverse by punishing herself. The closing movement places her on the living side of the boundary she has been approaching throughout the book. She can remember Cassie without joining her and can imagine a future made from repeated, difficult choices to remain alive.",
         "in_short": "Eighteen-year-old Lia Overbrook has relapsed into anorexia while convincing her family and clinicians that she is stable. When her estranged best friend Cassie dies alone in a motel after calling Lia thirty-three times, Lia hides the unanswered messages and turns her guilt into harsher restriction. Memories of the girls' shared drive to become thinner merge with visions of Cassie, who seems to demand that Lia follow her. Lia lies at weigh-ins, withdraws from her father, stepmother, stepsister, and physician mother, and seeks details of Cassie's final hours from motel worker Elijah. As her body weakens, the ghostly Cassie becomes harder to distinguish from Lia's illness and self-hatred. Lia finally reaches a physical and psychological crisis near the place Cassie died. Instead of surrendering, she calls for help and survives. Treatment begins again, and the ending offers no instant cure but shows Lia choosing honesty, food, connection, and life one step at a time.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3347,7 +3347,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3360,7 +3360,7 @@
       "recaps": {
         "ending": "The envoys' deaths were murder, arranged to protect a secret zilfium project, and the plot ran through the Cavenda family. Lovisa is the one who assembles the proof and acts on it, against both her parents, and it costs her the household she grew up in: the family's power collapses, and she is left responsible for her three younger brothers and free of her mother for the first time. Bitterblue, given up for drowned by everyone including Giddon and Hava, is alive, and is found and got free. Her reappearance ends the diplomatic fiction that Monsea was being told the truth about anything in Winterkeep. Bitterblue and Giddon, each having spent part of the book believing the other lost, stop pretending about what they are to each other and end the book together, openly. Bitterblue sails home to Monsea with Giddon, Hava and the knowledge of what Winterkeep's industrial politics is capable of, and Winterkeep's argument about whether to burn zilfium at all is left unresolved and now far more dangerous. The great creature at the bottom of the bay, and the fact that both the silbercows and the bonded foxes have long known things about their humans that their humans do not know about them, remain part of the world the story leaves open.",
         "in_short": "Two Monsean envoys drown when their ship sinks in Winterkeep's bay, and Queen Bitterblue refuses to accept it as an accident: they had been investigating zilfium, the fuel at the centre of Winterkeep's politics. She sails there with Giddon and her half-sister and spy Hava, and gets nothing but polite obstruction. Meanwhile Lovisa Cavenda, a student and the daughter of two of Winterkeep's most powerful politicians, starts noticing what her parents are hiding at the family's northern estate. Bitterblue's boat goes down in the bay and she is presumed dead; she is in fact alive, taken and held prisoner in the north, while Giddon and Hava grieve and keep digging. Lovisa uncovers the truth - that her father arranged the envoys' deaths to protect a secret weapon project, with her mother implicated - and it is Lovisa who finds and frees the queen. The Cavendas' power collapses, Lovisa is left to raise her younger brothers on her own terms, and Bitterblue and Giddon return to Monsea together, no longer pretending about each other.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3527,7 +3527,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3540,7 +3540,7 @@
       "recaps": {
         "ending": "The Milton women take Ree to the icy pond where Jessup's body was hidden. They make her reach into the water and hold his arms while they cut off his hands, giving her the physical proof needed to establish that he is dead. Ree brings the hands to the authorities, and the bondsman later returns the portion of the bond money left after his expenses. The Dolly house and land are therefore secure. Teardrop tells Ree that he now knows who killed his brother, but he does not identify the killer; his decision to pursue that knowledge leaves more violence possible. Ree considers using the money to buy a car and continues to plan for Sonny and Harold rather than abandoning them. When the boys worry that she might leave, she assures them that she cannot imagine herself without the responsibility of caring for them. Jessup is gone, but Ree has preserved the family's home and remains at its center.",
         "in_short": "Sixteen-year-old Ree Dolly keeps her family alive in the Missouri Ozarks while her father Jessup is missing and her mother is incapacitated. A deputy tells her that Jessup used their house and timberland as bail security, so his failure to appear in court will make the family homeless. Ree questions members of the extended Dolly and Milton clans, violating a code that protects the local meth trade. She is warned off, turned away, and eventually beaten by women from the Milton household. Her dangerous uncle Teardrop claims her as family and prevents further harm, but Ree still needs proof that Jessup is dead. The Milton women finally take her to his body in a pond and cut off his hands for her to deliver to the authorities. The proof saves the property, and leftover bond money gives the family a little stability. Teardrop learns who killed Jessup but withholds the name, while Ree stays with her brothers and plans a future built around keeping them together.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3698,7 +3698,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3711,7 +3711,7 @@
       "recaps": {
         "ending": "Winter's Heart ends with two turning points. Mat Cauthon breaks out of Seanchan-held Ebou Dar and flees north, taking with him Tuon, the Daughter of the Nine Moons and heir to the Seanchan empire, beginning the strange courtship prophecy demands of them. Far away, at the cursed ruins of Shadar Logoth, Rand al'Thor accomplishes what every Aes Sedai believed impossible. Using the great sa'angreal Choedan Kal, and linked through Nynaeve and Cadsuane's circle, he pits the tainted male Power against the ancient evil of the dead city and cleanses saidin of the Dark One's corruption. The Forsaken who come to stop him are driven off, and for the first time since the Breaking of the World men can channel without the certainty of madness, though few yet believe it has truly happened. Elayne consolidates her position in Caemlyn as she pursues the Lion Throne, and Perrin, still without Faile, continues his relentless hunt for the Shaido who hold her.",
         "in_short": "As the Seanchan occupy Ebou Dar, Mat Cauthon recovers in hiding and is drawn to the enemy heir, Tuon, the Daughter of the Nine Moons, whom prophecy says he must marry. When his cover collapses he escapes the city in a daring flight, carrying Tuon away with him. Meanwhile Rand resolves to do the impossible: to cleanse the male half of the One Power of the Dark One's taint, the curse that drives men who channel mad. Gathering channelers and the immense sa'angreal called the Choedan Kal, and shielded by Nynaeve and a circle of allies, he channels a torrent of the Power at the tainted, evil-soaked ruins of Shadar Logoth, using one poison to burn out the other. Several of the Forsaken sense the vast weave and attack to stop him, and a desperate battle rages, but Rand succeeds. Saidin runs clean for the first time in three thousand years. Elayne, in Caemlyn, gathers support for her claim to Andor's throne, while Perrin's search for the captive Faile goes on.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3876,7 +3876,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3889,7 +3889,7 @@
       "recaps": {
         "ending": "Winter refuses to end, burying the mountains and the Chalk under an enormous snowfall that kills livestock and traps whole villages, and the Wintersmith completes the human body he has been assembling out of the substances a man is made of, so that he can court Tiffany as a man. The Feegle, with Roland, reach the underworld and bring the Summer Lady back, along with a cornucopia that produces endless food, which is used to feed the snowbound. Tiffany goes to the Wintersmith's palace of ice and faces him. Because she has been carrying the Summer Lady's power since she stepped into the dance, she is able to give him what he has spent the book asking for: she accepts him and kisses him, and the heat she carries melts him away, ending the winter. The Summer Lady returns to take back her own role, and Tiffany hands the power over willingly, understanding at last that the seasons are a story that must be danced properly rather than improvised. Annagramma, propped up all year by Tiffany and the other trainees, finally learns that she has been helped and begins to make an honest job of her steading. Roland returns home a different young man, having gone into the underworld and come out again. Tiffany goes back to the Chalk older, steadier, and no longer interested in being noticed.",
         "in_short": "Tiffany Aching, thirteen and apprenticed to the ancient, blind Miss Treason, is taken to watch the dark, silent dance that turns the year from summer to winter, and, unable to stop herself, steps into it and dances with the Wintersmith. The elemental spirit of winter takes her for the Summer Lady, falls in love with her, and begins to court her with snowflakes shaped like her face, roses of ice, and icebergs carved into her likeness, while Tiffany finds that green shoots spring where she walks and that part of the Summer Lady's role has come to rest on her. Miss Treason dies at a time of her own choosing, and Tiffany moves to Nanny Ogg's while quietly holding together the steading her rival Annagramma has inherited. Winter deepens and will not end, because the story has been broken. The Wintersmith builds himself a human body to win her, the Nac Mac Feegle and Roland go down into the underworld to bring the Summer Lady back, and a great snowfall buries the Chalk. Tiffany goes to the Wintersmith's ice palace and ends him with the summer heat she has been carrying, giving the season back to its rightful owner.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4033,7 +4033,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "type": "community"
@@ -4044,7 +4044,7 @@
       "recaps": {
         "ending": "Wintersteel closes with the Uncrowned King tournament finished and its two Akura underdogs remade. Yerin, nearly killed by the dragon Sopharanatoth's forbidden use of power, has claimed the complete legacy of the Sage of the Endless Sword and advanced into a far higher and harder state of strength, turning the dragons' attempt to destroy her into their public humiliation. Lindon's true significance has been exposed to the continent's rulers: the Monarchs recognize that his origins and his ties to forces from beyond Cradle make him far more than the backwater competitor he appeared to be, and the reclusive Monarch Northstrider has taken him on as a personal student. The dragons and their patron, the lion Monarch Reigan Shen, leave the tournament set back and humiliated but with their ambitions intact. Lindon and Yerin part from the contest dramatically stronger and now firmly within the sight of the great powers, while the larger dangers overshadowing Cradle - the ancient dreadgods and the schemes of the Monarchs - rise to the fore. The path ahead points away from tournaments and toward far greater and more perilous conflicts.",
         "in_short": "In the concluding half of the Uncrowned King tournament, Lindon, Yerin, and Mercy fight through the contest's most dangerous final rounds against the strongest young artists of the continent. When the golden dragon Sopharanatoth and her backers channel forbidden power to destroy Yerin, they gravely wound her but provoke a crisis that forces the watching Monarchs to intervene. Pushed to her limit, Yerin embraces the full legacy of the Sage of the Endless Sword and advances into a far greater state of power, turning the dragons' overreach into their humiliation. Meanwhile the Monarchs perceive that Lindon is far more than a backwater competitor, and his connection to forces from beyond Cradle comes to light, marking him as a figure of extraordinary interest. By the tournament's end the reclusive Monarch Northstrider has taken Lindon as his personal student, and both Lindon and Yerin emerge transformed and vastly stronger. Reigan Shen and the dragons are set back but undeterred, and the greater threats facing Cradle move to the center of the story.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4204,7 +4204,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4217,7 +4217,7 @@
       "recaps": {
         "ending": "After a patrolman destroys his car, Hazel returns to Taulkinham and blinds himself with lime. He gives up public preaching and adopts private acts of penance, wrapping wire around his body, walking with stones in his shoes, and eating little. Mrs. Flood, his landlady, initially worries about his unpaid rent and imagines gaining control of his government pension, but his inaccessible inner life increasingly holds her attention. She proposes marriage as a way to keep him with her. Hazel instead leaves during a storm. Police officers find him collapsed in a ditch; one strikes him while taking him back, and Hazel dies before he is returned to the boardinghouse. Mrs. Flood has his body placed in bed and sits beside him. Looking into his ruined eyes, she imagines a distant point of light, ending beside the mystery she had tried to understand and possess.",
         "in_short": "Hazel Motes, a young veteran raised by preachers, arrives in Taulkinham determined to prove that there is no sin, salvation, or need for Christ. He buys a failing car and founds the Church Without Christ, while the lonely Enoch Emery follows intuitions he calls wise blood. Hazel becomes entangled with the supposedly blind preacher Asa Hawks and Hawks's daughter Sabbath Lily. Promoter Hoover Shoats tries to commercialize Hazel's church and hires Solace Layfield as a duplicate preacher; Hazel kills Layfield with his car. Enoch steals a museum mummy, then later steals a gorilla costume and disappears into the identity it offers. When a patrolman destroys Hazel's car, Hazel blinds himself and turns to extreme penance. His landlady Mrs. Flood tries first to profit from him and then to keep him, but he walks into a storm, is found by police, and dies as they return him to her house.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/data/works-community/0/witches-abroad.json
+++ b/data/works-community/0/witches-abroad.json
@@ -68,7 +68,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -81,7 +81,7 @@
       "recaps": {
         "ending": "In Genua, the witches discover that the city's ruling fairy godmother is Granny Weatherwax's own older sister, Lily, who left home long ago and built her power on mirrors and stories, forcing the people around her into fairy-tale parts so their lives will end the way she has decided. She is compelling the young woman Ella toward the role of a servant girl destined to marry a prince at a grand ball, the prince being a creature she has raised up into human shape. A rival power, the swamp witch Mrs Gogol, works to overthrow Lily through her own darker magic, so Granny finds herself opposing the enforcing of any story, on either side. The confrontation climaxes at the masked ball. Granny faces Lily directly and defeats her in a contest of mirror magic, leaving her lost in the infinite corridor of reflections, unable to find her way back to the single real world. With Lily gone, Genua is released from its imposed happy endings, and Ella is freed from the marriage that was being forced on her, left to live a life of her own choosing. The three witches, changed by what they have seen of what Granny might have become, begin the long journey back to Lancre.",
         "in_short": "When an old fairy godmother dies, her wand and an unfinished mission pass to young Magrat Garlick: travel to the distant city of Genua and stop a girl named Ella from marrying a prince. Granny Weatherwax and Nanny Ogg invite themselves along, and the three witches cross the Disc, blundering through a string of forced fairy-tale situations on the way. In Genua they find the city trapped inside stories against its will, ruled by another, far more powerful fairy godmother who bends people into fairy-tale roles to control them. She turns out to be Lily, Granny's estranged older sister, who long ago chose to use mirror and story magic to impose her idea of happy endings on everyone. Lily is forcing Ella into the role of a Cinderella figure and a marriage to a false prince. The witches side against her, and the conflict comes to a head at a great masked ball. Granny confronts her sister in a duel of mirror magic and traps Lily in the endless reflected world between the glasses. Genua is freed from its enforced stories, Ella is released from the marriage, and the witches head home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -319,7 +319,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B016J85CWW",
@@ -331,7 +331,7 @@
       "recaps": {
         "ending": "Reacher and Neagley turn Froelich's memorial in Grace, Wyoming, into a trap for the two men still targeting Armstrong. They drive the attackers away from town, pursue them through snowy ravines, and are briefly captured. A defective Beretta gives Reacher his opening. Neagley kills Peter Wilson, and Reacher kills Richard Wilson. Their identification establishes that the attackers were Idaho county detectives and brothers seeking revenge for abuse inflicted by Armstrong's father when they were young. Armstrong reaches the memorial safely. Reacher gives Stuyvesant the brothers' identification and evidence pointing to their Idaho home, including material connected to the coerced thumbprint campaign. A recent grocery receipt indicates that Nendick's wife may still be alive, and Stuyvesant leaves immediately to follow that lead. The immediate assassination threat is over, but her rescue remains unresolved. Reacher and Neagley dispose of their untraceable weapons, separate amicably in Denver, and Reacher returns briefly to New York before continuing his solitary travels.",
         "in_short": "Secret Service agent Froelich recruits Jack Reacher, on the recommendation of his late brother Joe, to test protection for vice president-elect Brook Armstrong. Reacher and Frances Neagley expose serious weaknesses, then learn that careful threats are backed by two killers. The attackers murder two unrelated men named Armstrong, coerce surveillance operator Nendick by abducting his wife, and stage attacks in North Dakota and Washington. Froelich saves Armstrong during the Thanksgiving shooting but dies with agent Corsetti. Reacher and Neagley trace the campaign to two brothers abused by Armstrong's father decades earlier. At Froelich's Wyoming memorial, they confront Idaho detectives Richard and Peter Wilson. Neagley kills Peter and Reacher kills Richard. Armstrong attends safely, while evidence suggests Nendick's wife may still be alive. Stuyvesant pursues that lead, and Reacher and Neagley part in Denver before Reacher resumes travelling.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -624,7 +624,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -637,7 +637,7 @@
       "recaps": {
         "ending": "The published novel stops before its planned final resolution because Elizabeth Gaskell died while it was still appearing in parts. By the surviving close, Osborne has died and the Squire has learned of his secret marriage. His first shock gives way to acceptance of Aimée and her child, who secure a future at Hamley. Cynthia has ended her engagement to Roger and becomes engaged to Mr Henderson, a match she enters more honestly than her earlier attachments. Roger returns from his scientific expedition to find that Cynthia's choice no longer wounds him as he expected. He begins to recognize that Molly's constancy, intelligence, and quiet care matter more deeply to him. Molly has loved him without declaring it. The text ends as their new understanding is forming, before Roger makes a proposal. The continuation described to the magazine's readers indicates that Gaskell intended Roger and Molly to marry, but that marriage is not dramatized in the completed manuscript.",
         "in_short": "Molly Gibson, the devoted daughter of a widowed country doctor, is sent among the Hamleys and becomes close to brothers Osborne and Roger. Her father marries the socially ambitious widow Clare Kirkpatrick, bringing Clare's beautiful daughter Cynthia into Molly's home. Roger falls for Cynthia and becomes engaged to her before leaving on a scientific expedition, although Cynthia has concealed an earlier engagement to the controlling Mr Preston. Molly helps free her from Preston and bears damaging gossip without exposing her stepsister. Cynthia eventually ends her engagement to Roger and later chooses Mr Henderson. Meanwhile Osborne dies after secretly marrying a Frenchwoman, Aimée, and the grieving Squire ultimately receives her and his grandson. Roger returns to discover that his feeling for Cynthia has passed and that he loves the steadfast Molly. Gaskell died before completing the last movement: the surviving novel ends before his proposal, though the announced intended conclusion was their marriage.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -793,7 +793,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -806,7 +806,7 @@
       "recaps": {
         "ending": "The search ends in two deaths. Betty is found at the bottom of an old well, and the evidence shows that Toby did not murder her. Toby nevertheless cannot safely surrender to a community and authorities that have already decided what kind of man he is; he is killed while being pursued. Annabelle is left to understand that telling the truth was necessary but could not undo every lie or prejudice that shaped the search. Her family knows Toby was innocent and mourns him as a person they had tried to protect, while Betty's death remains the grim outcome of the fear and cruelty she set in motion. Annabelle returns to the routines of farm and school altered by what she has witnessed. She carries both the burden of the choices she made in hiding Toby and a clearer sense that justice depends on seeing an isolated person fully, not merely accepting the story a frightened community tells about him.",
         "in_short": "In wartime rural Pennsylvania, twelve-year-old Annabelle McBride becomes the target of Betty Glengarry, an older newcomer whose threats escalate into violence against other children. Betty then directs suspicion toward Toby, a withdrawn First World War veteran whom the community already fears. When Betty disappears, Annabelle knows that her accusations against Toby were false and persuades her family to help protect him while the authorities search. Their efforts cannot overcome the rumors surrounding an armed, solitary man. Betty is eventually found dead in an old well, showing that Toby did not kill her, but Toby is also killed during the pursuit. Annabelle emerges from the crisis grieving both deaths and recognizing how silence, lies, and prejudice can combine to destroy an innocent person.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1012,7 +1012,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1025,7 +1025,7 @@
       "recaps": {
         "ending": "Richard Collins returns to Green Creek and is killed in the fighting, and Osmond is exposed as having worked with him from inside the wolf leadership all along. The cost is heavy: Ox's mother is among the dead, and the town and the pack are left to bury their own. Ox and Joe come through it together and are openly mates, and rather than one of them stepping aside, both stand as alphas of the Bennett pack: Joe by inheritance from his father, Ox by what the pack chose in him during the years he held it alone. Elizabeth, Mark, Carter, Kelly, Gordo, Robbie, Jessie, Chris, Tanner and Rico are all bound into that pack, wolves and humans together. Gordo and Mark have stopped pretending the past can be undone and have begun to rebuild. Green Creek is quiet again and the pack is whole, but the wolf leadership has been shown to be corrupt from the inside, Gordo's own history with his father is still unexplained, and the losses of the last decade are not undone by winning.",
         "in_short": "Ox Matheson is twelve when his father abandons him in Green Creek, Oregon, convinced he will never amount to much. At sixteen, working at Gordo Livingstone's garage, he is found in the woods by a small boy named Joe Bennett, who has not spoken in years and who talks to him at once. The Bennetts take Ox and his mother in, and Ox learns they are werewolves and that Thomas Bennett is their alpha. Ox is given a place in the pack and, as the years pass, grows into the person Joe has claimed from the beginning. When the rogue alpha Richard Collins comes for the Bennetts, Thomas is killed; Joe inherits his father's power and leaves with Carter, Kelly and Gordo to hunt Richard down, leaving Ox behind. Over three years Ox holds together everyone who stayed and becomes an alpha in his own right. When the hunters return empty-handed and Richard finally comes to Green Creek, the reunited pack fights and kills him, exposing a traitor inside the wolf leadership, and Ox and Joe stand together as alphas of what remains.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1220,7 +1220,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1233,7 +1233,7 @@
       "recaps": {
         "ending": "At the Alpine hotel, Gudrun increasingly prefers the company of the sculptor Loerke and treats Gerald's demands as a form of possession. During a final confrontation outside, Gerald nearly strangles Gudrun, releases her, strikes Loerke, and walks alone into the snow. He is later found frozen to death. Gudrun leaves with Loerke, her future unresolved but decisively separated from Gerald and from the paired life Ursula has chosen. Ursula and Birkin remain together and prepare to return to England. Birkin grieves for Gerald and tells Ursula that his marriage cannot answer every kind of love he needs: he had wanted an enduring bond with a man as well as his union with a woman. Ursula rejects the idea that another absolute relationship is either possible or necessary. Their disagreement closes the novel without undoing their marriage, leaving their partnership alive but unable to settle Birkin's larger ideal of human connection.",
         "in_short": "Sisters Ursula and Gudrun Brangwen become involved with two contrasting men in the English Midlands: the questioning intellectual Rupert Birkin and the industrial heir Gerald Crich. Ursula and Birkin struggle toward a marriage meant to preserve both intimacy and independence. Gudrun and Gerald are drawn together by fascination, power, and hostility while Gerald modernizes his family's mines and suppresses his emotional life. After his father's death, their affair deepens but becomes destructive. The two couples travel to the Alps, where Gudrun turns toward the German sculptor Loerke and Gerald's need for control intensifies. Gerald nearly kills Gudrun during a confrontation, then wanders into the snow and freezes to death. Gudrun departs with Loerke. Ursula and Birkin survive as a couple, but the final conversation exposes a lasting difference: Birkin believes he also needed a profound bond with Gerald, while Ursula insists their marriage should be enough.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1408,7 +1408,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1421,7 +1421,7 @@
       "recaps": {
         "ending": "The women agree that leaving Molotschna is the only course that can protect their children while giving them a chance to preserve a faith not defined by compulsory submission. They secretly organize wagons, supplies, animals, and the children, relying on August for a map and on one another for the practical knowledge denied them by the colony's rules. Disputes over which boys to take are settled in favor of bringing the young with them rather than abandoning them to the existing order. Ona chooses the uncertain journey despite her pregnancy, and the families depart before the colony's men can return and prevent them. August remains behind. His minutes preserve reasoning that the women themselves were not permitted to write, while the tasks they leave him offer a purpose beyond his despair: he can teach, bear witness, and help the boys and remaining men imagine relations not founded on domination. The destination and future are unknown, but the closing movement is an enacted decision rather than another debate: the women and children leave.",
         "in_short": "In the isolated Molotschna colony, women and girls discover that men have drugged and assaulted them for years. While most of the colony's men are away arranging bail for the accused, eight women meet in a hayloft to choose among doing nothing, staying to fight, or leaving. Since they cannot write, former colonist and schoolteacher August Epp records their discussion. Agata, Greta, Ona, Salome, Mariche, Mejal, Autje, and Neitje debate safety, pacifism, forgiveness, faith, motherhood, and whether they can build a community without reproducing its violence. Their differences are sharpened by anger, abuse, pregnancy, and concern for the boys they are raising. They finally decide that departure offers the only genuine chance to protect the children and keep their moral commitments freely. Working in secrecy, they gather wagons and supplies and take the children with them. The women leave before the men return; August stays behind with their minutes and a responsibility to teach and remember.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1596,7 +1596,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1609,7 +1609,7 @@
       "recaps": {
         "ending": "At the fifth-grade graduation ceremony, Mr. Tushman speaks about choosing kindness and presents Auggie with the school's Henry Ward Beecher medal for the quiet courage and positive influence he has shown throughout the year. The entire audience gives Auggie a standing ovation. He recognizes that many people helped carry him through the difficult months, while his classmates now see him as a friend rather than a spectacle. Julian will not return to Beecher Prep, and the social division he encouraged has largely dissolved. Via's relationship with her family is steadier after the strain surrounding her play and Daisy's death, and Miranda has reconnected with the Pullmans. As the family walks home after taking photographs, Auggie thanks his mother for making him attend school. She tells him that he is a wonder, closing the year with his difference still present but no longer defining the limits of his world.",
         "in_short": "August Pullman, a ten-year-old with severe facial differences, leaves home schooling to enter fifth grade at Beecher Prep. He meets open cruelty from Julian, uncertain friendship from Jack Will, and immediate kindness from Summer. After overhearing Jack speak harshly about him, Auggie withdraws, but Jack understands the damage, defends him, and repairs their friendship. The story also follows Auggie's sister Via, who loves him while struggling with how completely his needs shape their family. Her old friend Miranda secretly misses the Pullmans and ultimately gives Via the lead in the school play. During a class retreat, older pupils attack Auggie and his classmates defend him, changing his standing at school. By graduation, most classmates have moved past fear of his appearance. Auggie receives a school medal for courage and character and a standing ovation, and he thanks his mother for sending him to school.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -1808,7 +1808,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -1821,7 +1821,7 @@
       "recaps": {
         "ending": "Juliette crosses the hills from Silo 17 in a suit she has built herself, forces her way into Silo 18 through the airlock and survives the burn cycle meant to sterilize the chamber. Her return is more than the existing order can absorb. Bernard Holland's rule ends with his death, and Lukas Kyle, whom Bernard had been training as his shadow, is left holding IT and everything it guards: the Order, the hidden equipment in the server room, and the knowledge that Silo 18 is one of fifty. The cost of the uprising is enormous. Knox and many of Mechanical's and Supply's people are dead, whole levels are wrecked, and the survivors have to rebuild among neighbors who no longer believe the story they were raised on. Juliette, condemned and presumed dead, is now the only person who has walked outside and come back, which makes her both a danger to the silo's peace and the closest thing it has to a leader. Weeks later she is back in Mechanical with Shirly and Walker, refusing to let the silo settle into its old habits. She has left Solo alone in Silo 17 with a promise, and she begins working out how to reach him without crossing the poisoned surface, by digging through the earth between the two silos. A short closing scene returns to Silo 17 and the man waiting there.",
         "in_short": "Thousands of people live in a buried silo of more than a hundred and forty levels, taught that the air outside is lethal and that merely wishing to leave is a capital offense, punished by being sent out to clean the camera lenses and die on the hill. When Sheriff Holston follows his dead wife outside, he discovers that the beautiful landscape his helmet shows him is a fabrication and the real world is ruin. His replacement, the machinist Juliette Nichols, is fetched up from Mechanical at the bottom of the silo, and when she starts asking what the IT department is hiding she is condemned to cleaning herself. Friends in Mechanical and Supply secretly build her a suit that holds. Juliette refuses to clean, walks over the hill, sees dozens of other silos sunk into the landscape, and takes shelter in the derelict Silo 17, where a lone survivor called Solo has lived for decades. Her survival shatters the ritual that kept her own silo obedient and sets off a bloody uprising. She builds a working suit, walks back, and returns to a silo whose ruling order has collapsed and whose deepest secret, that there are fifty silos and someone outside is watching them all, now sits in friendlier hands.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2060,7 +2060,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -2073,7 +2073,7 @@
       "recaps": {
         "ending": "The war on the Shattered Plains ends not in victory but in transformation. Cornered, the Parshendi choose a fearsome new form of power and summon the Everstorm, a second storm that blows the wrong way and awakens their dormant kin across the world into potential enemies. In the final battle Kaladin speaks a further oath, comes fully into his Windrunner powers, and shields the armies from the double storm, defeating the assassin Szeth, who falls. Shallan uncovers and activates an ancient portal, carrying the survivors to Urithiru, the vast lost city that once housed the Knights Radiant. Adolin secretly kills the treacherous highprince Sadeas, removing a rival but staining his conscience. Jasnah, thought dead since the voyage that opened the book, reappears alive. The Kholins now hold the seat of the ancient Radiants and a small, growing order of new knights, but the cost is enormous: the true Desolation has arrived, the Everstorm is loose upon Roshar, and the parshmen everywhere are waking. Far away, the assassin's broken body is claimed by a mysterious figure and given a living sword, setting him on a new path. Dalinar's coalition has a fortress and a purpose, but the world stands on the edge of a war it has not faced in millennia.",
         "in_short": "The Alethi war on the Shattered Plains reaches its end as Dalinar Kholin pushes to reunite the fractured highprinces and refound the Knights Radiant, convinced an ancient enemy is returning. Shallan Davar, having survived the loss of her patron Jasnah at sea, reaches the war camps, becomes betrothed to Dalinar's son Adolin, and races to master her Radiant powers while hunting the lost city of the Radiants and tangling with a deadly secret society. Kaladin, now captain of Dalinar's guard, wrestles with his hatred of the lighteyes and is nearly drawn into a plot to murder the king before choosing to protect him and speaking a deeper Radiant oath. The Parshendi, facing annihilation, take a terrible new form and summon a second, dark storm that circles the world. In the climactic battle Kaladin saves the coalition, Shallan discovers an ancient portal and transports the army to the fabled city of Urithiru, and the assassin Szeth is defeated. Jasnah returns alive, but the true enemy has come: the age of Desolations begins.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -2260,7 +2260,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2273,7 +2273,7 @@
       "recaps": {
         "ending": "Human armies eventually reclaim most inhabited territory, and the United States marks victory after a continental campaign in which conventional soldiers methodically destroy the remaining concentrations of infected. Victory is incomplete: zombies still emerge from thawing ground, remain active on the ocean floor, and occupy uncleared regions. Whole countries and populations have vanished. China becomes a democracy after naval rebels help end the old regime, while Russia emerges as an authoritarian religious empire. Cuba gains wealth and political influence after sheltering refugees; other nations face environmental damage, depopulation, and transformed borders. North Korea's population remains missing, with no certainty about what survives in its underground facilities. The interviewees return to altered civilian lives or continue work shaped by the war. Todd Wainio remains in military service, and societies maintain watch for renewed outbreaks while rebuilding families, economies, and governments. The oral historian closes with personal testimony rather than a claim that the crisis is fully over: humanity survived by adapting, cooperating, and accepting immense losses, but the physical and political consequences will persist for generations.",
         "in_short": "A United Nations investigator records testimony about the global zombie war, beginning with suppressed cases in China and tracing how smuggling, organ trafficking, denial, and fraudulent medicine spread the infection. Governments respond too late. Refugees overwhelm borders, military doctrine fails spectacularly at Yonkers, and much of humanity retreats into fortified safe zones while abandoned populations serve as diversions. Survivors then rebuild industry and develop disciplined tactics based on destroying each zombie's brain, conserving ammunition, and holding formation. An international conference chooses counterattack over permanent isolation. Campaigns reclaim the United States and other territories, while resistance movements, submarine crews, pilots, astronauts, and civilians describe distinct parts of the struggle. Years later, organized zombie armies have been defeated but millions of infected remain underwater, frozen, or in inaccessible regions. China is reshaped by revolt, Russia by authoritarian religion, and Cuba by its refugee economy. Humanity has won enough to rebuild, not enough to restore the old world or stop guarding against another outbreak.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2491,7 +2491,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -2504,7 +2504,7 @@
       "recaps": {
         "ending": "Humanity defeats the great concentrations of zombies and declares victory, but the result is not a restoration of the old world. Billions are dead, many governments and borders have changed, and the surviving societies have been remade by conscription, scarcity, migration, and loss. The United States has reclaimed its territory through a slow continental campaign, while other nations have followed their own costly paths. Zombies still remain beneath oceans, in frozen regions, and in isolated places, so clearance and vigilance continue. The environmental effects of years of fire and industrial collapse are also still unfolding. The interviewer finishes preserving testimonies that his official report excluded: individual memories of warnings ignored, families broken, improvised survival, institutional failure, and adaptation. The speakers have returned to work, family, military duty, or uneasy retirement, but none treats the formal end of the war as an erasure of what happened.",
         "in_short": "Ten years after humanity's war against the walking dead, a United Nations investigator records the personal testimony omitted from his official report. Doctors, smugglers, officials, soldiers, refugees, pilots, sailors, astronauts, and civilians trace the disaster from concealed cases in China through international trafficking, denial, false cures, and mass panic. Conventional armies fail spectacularly, most notably at Yonkers, while governments preserve smaller safe populations through severe triage. Survivors then rebuild production, military doctrine, and social life around an enemy that does not tire or surrender. A coordinated global counteroffensive slowly clears inhabited territory, though every victory carries enormous human and moral cost. The war ends with civilization surviving but permanently changed: billions are dead, political orders have shifted, and zombies remain in remote, frozen, and underwater places. The interviewer's oral history preserves not a single heroic campaign but a mosaic of warnings, mistakes, endurance, and compromises from around the world.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -2937,7 +2937,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:uk:B0GCNLB1T5",
@@ -2949,7 +2949,7 @@
       "recaps": {
         "ending": "Kale remains alive in the Magi world after the wolf-like overseer and an abyss goddess escape separately to Talona. His magic spreads through the dormant Font network, and he loses consciousness beside Simeon Grey before the result can be determined. Abby has already returned to defend her own world from renewed attacks. On Talona, Queen Bael, Max, four surviving necromancers, and their allies have stabilized the Animus Seal with the Dead Forge, although the site still needs protection and a demon's claim on Queen Bael's unborn child remains unresolved. Max becomes custodian of Solakir while Kale is presumed lost. A wave of disappearances and damage between realities then reaches the fortress itself. Its protections fail, the castle catches fire, and Max loses consciousness during an emergency return. The conditions of Cassie, Kale's children, and the other defenders are not established.",
         "in_short": "Stranded on a world whose magic was destroyed in an old invasion, Kale travels with Abby toward the ruined Magi Citadel while fighting witches, daemons, undead, and life-draining crystal geodes. Abby develops electrical magic, and together they uncover the former Magi portal network. On Talona, Queen Bael inherits King Bael's necromantic power, Max takes responsibility for Solakir, and their allies use the Dead Forge to reinforce the Animus Seal. Beneath the citadel, an imprisoned wolf-like overseer and an abyss goddess escape separately to Talona. Abby returns home to confront attacks there, while Kale restores the dormant world's Font network and collapses alive beside Simeon Grey. On Talona, connected disappearances and damage between realities culminate in a breach that sets Solakir ablaze as Max attempts to return.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3284,7 +3284,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B0045VT4NY",
@@ -3296,7 +3296,7 @@
       "recaps": {
         "ending": "Reacher confirms that Margaret Coe died in the old barn and eliminates Eldridge Tyler, the fifth participant in the concealed crime. He traps the Duncans at their compound with burning vehicles. Jonas and Jasper Duncan are killed during the attack, Seth is killed after firing at Reacher, and Dorothy Coe kills Jacob after the evidence against the family is confirmed. The compound burns, and the surviving Duncan enforcers are to be released and expelled from the area. Eleanor Duncan arrives in the delayed shipment van with six women and ten girls trafficked from Thailand. She, the doctor, his wife, and Dorothy plan to take the victims toward Denver's Thai community for assistance returning home. Eleanor intends to rebuild her life elsewhere. The local trafficking operation is finished, but the wider customers and the question of official protection remain unresolved. Reacher returns to the road for Virginia, where he intends to meet Susan Turner.",
         "in_short": "In rural Nebraska, an injured Jack Reacher intervenes after Eleanor Duncan is beaten and becomes entangled with the powerful Duncan family. His inquiry into the decades-old disappearance of Margaret Coe coincides with a delayed shipment that draws armed intermediaries into the area. Reacher survives capture, turns the rival groups against one another, and finds proof that Margaret died in a barn guarded by Eldridge Tyler. He then destroys the Duncan compound. Jonas, Jasper, and Seth Duncan die in his assault, while Dorothy Coe kills Jacob Duncan. The shipment proves to be six women and ten girls trafficked from Thailand. Eleanor intercepts their van and joins local survivors in taking them toward help in Denver. Reacher leaves the dismantled operation behind and resumes his journey to Virginia to meet Susan Turner.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3397,7 +3397,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -3408,7 +3408,7 @@
         "work": "wrath-of-the-triple-goddess"
       },
       "recaps": {
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -3520,7 +3520,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3533,7 +3533,7 @@
       "recaps": {
         "ending": "Dorothy releases Nipper far from Waymer, but the pigeon is swept into the supply of birds sent to the town for Pigeon Day. Palmer recognizes him among the birds on the shooting field. After the firing, Palmer crosses the boundary in front of the crowd and picks up the wounded pigeon instead of killing him as a wringer is expected to do. Beans urges him to twist the bird's neck, but Palmer openly refuses. Nipper's familiar nip at Palmer's ear confirms their bond. Palmer carries the living bird away while applause begins among the spectators, transforming the public act he feared into a declaration of his own values. His choice does not erase the town's event, but it ends his secrecy: he rejects the role imposed on him and no longer treats compassion as something shameful.",
         "in_short": "In Waymer, boys who turn ten are expected to wring the necks of wounded birds at the annual Pigeon Day shoot. Palmer LaRue dreads that role but hides his fear so he can belong to Beans's gang, even joining its harassment of his neighbor Dorothy. His conflict becomes urgent when a pigeon adopts him. Palmer names the bird Nipper and secretly cares for him while pretending loyalty to boys who celebrate killing pigeons. Dorothy discovers the secret and becomes Palmer's trusted ally. Hoping to save Nipper, she takes him away for release, but the bird is accidentally returned with pigeons collected for Pigeon Day. Palmer recognizes Nipper after the shooting and walks onto the field before the whole town. Instead of serving as a wringer, he rescues the wounded bird, defies Beans, and carries Nipper away alive as people begin to applaud.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -3784,7 +3784,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -3797,7 +3797,7 @@
       "recaps": {
         "ending": "Jamie and Claire go home. They ride south to Fraser's Ridge, where the burned Big House is a cellar hole and the settlement has spent two years without them, and begin the work of building again, with Jenny Murray in the household and Frances Pocock, whom William entrusted to them, as their ward. Claire has recovered from the wound that nearly killed her; her marriage to Lord John has been undone by Jamie's being alive, and the friendship between the two men survives in a battered form. Young Ian and Rachel Hunter marry in the Friends' manner. William has left the army, refuses to be anyone's son and has attached himself to no cause, but he has done what he could for Jane's sister and has met his cousin Benjamin's widow, Amaranthus, and her infant, whose existence matters a great deal to the Grey family's affairs. Hal Grey is still in America and still short one son. In the eighteenth-century Highlands, Roger's family reaches him: Brianna, having recovered Jem from Rob Cameron in 1980, brought both children through the stones, and the MacKenzies are together again and bound for America. The war has moved south, and the Frasers, back on their own mountain, are directly in its path.",
         "in_short": "Philadelphia, June 1778. Jamie Fraser, reported drowned, walks in to find Claire married to Lord John Grey and his natural son William newly told who his father is. Everything comes apart at once: William repudiates his name and rides off, Lord John is taken prisoner, and the British army evacuates the city with Washington's army after it. Jamie takes a Continental command; Claire is shot and nearly dies, and is still convalescing when the two armies meet at Monmouth Court House in punishing heat and fight to a bloody draw that the Americans count a victory. Afterwards Jamie resigns his commission. William, adrift, tries and fails to save a young woman named Jane from the gallows and takes her small sister into his keeping. In the twentieth century Brianna hunts down the man who took her son, recovers Jem, and takes both children through the stones after Roger, who has been stranded in the Highlands two centuries early with William Buccleigh MacKenzie. The families converge: the MacKenzies are reunited in the past, Young Ian marries Rachel Hunter, and Jamie and Claire go home to Fraser's Ridge to rebuild.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -4002,7 +4002,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4015,7 +4015,7 @@
       "recaps": {
         "ending": "Heathcliff's revenge succeeds but leaves him hollow. After Edgar Linton dies and his own son Linton dies soon after marrying young Cathy, Heathcliff controls both Wuthering Heights and Thrushcross Grange, with Cathy his trapped, widowed dependent and Hareton reduced to an ignorant laborer. Yet possession brings him no peace. Haunted by the memory of the elder Catherine and convinced her spirit is near, he grows increasingly strange, abandons his schemes, refuses food and sleep, and after several days is found dead by an open window with an odd look of triumph on his face. He is buried beside Catherine as he wished. With Heathcliff gone, the surviving young pair he had kept apart draw together: Cathy teaches Hareton to read, their affection heals the old hatred between the families, and they plan to marry and move to the Grange, leaving the Heights largely to Joseph. Lockwood, revisiting the three graves on the moor, wonders whether the dead rest quietly, though local people claim to see Heathcliff and Catherine walking the hills together. The two estates pass to Hareton and Cathy, restoring the Earnshaw line and closing the cycle of cruelty Heathcliff began.",
         "in_short": "A tenant renting Thrushcross Grange hears from his housekeeper, Nelly Dean, the history of the neighboring house, Wuthering Heights. Years earlier, Mr. Earnshaw brought home an orphan, Heathcliff, who grew inseparable from his daughter Catherine but was tormented by his son Hindley. Catherine, though she loves Heathcliff, marries the gentle Edgar Linton for comfort and status, and Heathcliff runs away. He returns wealthy and set on revenge: he marries Edgar's sister Isabella to spite them, and Catherine, torn between the two men, falls ill and dies giving birth to a daughter, Cathy. Over the next generation Heathcliff ruins Hindley, degrades Hindley's son Hareton, and forces his own frail son Linton to marry young Cathy so that on their deaths he seizes both estates. His revenge complete, Heathcliff is consumed by longing for the dead Catherine, loses all will to live, and dies. Freed of him, Cathy and Hareton grow close and plan to marry, ending the long feud.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4213,7 +4213,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4226,7 +4226,7 @@
       "recaps": {
         "ending": "After Cathy and Hareton become friends, she teaches him to read and he answers her earlier contempt with patience. Their affection gives both young people a way out of the isolation and inherited hostility of Wuthering Heights. Heathcliff initially objects, but his revenge has lost its purpose. He becomes increasingly absorbed by the sense that Catherine is near, stops eating, wanders on the moors, and dies in Catherine's old room. He is buried beside Catherine and Edgar, according to the arrangement he had long desired. Hareton mourns him despite the abuse and deprivation he suffered under Heathcliff's control. Cathy and Hareton plan to marry on New Year's Day and move to Thrushcross Grange, leaving Wuthering Heights to Joseph. When Lockwood visits the three graves, the moors appear quiet, although local stories claim that Heathcliff and Catherine still wander together.",
         "in_short": "Tenant Lockwood asks his housekeeper, Nelly Dean, to explain the hostile household at Wuthering Heights. Nelly recounts how the orphan Heathcliff and Catherine Earnshaw formed an intense childhood bond, but Catherine married the genteel Edgar Linton. Heathcliff returned after an unexplained absence and pursued revenge: he married Edgar's sister Isabella, gained Wuthering Heights from Catherine's ruined brother Hindley, and later used his sickly son Linton to seize Thrushcross Grange. Catherine died after giving birth to Cathy, leaving Heathcliff consumed by grief and obsession. In the next generation, Heathcliff forced Cathy to marry Linton, then kept her at the Heights after both Linton and Edgar died. His plan weakens when Cathy befriends Hareton, Hindley's neglected son, and teaches him to read. As they fall in love, Heathcliff loses interest in revenge, becomes preoccupied with Catherine's presence, and dies. Cathy and Hareton prepare to marry and leave the Heights, ending the cycle of hostility.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4417,7 +4417,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4430,7 +4430,7 @@
       "recaps": {
         "ending": "After Cathy and Hareton become friends, she teaches him to read and he answers her earlier contempt with patience. Their affection gives both young people a way out of the isolation and inherited hostility of Wuthering Heights. Heathcliff initially objects, but his revenge has lost its purpose. He becomes increasingly absorbed by the sense that Catherine is near, stops eating, wanders on the moors, and dies in Catherine's old room. He is buried beside Catherine and Edgar, according to the arrangement he had long desired. Hareton mourns him despite the abuse and deprivation he suffered under Heathcliff's control. Cathy and Hareton plan to marry on New Year's Day and move to Thrushcross Grange, leaving Wuthering Heights to Joseph. When Lockwood visits the three graves, the moors appear quiet, although local stories claim that Heathcliff and Catherine still wander together.",
         "in_short": "Tenant Lockwood asks his housekeeper, Nelly Dean, to explain the hostile household at Wuthering Heights. Nelly recounts how the orphan Heathcliff and Catherine Earnshaw formed an intense childhood bond, but Catherine married the genteel Edgar Linton. Heathcliff returned after an unexplained absence and pursued revenge: he married Edgar's sister Isabella, gained Wuthering Heights from Catherine's ruined brother Hindley, and later used his sickly son Linton to seize Thrushcross Grange. Catherine died after giving birth to Cathy, leaving Heathcliff consumed by grief and obsession. In the next generation, Heathcliff forced Cathy to marry Linton, then kept her at the Heights after both Linton and Edgar died. His plan weakens when Cathy befriends Hareton, Hindley's neglected son, and teaches him to read. As they fall in love, Heathcliff loses interest in revenge, becomes preoccupied with Catherine's presence, and dies. Cathy and Hareton prepare to marry and leave the Heights, ending the cycle of hostility.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4621,7 +4621,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4634,7 +4634,7 @@
       "recaps": {
         "ending": "After Cathy and Hareton become friends, she teaches him to read and he answers her earlier contempt with patience. Their affection gives both young people a way out of the isolation and inherited hostility of Wuthering Heights. Heathcliff initially objects, but his revenge has lost its purpose. He becomes increasingly absorbed by the sense that Catherine is near, stops eating, wanders on the moors, and dies in Catherine's old room. He is buried beside Catherine and Edgar, according to the arrangement he had long desired. Hareton mourns him despite the abuse and deprivation he suffered under Heathcliff's control. Cathy and Hareton plan to marry on New Year's Day and move to Thrushcross Grange, leaving Wuthering Heights to Joseph. When Lockwood visits the three graves, the moors appear quiet, although local stories claim that Heathcliff and Catherine still wander together.",
         "in_short": "Tenant Lockwood asks his housekeeper, Nelly Dean, to explain the hostile household at Wuthering Heights. Nelly recounts how the orphan Heathcliff and Catherine Earnshaw formed an intense childhood bond, but Catherine married the genteel Edgar Linton. Heathcliff returned after an unexplained absence and pursued revenge: he married Edgar's sister Isabella, gained Wuthering Heights from Catherine's ruined brother Hindley, and later used his sickly son Linton to seize Thrushcross Grange. Catherine died after giving birth to Cathy, leaving Heathcliff consumed by grief and obsession. In the next generation, Heathcliff forced Cathy to marry Linton, then kept her at the Heights after both Linton and Edgar died. His plan weakens when Cathy befriends Hareton, Hindley's neglected son, and teaches him to read. As they fall in love, Heathcliff loses interest in revenge, becomes preoccupied with Catherine's presence, and dies. Cathy and Hareton prepare to marry and leave the Heights, ending the cycle of hostility.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4804,7 +4804,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -4817,7 +4817,7 @@
       "recaps": {
         "ending": "After years of pursuing possession and revenge, Heathcliff loses interest in controlling the younger generation. He is increasingly absorbed by the memory of Catherine Earnshaw, stops eating, wanders outdoors, and dies in her former room with the window open. Hareton mourns him despite the abuse he suffered. Catherine Linton and Hareton have meanwhile overcome their hostility: she teaches him to read, he responds with loyalty, and their affection repairs a relationship Heathcliff tried to deform. They plan to marry on New Year's Day and move to Thrushcross Grange, leaving Joseph at Wuthering Heights. Lockwood visits the graves of Catherine, Edgar, and Heathcliff and hears local claims that Catherine and Heathcliff are seen together on the moors. The two estates will pass into the hands of Catherine and Hareton, descendants of the families whose conflict dominated the previous generation.",
         "in_short": "Tenant Lockwood asks housekeeper Nelly Dean to explain the hostile household at Wuthering Heights. She recounts how Catherine Earnshaw and the orphan Heathcliff grew up together, while Catherine's brother Hindley degraded him. Catherine married the refined Edgar Linton despite declaring a profound bond with Heathcliff. Heathcliff returned wealthy and devoted himself to revenge: he married and abused Edgar's sister Isabella, ruined Hindley, acquired Wuthering Heights, and later forced the younger Catherine to marry his dying son Linton so he could gain Thrushcross Grange. The elder Catherine died after giving birth, and Heathcliff remained consumed by her loss. In the next generation, Catherine's daughter and Hindley's neglected son Hareton begin in mutual contempt but grow close as she teaches him to read. Heathcliff abandons his revenge, becomes preoccupied with Catherine's presence, and dies. Catherine and Hareton plan to marry and unite the families and estates.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -4971,7 +4971,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -4984,7 +4984,7 @@
       "recaps": {
         "ending": "The traveling players come back to Lancre to perform the Duke's commissioned play, but on the night it is staged the witches turn its own magic back on him. Confronted with the truth of the murder and hounded by his own guilt and the disapproving land, Duke Felmet loses his mind entirely and falls to his death from the castle, his wife's schemes collapsing with him. With the usurpers gone, the question of the crown is settled. Tomjon, the murdered king's son raised among actors, is offered the throne but refuses it: he belongs to the theatre and has no wish to rule. The crown instead passes to the castle's Fool, who becomes the new King of Lancre. He and Magrat Garlick, who have fallen for one another over the course of events, are drawn together, setting up her future as queen. Granny Weatherwax, who spent the whole affair insisting witches must never interfere in the business of kings, has interfered decisively, and Lancre settles under a rightful ruler once more.",
         "in_short": "In the small mountain kingdom of Lancre, Duke Felmet and his ruthless wife murder King Verence and seize the throne. The dead king's crown and infant son are carried to safety by three witches, Granny Weatherwax, Nanny Ogg, and young Magrat Garlick, who pass the baby to a traveling theatre company to raise as an actor and hide the crown among the props. Felmet rules badly, tormented by guilt, while the land itself sickens under a usurper it never accepted. To let the true heir grow up, the witches push the whole kingdom fifteen years forward in time. The boy, Tomjon, becomes a brilliant young performer, and the guilty Duke commissions a play meant to blacken the witches' name and justify his own rule. The company returns to Lancre to stage it, bringing the confrontation to a head. Felmet is undone and dies, and the throne passes not to Tomjon, who wants only the stage, but to the castle's Fool, who becomes the new King of Lancre, with Magrat at his side.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5161,7 +5161,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B09DHPYLQM",
@@ -5173,7 +5173,7 @@
       "recaps": {
         "ending": "The Lunar Eternal, Mercy, and Asher obtain the final two shards beneath the Spire, although both the Great Worm and the White Prophet die during the attempt. Joining all six pieces does not create the expected defense. It frees the Void God, whose soul had been confined within the broken weapon. The release nearly destroys the party. Mercy is killed so that she can respawn, Asher's spirit is directed toward Talon's Keep, and the Lunar Eternal turns the god's own weapon against it before resurrecting. The three reunite at the Keep, where Mercy retains scars from the Void attack. Saren remains permanently dead, killed by the Alvarin Empress, while Leofric and Orphea are also gone. The Empress has withdrawn as an enemy, the displaced Shagnar Fawn have no settled future, and the condition of the Void God after the counterattack is uncertain. Believing it still active and threatening Amaranth, the surviving companions tell Gunnhild's Dvergar what happened and commit themselves to stopping it. The Lunar Eternal also retains the longer-term hope of recovering Saren after the immediate crisis.",
         "in_short": "The Lunar Eternal leads Mercy and Asher in gathering the remaining pieces of a weapon believed capable of stopping the Void God. Their search takes them through Leofric's coercive stronghold, a hidden Shagnar Fawn settlement, the realm of the dead, an attack on Talon's Keep, and a deadly ambush at the Serpent's Gate. They recover shards from Leofric and the corrupted spirit of Gorgafel, while the Lunar Eternal's concealed Void powers fracture trust within the group. The Alvarin Empress answers Saren's call for help but kills Saren and retreats after the Lunar Eternal wounds her. Leofric and Orphea then die, and the surviving party reconciles before reaching the Spire. The last shards are removed from a corrupted Great Worm at the cost of the worm and the White Prophet. Reforging all six pieces releases the Void God rather than defeating it. The three companions survive, return to Talon's Keep, and pledge to oppose the newly freed threat to Amaranth.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5372,7 +5372,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-25",
@@ -5385,7 +5385,7 @@
       "recaps": {
         "ending": "The novel ends in the middle of the larger struggle, with a breakthrough that changes everything and a threat still looming. On Lusitania the scientists confirm that the Descolada is no ordinary plague but a designed, perhaps sentient organism essential to the pequeninos' life cycle, which makes curing it without killing the natives desperately difficult. A fanatical pequenino faction spreads the virus as a weapon and martyrs the missionary Quim, and Grego's fury ignites a mob that slaughters pequeninos before the violence is contained. Meanwhile Han Qing-jao on the world of Path uncovers the truth of Jane and the sabotaged network, but her devotion to the gods, which is really an engineered mental compulsion, leads her to side with Congress against the very intelligence that could save countless lives. Drawing on the hive queen's insight and the physics of the philotic connections binding all things, Ender's family and Jane learn to travel instantly by slipping Outside ordinary reality and returning. On that first voyage Ela brings back an organism to replace and tame the Descolada, Miro steps out in a healed, whole body, and Ender unintentionally gives physical existence to living embodiments of his long-dead brother and sister, drawn from his own mind. The planet-killing fleet is still on its way, and Congress still intends to shut down the network and end Jane, leaving the fate of the three species, and of Jane herself, to be decided in the story to come.",
         "in_short": "Starways Congress sends a fleet armed with a planet-destroying weapon to wipe out Lusitania, fearing both its rebellion and the deadly Descolada virus that could escape and ravage other worlds. On the distant world of Path, the godspoken prodigy Han Qing-jao is ordered to find whoever crippled the interstellar network; with her clever servant Wang-mu she deduces the existence of Jane, the network intelligence, though her rigid faith turns her against her. On Lusitania, Ela, Novinha, and the others race to understand the Descolada, which they realize is not a natural disease but an engineered, possibly intelligent organism woven into pequenino biology. A militant faction of pequeninos spreads the virus as a weapon and murders the missionary Quim, hardening the crisis, and Grego's rage sparks a mob that kills natives, deepening the bloodshed. Working with the hive queen and Ender's family, the scientists and Jane discover a way to travel faster than light by passing Outside reality and back through sheer pattern and will. In doing so, Ela creates a cure to neutralize the Descolada, Miro's broken body is remade whole, and Ender inadvertently gives physical form to figures from his own mind. But the fleet still approaches, and Congress prepares to shut down the network that keeps Jane alive.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5503,7 +5503,7 @@
             "role": "minor"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5516,7 +5516,7 @@
       "recaps": {
         "ending": "Candice draws June into a final confrontation and obtains June's own account of taking Athena's manuscript and publishing it under her name. June's instinct is still to seize control of the narrative rather than accept responsibility. Even with her credibility collapsing and the evidence no longer confined to rumor, she begins constructing a version in which she is the target of manipulation, online cruelty, and racialized assumptions. She plans to write and publish her story before Candice can define it for her, treating confession, exposure, and even disgrace as material for another marketable book. Athena remains dead, Candice has forced the truth into the open, and June ends much as she began: convinced that authorship belongs to whoever can package an experience most persuasively.",
         "in_short": "Struggling novelist June Hayward witnesses the accidental death of her celebrated friend and rival Athena Liu, then steals Athena's draft of a historical novel about Chinese laborers in the First World War. June extensively edits it, sells it as her own, and becomes a bestseller under the racially suggestive name Juniper Song. Accusations of cultural appropriation turn into specific claims of plagiarism, amplified by an anonymous account using Athena's identity. June alternately denies, rationalizes, intimidates, and manipulates, persuading herself that her revisions made the book hers. She identifies former publishing employee Candice Lee as the person pressing the accusation and temporarily discredits her, but the scandal corrodes June's career and sense of reality. Candice eventually engineers a confrontation that captures June admitting what she did. Faced with exposure, June immediately plans to publish her own version first and cast herself as the victim, attempting once again to convert another person's story into her property.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -5665,7 +5665,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5678,7 +5678,7 @@
       "recaps": {
         "ending": "Inside the castle, Bond confirms that Doctor Shatterhand is Blofeld and that the woman with him is Irma Bunt. Captured and tortured, Bond refuses to give Blofeld the submission he wants. Bond escapes his immediate restraints, fights Blofeld, and kills him with his hands, taking personal revenge for Tracy. He triggers the destruction of the castle but is struck in the head while escaping and falls into the sea. Kissy Suzuki finds him alive and nurses him in her village. His injury has erased his personal memory, and Kissy withholds his true identity so that they can live quietly together; she later realizes she is pregnant. A reference to Vladivostok in a scrap of newspaper stirs a fragment of recognition in Bond. Believing Russia may contain the answer to who he is, he leaves Kissy and travels toward the Soviet Union. She does not tell him about the child. Britain presumes him dead, Blofeld's death garden is gone, and Bond ends the novel alive but separated from his name, service, and home.",
         "in_short": "After Blofeld murders Tracy on their wedding day, Bond sinks into grief and fails at his work. M gives him a diplomatic intelligence mission in Japan, where he befriends service chief Tiger Tanaka. To earn access to valuable Soviet intercepts, Bond agrees to eliminate Doctor Guntram Shatterhand, a foreigner whose poisonous castle garden has become a destination for suicides. Disguised as a Japanese fisherman and aided by Kissy Suzuki, Bond enters the castle and discovers that Shatterhand and his wife are Blofeld and Irma Bunt. Captured and tortured, Bond breaks free and kills Blofeld, then destroys the castle. A head injury leaves him amnesiac after Kissy rescues him from the sea. She conceals his identity, builds a life with him, and becomes pregnant. When the word Vladivostok awakens a faint memory, Bond leaves for Russia in search of his past, unaware of Kissy's pregnancy while Britain assumes he is dead.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -5846,7 +5846,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -5859,7 +5859,7 @@
       "recaps": {
         "ending": "Back in Babylon, Zadig enters the contest intended to select Astarte's husband and the kingdom's ruler. He wins the fighting, but Itobad steals his white armor and presents himself as the champion. The deception does not survive the second part of the contest: Zadig solves the riddles that defeat the other candidates, explains how his victory was stolen, and defeats Itobad again while their equipment makes their identities unmistakable. Recognized as the true victor, Zadig marries Astarte and becomes king. His eventual happiness follows a long sequence in which correct observation was often punished, good intentions produced danger, and events could not be understood from their nearest effects. As ruler he applies the justice and discernment that first advanced him at Moabdar's court, while the hermit's lesson leaves the tale's argument about fate and providence deliberately larger than any single human judgment.",
         "in_short": "Zadig, a learned young Babylonian, repeatedly discovers that intelligence and virtue do not guarantee happiness. Failed relationships, false accusations, and an enemy's intrigue lead unexpectedly to royal favor, and King Moabdar makes him chief minister. When affection grows between Zadig and Queen Astarte, the jealous king threatens them and Zadig flees. In Egypt he is enslaved after intervening in an assault, but his judgment wins the confidence of the merchant Setoc and helps change destructive customs. Further travels bring him news of Babylon's collapse and Astarte's captivity. He helps restore her freedom, then journeys with a mysterious hermit whose apparently cruel actions expose the limits of judging providence from isolated events. Returning to Babylon, Zadig wins the contest for Astarte and the throne; although Itobad steals the visible proof of his victory, Zadig solves the final riddles, exposes him, marries Astarte, and governs justly.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",
@@ -6193,7 +6193,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-07-22",
@@ -6206,7 +6206,7 @@
       "recaps": {
         "ending": "Ruwen reaches the final battle with a restored level-four soul and the ability to change between his human and destruction-seraph bodies. His new boundaryless core absorbs soul power efficiently, but its first use also tears the Destruction Realm reservoir free and may endanger all three linked realms. With Overlord and the golden guardians, Ruwen transfers the whole of Nameless into the zealot as a mental attack. Echo receives the Book of the Dead, yet returns to the cathedral and is taken hostage. Ruwen uses her bond to the Death Tower to pull her free, then carries her into the void under cover of fear magic and protective essence crows. The Infernal Lord returns rather than escaping, apologizes to his daughter, and detonates a crossing ring to prevent the zealot from completing the crusade. He is apparently killed. Ruwen and Echo survive, but Vex's final location is uncertain, Rami remains away with her father, and Hamma, Sift, and Lylan are fortified axioms carrying severe temporal offset. The zealot's survival is not confirmed. The displaced reservoir, the unsafe realm-energy cycle, Ruwen's unstable dual-form balance, and the Last Emperor prophecy remain open.",
         "in_short": "Ruwen survives his apparent death in a destruction-seraph body and learns that his new Destruction Emperor class ties him to a ruined royal line and a prophecy of the Last Emperor. While developing his damaged pathways, tower harmonics, Outer Mind, and Voidwalker powers, he helps Hamma, Sift, and Lylan become fortified axioms. The Dark Tower warden reveals that an outside zealot threatens the universe, and Ruwen enters the battle to save Echo. The zealot's soul power unexpectedly repairs Ruwen's soul and human body, allowing him to switch between human and seraph forms. Ruwen then builds a boundaryless core that accidentally pulls free the Destruction Realm reservoir. He captures Nameless and helps plant the entity in the zealot's mind. When the zealot takes Echo hostage, Ruwen extracts her through the Death Tower connection. The Infernal Lord sacrifices himself in an explosion to halt the crusader, while Ruwen and Echo escape into the void. The zealot's fate and the danger to the linked realms remain unresolved.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -6471,7 +6471,7 @@
             "role": "supporting"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "ref": "audible:us:B078RV7BWR",
@@ -6483,7 +6483,7 @@
       "recaps": {
         "ending": "Bishop survives activating the Sentinel conduit, and Skippy destroys the anti-Elder worm. Skippy regains substantial ability, but his origins, missing memories, and the ancient attacks on Elder sites remain unresolved. Nagatha survives severe degradation in storage while Skippy attempts to restore her carefully. The crew rebuilds the Flying Dutchman from salvaged wreckage and escapes the Roach Motel after destroying a covert Maxolhx vessel and containing its evidence of humanity. Bishop, Chotek, Chang, Smythe, Adams, Desai, Simms, and Rene Giraud remain with the surviving expedition. The ship is mobile but improvised, damaged, and in need of fuel and cautious handling. The Thuranin descendants on Gingerbread are left behind, and Skippy expects the Guardians may destroy them and the remaining derelicts. The Kristang civil war makes that species no foreseeable threat to Earth, while the weakened Thuranin are unlikely to pose a danger for roughly twenty years. Before the Dutchman can go home, a relay reveals a secret Kristang operation involving an unnamed human major and team away from Paradise, creating the crew's next immediate problem.",
         "in_short": "The Flying Dutchman is stranded with Skippy under attack by an anti-Elder worm. Failed conduit raids and a desperate escape lead the crew into the hidden Roach Motel system, where Elder defenses destroy the ship's engineering section. On Gingerbread, they survive hostile Thuranin descendants, find only a dead planetary conduit, and turn to a broken Sentinel. Bishop powers its active conduit at nearly fatal cost, enabling Skippy to destroy the worm. Over ten months the crew rebuilds the Dutchman from wreckage. They then destroy a concealed Maxolhx ship before it can carry proof of humanity out of the system and escape the Guardian field. Kristang civil war has removed the foreseeable threat to Earth, but relay intelligence about a secret operation involving an unnamed human major and team diverts the crew from a direct return home.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "series",
@@ -6650,7 +6650,7 @@
             "role": "antagonist"
           }
         ],
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "sources": [
           {
             "imported_at": "2026-08-07",
@@ -6663,7 +6663,7 @@
       "recaps": {
         "ending": "The narrator's Cretan venture ends in material failure. Madame Hortense dies after waiting for the marriage Zorba has allowed her to expect, and local women immediately strip her room of its possessions. The widow, after finally accepting the narrator, is blamed for Pavli's suicide and killed by villagers despite Zorba's attempt to protect her. Zaharia burns the monastery he hates. At the ceremonial launch of the timber cable system, the descending trunks wreck the structure, destroying the scheme on which the mine depended. The narrator and Zorba respond by eating, drinking, and dancing together on the beach. News then arrives that Stavridaki has died, and narrator and Zorba separate. Years of occasional reports follow. Zorba continues wandering and eventually dies in Skopje, leaving instructions that his santuri should go to his former boss. The narrator, unable to retrieve it, finally undertakes the act of remembrance that becomes the book.",
         "in_short": "An unnamed Greek intellectual hires the exuberant laborer Alexis Zorba to help reopen a lignite mine on Crete. Zorba manages the physical work, plays the santuri, courts the aging innkeeper Madame Hortense, and draws his book-bound employer toward appetite, risk, and action. Their mine proves difficult, so they invest in a cable system to bring timber from a monastery forest. The narrator desires a village widow and eventually spends a night with her, but villagers blaming her for Pavli's suicide kill her while Zorba tries to intervene. Hortense also dies, and her neighbors loot her home. The timber installation collapses during its public inauguration, ruining the business. Boss and worker share a final meal and dance before parting. The narrator later learns that both his distant friend Stavridaki and, years afterward, Zorba have died. Remembering Zorba becomes his belated way of answering a life he admired but could never wholly imitate.",
-        "license": "CC-BY-SA-3.0",
+        "license": "CC-BY-SA-4.0",
         "recaps": [
           {
             "scope": "book",

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -62,7 +62,7 @@ func fixtureCatalog() *model.Catalog {
 	}
 
 	chars := &model.Characters{
-		Work: "project-hail-mary", License: "CC-BY-SA-3.0",
+		Work: "project-hail-mary", License: "CC-BY-SA-4.0",
 		Sources: []model.Source{{Type: "community"}},
 		Characters: []model.Character{
 			{
@@ -80,7 +80,7 @@ func fixtureCatalog() *model.Catalog {
 	}
 	// Deliberately out of position order to prove the build sorts recaps.
 	recaps := &model.Recaps{
-		Work: "project-hail-mary", License: "CC-BY-SA-3.0",
+		Work: "project-hail-mary", License: "CC-BY-SA-4.0",
 		Sources: []model.Source{{Type: "community"}},
 		InShort: "A lone amnesiac wakes aboard an interstellar ship, befriends an alien engineer, and saves both their worlds.",
 		Ending:  "Grace stays behind on Erid, teaching, while the cure heads home.",
@@ -390,7 +390,7 @@ func TestBuildCharacters(t *testing.T) {
 		t.Fatalf("got %d characters, want 2", len(got))
 	}
 	if got[0].id != "ryland-grace" || got[0].ord != 0 || got[0].reveal != 1 || got[0].role != "protagonist" ||
-		got[0].wiki != "Q110001" || got[0].license != "CC-BY-SA-3.0" {
+		got[0].wiki != "Q110001" || got[0].license != "CC-BY-SA-4.0" {
 		t.Errorf("character[0] = %+v", got[0])
 	}
 	if got[1].id != "rocky" || got[1].ord != 1 || got[1].reveal != 8 {
@@ -465,7 +465,7 @@ func TestBuildRecapsServedByPosition(t *testing.T) {
 		if err := rows.Scan(&ch, &scope, &license); err != nil {
 			t.Fatal(err)
 		}
-		if scope != "book" || license != "CC-BY-SA-3.0" {
+		if scope != "book" || license != "CC-BY-SA-4.0" {
 			t.Errorf("recap through %d: scope=%q license=%q", ch, scope, license)
 		}
 		chapters = append(chapters, ch)
@@ -491,7 +491,7 @@ func TestBuildRecapSummaries(t *testing.T) {
 		Scan(&inShort, &ending, &license); err != nil {
 		t.Fatal(err)
 	}
-	if inShort == "" || ending == "" || license != "CC-BY-SA-3.0" {
+	if inShort == "" || ending == "" || license != "CC-BY-SA-4.0" {
 		t.Errorf("recap_summary row = in_short=%q ending=%q license=%q", inShort, ending, license)
 	}
 }
@@ -507,7 +507,7 @@ func TestBuildRecapSummaryAbsentWithoutFields(t *testing.T) {
 			Authors: []string{"andy-weir"}, License: "CC0-1.0",
 		}},
 		Recaps: []*model.Recaps{{
-			Work: "project-hail-mary", License: "CC-BY-SA-3.0",
+			Work: "project-hail-mary", License: "CC-BY-SA-4.0",
 			Sources: []model.Source{{Type: "community"}},
 			Recaps:  []model.Recap{{Through: model.Position{Chapter: 1}, Text: "It begins."}},
 		}},

--- a/internal/issueform/compose_pack_test.go
+++ b/internal/issueform/compose_pack_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // validRecapsJSON is a minimal, schema-valid recaps sidecar for existing-work.
-const validRecapsJSON = `{"work":"existing-work","recaps":[{"through":{"chapter":1},"text":"Alice sets out, and by the end of the first chapter she has left home."}],"license":"CC-BY-SA-3.0","sources":[{"type":"community"}]}`
+const validRecapsJSON = `{"work":"existing-work","recaps":[{"through":{"chapter":1},"text":"Alice sets out, and by the end of the first chapter she has left home."}],"license":"CC-BY-SA-4.0","sources":[{"type":"community"}]}`
 
 // recapsBody builds an add-recaps submission body.
 func recapsBody(workRef, attachment string, license bool) string {

--- a/internal/issueform/compose_sidecar.go
+++ b/internal/issueform/compose_sidecar.go
@@ -29,7 +29,7 @@ var sidecarMembers = map[model.Kind]struct{ member, fileName string }{
 // positions.
 func (c *composer) addSidecar(s sections, kind model.Kind) {
 	if !s.checked(fSidecarLicense) {
-		c.fail(StatusInvalid, "the CC BY-SA 3.0 license checkbox is not ticked")
+		c.fail(StatusInvalid, "the CC BY-SA 4.0 license checkbox is not ticked")
 		return
 	}
 

--- a/internal/issueform/compose_sidecar.go
+++ b/internal/issueform/compose_sidecar.go
@@ -29,7 +29,7 @@ var sidecarMembers = map[model.Kind]struct{ member, fileName string }{
 // positions.
 func (c *composer) addSidecar(s sections, kind model.Kind) {
 	if !s.checked(fSidecarLicense) {
-		c.fail(StatusInvalid, "the CC BY-SA 4.0 license checkbox is not ticked")
+		c.fail(StatusInvalid, "the "+licenseBySALabel+" license checkbox is not ticked")
 		return
 	}
 

--- a/internal/issueform/issueform.go
+++ b/internal/issueform/issueform.go
@@ -170,7 +170,7 @@ func Process(opts Options) Result {
 func licenseLayer(tmpl string) string {
 	switch tmpl {
 	case "characters", "recaps":
-		return "CC BY-SA 4.0 (community expressive layer)"
+		return licenseBySALabel + " (community expressive layer)"
 	default:
 		return "CC0-1.0 (factual core)"
 	}

--- a/internal/issueform/issueform.go
+++ b/internal/issueform/issueform.go
@@ -163,14 +163,14 @@ func Process(opts Options) Result {
 
 // licenseLayer names the license layer the composed records carry, keyed off the
 // normalized routing template: the community expressive sidecars (characters/
-// recaps) are CC BY-SA 3.0, every core template (work/recording/correction/
+// recaps) are CC BY-SA 4.0, every core template (work/recording/correction/
 // import) is CC0-1.0. Go owns this classification (the schema enforces the same
 // split structurally); the intake workflow reads Result.License for the pull-
 // request body instead of re-deriving it in bash.
 func licenseLayer(tmpl string) string {
 	switch tmpl {
 	case "characters", "recaps":
-		return "CC BY-SA 3.0 (community expressive layer)"
+		return "CC BY-SA 4.0 (community expressive layer)"
 	default:
 		return "CC0-1.0 (factual core)"
 	}

--- a/internal/issueform/issueform_test.go
+++ b/internal/issueform/issueform_test.go
@@ -621,7 +621,7 @@ func TestCorrectDataRecordNotFound(t *testing.T) {
 	}
 }
 
-const validCharactersJSON = `{"work":"existing-work","characters":[{"id":"alice","name":"Alice","reveal":{"chapter":1},"description":"A brave adventurer introduced early in the book."}],"license":"CC-BY-SA-3.0","sources":[{"type":"community"}]}`
+const validCharactersJSON = `{"work":"existing-work","characters":[{"id":"alice","name":"Alice","reveal":{"chapter":1},"description":"A brave adventurer introduced early in the book."}],"license":"CC-BY-SA-4.0","sources":[{"type":"community"}]}`
 
 func charactersBody(workRef, attachment string, license bool) string {
 	b := field(fWorkRef, workRef) +

--- a/internal/issueform/out.go
+++ b/internal/issueform/out.go
@@ -19,6 +19,10 @@ import (
 
 const (
 	licenseCC0 = "CC0-1.0"
+	// licenseBySALabel is the human name of the community layer's license, the
+	// one spelling the checkbox message and the PR-body layer name share so a
+	// future license bump edits one line here.
+	licenseBySALabel = "CC BY-SA 4.0"
 	// sourceUser is the provenance stamped on records composed from an issue
 	// form. It is the vocabulary pkg/model ranks (model.TierOfSource), which is
 	// what makes a submission user-library tier.

--- a/internal/issueform/review_fixes_test.go
+++ b/internal/issueform/review_fixes_test.go
@@ -160,7 +160,7 @@ func TestResultLicenseLayer(t *testing.T) {
 	if side.Status != StatusOK {
 		t.Fatalf("sidecar status = %q, %v", side.Status, side.Messages)
 	}
-	if side.License != "CC BY-SA 3.0 (community expressive layer)" {
+	if side.License != "CC BY-SA 4.0 (community expressive layer)" {
 		t.Errorf("sidecar License = %q", side.License)
 	}
 }

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -26,8 +26,8 @@ func legacyFixture() map[string]string {
 		"works/du/dune/recordings/ann-doe-2021.json": `{"id":"ann-doe-2021","language":"en","license":"CC0-1.0","narrators":["ann-doe"],` +
 			`"sources":[{"type":"user"}],"work":"dune"}`,
 		"works/du/dune/characters.json": `{"characters":[{"description":"A duke's heir.","id":"paul","name":"Paul","reveal":{"chapter":1}}],` +
-			`"license":"CC-BY-SA-3.0","sources":[{"type":"community"}],"work":"dune"}`,
-		"works/du/dune/recaps.json": `{"license":"CC-BY-SA-3.0","recaps":[{"text":"Paul arrives on Arrakis.","through":{"chapter":1}}],` +
+			`"license":"CC-BY-SA-4.0","sources":[{"type":"community"}],"work":"dune"}`,
+		"works/du/dune/recaps.json": `{"license":"CC-BY-SA-4.0","recaps":[{"text":"Paul arrives on Arrakis.","through":{"chapter":1}}],` +
 			`"sources":[{"type":"community"}],"work":"dune"}`,
 		"works/em/emma/work.json": `{"authors":["ann-doe"],"id":"emma","language":"en","license":"CC0-1.0","sources":[{"type":"user"}],"title":"Emma"}`,
 		"works/em/emma/recordings/ann-doe-2019.json": `{"id":"ann-doe-2019","language":"en","license":"CC0-1.0","narrators":["ann-doe"],` +

--- a/internal/migrate/refuse_test.go
+++ b/internal/migrate/refuse_test.go
@@ -188,7 +188,7 @@ func TestScanRefusals(t *testing.T) {
 				delete(f, "works/em/emma/work.json")
 				delete(f, "works/em/emma/recordings/ann-doe-2019.json")
 				f["works/em/emma/characters.json"] = `{"characters":[{"id":"x","name":"X","reveal":{"chapter":1}}],` +
-					`"license":"CC-BY-SA-3.0","sources":[{"type":"community"}],"work":"emma"}`
+					`"license":"CC-BY-SA-4.0","sources":[{"type":"community"}],"work":"emma"}`
 			},
 			want: "has recordings or sidecars but no work.json",
 		},

--- a/internal/serve/coverage_test.go
+++ b/internal/serve/coverage_test.go
@@ -33,7 +33,7 @@ func coverageCatalog() *model.Catalog {
 
 	chars := func(work string) *model.Characters {
 		return &model.Characters{
-			Work: work, License: "CC-BY-SA-3.0",
+			Work: work, License: "CC-BY-SA-4.0",
 			Sources: []model.Source{{Type: "community"}},
 			Characters: []model.Character{
 				{ID: "someone", Name: "Someone", Reveal: model.Position{Chapter: 1}},
@@ -42,7 +42,7 @@ func coverageCatalog() *model.Catalog {
 	}
 	// alpha is fully covered: characters + recaps + a whole-book summary.
 	alphaRecaps := &model.Recaps{
-		Work: "alpha-covered", License: "CC-BY-SA-3.0",
+		Work: "alpha-covered", License: "CC-BY-SA-4.0",
 		Sources: []model.Source{{Type: "community"}},
 		InShort: "The whole arc in one paragraph.",
 		Ending:  "It ends well.",

--- a/internal/serve/guides.go
+++ b/internal/serve/guides.go
@@ -51,11 +51,11 @@ const (
 	charactersSuffix = "/" + model.GuideSegmentCharacters
 )
 
-// ccBySA30URL is the deed the community layer is licensed under. Both guide
+// ccBySA40URL is the deed the community layer is licensed under. Both guide
 // pages carry it as a rel="license" link and in their JSON-LD, because the CC
 // BY-SA layer's terms travel with the text wherever it is republished - see
 // LICENSING.md.
-const ccBySA30URL = "https://creativecommons.org/licenses/by-sa/3.0/"
+const ccBySA40URL = "https://creativecommons.org/licenses/by-sa/4.0/"
 
 // workGuidePath composes one guide page's path. Written once so the canonical
 // URL, the work page's link, the sibling link and the sitemap loc cannot spell
@@ -347,7 +347,7 @@ func newRecapView(d *workDetail) guideView {
 		Authors: d.Authors,
 		Notice: "Every recap below is hidden until you open it. Each one is safe to read " +
 			"once you have finished the chapter it names.",
-		LicenseURL:     ccBySA30URL,
+		LicenseURL:     ccBySA40URL,
 		ContributeURL:  contributeURL(d.ID, "recaps"),
 		ContributeText: "Improve this recap",
 	}
@@ -374,7 +374,7 @@ func newCharactersView(d *workDetail) guideView {
 		Authors: d.Authors,
 		Notice: "Every entry below is hidden until you open it, and each names the chapter " +
 			"the character first appears in.",
-		LicenseURL:     ccBySA30URL,
+		LicenseURL:     ccBySA40URL,
 		ContributeURL:  contributeURL(d.ID, "characters"),
 		ContributeText: "Improve this character guide",
 	}
@@ -545,6 +545,6 @@ const guideTemplates = `
 <h2>More about this book</h2>
 {{template "linklist" .Links}}
 {{- end}}
-<p class="text-dim">Community-written - <a rel="license" href="{{.LicenseURL}}">CC BY-SA 3.0</a>. <a href="{{.ContributeURL}}">{{.ContributeText}}</a></p>
+<p class="text-dim">Community-written - <a rel="license" href="{{.LicenseURL}}">CC BY-SA 4.0</a>. <a href="{{.ContributeURL}}">{{.ContributeText}}</a></p>
 </section>{{end}}
 `

--- a/internal/serve/guides.go
+++ b/internal/serve/guides.go
@@ -51,11 +51,16 @@ const (
 	charactersSuffix = "/" + model.GuideSegmentCharacters
 )
 
-// ccBySA40URL is the deed the community layer is licensed under. Both guide
-// pages carry it as a rel="license" link and in their JSON-LD, because the CC
-// BY-SA layer's terms travel with the text wherever it is republished - see
-// LICENSING.md.
-const ccBySA40URL = "https://creativecommons.org/licenses/by-sa/4.0/"
+// ccBySAURL is the deed the community layer is licensed under, and ccBySALabel
+// the human name the pages print for it. Both guide pages carry the pair as a
+// rel="license" link and in their JSON-LD, because the CC BY-SA layer's terms
+// travel with the text wherever it is republished - see LICENSING.md. The names
+// are version-neutral and the label rides the view beside the URL, so a future
+// license bump edits these two lines and nothing else.
+const (
+	ccBySAURL   = "https://creativecommons.org/licenses/by-sa/4.0/"
+	ccBySALabel = "CC BY-SA 4.0"
+)
 
 // workGuidePath composes one guide page's path. Written once so the canonical
 // URL, the work page's link, the sibling link and the sitemap loc cannot spell
@@ -335,6 +340,7 @@ type guideView struct {
 	Rows           []guideRow
 	Links          []guideLink
 	LicenseURL     string
+	LicenseLabel   string
 	ContributeURL  string
 	ContributeText string
 }
@@ -347,7 +353,8 @@ func newRecapView(d *workDetail) guideView {
 		Authors: d.Authors,
 		Notice: "Every recap below is hidden until you open it. Each one is safe to read " +
 			"once you have finished the chapter it names.",
-		LicenseURL:     ccBySA40URL,
+		LicenseURL:     ccBySAURL,
+		LicenseLabel:   ccBySALabel,
 		ContributeURL:  contributeURL(d.ID, "recaps"),
 		ContributeText: "Improve this recap",
 	}
@@ -374,7 +381,8 @@ func newCharactersView(d *workDetail) guideView {
 		Authors: d.Authors,
 		Notice: "Every entry below is hidden until you open it, and each names the chapter " +
 			"the character first appears in.",
-		LicenseURL:     ccBySA40URL,
+		LicenseURL:     ccBySAURL,
+		LicenseLabel:   ccBySALabel,
 		ContributeURL:  contributeURL(d.ID, "characters"),
 		ContributeText: "Improve this character guide",
 	}
@@ -545,6 +553,6 @@ const guideTemplates = `
 <h2>More about this book</h2>
 {{template "linklist" .Links}}
 {{- end}}
-<p class="text-dim">Community-written - <a rel="license" href="{{.LicenseURL}}">CC BY-SA 4.0</a>. <a href="{{.ContributeURL}}">{{.ContributeText}}</a></p>
+<p class="text-dim">Community-written - <a rel="license" href="{{.LicenseURL}}">{{.LicenseLabel}}</a>. <a href="{{.ContributeURL}}">{{.ContributeText}}</a></p>
 </section>{{end}}
 `

--- a/internal/serve/guides_test.go
+++ b/internal/serve/guides_test.go
@@ -284,7 +284,7 @@ func TestGuidePageJSONLD(t *testing.T) {
 	if doc["headline"] != "Project Hail Mary recap" {
 		t.Errorf("headline = %v", doc["headline"])
 	}
-	if doc["license"] != ccBySA40URL {
+	if doc["license"] != ccBySAURL {
 		t.Errorf("license = %v, want the CC BY-SA deed", doc["license"])
 	}
 	about, _ := doc["about"].(map[string]any)

--- a/internal/serve/guides_test.go
+++ b/internal/serve/guides_test.go
@@ -46,7 +46,7 @@ func TestRecapPageCarriesTheRankingSubstance(t *testing.T) {
 		"<summary>Story so far - through chapter 9",
 		"<summary>How does it end?",
 		`<div data-nosnippet>`,
-		`<a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>`,
+		`<a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>`,
 		`href="/build?work=project-hail-mary&amp;kind=recaps"`,
 		// The crawl mesh: back to the work, across to the sibling guide.
 		`<a href="/works/project-hail-mary">Full details for Project Hail Mary</a>`,
@@ -102,7 +102,7 @@ func TestCharactersPageCarriesTheRankingSubstance(t *testing.T) {
 		"Also known as Dr. Grace",
 		"Appears from the start",
 		"First appears in chapter 8",
-		`<a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>`,
+		`<a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>`,
 		`href="/build?work=project-hail-mary&amp;kind=characters"`,
 		`<a href="/works/project-hail-mary/recap">Project Hail Mary recap</a>`,
 	} {
@@ -284,7 +284,7 @@ func TestGuidePageJSONLD(t *testing.T) {
 	if doc["headline"] != "Project Hail Mary recap" {
 		t.Errorf("headline = %v", doc["headline"])
 	}
-	if doc["license"] != ccBySA30URL {
+	if doc["license"] != ccBySA40URL {
 		t.Errorf("license = %v, want the CC BY-SA deed", doc["license"])
 	}
 	about, _ := doc["about"].(map[string]any)
@@ -367,15 +367,15 @@ func guideCatalog() *model.Catalog {
 			work("plain-work", "Plain Work"),
 		},
 		Characters: []*model.Characters{{
-			Work: "only-characters", License: "CC-BY-SA-3.0",
+			Work: "only-characters", License: "CC-BY-SA-4.0",
 			Characters: []model.Character{{ID: "someone", Name: "Someone", Reveal: model.Position{Chapter: 3}}},
 		}},
 		Recaps: []*model.Recaps{
 			{
-				Work: "only-chapters", License: "CC-BY-SA-3.0",
+				Work: "only-chapters", License: "CC-BY-SA-4.0",
 				Recaps: []model.Recap{{Through: model.Position{Chapter: 4}, Scope: "book", Text: "Things happen."}},
 			},
-			{Work: "only-summary", License: "CC-BY-SA-3.0", InShort: "It all works out."},
+			{Work: "only-summary", License: "CC-BY-SA-4.0", InShort: "It all works out."},
 		},
 	}
 }

--- a/internal/serve/jsonld.go
+++ b/internal/serve/jsonld.go
@@ -156,7 +156,7 @@ func guideJSONLD(headline, siteURL, canonical, workCanonical string) []byte {
 		Context: ldContext, Type: "Article", Headline: headline,
 		URL: canonical, MainEntityOfPage: canonical,
 		About:    &ldRef{ID: workNodeID(workCanonical)},
-		License:  ccBySA30URL,
+		License:  ccBySA40URL,
 		IsPartOf: &ldWebSite{Type: "WebSite", Name: siteName, URL: siteURL},
 	})
 }

--- a/internal/serve/jsonld.go
+++ b/internal/serve/jsonld.go
@@ -156,7 +156,7 @@ func guideJSONLD(headline, siteURL, canonical, workCanonical string) []byte {
 		Context: ldContext, Type: "Article", Headline: headline,
 		URL: canonical, MainEntityOfPage: canonical,
 		About:    &ldRef{ID: workNodeID(workCanonical)},
-		License:  ccBySA40URL,
+		License:  ccBySAURL,
 		IsPartOf: &ldWebSite{Type: "WebSite", Name: siteName, URL: siteURL},
 	})
 }

--- a/internal/serve/openapi.json
+++ b/internal/serve/openapi.json
@@ -4,9 +4,9 @@
     "title": "AudioSilo Meta API",
     "version": "1.0.0",
     "summary": "The read-only JSON API over the AudioSilo community audiobook metadata database.",
-    "description": "A read-only API over a compiled snapshot of the community metadata database at https://github.com/kodestar/audiosilo-meta.\n\nEverything readable is public: no authentication, no API key and no rate-limit token, and no endpoint writes anything. (A production deployment may additionally register a release-notification hook at `/hooks/github/release`; that one route is HMAC-authenticated and is not part of the read surface.)\n\nThe API surface - `/api/v1/*` and `/abs/search` - carries permissive CORS headers (`Access-Control-Allow-Origin: *`), so a browser may call it directly. `/healthz` and the hook do not.\n\nThe server holds one compiled artifact at a time and swaps in a newer one without a restart, so a response is always a consistent view of a single release. While no artifact has loaded yet (a cold boot still fetching the newest release) every data route answers `503` with a `Retry-After` header; `/api/v1/openapi.json` and the static site are served regardless.\n\nSome fields on `GET /works/{id}` depend on the loaded artifact's internal schema version - characters and recaps need version 2, the whole-book recap summary version 3, genres version 4. A server briefly serving an older artifact omits them rather than failing, so treat every one of them as optional.\n\nSlugs are stable, and a slug a data-quality repair RETIRES keeps resolving: every route that takes an id answers `301` with a `Location` at the same route under the slug that replaced it, plus a body naming that slug so a stored id can be healed. The redirect is bounded by `Cache-Control` rather than permanent, because reversing a merge withdraws it. Redirects need artifact version 5; below it a retired slug is a `404`.\n\nLicensing: the factual core (works, recordings, people, series) is dedicated to the public domain under CC0-1.0 and the community layer (characters, recaps) is CC BY-SA 3.0 - see LICENSING.md in the repository for what attribution the share-alike layer requires.",
+    "description": "A read-only API over a compiled snapshot of the community metadata database at https://github.com/kodestar/audiosilo-meta.\n\nEverything readable is public: no authentication, no API key and no rate-limit token, and no endpoint writes anything. (A production deployment may additionally register a release-notification hook at `/hooks/github/release`; that one route is HMAC-authenticated and is not part of the read surface.)\n\nThe API surface - `/api/v1/*` and `/abs/search` - carries permissive CORS headers (`Access-Control-Allow-Origin: *`), so a browser may call it directly. `/healthz` and the hook do not.\n\nThe server holds one compiled artifact at a time and swaps in a newer one without a restart, so a response is always a consistent view of a single release. While no artifact has loaded yet (a cold boot still fetching the newest release) every data route answers `503` with a `Retry-After` header; `/api/v1/openapi.json` and the static site are served regardless.\n\nSome fields on `GET /works/{id}` depend on the loaded artifact's internal schema version - characters and recaps need version 2, the whole-book recap summary version 3, genres version 4. A server briefly serving an older artifact omits them rather than failing, so treat every one of them as optional.\n\nSlugs are stable, and a slug a data-quality repair RETIRES keeps resolving: every route that takes an id answers `301` with a `Location` at the same route under the slug that replaced it, plus a body naming that slug so a stored id can be healed. The redirect is bounded by `Cache-Control` rather than permanent, because reversing a merge withdraws it. Redirects need artifact version 5; below it a retired slug is a `404`.\n\nLicensing: the factual core (works, recordings, people, series) is dedicated to the public domain under CC0-1.0 and the community layer (characters, recaps) is CC BY-SA 4.0 - see LICENSING.md in the repository for what attribution the share-alike layer requires.",
     "license": {
-      "name": "CC0-1.0 core with a CC BY-SA 3.0 community layer",
+      "name": "CC0-1.0 core with a CC BY-SA 4.0 community layer",
       "url": "https://github.com/kodestar/audiosilo-meta/blob/main/LICENSING.md"
     }
   },
@@ -1022,7 +1022,7 @@
       },
       "Character": {
         "type": "object",
-        "description": "A community-authored, spoiler-gated character entry (CC BY-SA 3.0). Recurring characters are re-described per book, so spoilers stay bounded by which book the reader is in.",
+        "description": "A community-authored, spoiler-gated character entry (CC BY-SA 4.0). Recurring characters are re-described per book, so spoilers stay bounded by which book the reader is in.",
         "required": ["id", "name", "reveal"],
         "properties": {
           "id": {
@@ -1051,7 +1051,7 @@
       },
       "Recap": {
         "type": "object",
-        "description": "A community-authored \"story so far\" (CC BY-SA 3.0), safe to show once the listener has finished `through`.",
+        "description": "A community-authored \"story so far\" (CC BY-SA 4.0), safe to show once the listener has finished `through`.",
         "required": ["through", "text"],
         "properties": {
           "through": {
@@ -1108,12 +1108,12 @@
           },
           "characters": {
             "type": "array",
-            "description": "The community character guide, in authored order. CC BY-SA 3.0. Omitted when the work has none.",
+            "description": "The community character guide, in authored order. CC BY-SA 4.0. Omitted when the work has none.",
             "items": { "$ref": "#/components/schemas/Character" }
           },
           "recaps": {
             "type": "array",
-            "description": "The community story-so-far recaps, ordered by position. CC BY-SA 3.0. Omitted when the work has none.",
+            "description": "The community story-so-far recaps, ordered by position. CC BY-SA 4.0. Omitted when the work has none.",
             "items": { "$ref": "#/components/schemas/Recap" }
           },
           "recap_summary": { "$ref": "#/components/schemas/RecapSummary" }

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -76,7 +76,7 @@ func fixtureCatalog() *model.Catalog {
 		},
 	}
 	chars := &model.Characters{
-		Work: "project-hail-mary", License: "CC-BY-SA-3.0",
+		Work: "project-hail-mary", License: "CC-BY-SA-4.0",
 		Sources: []model.Source{{Type: "community"}},
 		Characters: []model.Character{
 			{
@@ -89,7 +89,7 @@ func fixtureCatalog() *model.Catalog {
 		},
 	}
 	recaps := &model.Recaps{
-		Work: "project-hail-mary", License: "CC-BY-SA-3.0",
+		Work: "project-hail-mary", License: "CC-BY-SA-4.0",
 		Sources: []model.Source{{Type: "community"}},
 		InShort: "A lone amnesiac wakes aboard a ship, befriends an alien, and saves both worlds.",
 		Ending:  "Grace stays on Erid while the cure flies home.",

--- a/internal/serve/testdata/golden/characters.html
+++ b/internal/serve/testdata/golden/characters.html
@@ -17,7 +17,7 @@
 <meta name="twitter:title" content="Project Hail Mary characters - a spoiler-safe character guide - AudioSilo Meta">
 <meta name="twitter:description" content="Character guide to Project Hail Mary, by Andy Weir, 2 characters, each hidden behind the chapter they first appear in.">
 <meta name="twitter:image" content="https://example.test/phm.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Project Hail Mary characters","url":"https://meta.test/works/project-hail-mary/characters","mainEntityOfPage":"https://meta.test/works/project-hail-mary/characters","about":{"@id":"https://meta.test/works/project-hail-mary#book"},"license":"https://creativecommons.org/licenses/by-sa/3.0/","isPartOf":{"@type":"WebSite","name":"AudioSilo Meta","url":"https://meta.test"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Project Hail Mary characters","url":"https://meta.test/works/project-hail-mary/characters","mainEntityOfPage":"https://meta.test/works/project-hail-mary/characters","about":{"@id":"https://meta.test/works/project-hail-mary#book"},"license":"https://creativecommons.org/licenses/by-sa/4.0/","isPartOf":{"@type":"WebSite","name":"AudioSilo Meta","url":"https://meta.test"}}</script>
 <!--/ssr:head-->
 <link rel="stylesheet" href="/styles.css">
 </head>
@@ -47,7 +47,7 @@
 <li><a href="/works/project-hail-mary">Full details for Project Hail Mary</a></li>
 <li><a href="/works/project-hail-mary/recap">Project Hail Mary recap</a></li>
 </ul>
-<p class="text-dim">Community-written - <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>. <a href="/build?work=project-hail-mary&amp;kind=characters">Improve this character guide</a></p>
+<p class="text-dim">Community-written - <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>. <a href="/build?work=project-hail-mary&amp;kind=characters">Improve this character guide</a></p>
 </section></div><script type="application/json" id="entity-data">{"id":"project-hail-mary","title":"Project Hail Mary","authors":[{"id":"andy-weir","name":"Andy Weir"}],"language":"en","genres":["hard-science-fiction","science-fiction"],"series":[],"recordings":[{"id":"ray-porter-2021","narrators":[{"id":"ray-porter","name":"Ray Porter"}],"runtime_min":970,"release_date":"2021-05-04","publisher":"Audible Studios","asin":[{"region":"us","asin":"B08G9PRS1K"}],"isbn":[],"purchase_links":[{"retailer":"audible","id":"B08G9PRS1K","region":"us","url":"https://www.audible.com/pd/B08G9PRS1K","availability":"unknown"}],"cover_url":"https://example.test/phm.jpg","chapter_count":3}],"characters":[{"id":"ryland-grace","name":"Ryland Grace","aliases":["Dr. Grace"],"role":"protagonist","reveal":{"chapter":1},"description":"A science teacher who wakes aboard the ship with amnesia.","xref":{"wikidata":"Q110001"}},{"id":"rocky","name":"Rocky","role":"supporting","reveal":{"chapter":8}}],"recaps":[{"through":{"chapter":2},"scope":"book","text":"Grace wakes with amnesia."},{"through":{"chapter":9},"scope":"book","text":"First contact is made."}],"recap_summary":{"in_short":"A lone amnesiac wakes aboard a ship, befriends an alien, and saves both worlds.","ending":"Grace stays on Erid while the cure flies home."}}</script><div id="island-root"></div>
 </main>
 <footer>SHELL FOOTER</footer>

--- a/internal/serve/testdata/golden/recap.html
+++ b/internal/serve/testdata/golden/recap.html
@@ -17,7 +17,7 @@
 <meta name="twitter:title" content="Project Hail Mary recap - story so far and chapter summaries - AudioSilo Meta">
 <meta name="twitter:description" content="Spoiler-safe recaps of Project Hail Mary, by Andy Weir, 2 story-so-far summaries through chapter 9, a whole-book summary, how the story ends.">
 <meta name="twitter:image" content="https://example.test/phm.jpg">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Project Hail Mary recap","url":"https://meta.test/works/project-hail-mary/recap","mainEntityOfPage":"https://meta.test/works/project-hail-mary/recap","about":{"@id":"https://meta.test/works/project-hail-mary#book"},"license":"https://creativecommons.org/licenses/by-sa/3.0/","isPartOf":{"@type":"WebSite","name":"AudioSilo Meta","url":"https://meta.test"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Project Hail Mary recap","url":"https://meta.test/works/project-hail-mary/recap","mainEntityOfPage":"https://meta.test/works/project-hail-mary/recap","about":{"@id":"https://meta.test/works/project-hail-mary#book"},"license":"https://creativecommons.org/licenses/by-sa/4.0/","isPartOf":{"@type":"WebSite","name":"AudioSilo Meta","url":"https://meta.test"}}</script>
 <!--/ssr:head-->
 <link rel="stylesheet" href="/styles.css">
 </head>
@@ -57,7 +57,7 @@
 <li><a href="/works/project-hail-mary">Full details for Project Hail Mary</a></li>
 <li><a href="/works/project-hail-mary/characters">Project Hail Mary character guide</a></li>
 </ul>
-<p class="text-dim">Community-written - <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>. <a href="/build?work=project-hail-mary&amp;kind=recaps">Improve this recap</a></p>
+<p class="text-dim">Community-written - <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>. <a href="/build?work=project-hail-mary&amp;kind=recaps">Improve this recap</a></p>
 </section></div><script type="application/json" id="entity-data">{"id":"project-hail-mary","title":"Project Hail Mary","authors":[{"id":"andy-weir","name":"Andy Weir"}],"language":"en","genres":["hard-science-fiction","science-fiction"],"series":[],"recordings":[{"id":"ray-porter-2021","narrators":[{"id":"ray-porter","name":"Ray Porter"}],"runtime_min":970,"release_date":"2021-05-04","publisher":"Audible Studios","asin":[{"region":"us","asin":"B08G9PRS1K"}],"isbn":[],"purchase_links":[{"retailer":"audible","id":"B08G9PRS1K","region":"us","url":"https://www.audible.com/pd/B08G9PRS1K","availability":"unknown"}],"cover_url":"https://example.test/phm.jpg","chapter_count":3}],"characters":[{"id":"ryland-grace","name":"Ryland Grace","aliases":["Dr. Grace"],"role":"protagonist","reveal":{"chapter":1},"description":"A science teacher who wakes aboard the ship with amnesia.","xref":{"wikidata":"Q110001"}},{"id":"rocky","name":"Rocky","role":"supporting","reveal":{"chapter":8}}],"recaps":[{"through":{"chapter":2},"scope":"book","text":"Grace wakes with amnesia."},{"through":{"chapter":9},"scope":"book","text":"First contact is made."}],"recap_summary":{"in_short":"A lone amnesiac wakes aboard a ship, befriends an alien, and saves both worlds.","ending":"Grace stays on Erid while the cure flies home."}}</script><div id="island-root"></div>
 </main>
 <footer>SHELL FOOTER</footer>

--- a/internal/testpack/fixtures.go
+++ b/internal/testpack/fixtures.go
@@ -225,7 +225,7 @@ func CharactersJSON(t testing.TB, work, charID string) string {
 			"id": charID, "name": "Someone", "reveal": map[string]int{"chapter": 1},
 			"description": "A character, described in the community's own words.",
 		}},
-		"license": "CC-BY-SA-3.0",
+		"license": "CC-BY-SA-4.0",
 		"sources": []map[string]string{{"type": "community", "imported_at": "2026-01-01"}},
 	})
 }
@@ -239,7 +239,7 @@ func RecapsJSON(t testing.TB, work string, throughChapter int) string {
 			"through": map[string]int{"chapter": throughChapter},
 			"text":    "The story so far, in the community's own words.",
 		}},
-		"license": "CC-BY-SA-3.0",
+		"license": "CC-BY-SA-4.0",
 		"sources": []map[string]string{{"type": "community", "imported_at": "2026-01-01"}},
 	})
 }

--- a/pkg/check/advisories_test.go
+++ b/pkg/check/advisories_test.go
@@ -352,9 +352,9 @@ func sidecarSpread(at ...int) (string, string) {
 		rs = append(rs, fmt.Sprintf(`{"scope":"book","text":"The story so far, in the contributor's own words.",`+
 			`"through":{"chapter":%d}}`, p))
 	}
-	chars := `{"characters":[` + strings.Join(cs, ",") + `],"license":"CC-BY-SA-3.0",` +
+	chars := `{"characters":[` + strings.Join(cs, ",") + `],"license":"CC-BY-SA-4.0",` +
 		`"sources":[{"type":"community"}],"work":"book-one"}`
-	recaps := `{"license":"CC-BY-SA-3.0","recaps":[` + strings.Join(rs, ",") + `],` +
+	recaps := `{"license":"CC-BY-SA-4.0","recaps":[` + strings.Join(rs, ",") + `],` +
 		`"sources":[{"type":"community"}],"work":"book-one"}`
 	return chars, recaps
 }

--- a/pkg/check/check_test.go
+++ b/pkg/check/check_test.go
@@ -209,11 +209,11 @@ func TestLibexImportSourceType(t *testing.T) {
 // validCharacters / validRecaps are minimal, valid per-work sidecars for the
 // given work, in canonical (sorted-key) form.
 func validCharacters(work string) string {
-	return `{"characters":[{"aliases":["The Kid"],"description":"A brave hero.","id":"hero","name":"Hero","reveal":{"chapter":1},"role":"protagonist","xref":{"wikidata":"Q42"}}],"license":"CC-BY-SA-3.0","sources":[{"type":"community"}],"work":"` + work + `"}`
+	return `{"characters":[{"aliases":["The Kid"],"description":"A brave hero.","id":"hero","name":"Hero","reveal":{"chapter":1},"role":"protagonist","xref":{"wikidata":"Q42"}}],"license":"CC-BY-SA-4.0","sources":[{"type":"community"}],"work":"` + work + `"}`
 }
 
 func validRecaps(work string) string {
-	return `{"license":"CC-BY-SA-3.0","recaps":[{"scope":"series","text":"Previously, in earlier books.","through":{"chapter":0}},{"scope":"book","text":"So far, the hero set out.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"` + work + `"}`
+	return `{"license":"CC-BY-SA-4.0","recaps":[{"scope":"series","text":"Previously, in earlier books.","through":{"chapter":0}},{"scope":"book","text":"So far, the hero set out.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"` + work + `"}`
 }
 
 // TestCharactersRecapsValid covers the CC BY-SA per-work sidecars: a valid
@@ -240,7 +240,7 @@ func TestRecapsSummaryFields(t *testing.T) {
 	dir := t.TempDir()
 	files := baseValid()
 	longText := strings.Repeat("word ", 500) // 2500 chars, over the old 2000 cap
-	files["works/bo/book-one/recaps.json"] = `{"ending":"The hero wins and goes home.","in_short":"A hero sets out, struggles, and prevails.","license":"CC-BY-SA-3.0","recaps":[{"scope":"book","text":"` + longText + `","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
+	files["works/bo/book-one/recaps.json"] = `{"ending":"The hero wins and goes home.","in_short":"A hero sets out, struggles, and prevails.","license":"CC-BY-SA-4.0","recaps":[{"scope":"book","text":"` + longText + `","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
 	writeEntities(t, dir, files)
 	res := Load(dir)
 	if !res.OK() {
@@ -678,14 +678,14 @@ func TestLoadRuleViolations(t *testing.T) {
 		{
 			name: "characters with CC0 license rejected (must be CC BY-SA)",
 			mutate: func(f map[string]string) {
-				f["works/bo/book-one/characters.json"] = strings.Replace(validCharacters("book-one"), `"CC-BY-SA-3.0"`, `"CC0-1.0"`, 1)
+				f["works/bo/book-one/characters.json"] = strings.Replace(validCharacters("book-one"), `"CC-BY-SA-4.0"`, `"CC0-1.0"`, 1)
 			},
 			want: "license",
 		},
 		{
 			name: "duplicate character id within file",
 			mutate: func(f map[string]string) {
-				f["works/bo/book-one/characters.json"] = `{"characters":[{"id":"hero","name":"Hero","reveal":{"chapter":1}},{"id":"hero","name":"Hero Twin","reveal":{"chapter":2}}],"license":"CC-BY-SA-3.0","sources":[{"type":"community"}],"work":"book-one"}`
+				f["works/bo/book-one/characters.json"] = `{"characters":[{"id":"hero","name":"Hero","reveal":{"chapter":1}},{"id":"hero","name":"Hero Twin","reveal":{"chapter":2}}],"license":"CC-BY-SA-4.0","sources":[{"type":"community"}],"work":"book-one"}`
 			},
 			want: `duplicate character id "hero"`,
 		},
@@ -693,7 +693,7 @@ func TestLoadRuleViolations(t *testing.T) {
 			name: "character description exceeds length cap",
 			mutate: func(f map[string]string) {
 				long := strings.Repeat("a", 1501)
-				f["works/bo/book-one/characters.json"] = `{"characters":[{"description":"` + long + `","id":"hero","name":"Hero","reveal":{"chapter":1}}],"license":"CC-BY-SA-3.0","sources":[{"type":"community"}],"work":"book-one"}`
+				f["works/bo/book-one/characters.json"] = `{"characters":[{"description":"` + long + `","id":"hero","name":"Hero","reveal":{"chapter":1}}],"license":"CC-BY-SA-4.0","sources":[{"type":"community"}],"work":"book-one"}`
 			},
 			want: "/characters/0/description",
 		},
@@ -714,7 +714,7 @@ func TestLoadRuleViolations(t *testing.T) {
 		{
 			name: "duplicate recap through-position",
 			mutate: func(f map[string]string) {
-				f["works/bo/book-one/recaps.json"] = `{"license":"CC-BY-SA-3.0","recaps":[{"text":"A.","through":{"chapter":3}},{"text":"B.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
+				f["works/bo/book-one/recaps.json"] = `{"license":"CC-BY-SA-4.0","recaps":[{"text":"A.","through":{"chapter":3}},{"text":"B.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
 			},
 			want: "duplicate recap through chapter 3",
 		},
@@ -728,7 +728,7 @@ func TestLoadRuleViolations(t *testing.T) {
 		{
 			name: "recap negative chapter rejected",
 			mutate: func(f map[string]string) {
-				f["works/bo/book-one/recaps.json"] = `{"license":"CC-BY-SA-3.0","recaps":[{"text":"A.","through":{"chapter":-1}}],"sources":[{"type":"community"}],"work":"book-one"}`
+				f["works/bo/book-one/recaps.json"] = `{"license":"CC-BY-SA-4.0","recaps":[{"text":"A.","through":{"chapter":-1}}],"sources":[{"type":"community"}],"work":"book-one"}`
 			},
 			want: "chapter",
 		},
@@ -736,7 +736,7 @@ func TestLoadRuleViolations(t *testing.T) {
 			name: "recap text exceeds raised length cap",
 			mutate: func(f map[string]string) {
 				long := strings.Repeat("a", 3001)
-				f["works/bo/book-one/recaps.json"] = `{"license":"CC-BY-SA-3.0","recaps":[{"text":"` + long + `","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
+				f["works/bo/book-one/recaps.json"] = `{"license":"CC-BY-SA-4.0","recaps":[{"text":"` + long + `","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
 			},
 			want: "/recaps/0/text",
 		},
@@ -744,14 +744,14 @@ func TestLoadRuleViolations(t *testing.T) {
 			name: "in_short exceeds length cap",
 			mutate: func(f map[string]string) {
 				long := strings.Repeat("a", 1501)
-				f["works/bo/book-one/recaps.json"] = `{"in_short":"` + long + `","license":"CC-BY-SA-3.0","recaps":[{"text":"A.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
+				f["works/bo/book-one/recaps.json"] = `{"in_short":"` + long + `","license":"CC-BY-SA-4.0","recaps":[{"text":"A.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
 			},
 			want: "/in_short",
 		},
 		{
 			name: "in_short empty string rejected",
 			mutate: func(f map[string]string) {
-				f["works/bo/book-one/recaps.json"] = `{"in_short":"","license":"CC-BY-SA-3.0","recaps":[{"text":"A.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
+				f["works/bo/book-one/recaps.json"] = `{"in_short":"","license":"CC-BY-SA-4.0","recaps":[{"text":"A.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
 			},
 			want: "/in_short",
 		},
@@ -759,14 +759,14 @@ func TestLoadRuleViolations(t *testing.T) {
 			name: "ending exceeds length cap",
 			mutate: func(f map[string]string) {
 				long := strings.Repeat("a", 2001)
-				f["works/bo/book-one/recaps.json"] = `{"ending":"` + long + `","license":"CC-BY-SA-3.0","recaps":[{"text":"A.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
+				f["works/bo/book-one/recaps.json"] = `{"ending":"` + long + `","license":"CC-BY-SA-4.0","recaps":[{"text":"A.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
 			},
 			want: "/ending",
 		},
 		{
 			name: "ending wrong type rejected",
 			mutate: func(f map[string]string) {
-				f["works/bo/book-one/recaps.json"] = `{"ending":42,"license":"CC-BY-SA-3.0","recaps":[{"text":"A.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
+				f["works/bo/book-one/recaps.json"] = `{"ending":42,"license":"CC-BY-SA-4.0","recaps":[{"text":"A.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}`
 			},
 			want: "/ending",
 		},

--- a/pkg/check/packcheck_test.go
+++ b/pkg/check/packcheck_test.go
@@ -306,7 +306,7 @@ func TestPackProblemPaths(t *testing.T) {
 			mutate: func(f map[string]string) {
 				f["works-community/0/0.json"] = packOf(map[string]string{
 					"book-one": `{"characters":` +
-						strings.Replace(validCharacters("book-one"), `"CC-BY-SA-3.0"`, `"CC0-1.0"`, 1) + `}`,
+						strings.Replace(validCharacters("book-one"), `"CC-BY-SA-4.0"`, `"CC0-1.0"`, 1) + `}`,
 				})
 			},
 			want: "works-community/0/0.json: entry book-one: characters",
@@ -576,7 +576,7 @@ func TestPackRuleViolations(t *testing.T) {
 			name: "share-alike license on a works entry",
 			mutate: func(f map[string]string) {
 				f["works/0/0.json"] = packOf(map[string]string{
-					"book-one": composite(strings.Replace(pkWorkOne, `"CC0-1.0"`, `"CC-BY-SA-3.0"`, 1),
+					"book-one": composite(strings.Replace(pkWorkOne, `"CC0-1.0"`, `"CC-BY-SA-4.0"`, 1),
 						map[string]string{"rec-one": pkRecOne}),
 				})
 			},
@@ -587,7 +587,7 @@ func TestPackRuleViolations(t *testing.T) {
 			mutate: func(f map[string]string) {
 				f["works/0/0.json"] = packOf(map[string]string{
 					"book-one": composite(pkWorkOne, map[string]string{
-						"rec-one": strings.Replace(pkRecOne, `"license":"CC0-1.0"`, `"license":"CC-BY-SA-3.0"`, 1),
+						"rec-one": strings.Replace(pkRecOne, `"license":"CC0-1.0"`, `"license":"CC-BY-SA-4.0"`, 1),
 					}),
 				})
 			},
@@ -597,7 +597,7 @@ func TestPackRuleViolations(t *testing.T) {
 			name: "CC0 license on a community sidecar",
 			mutate: func(f map[string]string) {
 				f["works-community/0/0.json"] = packOf(map[string]string{
-					"book-one": `{"recaps":` + strings.Replace(validRecaps("book-one"), `"CC-BY-SA-3.0"`, `"CC0-1.0"`, 1) + `}`,
+					"book-one": `{"recaps":` + strings.Replace(validRecaps("book-one"), `"CC-BY-SA-4.0"`, `"CC0-1.0"`, 1) + `}`,
 				})
 			},
 			want: "works-community/0/0.json: entry book-one: recaps: /license",
@@ -661,7 +661,7 @@ func TestPackRuleViolations(t *testing.T) {
 			name: "duplicate character id within an entry",
 			mutate: func(f map[string]string) {
 				f["works-community/0/0.json"] = packOf(map[string]string{
-					"book-one": `{"characters":{"characters":[{"id":"hero","name":"Hero","reveal":{"chapter":1}},{"id":"hero","name":"Twin","reveal":{"chapter":2}}],"license":"CC-BY-SA-3.0","sources":[{"type":"community"}],"work":"book-one"}}`,
+					"book-one": `{"characters":{"characters":[{"id":"hero","name":"Hero","reveal":{"chapter":1}},{"id":"hero","name":"Twin","reveal":{"chapter":2}}],"license":"CC-BY-SA-4.0","sources":[{"type":"community"}],"work":"book-one"}}`,
 				})
 			},
 			want: `duplicate character id "hero"`,
@@ -670,7 +670,7 @@ func TestPackRuleViolations(t *testing.T) {
 			name: "duplicate recap through-position within an entry",
 			mutate: func(f map[string]string) {
 				f["works-community/0/0.json"] = packOf(map[string]string{
-					"book-one": `{"recaps":{"license":"CC-BY-SA-3.0","recaps":[{"text":"A.","through":{"chapter":3}},{"text":"B.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}}`,
+					"book-one": `{"recaps":{"license":"CC-BY-SA-4.0","recaps":[{"text":"A.","through":{"chapter":3}},{"text":"B.","through":{"chapter":3}}],"sources":[{"type":"community"}],"work":"book-one"}}`,
 				})
 			},
 			want: "duplicate recap through chapter 3",

--- a/pkg/check/parallel_test.go
+++ b/pkg/check/parallel_test.go
@@ -90,7 +90,7 @@ func parallelTree() map[string]string {
 	})
 	files["works/0/book-d.json"] = packOf(map[string]string{
 		"book-a3": pkTitled("book-a3"),
-		"book-d": `{"authors":["author-one"],"id":"book-d","language":"en","license":"CC-BY-SA-3.0",` +
+		"book-d": `{"authors":["author-one"],"id":"book-d","language":"en","license":"CC-BY-SA-4.0",` +
 			`"sources":[{"type":"user"}],"title":"book-d"}`,
 	})
 	wide := map[string]string{}

--- a/pkg/check/review_test.go
+++ b/pkg/check/review_test.go
@@ -180,7 +180,7 @@ func TestSchemaMessagesAtRecordingPrecision(t *testing.T) {
 			want: "/runtime_min: got string, want integer",
 		},
 		"share-alike license on a CC0 record": {
-			rec:  strings.Replace(pkRecOne, `"license":"CC0-1.0"`, `"license":"CC-BY-SA-3.0"`, 1),
+			rec:  strings.Replace(pkRecOne, `"license":"CC0-1.0"`, `"license":"CC-BY-SA-4.0"`, 1),
 			want: "/license: value must be 'CC0-1.0'",
 		},
 		// An anyOf reports every branch it tried, which is the useful answer for

--- a/pkg/check/schema_pack_test.go
+++ b/pkg/check/schema_pack_test.go
@@ -105,11 +105,11 @@ const (
 		"license": "CC0-1.0", "sources": [{"type": "user"}]
 	}`
 	packValidCharacters = `{
-		"work": "dune", "license": "CC-BY-SA-3.0", "sources": [{"type": "community"}],
+		"work": "dune", "license": "CC-BY-SA-4.0", "sources": [{"type": "community"}],
 		"characters": [{"id": "paul", "name": "Paul", "reveal": {"chapter": 1}}]
 	}`
 	packValidRecaps = `{
-		"work": "dune", "license": "CC-BY-SA-3.0", "sources": [{"type": "community"}],
+		"work": "dune", "license": "CC-BY-SA-4.0", "sources": [{"type": "community"}],
 		"recaps": [{"through": {"chapter": 1}, "text": "A start."}]
 	}`
 )
@@ -204,7 +204,7 @@ func TestPackWrapperSchemas(t *testing.T) {
 				"non-slug key":         `{"entries": {"Dune!": ` + validWork + `}}`,
 				"invalid entry":        `{"entries": {"dune": {"id": "dune"}}}`,
 				"share-alike license": `{"entries": {"dune": ` +
-					strings.Replace(validWork, `"CC0-1.0"`, `"CC-BY-SA-3.0"`, 1) + `}}`,
+					strings.Replace(validWork, `"CC0-1.0"`, `"CC-BY-SA-4.0"`, 1) + `}}`,
 			},
 		},
 		{
@@ -231,7 +231,7 @@ func TestPackWrapperSchemas(t *testing.T) {
 				"neither member":   `{"entries": {"dune": {}}}`,
 				"unknown member":   `{"entries": {"dune": {"notes": {}}}}`,
 				"invalid sidecar":  `{"entries": {"dune": {"characters": {"work": "dune"}}}}`,
-				"CC0 on a sidecar": `{"entries": {"dune": {"characters": ` + strings.Replace(packValidCharacters, `"CC-BY-SA-3.0"`, `"CC0-1.0"`, 1) + `}}}`,
+				"CC0 on a sidecar": `{"entries": {"dune": {"characters": ` + strings.Replace(packValidCharacters, `"CC-BY-SA-4.0"`, `"CC0-1.0"`, 1) + `}}}`,
 			},
 		},
 	}

--- a/pkg/check/schema_pack_test.go
+++ b/pkg/check/schema_pack_test.go
@@ -232,13 +232,10 @@ func TestPackWrapperSchemas(t *testing.T) {
 				"unknown member":   `{"entries": {"dune": {"notes": {}}}}`,
 				"invalid sidecar":  `{"entries": {"dune": {"characters": {"work": "dune"}}}}`,
 				"CC0 on a sidecar": `{"entries": {"dune": {"characters": ` + strings.Replace(packValidCharacters, `"CC-BY-SA-4.0"`, `"CC0-1.0"`, 1) + `}}}`,
-				// The 2026-08-21 upgrade REPLACED the community enum value
-				// rather than widening it: every sidecar in the tree had been
-				// authored in-house, so there was no third-party 3.0 content to
-				// keep accepting. The retired spelling must therefore stay
-				// REJECTED, which is what this pins - a later "re-add 3.0 for
-				// compatibility" would silently reopen the layer to content the
-				// project cannot relicense. See LICENSING.md, "The 4.0 upgrade".
+				// The 2026-08-21 upgrade replaced the enum value, so the retired
+				// 3.0 spelling must stay rejected; re-adding it would reopen the
+				// layer to content the project cannot relicense (see LICENSING.md,
+				// "The 4.0 upgrade").
 				"retired 3.0 on a sidecar": `{"entries": {"dune": {"characters": ` + strings.Replace(packValidCharacters, `"CC-BY-SA-4.0"`, `"CC-BY-SA-3.0"`, 1) + `}}}`,
 			},
 		},

--- a/pkg/check/schema_pack_test.go
+++ b/pkg/check/schema_pack_test.go
@@ -232,6 +232,14 @@ func TestPackWrapperSchemas(t *testing.T) {
 				"unknown member":   `{"entries": {"dune": {"notes": {}}}}`,
 				"invalid sidecar":  `{"entries": {"dune": {"characters": {"work": "dune"}}}}`,
 				"CC0 on a sidecar": `{"entries": {"dune": {"characters": ` + strings.Replace(packValidCharacters, `"CC-BY-SA-4.0"`, `"CC0-1.0"`, 1) + `}}}`,
+				// The 2026-08-21 upgrade REPLACED the community enum value
+				// rather than widening it: every sidecar in the tree had been
+				// authored in-house, so there was no third-party 3.0 content to
+				// keep accepting. The retired spelling must therefore stay
+				// REJECTED, which is what this pins - a later "re-add 3.0 for
+				// compatibility" would silently reopen the layer to content the
+				// project cannot relicense. See LICENSING.md, "The 4.0 upgrade".
+				"retired 3.0 on a sidecar": `{"entries": {"dune": {"characters": ` + strings.Replace(packValidCharacters, `"CC-BY-SA-4.0"`, `"CC-BY-SA-3.0"`, 1) + `}}}`,
 			},
 		},
 	}

--- a/schema/common.schema.json
+++ b/schema/common.schema.json
@@ -15,7 +15,7 @@
     "license_content": {
       "description": "The share-alike layer for community-authored expressive content (characters, recaps). Kept in a separate def so a CC0 core record can never carry it and vice versa.",
       "type": "string",
-      "enum": ["CC-BY-SA-3.0"]
+      "enum": ["CC-BY-SA-4.0"]
     },
     "position": {
       "description": "A spoiler position within a work's own timeline. chapter is the logical (edition-independent) work chapter, 1-based; 0 means front matter or knowledge carried from earlier books in a series.",

--- a/scripts/packmerge_test.go
+++ b/scripts/packmerge_test.go
@@ -49,12 +49,12 @@ func community(id string, members ...string) string {
 }
 
 func charsMember(work, name string) string {
-	return `"characters":{"work":"` + work + `","license":"CC-BY-SA-3.0",` +
+	return `"characters":{"work":"` + work + `","license":"CC-BY-SA-4.0",` +
 		`"characters":[{"id":"c1","name":"` + name + `"}]}`
 }
 
 func recapsMember(work, text string) string {
-	return `"recaps":{"work":"` + work + `","license":"CC-BY-SA-3.0",` +
+	return `"recaps":{"work":"` + work + `","license":"CC-BY-SA-4.0",` +
 		`"recaps":[{"through":{"chapter":1},"text":"` + text + `"}]}`
 }
 

--- a/site/README.md
+++ b/site/README.md
@@ -184,7 +184,7 @@ public/img/card/          card art (greyscale webp, generated - no attribution o
 - **Copy is true to what exists.** The in-browser import page is live (it parses
   OpenAudible, Libation, Audiobookshelf, and metascan folder-scan exports client-
   side); the command-line importer exists alongside it. The factual data core is
-  CC0; the characters/recaps layer is CC BY-SA 3.0; the code is AGPL-3.0.
+  CC0; the characters/recaps layer is CC BY-SA 4.0; the code is AGPL-3.0.
 - **Dark-only**, cinematic, pink `#db2777` as an accent (not a paint bucket).
 - **Hyphens, never em dashes.** British-neutral English.
 - Animations respect `prefers-reduced-motion`; scroll-reveal degrades to fully

--- a/site/src/components/build/BuildTool.tsx
+++ b/site/src/components/build/BuildTool.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { getWork, getSeries, href, personNames, type Character, type Work } from '../../lib/api'
 import { addCharactersIssueUrl, addRecapsIssueUrl } from '../../lib/github-prefill'
 import { downloadJson } from '../../lib/download'
+import { CC_BY_SA_LABEL } from '../../lib/expressive'
 import {
   buildCharactersObject,
   buildRecapsObject,
@@ -388,7 +389,7 @@ function Explainer({ isChars }: { isChars: boolean }) {
       )}
       <p className="mt-2 text-dim">
         Own words only, neutral reference-guide voice - no verbatim text, jokes, or editorializing.
-        This is the community <span className="font-medium text-pink-300">CC BY-SA 4.0</span> layer.
+        This is the community <span className="font-medium text-pink-300">{CC_BY_SA_LABEL}</span> layer.
       </p>
     </div>
   )

--- a/site/src/components/build/BuildTool.tsx
+++ b/site/src/components/build/BuildTool.tsx
@@ -388,7 +388,7 @@ function Explainer({ isChars }: { isChars: boolean }) {
       )}
       <p className="mt-2 text-dim">
         Own words only, neutral reference-guide voice - no verbatim text, jokes, or editorializing.
-        This is the community <span className="font-medium text-pink-300">CC BY-SA 3.0</span> layer.
+        This is the community <span className="font-medium text-pink-300">CC BY-SA 4.0</span> layer.
       </p>
     </div>
   )

--- a/site/src/components/detail/work-guide.tsx
+++ b/site/src/components/detail/work-guide.tsx
@@ -158,7 +158,7 @@ function Loaded({ work, guide, hydrated }: { work: Work; guide: WorkGuide; hydra
       <p className="mt-12 border-t border-edge pt-6 text-sm text-dim">
         Community-written and published under{' '}
         <a href={CC_BY_SA_URL} rel="license noopener" target="_blank" className={TEXT_LINK}>
-          CC BY-SA 3.0
+          CC BY-SA 4.0
         </a>
         {present ? (
           <>

--- a/site/src/components/detail/work-guide.tsx
+++ b/site/src/components/detail/work-guide.tsx
@@ -15,7 +15,7 @@
 
 import type { ReactNode } from 'react'
 import { getWork, href, type Work } from '../../lib/api'
-import { CC_BY_SA_URL, hasGuide, storyRowsOf, type StoryRow } from '../../lib/expressive'
+import { CC_BY_SA_LABEL, CC_BY_SA_URL, hasGuide, storyRowsOf, type StoryRow } from '../../lib/expressive'
 import type { WorkGuide } from '../../lib/entity-url'
 import PersonLinks from '../cards/PersonLinks'
 import { PILL_LINK, TEXT_LINK } from '../ui'
@@ -158,7 +158,7 @@ function Loaded({ work, guide, hydrated }: { work: Work; guide: WorkGuide; hydra
       <p className="mt-12 border-t border-edge pt-6 text-sm text-dim">
         Community-written and published under{' '}
         <a href={CC_BY_SA_URL} rel="license noopener" target="_blank" className={TEXT_LINK}>
-          CC BY-SA 4.0
+          {CC_BY_SA_LABEL}
         </a>
         {present ? (
           <>

--- a/site/src/lib/builder.test.ts
+++ b/site/src/lib/builder.test.ts
@@ -246,7 +246,7 @@ describe('buildCharactersObject', () => {
   it('emits the fixed contract fields and required per-card fields', () => {
     const file = buildCharactersObject('a-deadly-education', [charDraft({ id: 'el', name: 'El', reveal: '1' })])
     expect(file.work).toBe('a-deadly-education')
-    expect(file.license).toBe('CC-BY-SA-3.0')
+    expect(file.license).toBe('CC-BY-SA-4.0')
     expect(file.sources).toEqual([{ type: 'community' }])
     expect(file.characters[0]).toEqual({ id: 'el', name: 'El', reveal: { chapter: 1 } })
   })
@@ -292,7 +292,7 @@ describe('buildRecapsObject', () => {
       ending: '  It ends thus.  ',
     })
     expect(withSummaries.work).toBe('w')
-    expect(withSummaries.license).toBe('CC-BY-SA-3.0')
+    expect(withSummaries.license).toBe('CC-BY-SA-4.0')
     expect(withSummaries.recaps[0]).toEqual({ through: { chapter: 3 }, scope: 'series', text: 'Previously.' })
     expect(withSummaries.in_short).toBe('The whole arc.')
     expect(withSummaries.ending).toBe('It ends thus.')

--- a/site/src/lib/builder.test.ts
+++ b/site/src/lib/builder.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
 import {
   slugify,
   isValidSlug,
@@ -21,6 +22,7 @@ import {
   type RecapsDraft,
 } from './builder'
 import type { Character } from './api'
+import { CC_BY_SA_SPDX } from './expressive'
 
 function charDraft(extra: Partial<CharacterDraft> = {}): CharacterDraft {
   return { ...emptyCharacterDraft(), id: 'el', name: 'El', reveal: '1', ...extra }
@@ -246,7 +248,7 @@ describe('buildCharactersObject', () => {
   it('emits the fixed contract fields and required per-card fields', () => {
     const file = buildCharactersObject('a-deadly-education', [charDraft({ id: 'el', name: 'El', reveal: '1' })])
     expect(file.work).toBe('a-deadly-education')
-    expect(file.license).toBe('CC-BY-SA-4.0')
+    expect(file.license).toBe(CC_BY_SA_SPDX)
     expect(file.sources).toEqual([{ type: 'community' }])
     expect(file.characters[0]).toEqual({ id: 'el', name: 'El', reveal: { chapter: 1 } })
   })
@@ -292,7 +294,7 @@ describe('buildRecapsObject', () => {
       ending: '  It ends thus.  ',
     })
     expect(withSummaries.work).toBe('w')
-    expect(withSummaries.license).toBe('CC-BY-SA-4.0')
+    expect(withSummaries.license).toBe(CC_BY_SA_SPDX)
     expect(withSummaries.recaps[0]).toEqual({ through: { chapter: 3 }, scope: 'series', text: 'Previously.' })
     expect(withSummaries.in_short).toBe('The whole arc.')
     expect(withSummaries.ending).toBe('It ends thus.')
@@ -428,5 +430,19 @@ describe('emptyRecapsDraft', () => {
     expect(d.entries.length).toBe(1)
     expect(d.inShort).toBe('')
     expect(d.ending).toBe('')
+  })
+})
+
+// The schema enum is the single definition of the community layer's license
+// value (see LICENSING.md); the guided builder is the one production writer of
+// it on the site, through CC_BY_SA_SPDX. If the two ever disagree, every file
+// the builder emits fails metacheck at submission time - so pin them equal
+// here, at build time, in the style of audible-genres.test.ts.
+describe('community license value', () => {
+  it('matches the schema license_content enum exactly', () => {
+    const schema = JSON.parse(
+      readFileSync(new URL('../../../schema/common.schema.json', import.meta.url), 'utf8')
+    )
+    expect(schema.$defs.license_content.enum).toEqual([CC_BY_SA_SPDX])
   })
 })

--- a/site/src/lib/builder.ts
+++ b/site/src/lib/builder.ts
@@ -247,7 +247,7 @@ export interface CharacterOut {
 export interface CharactersFile {
   work: string
   characters: CharacterOut[]
-  license: 'CC-BY-SA-3.0'
+  license: 'CC-BY-SA-4.0'
   sources: { type: string }[]
 }
 
@@ -262,7 +262,7 @@ export interface RecapsFile {
   recaps: RecapOut[]
   in_short?: string
   ending?: string
-  license: 'CC-BY-SA-3.0'
+  license: 'CC-BY-SA-4.0'
   sources: { type: string }[]
 }
 
@@ -271,7 +271,7 @@ export interface RecapsFile {
 export function buildCharactersObject(workId: string, drafts: CharacterDraft[]): CharactersFile {
   return {
     work: workId,
-    license: 'CC-BY-SA-3.0',
+    license: 'CC-BY-SA-4.0',
     sources: [{ type: 'community' }],
     characters: drafts.map((d) => {
       const out: CharacterOut = {
@@ -295,7 +295,7 @@ export function buildCharactersObject(workId: string, drafts: CharacterDraft[]):
 export function buildRecapsObject(workId: string, draft: RecapsDraft): RecapsFile {
   const file: RecapsFile = {
     work: workId,
-    license: 'CC-BY-SA-3.0',
+    license: 'CC-BY-SA-4.0',
     sources: [{ type: 'community' }],
     recaps: draft.entries.map((e) => {
       const out: RecapOut = {

--- a/site/src/lib/builder.ts
+++ b/site/src/lib/builder.ts
@@ -10,6 +10,7 @@
 // are OMITTED when empty rather than emitted null/empty, so the output validates.
 
 import type { Character, Position } from './api'
+import { CC_BY_SA_SPDX } from './expressive'
 
 // The output shapes reuse the wire Position (both mirror the schema's
 // edition-independent chapter position); re-exported so builder consumers
@@ -247,7 +248,7 @@ export interface CharacterOut {
 export interface CharactersFile {
   work: string
   characters: CharacterOut[]
-  license: 'CC-BY-SA-4.0'
+  license: typeof CC_BY_SA_SPDX
   sources: { type: string }[]
 }
 
@@ -262,7 +263,7 @@ export interface RecapsFile {
   recaps: RecapOut[]
   in_short?: string
   ending?: string
-  license: 'CC-BY-SA-4.0'
+  license: typeof CC_BY_SA_SPDX
   sources: { type: string }[]
 }
 
@@ -271,7 +272,7 @@ export interface RecapsFile {
 export function buildCharactersObject(workId: string, drafts: CharacterDraft[]): CharactersFile {
   return {
     work: workId,
-    license: 'CC-BY-SA-4.0',
+    license: CC_BY_SA_SPDX,
     sources: [{ type: 'community' }],
     characters: drafts.map((d) => {
       const out: CharacterOut = {
@@ -295,7 +296,7 @@ export function buildCharactersObject(workId: string, drafts: CharacterDraft[]):
 export function buildRecapsObject(workId: string, draft: RecapsDraft): RecapsFile {
   const file: RecapsFile = {
     work: workId,
-    license: 'CC-BY-SA-4.0',
+    license: CC_BY_SA_SPDX,
     sources: [{ type: 'community' }],
     recaps: draft.entries.map((e) => {
       const out: RecapOut = {

--- a/site/src/lib/expressive.ts
+++ b/site/src/lib/expressive.ts
@@ -15,6 +15,16 @@ import type { WorkGuide } from './entity-url'
     LICENSING.md for what the two layers mean. */
 export const CC_BY_SA_URL = 'https://creativecommons.org/licenses/by-sa/4.0/'
 
+/** The same license's human label and SPDX identifier, stated beside the deed
+    URL so the three can never drift: the label is what every surface prints
+    next to the CC_BY_SA_URL link, and the SPDX value is what the guided
+    builder writes into a sidecar's `license` field - the one production
+    writer of that value on the site (the schema enum in
+    schema/common.schema.json is the definition of record; builder.test.ts
+    pins the two are equal). */
+export const CC_BY_SA_LABEL = 'CC BY-SA 4.0'
+export const CC_BY_SA_SPDX = 'CC-BY-SA-4.0'
+
 /** Human label for a character role, or null when the role is absent/unknown. */
 export function roleLabel(role: Character['role']): string | null {
   switch (role) {

--- a/site/src/lib/expressive.ts
+++ b/site/src/lib/expressive.ts
@@ -13,7 +13,7 @@ import type { WorkGuide } from './entity-url'
     footer, and anything that grows one later - links the same deed.
     internal/serve carries its own copy for the server-rendered pages; see
     LICENSING.md for what the two layers mean. */
-export const CC_BY_SA_URL = 'https://creativecommons.org/licenses/by-sa/3.0/'
+export const CC_BY_SA_URL = 'https://creativecommons.org/licenses/by-sa/4.0/'
 
 /** Human label for a character role, or null when the role is absent/unknown. */
 export function roleLabel(role: Character['role']): string | null {

--- a/site/src/pages/contribute.astro
+++ b/site/src/pages/contribute.astro
@@ -36,7 +36,7 @@ const AUTHORING = `${REPO}/blob/main/AUTHORING.md`
             href={CC_BY_SA_URL}
             target="_blank"
             rel="noopener"
-            class="text-pink-400 transition-colors hover:text-pink-300">CC BY-SA 3.0</a
+            class="text-pink-400 transition-colors hover:text-pink-300">CC BY-SA 4.0</a
           >
           - not copied from a publisher blurb or another site. See the
           <a

--- a/site/src/pages/contribute.astro
+++ b/site/src/pages/contribute.astro
@@ -2,7 +2,7 @@
 import Base from '../layouts/Base.astro'
 import Backdrop from '../components/Backdrop.astro'
 import CoveragePanel from '../components/contribute/CoveragePanel.tsx'
-import { CC_BY_SA_URL } from '../lib/expressive'
+import { CC_BY_SA_LABEL, CC_BY_SA_URL } from '../lib/expressive'
 
 const REPO = 'https://github.com/kodestar/audiosilo-meta'
 const AUTHORING = `${REPO}/blob/main/AUTHORING.md`
@@ -36,7 +36,7 @@ const AUTHORING = `${REPO}/blob/main/AUTHORING.md`
             href={CC_BY_SA_URL}
             target="_blank"
             rel="noopener"
-            class="text-pink-400 transition-colors hover:text-pink-300">CC BY-SA 4.0</a
+            class="text-pink-400 transition-colors hover:text-pink-300">{CC_BY_SA_LABEL}</a
           >
           - not copied from a publisher blurb or another site. See the
           <a

--- a/site/src/pages/privacy.astro
+++ b/site/src/pages/privacy.astro
@@ -112,7 +112,7 @@ const code =
         <a class={link} href="https://github.com/site/privacy" target="_blank" rel="noopener"
           >GitHub's own terms and privacy policy</a
         >. Contributions are public and permanently recorded in the repository's history, and the
-        data itself is published under open licences (CC0-1.0 for the factual core, CC BY-SA 3.0 for
+        data itself is published under open licences (CC0-1.0 for the factual core, CC BY-SA 4.0 for
         the community layer). A contributor's GitHub username is therefore part of the public record
         and cannot meaningfully be withdrawn later.
       </p>


### PR DESCRIPTION
Migrates the community content layer (the characters/recaps sidecars in `data/works-community/`) from **CC BY-SA 3.0 to CC BY-SA 4.0**, everywhere in this repository, in one change.

The maintainer confirmed (2026-08-21) that every existing community entry was authored in-house, so there is no third-party 3.0 content: the schema enum value is **replaced outright**, not widened to two values, and there is no dual-licensed period for any reader to reason about. Design basis: `.claude/community/PLAN.md`, decisions log item 2.

## Why

- **The original reason for 3.0 survives the upgrade.** BY-SA 3.0's ShareAlike clause permits licensing an adaptation under a later version of the licence, and our posture is derived, own-words content, never verbatim mirroring - so Fandom and LibraryThing CK (3.0 at source) still flow into a 4.0 project.
- **The reverse never held.** 4.0 content can never flow into a 3.0 project, and Wikipedia has been BY-SA 4.0 since 2023. Staying on 3.0 would have foreclosed every 4.0 source permanently.
- **4.0 explicitly licenses sui generis database rights** - directly relevant for a project that IS a database (EU/UK) - plus the 30-day cure provision, and one international instrument instead of ported jurisdiction variants.

## What changed

**Schema** - `schema/common.schema.json`, `$defs/license_content` enum `"CC-BY-SA-3.0"` -> `"CC-BY-SA-4.0"`. Embedded via `schema.go`, so this is a code change with tests.

**Data** - 6,098 `license` fields across 154 `data/works-community/` pack files, rewritten mechanically, then `metafmt --write`. The core families were verified to carry only `CC0-1.0` (grep census before and after) and are untouched.

**Code**
- `internal/serve/guides.go` - `ccBySA30URL` -> `ccBySA40URL` (`.../by-sa/4.0/`) and the `rel="license"` notice text on both guide pages
- `internal/serve/jsonld.go` - the guide-page JSON-LD `license` (via the same constant)
- `internal/serve/openapi.json` - the four prose mentions and the `info.license.name`
- `internal/serve/testdata/golden/{recap,characters}.html` - regenerated expectations
- `internal/issueform/issueform.go` - `licenseLayer`'s community label
- `internal/issueform/compose_sidecar.go` - the unticked-checkbox refusal text
- `internal/testpack/fixtures.go` - the sidecar fixture renderers
- every test pinning the value (`pkg/check`, `internal/build`, `internal/migrate`, `internal/serve`, `internal/issueform`, `scripts/packmerge_test.go`)

**Site** - `site/src/lib/expressive.ts` (`CC_BY_SA_URL`), `site/src/lib/builder.ts` + its test, `work-guide.tsx`, `BuildTool.tsx`, `contribute.astro`, `privacy.astro`, `site/README.md`.

**Docs and intake** - `LICENSING.md` (see below), `AUTHORING.md`, `README.md`, `CONTRIBUTING.md`, `PACK-SPEC.md`, `CLAUDE.md`, `EXTRACTION.md`, `.github/ISSUE_TEMPLATE/add-characters.yml` + `add-recaps.yml` (the contribution checkbox now names 4.0), `.github/scripts/ai-verify.sh` (the license-layer rule the AI reviewer applies). `GOVERNANCE.md` carries no version-specific mention and needed no edit.

## No SchemaVersion bump

**No reader branches on the license value.** `internal/build` writes it as an opaque column on `works`/`recordings`/`people`/`series`/`characters`/`recaps`/`recap_summaries`; `internal/serve` emits a hardcoded deed URL constant and never compares the stored string; `pkg/check` enforces the layer split purely through the JSON Schema enum. Artifact `schema_version` stays at **5**.

## Verification

- `go build ./... && go vet ./... && go test -race ./... && golangci-lint run` - all green (`0 issues.`)
- `go run ./cmd/metacheck` - **exit 0**: `ok: 277618 works, 123117 people, 45170 series (2901 advisory)`; the advisory classes are the pre-existing data-quality census, unchanged by this PR
- `go run ./cmd/metafmt --check` - clean
- `go run ./cmd/metabuild` - built 277,618 works; spot-checked with sqlite3, every license-bearing table:

  | table | license | rows |
  |---|---|---|
  | characters | CC-BY-SA-4.0 | 43,203 |
  | recaps | CC-BY-SA-4.0 | 19,065 |
  | recap_summaries | CC-BY-SA-4.0 | 3,035 |
  | works | CC0-1.0 | 277,618 |
  | recordings | CC0-1.0 | 291,543 |
  | people | CC0-1.0 | 123,117 |
  | series | CC0-1.0 | 45,170 |

  Nothing in the artifact carries 3.0; `meta.schema_version` = 5.
- Site: `yarn test` (407 passed) and `yarn run check` (0 errors) both green.
- Final repo-wide grep for `CC-BY-SA-3.0` / `by-sa/3.0` / `BY-SA 3.0` / `CC BY-SA 3.0` returns **five deliberate mentions**: four in `LICENSING.md` (the note that Fandom / LibraryThing CK are 3.0 *at source*, and the **"The 4.0 upgrade (2026-08-21)"** section recording that the layer was 3.0 until this change, that every pre-upgrade contribution was in-house, why 3.0 sources still flow in, and how a maintainer triages an attachment authored against the 3.0 instructions), and one in `pkg/check/schema_pack_test.go` - the fixture below that pins the value as **rejected**.

## Regression guard

Every prior occurrence of the old value was string-replaced rather than kept as a deliberately-rejected one, so nothing pinned the enum against a future re-widen ("re-add 3.0 for compatibility"), which would silently reopen the layer to content the project cannot relicense. `pkg/check`'s existing wrong-license schema fixtures gain **`"retired 3.0 on a sidecar"`** - beside `"CC0 on a sidecar"` and the core families' `"share-alike license"` - asserting that a works-community `characters` member carrying the literal `"CC-BY-SA-3.0"` is rejected by schema validation, with a comment recording the replaced-not-widened decision it guards.

## Follow-ups (out of scope here)

- **audiosilo-sidecars** emits the license value when generating sidecars - it must be updated in step, before its next contribution, or its output will fail `metacheck` against the new enum.
- The **workspace-level `~/dev/audiosilo/CLAUDE.md`** still describes the community layer as CC BY-SA 3.0.
- Nothing in audiosilo-server or audiosilo-frontend was touched.
